### PR TITLE
[RHCEPHQE-19212]: [Case-sensitivity] New TC coverage for subvolume and subvolumegroups

### DIFF
--- a/cli/ceph/fs/fs.py
+++ b/cli/ceph/fs/fs.py
@@ -1,7 +1,7 @@
 from cli import Cli
 
-from .sub_volume_group import SubVolumeGroup
 from .subvolume.sub_volume import SubVolume
+from .subvolumegroup.sub_volume_group import SubVolumeGroup
 from .volume import Volume
 
 

--- a/cli/ceph/fs/subvolume/charmap.py
+++ b/cli/ceph/fs/subvolume/charmap.py
@@ -1,0 +1,113 @@
+import json
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+from tests.cephfs.exceptions import CharMapGetError, CharMapRemoveError, CharMapSetError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class Charmap(Cli):
+    """This module provides CLI interface for FS subvolume charmaps related operations"""
+
+    def __init__(self, nodes, base_cmd):
+        super(Charmap, self).__init__(nodes)
+        self.base_cmd = f"{base_cmd} charmap"
+
+    def set(self, volume, subvolume_name, attributes, **kwargs):
+        """
+        Sets charmaps to the subvolume
+        Args:
+            volume (str): Name of vol where subvol is present
+            subvolume (str): subvol name
+            subvolume_group (str): subvol group name
+            kwargs: Key/value pairs of charmaps to be set
+            Example:
+                {
+                    "casesensitive": "true",
+                    "normalization": "nfc"
+                }
+        Raises:
+            CharMapSetError: If the command execution fails
+        """
+        for attr, val in attributes.items():
+            cmd = f"{self.base_cmd} set {volume} {subvolume_name} {attr} {val}"
+            cmd += build_cmd_from_args(**kwargs)
+
+            try:
+                self.execute(sudo=True, cmd=cmd, check_ec=True)
+            except Exception as e:
+                raise CharMapSetError(
+                    "Failed to set charmaps: {} for subvolume {}".format(
+                        e, subvolume_name
+                    )
+                )
+
+    def get(self, volume, subvolume_name, charmap_attribute=None, **kwargs):
+        """
+        Gets the charmaps from the subvolume
+        Args:
+            volume (str): Name of vol where subvol is present
+            subvolume (str): subvol name
+            charmap_attribute (str, optional): Specific charmaps attribute to get. Ex: "casesensitive", "normalization".
+            kwargs: Additional command arguments
+        Returns:
+            str: Charmaps information from the subvolume
+        Raises:
+            CharMapGetError: If the command execution fails
+        """
+        cmd = f"{self.base_cmd} get {volume} {subvolume_name}"
+
+        cmd += build_cmd_from_args(**kwargs)
+
+        if charmap_attribute:
+            cmd += f" {charmap_attribute}"
+
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=True)
+            log.debug("output: {}".format(out))
+        except Exception as e:
+            raise CharMapGetError(
+                "Failed to get charmaps: {} for subvolume {}".format(e, subvolume_name)
+            )
+
+        if isinstance(out, tuple):
+            out = out[0]
+
+        out = out.strip()
+
+        if not charmap_attribute:
+            try:
+                return json.loads(out)
+            except json.JSONDecodeError as e:
+                raise CharMapGetError(f"Failed to parse charmaps JSON output: {e}")
+
+        return out
+
+    def remove(self, volume, subvolume_name, **kwargs):
+        """
+        Remove the charmaps from the subvolume
+        Args:
+            volume (str): Name of vol where subvol is present
+            subvolume (str): subvol name
+        Returns:
+            str: Output from the command
+        Raises:
+            CharMapRemoveError: If the command execution fails
+        """
+        cmd = f"{self.base_cmd} rm {volume} {subvolume_name} {build_cmd_from_args(**kwargs)}"
+
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=True)
+            log.debug("output: {}".format(out))
+        except Exception as e:
+            raise CharMapRemoveError(
+                "Failed to remove charmaps: {} for subvolume {}".format(
+                    e, subvolume_name
+                )
+            )
+
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out

--- a/cli/ceph/fs/subvolumegroup/charmap.py
+++ b/cli/ceph/fs/subvolumegroup/charmap.py
@@ -1,0 +1,114 @@
+import json
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+from tests.cephfs.exceptions import CharMapGetError, CharMapRemoveError, CharMapSetError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class Charmap(Cli):
+    """This module provides CLI interface for FS subvolume charmaps related operations"""
+
+    def __init__(self, nodes, base_cmd):
+        super(Charmap, self).__init__(nodes)
+        self.base_cmd = f"{base_cmd} charmap"
+
+    def set(self, volume, subvolume_group, **kwargs):
+        """
+        Sets charmaps to the subvolume
+        Args:
+            volume (str): Name of vol where subvol is present
+            subvolume_group (str): subvol group name
+            kwargs: Key/value pairs of charmaps to be set
+            Example:
+                {
+                    "casesensitive": "true",
+                    "normalization": "nfc"
+                }
+        Raises:
+            CharMapSetError: If the command execution fails
+        """
+        for attr, val in kwargs.items():
+            cmd = f"{self.base_cmd} set {volume} {subvolume_group} {attr} {val}"
+
+            try:
+                self.execute(sudo=True, cmd=cmd, check_ec=True)
+            except Exception as e:
+                raise CharMapSetError(
+                    "Failed to set charmaps: {} for subvolume {}".format(
+                        e, subvolume_group
+                    )
+                )
+        return True
+
+    def get(self, volume, subvolume_group, charmap_attribute=None, **kwargs):
+        """
+        Gets the charmaps from the subvolume
+        Args:
+            volume (str): Name of vol where subvol is present
+            subvolume_group (str): subvol group name
+            charmap_attribute (str, optional): Specific charmaps attribute to get. Ex: "casesensitive", "normalization".
+            kwargs: Additional command arguments
+        Returns:
+            str: Charmaps information from the subvolume
+        Raises:
+            CharMapGetError: If the command execution fails
+        """
+        cmd = f"{self.base_cmd} get {volume} {subvolume_group}"
+
+        cmd += build_cmd_from_args(**kwargs)
+
+        if charmap_attribute:
+            cmd += f" {charmap_attribute}"
+
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=True)
+            log.debug("output: {}".format(out))
+        except Exception as e:
+            raise CharMapGetError(
+                "Failed to get charmaps: {} for subvolumegroup {}".format(
+                    e, subvolume_group
+                )
+            )
+
+        if isinstance(out, tuple):
+            out = out[0]
+
+        out = out.strip()
+
+        if not charmap_attribute:
+            try:
+                return json.loads(out)
+            except json.JSONDecodeError as e:
+                raise CharMapGetError(f"Failed to parse charmaps JSON output: {e}")
+
+        return out
+
+    def remove(self, volume, subvolume_group, **kwargs):
+        """
+        Remove the charmaps from the subvolume
+        Args:
+            volume (str): Name of vol where subvol is present
+            subvolumegroup (str): subvol group name
+        Returns:
+            str: Output from the command
+        Raises:
+            CharMapRemoveError: If the command execution fails
+        """
+        cmd = f"{self.base_cmd} rm {volume} {subvolume_group} {build_cmd_from_args(**kwargs)}"
+
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=True)
+            log.debug("output: {}".format(out))
+        except Exception as e:
+            raise CharMapRemoveError(
+                "Failed to remove charmaps: {} for subvolumegroup {}".format(
+                    e, subvolume_group
+                )
+            )
+
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out

--- a/cli/ceph/fs/volume.py
+++ b/cli/ceph/fs/volume.py
@@ -1,4 +1,5 @@
 from cli import Cli
+from tests.cephfs.exceptions import VolumeDeleteError, VolumeRenameError
 
 
 class Volume(Cli):
@@ -29,7 +30,12 @@ class Volume(Cli):
         cmd = f"{self.base_cmd} rm {volume}"
         if yes_i_really_mean_it:
             cmd += " --yes-i-really-mean-it"
-        out = self.execute(sudo=True, cmd=cmd)
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=True)
+        except Exception as e:
+            raise VolumeDeleteError(
+                "Failed to remove volume {}: {}".format(volume, str(e))
+            )
         if isinstance(out, tuple):
             return out[0].strip()
         return out
@@ -40,6 +46,31 @@ class Volume(Cli):
         """
         cmd = f"{self.base_cmd} ls"
         out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out
+
+    def rename(self, volume, new_volume, yes_i_really_mean_it=False):
+        """
+        Renames ceph volume
+        Args:
+            volume (str): Name of vol to be renamed
+            new_volume (str): New name for the volume
+            yes_i_really_mean_it (bool): Confirmation flag to proceed with the rename
+        Raises:
+            VolumeRenameError: If the command execution fails
+        """
+        cmd = f"{self.base_cmd} rename {volume} {new_volume}"
+        if yes_i_really_mean_it:
+            cmd += " --yes-i-really-mean-it"
+
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=True)
+        except Exception as e:
+            raise VolumeRenameError(
+                "Failed to rename volume {}: {}".format(volume, str(e))
+            )
+
         if isinstance(out, tuple):
             return out[0].strip()
         return out

--- a/conf/squid/cephfs/tier-1_cephfs_smb_nfs.yaml
+++ b/conf/squid/cephfs/tier-1_cephfs_smb_nfs.yaml
@@ -1,0 +1,60 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - smb
+      node2:
+        role:
+          - mon
+          - mgr
+          - smb
+      node3:
+        role:
+          - mon
+          - mds
+          - osd
+          - smb
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - osd
+          - mds
+          - smb
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - osd
+          - mds
+          - smb
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - osd
+          - nfs
+          - mds
+        no-of-volumes: 4
+        disk-size: 20
+      node7:
+        role:
+          - mds
+          - nfs
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client
+      node10:
+        role:
+          - client
+      node11:
+        role:
+          - client

--- a/suites/squid/cephfs/tier-1_cephfs_case_sensitivity.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_case_sensitivity.yaml
@@ -2,7 +2,7 @@
 #===============================================================================================
 # Tier-level: 1
 # Test-Suite: tier-1_cephfs_case_sensitivity
-# Conf file : conf/squid/cephfs/tier-1_fs.yaml
+# Conf file : conf/squid/cephfs/tier-1_cephfs_smb_nfs.yaml
 # Test-Case Covered:
 # CEPH-83606639 Verify Case Sensitivity Functionality
 #===============================================================================================
@@ -63,6 +63,8 @@ tests:
         install_packages:
           - ceph-common
           - ceph-fuse
+          - samba-client
+          - cifs-utils
         node: node8
       desc: "Configure the Cephfs client system 1"
       destroy-cluster: false
@@ -77,6 +79,8 @@ tests:
         install_packages:
           - ceph-common
           - ceph-fuse
+          - samba-client
+          - cifs-utils
         node: node9
       desc: "Configure the Cephfs client system 2"
       destroy-cluster: false
@@ -91,6 +95,8 @@ tests:
         install_packages:
           - ceph-common
           - ceph-fuse
+          - samba-client
+          - cifs-utils
         node: node10
       desc: "Configure the Cephfs client system 3"
       destroy-cluster: false
@@ -105,6 +111,8 @@ tests:
         install_packages:
           - ceph-common
           - ceph-fuse
+          - samba-client
+          - cifs-utils
         node: node11
       desc: "Configure the Cephfs client system 4"
       destroy-cluster: false
@@ -127,4 +135,11 @@ tests:
       module: cephfs_case_sensitivity.case_sensitivity_disruptive.py
       polarion-id: CEPH-83611928
       desc: Test fs attributes for disruptive use case
+      abort-on-fail: false
+
+  - test:
+      name: test cephfs attributes - subvolume
+      module: cephfs_case_sensitivity.case_sensitivity_subvolume.py
+      polarion-id: CEPH-83606639
+      desc: Test fs attributes for functional use case
       abort-on-fail: false

--- a/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_subvolume.py
+++ b/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_subvolume.py
@@ -1,0 +1,951 @@
+import traceback
+
+from cli.ceph.ceph import Ceph
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from tests.cephfs.exceptions import CharMapGetError, CharMapRemoveError, CharMapSetError
+from tests.cephfs.lib.cephfs_attributes_lib import CephFSAttributeUtilities
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+
+# from tests.cephfs.lib.cephfs_recovery_lib import FSRecovery
+from tests.smb.smb_operations import (
+    check_smb_cluster,
+    create_smb_cluster,
+    create_smb_share,
+    remove_smb_cluster,
+    remove_smb_share,
+    smb_cifs_mount,
+    smbclient_check_shares,
+    verify_smb_service,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def extract_case_and_normalization(info):
+    """Extracts case sensitivity and normalization attributes from subvolume info.
+    Args:
+        info (dict): Subvolume info dictionary.
+    Returns:
+        dict: A dictionary containing 'casesensitive' and 'normalization' attributes.
+    """
+    return {
+        "casesensitive": not info.get("case_insensitive", ""),
+        "normalization": info.get("normalization", ""),
+    }
+
+
+def create_svgroup_charmap_test():
+    """Create subvolume group and validate different charmap settings using charmap set/get."""
+    Ceph(client1).fs.sub_volume_group.create(
+        cephfs_vol,
+        cephfs_subvol_group1,
+    )
+
+    Ceph(client1).fs.sub_volume_group.charmap.set(
+        cephfs_vol,
+        cephfs_subvol_group1,
+        **{
+            "casesensitive": "false",
+        },
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume_group.charmap.get(
+        cephfs_vol, cephfs_subvol_group1
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfd",
+            "encoding": "utf8",
+        },
+    )
+
+    Ceph(client1).fs.sub_volume_group.create(
+        cephfs_vol,
+        cephfs_subvol_group2,
+    )
+
+    Ceph(client1).fs.sub_volume_group.charmap.set(
+        cephfs_vol,
+        cephfs_subvol_group2,
+        **{
+            "normalization": "nfkc",
+        },
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume_group.charmap.get(
+        cephfs_vol, cephfs_subvol_group2
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": True,
+            "normalization": "nfkc",
+            "encoding": "utf8",
+        },
+    )
+
+
+def validate_svg_unsupported_charmaps():
+    """Validate unsupported charmaps for subvolume group."""
+    try:
+        Ceph(client1).fs.sub_volume_group.charmap.set(
+            cephfs_vol,
+            cephfs_subvol_group1,
+            **{
+                "casesensitive": "falsey",
+            },
+        )
+        log.error("Charmap set should have failed with invalid value")
+        return 1
+
+    except CharMapSetError as e:
+        log.info("Passed: Failed as expected with invalid value: {}".format(str(e)))
+
+    try:
+        Ceph(client1).fs.sub_volume_group.charmap.set(
+            cephfs_vol,
+            cephfs_subvol_group1,
+            **{
+                "casesensitive": "none",
+            },
+        )
+        log.error("Charmap set should have failed with invalid value")
+        return 1
+    except CharMapSetError as e:
+        log.info("Passed: Failed as expected with invalid value: {}".format(str(e)))
+
+    # BZ-2358289
+    # try:
+    #     Ceph(client1).fs.sub_volume_group.charmap.set(
+    #         cephfs_vol,
+    #         cephfs_subvol_group1,
+    #         **{
+    #             "normalization": "nd",
+    #         },
+    #     )
+    #     log.error("Charmap set should have failed with invalid value")
+    #     return 1
+    # except CharMapSetError as e:
+    #     log.info("Passed: Failed as expected with invalid value: {}".format(str(e)))
+
+    # try:
+    #     Ceph(client1).fs.sub_volume_group.charmap.set(
+    #         cephfs_vol,
+    #         cephfs_subvol_group1,
+    #         **{
+    #             "normalization": "none",
+    #         },
+    #     )
+    #     log.error("Charmap set should have failed with invalid value")
+    #     return 1
+    # except CharMapSetError as e:
+    #     log.info("Passed: Failed as expected with invalid value: {}".format(str(e)))
+
+    get_charmap = Ceph(client1).fs.sub_volume_group.charmap.get(
+        cephfs_vol, cephfs_subvol_group1
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfd",
+            "encoding": "utf8",
+        },
+    )
+
+
+def test_sv_creation_with_charmap():
+    """Create subvolume under subvolume group 2 where charmap set."""
+    Ceph(client1).fs.sub_volume.create(
+        cephfs_vol,
+        cephfs_subvol,
+        **{"group-name": cephfs_subvol_group2},
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol,
+        cephfs_subvol,
+        **{"group-name": cephfs_subvol_group2},
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": True,
+            "normalization": "nfkc",
+            "encoding": "utf8",
+        },
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_vol,
+        cephfs_subvol,
+        **{"group-name": cephfs_subvol_group2},
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": True, "normalization": "nfkc"},
+    )
+
+
+def modify_charmap_svg2():
+    """Modify charmaps of subvolume group 2 and validate."""
+    try:
+        Ceph(client1).fs.sub_volume_group.charmap.set(
+            cephfs_vol,
+            cephfs_subvol_group2,
+            **{
+                "normalization": "nfd",
+                "casesensitive": "false",
+            },
+        )
+        log.error("Charmap set should have failed since subvol group is not empty")
+        return 1
+    except CharMapSetError as e:
+        log.info("Passed: Failed as expected with error: {}".format(str(e)))
+
+    get_charmap = Ceph(client1).fs.sub_volume_group.charmap.get(
+        cephfs_vol, cephfs_subvol_group2
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": True,
+            "normalization": "nfkc",
+            "encoding": "utf8",
+        },
+    )
+
+
+def sv1_create_and_mount():
+    """Create subvolume1 under subvolume group 1 and mount across different clients."""
+    global fuse_mounting_dir, nfs_mounting_dir, smb_mounting_dir, nfs_params, smb_params
+
+    Ceph(client1).fs.sub_volume.create(
+        cephfs_vol,
+        cephfs_subvol,
+        **{"group-name": cephfs_subvol_group1, "mode": "0777"},
+    )
+
+    if ibm_build:
+        log.info("*** Mounting via SMB ***")
+        smb_mounting_dir = "/mnt/smb_{}/".format(common_util.generate_mount_dir())
+        smb_params = {
+            "smb_cluster_id": "smb-sv-1",
+            "smb_shares": ["share-sv-1"],
+            "installer": installer,
+        }
+
+        # Create smb cluster with auth_mode
+        create_smb_cluster(
+            installer,
+            smb_cluster_id=smb_params.get("smb_cluster_id"),
+            auth_mode="user",
+            domain_realm="",
+            smb_user_name="user1",
+            smb_user_password="passwd",
+            custom_dns="",
+            clustering="default",
+        )
+
+        # Check smb cluster
+        check_smb_cluster(installer, smb_cluster_id=smb_params.get("smb_cluster_id"))
+
+        # Create smb share
+        create_smb_share(
+            installer,
+            smb_params.get("smb_shares"),
+            smb_params.get("smb_cluster_id"),
+            cephfs_vol,
+            "/",
+            cephfs_subvol_group1,
+            [cephfs_subvol],
+        )
+
+        # Check smb service
+        verify_smb_service(installer, service_name="smb")
+
+        smbclient_check_shares(
+            smb_nodes,
+            client1,
+            smb_params.get("smb_shares"),
+            smb_user_name="user1",
+            smb_user_password="passwd",
+            auth_mode="user",
+            domain_realm="",
+        )
+
+        smb_cifs_mount(
+            smb_nodes[0],
+            client1,
+            smb_params.get("smb_shares")[0],
+            smb_user_name="user1",
+            smb_user_password="passwd",
+            auth_mode="user",
+            domain_realm="",
+            cifs_mount_point=smb_mounting_dir,
+        )
+
+    sub_vol_path_1 = common_util.subvolume_get_path(
+        client1,
+        cephfs_vol,
+        subvolume_name=cephfs_subvol,
+        subvolume_group=cephfs_subvol_group1,
+    )
+
+    log.info("*** Mounting Subvolume via FUSE ***")
+    fuse_mounting_dir = common_util.setup_fuse_mount(
+        client1,
+        cephfs_vol,
+        mount_path="/mnt/fuse_{}/".format(common_util.generate_mount_dir()),
+        subvolume_name=cephfs_subvol,
+        subvol_path=sub_vol_path_1,
+    )
+    log.info("Mounting dir for FUSE: {}".format(fuse_mounting_dir))
+
+    # log.info("*** Mounting via NFS ***")
+
+    # mds = fs_util.get_active_mdss(client1, cephfs_vol)
+    # active_mds_hostnames = [i.split(".")[1] for i in mds]
+    # nfs_server_name = active_mds_hostnames[0]
+    # log.debug("Active MDS Hostname: {}".format(nfs_server_name))
+
+    # nfs_params = {
+    #     "nfs_cluster_name": "nfs-sv-1",
+    #     "nfs_server_name": nfs_server_name,
+    #     "binding": "/export_binding_nfs_sv_1",
+    # }
+    # nfs_mounting_dir = common_util.setup_nfs_mount(
+    #     client1,
+    #     cephfs_vol,
+    #     mount_path="/mnt/nfs_{}/".format(common_util.generate_mount_dir()),
+    #     subvol_path=sub_vol_path_1,
+    #     nfs_server_name=nfs_params.get("nfs_server_name"),
+    #     cluster=nfs_params.get("nfs_cluster_name"),
+    #     binding=nfs_params.get("binding"),
+    # )
+    # log.info("NFS Mounting dir: {}".format(nfs_mounting_dir))
+
+
+def validate_charmap_sv1():
+    """Validate attribute of subvolume1 created under subvolume group 1."""
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol,
+        cephfs_subvol,
+        **{"group-name": cephfs_subvol_group1},
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfd",
+            "encoding": "utf8",
+        },
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_vol, cephfs_subvol, **{"group-name": cephfs_subvol_group1}
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": False, "normalization": "nfd"},
+    )
+
+    attr_util.validate_charmap(
+        client1,
+        fuse_mounting_dir,
+        {"normalization": "nfd", "encoding": "utf8", "casesensitive": False},
+    )
+
+
+def modify_and_validate_charmap_sv1():
+    """Modify and validate attribute of subvolume1 created under subvolume group 1."""
+    Ceph(client1).fs.sub_volume.charmap.set(
+        cephfs_vol,
+        cephfs_subvol,
+        {
+            "casesensitive": "false",
+            "normalization": "nfkd",
+        },
+        **{"group-name": cephfs_subvol_group1},
+    )
+
+    attr_util.validate_charmap(
+        client1,
+        fuse_mounting_dir,
+        {"normalization": "nfkd", "encoding": "utf8", "casesensitive": False},
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume_group.charmap.get(
+        cephfs_vol, cephfs_subvol_group1
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfd",
+            "encoding": "utf8",
+        },
+    )
+
+
+def snap_clone_sv_and_validate_charmap():
+    """Create snapshot and clone subvolume, then validate charmaps."""
+    fs_util.create_snapshot(
+        client1,
+        cephfs_vol,
+        cephfs_subvol,
+        cephfs_snap1,
+        **{"group_name": cephfs_subvol_group1},
+    )
+
+    clone_status_1 = {
+        "vol_name": cephfs_vol,
+        "subvol_name": cephfs_subvol,
+        "snap_name": cephfs_snap1,
+        "target_subvol_name": cephfs_clone_subvol,
+        "group_name": cephfs_subvol_group1,
+        "target_group_name": cephfs_subvol_group1,
+    }
+
+    fs_util.create_clone(client1, **clone_status_1)
+    fs_util.validate_clone_state(client1, clone_status_1)
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol,
+        cephfs_clone_subvol,
+        **{
+            "group-name": cephfs_subvol_group1,
+        },
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfkd",
+            "encoding": "utf8",
+        },
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_vol, cephfs_clone_subvol, **{"group-name": cephfs_subvol_group1}
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": False, "normalization": "nfkd"},
+    )
+
+
+def resize_clone_sv_and_validate_charmap():
+    """Resize cloned subvolume and validate charmaps."""
+    Ceph(client1).fs.sub_volume.resize(
+        cephfs_vol,
+        cephfs_clone_subvol,
+        "1073741824",
+        **{"group-name": cephfs_subvol_group1},
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol,
+        cephfs_clone_subvol,
+        **{
+            "group-name": cephfs_subvol_group1,
+        },
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfkd",
+            "encoding": "utf8",
+        },
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_vol, cephfs_clone_subvol, **{"group-name": cephfs_subvol_group1}
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": False, "normalization": "nfkd"},
+    )
+
+
+def rename_clone_sv_and_validate_charmap():
+    """Rename cloned subvolume and validate charmaps."""
+    fs_util.rename_volume(client1, cephfs_vol, cephfs_rename_vol)
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_rename_vol,
+        cephfs_clone_subvol,
+        **{
+            "group-name": cephfs_subvol_group1,
+        },
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfkd",
+            "encoding": "utf8",
+        },
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_rename_vol, cephfs_clone_subvol, **{"group-name": cephfs_subvol_group1}
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": False, "normalization": "nfkd"},
+    )
+
+    fs_util.rename_volume(client1, cephfs_rename_vol, cephfs_vol)
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol,
+        cephfs_clone_subvol,
+        **{
+            "group-name": cephfs_subvol_group1,
+        },
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfkd",
+            "encoding": "utf8",
+        },
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_vol, cephfs_clone_subvol, **{"group-name": cephfs_subvol_group1}
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": False, "normalization": "nfkd"},
+    )
+
+
+def run_io_sv_and_validate_charmap():
+    """Run IO on subvolume and validate charmaps."""
+    fs_util.run_ios_V1(client1, fuse_mounting_dir, ["dd"])
+
+    attr_util.validate_charmap(
+        client1,
+        fuse_mounting_dir,
+        {"normalization": "nfkd", "encoding": "utf8", "casesensitive": False},
+    )
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(
+        cephfs_vol, cephfs_subvol, **{"group-name": cephfs_subvol_group1}
+    )
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": False, "normalization": "nfkd"},
+    )
+
+
+def sv_default_validate_charmap():
+    """Create subvolume with default charmaps and validate."""
+    Ceph(client1).fs.sub_volume.create(
+        cephfs_vol,
+        cephfs_subvol_default,
+    )
+
+    Ceph(client1).fs.sub_volume.charmap.set(
+        cephfs_vol,
+        cephfs_subvol_default,
+        {
+            "normalization": "nfkc",
+            "casesensitive": "false",
+        },
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol, cephfs_subvol_default
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfkc",
+            "encoding": "utf8",
+        },
+    )
+
+    Ceph(client1).fs.sub_volume.charmap.set(
+        cephfs_vol,
+        cephfs_subvol_default,
+        {
+            "normalization": "nfc",
+        },
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol, cephfs_subvol_default
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfc",
+            "encoding": "utf8",
+        },
+    )
+
+    Ceph(client1).fs.sub_volume.charmap.set(
+        cephfs_vol,
+        cephfs_subvol_default,
+        {
+            "normalization": "nfd",
+        },
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol, cephfs_subvol_default
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfd",
+            "encoding": "utf8",
+        },
+    )
+
+    Ceph(client1).fs.sub_volume.charmap.set(
+        cephfs_vol,
+        cephfs_subvol_default,
+        {
+            "normalization": "nfkd",
+        },
+    )
+
+    get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+        cephfs_vol, cephfs_subvol_default
+    )
+
+    attr_util.validate_charmap_with_values(
+        get_charmap,
+        {
+            "casesensitive": False,
+            "normalization": "nfkd",
+            "encoding": "utf8",
+        },
+    )
+
+
+def remove_charmap_and_validate():
+    """Remove charmaps from subvolume, subvolumegroup and validate."""
+    try:
+        log.info("Try removing charmaps from subvolume where dir exists")
+        Ceph(client1).fs.sub_volume.charmap.remove(
+            cephfs_vol, cephfs_subvol, **{"group-name": cephfs_subvol_group1}
+        )
+        log.error("Charmap remove should have failed since subvolume exists")
+        return 1
+    except CharMapRemoveError as e:
+        log.info("Passed: Failed as expected with error: {}".format(str(e)))
+
+    log.info("Removing charmaps from subvolume where dir does not exist")
+    Ceph(client1).fs.sub_volume.charmap.remove(cephfs_vol, cephfs_subvol_default)
+
+    try:
+        get_charmap = Ceph(client1).fs.sub_volume.charmap.get(
+            cephfs_vol, cephfs_subvol_default
+        )
+        log.error(
+            "Charmap get should have failed after removing charmaps {}".format(
+                get_charmap
+            )
+        )
+        return 1
+    except CharMapGetError as e:
+        log.info("Passed: Failed as expected with error: {}".format(str(e)))
+
+    get_subvolume = Ceph(client1).fs.sub_volume.info(cephfs_vol, cephfs_subvol_default)
+
+    attr_util.validate_charmap_with_values(
+        extract_case_and_normalization(get_subvolume),
+        {"casesensitive": True, "normalization": "none"},
+    )
+
+    try:
+        log.info("Try removing charmaps from subvolumegroup where dir exists")
+        Ceph(client1).fs.sub_volume_group.charmap.remove(
+            cephfs_vol, cephfs_subvol_group1
+        )
+        log.error("Charmap remove should have failed since subvolumegroup exists")
+        return 1
+    except CharMapRemoveError as e:
+        log.info("Passed: Failed as expected with error: {}".format(str(e)))
+
+    log.info("Removing charmaps from subvolumegroup where dir does not exist")
+    Ceph(client1).fs.sub_volume.rm(cephfs_vol, cephfs_subvol, cephfs_subvol_group2)
+    Ceph(client1).fs.sub_volume_group.charmap.remove(cephfs_vol, cephfs_subvol_group2)
+
+    try:
+        get_charmap = Ceph(client1).fs.sub_volume_group.charmap.get(
+            cephfs_vol, cephfs_subvol_group2
+        )
+        log.error(
+            "Charmap get should have failed after removing charmaps {}".format(
+                get_charmap
+            )
+        )
+        return 1
+    except CharMapGetError as e:
+        log.info("Passed: Failed as expected with error: {}".format(str(e)))
+
+
+def run(ceph_cluster, **kw):
+    try:
+        test_data = kw.get("test_data")
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+
+        log.info("checking Pre-requisites")
+        if len(clients) < 1:
+            log.error(
+                "This test requires minimum 1 client nodes. This has only {} clients".format(
+                    len(clients)
+                )
+            )
+            return 1
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Pre-Requisite : Create volume and define global params "
+            "\n---------------***************-----------------------------"
+        )
+        global client1, installer, common_util, attr_util, fs_util, smb_nodes, ibm_build
+        global cephfs_vol, cephfs_subvol, cephfs_clone_subvol, cephfs_subvol_group1
+        global cephfs_subvol_group2, cephfs_snap1, cephfs_rename_vol, cephfs_subvol_default
+
+        attr_util = CephFSAttributeUtilities(ceph_cluster)
+        common_util = CephFSCommonUtils(ceph_cluster)
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        fs_util.auth_list(clients)
+        client1 = clients[0]
+        installer = ceph_cluster.get_nodes(role="installer")[0]
+        ibm_build = config.get("ibm_build", False)
+        smb_nodes = ceph_cluster.get_nodes("smb")
+        fs_util.prepare_clients([client1], build)
+
+        cephfs_vol = "mani-fs-2"
+        cephfs_rename_vol = "mani-fs-2-renamed"
+        cephfs_subvol = "subvol1"
+        cephfs_subvol_default = "subvol2"
+        cephfs_clone_subvol = "subvol-clone1"
+        cephfs_subvol_group1 = "subvolgroup1"
+        cephfs_subvol_group2 = "subvolgroup2"
+        cephfs_snap1 = "sv1-snap-1"
+
+        Ceph(client1).fs.volume.create(cephfs_vol)
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 1: Create subvolume group1 and validate different charmap settings using charmap set/get "
+            "\n---------------***************-----------------------------"
+        )
+
+        create_svgroup_charmap_test()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 2: [Negative] Try invalid/unsupported values for subvolumegroup charmap set "
+            "\n---------------***************-----------------------------"
+        )
+        validate_svg_unsupported_charmaps()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 3: Create subvolume under subvolume group 2 where charmap set "
+            "\n---------------***************-----------------------------"
+        )
+        test_sv_creation_with_charmap()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 4: [Negative] Try modifying charmaps of subvolume group 2 "
+            "\n---------------***************-----------------------------"
+        )
+        modify_charmap_svg2()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 5: Create subvolume1 under subvolume group 1 and mount across different clients "
+            "\n---------------***************-----------------------------"
+        )
+
+        sv1_create_and_mount()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 6: Validate attribute of subvolume1 created under subvolume group 1 "
+            "\n---------------***************-----------------------------"
+        )
+        validate_charmap_sv1()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 7: Modify and validate attribute of subvolume1 created under subvolume group 1 "
+            "\n---------------***************-----------------------------"
+        )
+        modify_and_validate_charmap_sv1()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 8: Snap, Clone subvolume1 and validate charmaps "
+            "\n---------------***************-----------------------------"
+        )
+        snap_clone_sv_and_validate_charmap()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 9: Resize cloned subvolume and validate charmaps "
+            "\n---------------***************-----------------------------"
+        )
+        resize_clone_sv_and_validate_charmap()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 10: Rename cloned subvolume and validate charmaps "
+            "\n---------------***************-----------------------------"
+        )
+        rename_clone_sv_and_validate_charmap()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 11: Run IO on the subvolume and validate charmaps "
+            "\n---------------***************-----------------------------"
+        )
+        run_io_sv_and_validate_charmap()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 12: Create subvolume in default group and validate normalization values "
+            "\n---------------***************-----------------------------"
+        )
+        sv_default_validate_charmap()
+
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Usecase 13: Remove charmap attribute from subvolume "
+            "\n---------------***************-----------------------------"
+        )
+        remove_charmap_and_validate()
+
+        log.info("*** Passed: Completed Subvolume Charmap tests successfully ***")
+        return 0
+
+    except Exception as e:
+        log.error("Test execution failed: {}".format(str(e)))
+        log.error(traceback.format_exc())
+        return 1
+
+    finally:
+        log.info(
+            "\n"
+            "\n---------------***************-----------------------------"
+            "\n  Cleaning up the file system and subvolumes created "
+            "\n---------------***************-----------------------------"
+        )
+
+        log.info("Unmounting and cleaning up the FUSE mounts")
+        fs_util.client_clean_up(
+            "umount", fuse_clients=[client1], mounting_dir=fuse_mounting_dir
+        )
+
+        # log.info("Unmounting and cleaning up the NFS mounts")
+        # fs_util.client_clean_up(
+        #     "umount", kernel_clients=[client1], mounting_dir=nfs_mounting_dir
+        # )
+
+        # fs_util.remove_nfs_export(
+        #     client1,
+        #     nfs_params.get("nfs_cluster_name"),
+        #     nfs_params.get("binding"),
+        # )
+
+        # fs_util.remove_nfs_cluster(client1, nfs_params.get("nfs_cluster_name"))
+        if ibm_build:
+            log.info("Unmounting and cleaning up the SMB mounts")
+            client1.exec_command(
+                sudo=True,
+                cmd=f"rm -rf {smb_mounting_dir}/*",
+            )
+
+            client1.exec_command(
+                sudo=True,
+                cmd=f"umount {smb_mounting_dir}",
+            )
+
+            remove_smb_share(
+                smb_params.get("installer"),
+                smb_params.get("smb_shares"),
+                smb_params.get("smb_cluster_id"),
+            )
+
+            remove_smb_cluster(
+                smb_params.get("installer"), smb_params.get("smb_cluster_id")
+            )
+
+        log.info("Removing Subvolume and Subvolume Groups")
+        fs_util.remove_snapshot(
+            client1,
+            cephfs_vol,
+            cephfs_subvol,
+            cephfs_snap1,
+            **{"group_name": cephfs_subvol_group1},
+        )
+        Ceph(client1).fs.sub_volume.rm(cephfs_vol, cephfs_subvol_default)
+        Ceph(client1).fs.sub_volume.rm(
+            cephfs_vol, cephfs_clone_subvol, cephfs_subvol_group1
+        )
+        Ceph(client1).fs.sub_volume.rm(cephfs_vol, cephfs_subvol, cephfs_subvol_group1)
+        Ceph(client1).fs.sub_volume_group.rm(
+            cephfs_vol, cephfs_subvol_group1, force=True
+        )
+        Ceph(client1).fs.sub_volume_group.rm(
+            cephfs_vol, cephfs_subvol_group2, force=True
+        )
+        Ceph(client1).fs.volume.rm(cephfs_vol, yes_i_really_mean_it=True)
+        log.info("Cleanup completed successfully.")

--- a/tests/cephfs/exceptions.py
+++ b/tests/cephfs/exceptions.py
@@ -14,6 +14,7 @@ Generic Exception Handler
 7. Attribute & CharMap Errors
 8. File Operations on Mounts
 9. Snapshot Operations
+10. Subvolume Group Operations
 """
 
 import logging
@@ -107,6 +108,18 @@ class SubvolumeError(FsBaseException):
     pass
 
 
+class SubvolumeCreateError(SubvolumeError):
+    """Raised when subvolume set operation fails."""
+
+    pass
+
+
+class SubvolumeGetError(SubvolumeError):
+    """Raised when subvolume deletion fails."""
+
+    pass
+
+
 class SubvolumeDeleteError(SubvolumeError):
     """Raised when subvolume deletion fails."""
 
@@ -152,6 +165,12 @@ class VolumeAlreadyExists(VolumeError):
     pass
 
 
+class VolumeRenameError(VolumeError):
+    """Raised when renaming a volume fails."""
+
+    pass
+
+
 # --------------------------------------
 # 6. Quota Operations
 # --------------------------------------
@@ -174,6 +193,24 @@ class QuotaGetError(QuotaError):
 
 class CharMapValidationError(FsBaseException):
     """Raised when a charmap validation operation fails."""
+
+    pass
+
+
+class CharMapSetError(CharMapValidationError):
+    """Raised when setting a charmap fails."""
+
+    pass
+
+
+class CharMapGetError(CharMapValidationError):
+    """Raised when getting a charmap fails."""
+
+    pass
+
+
+class CharMapRemoveError(CharMapValidationError):
+    """Raised when removing a charmap fails."""
 
     pass
 
@@ -234,5 +271,32 @@ class LinkDeletionError(FileOperationError):
 # --------------------------------------
 class SnapshotValidationError(FsBaseException):
     """Raised when a snapshot validation fails."""
+
+    pass
+
+
+# --------------------------------------
+# 10. Subvolume Group Operations
+# --------------------------------------
+class SubvolumeGroupError(FsBaseException):
+    """Raised when subvolume group operation fails."""
+
+    pass
+
+
+class SubvolumeGroupCreateError(SubvolumeGroupError):
+    """Raised when creating a subvolume group fails."""
+
+    pass
+
+
+class SubvolumeGroupGetError(SubvolumeGroupError):
+    """Raised when getting subvolume group information fails."""
+
+    pass
+
+
+class SubvolumeGroupDeleteError(SubvolumeGroupError):
+    """Raised when deleting a subvolume group fails."""
 
     pass

--- a/tests/cephfs/lib/cephfs_attributes_lib.py
+++ b/tests/cephfs/lib/cephfs_attributes_lib.py
@@ -109,8 +109,39 @@ class CephFSAttributeUtilities(object):
             bool: True if all expected values match.
         """
         charmap = self.get_charmap(client, dir)
+        log.info("Validating charmap for directory: {}".format(dir))
+        log.debug("\nActual: {} \nExpected: {}".format(charmap, expected_values))
         for key, expected in expected_values.items():
             actual = charmap.get(key)
+            if actual != expected:
+                raise CharMapValidationError(
+                    "{}: {} must be {}, got {}".format(
+                        dir, key, repr(expected), repr(actual)
+                    )
+                )
+        return True
+
+    def validate_charmap_with_values(self, actual_values, expected_values):
+        """
+        Validates that specific attributes in a charmap match expected values.
+
+        Parameters:
+            actual_values (dict): A dictionary of actual key-value pairs from the charmap.
+            expected_values (dict): A dictionary of expected key-value pairs to check
+                                    in the charmap (e.g., {"encoding": "utf8"}).
+
+        Raises:
+            ValueError: If any expected value does not match the actual value in the charmap.
+
+        Returns:
+            bool: True if all expected values match.
+        """
+        log.info("Validating charmap values")
+        log.debug(
+            "\n Actual: {},\n Expected: {}".format(actual_values, expected_values)
+        )
+        for key, expected in expected_values.items():
+            actual = actual_values.get(key)
             if actual != expected:
                 raise CharMapValidationError(
                     "{}: {} must be {}, got {}".format(

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -375,7 +375,9 @@ class CephFSCommonUtils(FsUtils):
         log.info("Setting up smb mount")
         mount_path = kwargs.get("mount_path")
         smb_nodes = self.ceph_cluster.get_nodes("smb")
-        installer = self.ceph_cluster.get_nodes(role="installer")[0]
+        installer = kwargs.get(
+            "installer", self.ceph_cluster.get_nodes(role="installer")[0]
+        )
 
         try:
             deploy_smb_service_imperative(


### PR DESCRIPTION
# Description

New Polarion TC - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83617010

## High Level Changes:

- Included new TC scenario for Subvolume and Subvolume group scenarios
- Included in 8.1 sanity suite file
- Cleaned and handled the cli lib function
- Enhanced the exception file
- New conf file to support nfs and smb for this feature
- Enabled few debug loggers

## Logs
http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-19212/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
