### PR TITLE
[TFA] fix issue with test_Mbuckets_with_Nobjects_compression

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -133,6 +133,20 @@ tests:
 
   # Basic Bucket Operation Tests
 
+  # configuring HAproxy on the client node 'node4' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   - test:
       name: Mbuckets
       desc: test to create "M" no of buckets
@@ -150,6 +164,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+        run-on-haproxy: true
 
   - test:
       name: compresstion_with_zstd_type
@@ -159,6 +174,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
+        run-on-haproxy: true
 
   - test:
       name: compresstion_with_snappy_type
@@ -168,6 +184,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
+        run-on-haproxy: true
 
   - test:
       name: Mbuckets_with_Nobjects with sharing enabled

--- a/suites/reef/rgw/tier-1_rgw_sw_qat.yaml
+++ b/suites/reef/rgw/tier-1_rgw_sw_qat.yaml
@@ -75,6 +75,20 @@ tests:
       module: test_client.py
       name: configure client
 
+  # configuring HAproxy on the client node 'node4' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   - test:
       abort-on-fail: true
       config:
@@ -109,6 +123,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
+        run-on-haproxy: true
 
   - test:
       name: compresstion_with_snappy_type
@@ -118,6 +133,8 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
+        run-on-haproxy: true
+
   - test:
       name: compresstion_with_Zlib_type
       desc: test compresstion with Zlib
@@ -126,6 +143,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+        run-on-haproxy: true
 
   - test:
       config:

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -110,6 +110,20 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+  # configuring HAproxy on the client node 'node4' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   # Basic Bucket Operation Tests
   - test:
       name: compresstion_with_zstd_type
@@ -119,6 +133,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
+        run-on-haproxy: true
 
   - test:
       name: compresstion_with_snappy_type
@@ -128,6 +143,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
+        run-on-haproxy: true
 
   # Swift basic operation
 


### PR DESCRIPTION
# Description
run-on-haproxy: true was missed in test_Mbuckets_with_Nobjects_compression
fail log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-327/rgw/68/tier-1_rgw_sw_qat/

pass log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-PWHR8A/ 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
