### PR TITLE
[TFA] [CI stabilisation] tier-3_rados_test-4-node-ecpools.yaml 

### DIFF
--- a/suites/reef/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/reef/rados/tier-2_rados_test-brownfield.yaml
@@ -308,8 +308,10 @@ tests:
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
 
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+#  Uncomment test case once stabilisation is completed
+#  CI stabilisation: https://issues.redhat.com/browse/RHCEPHQE-19549
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -185,7 +185,21 @@ tests:
                 - "1099511627776"
 
   - test:
-      name: EC pool 2=2@4 LC
+      name: Upgrade cluster to latest 7.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
+      abort-on-fail: true
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 1,2
       module: test_four_node_ecpool.py
       polarion-id: CEPH-83575858
       abort-on-fail: true
@@ -201,6 +215,53 @@ tests:
         remove_host: true
         delete_pools:
           - test_ec_pool
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
+          - scenario-3
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 3
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-4
+          - scenario-5
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 4
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-6
       desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
 
   - test:

--- a/suites/squid/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/squid/rados/tier-2_rados_test-brownfield.yaml
@@ -310,8 +310,10 @@ tests:
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
 
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+#  Uncomment test case once stabilisation is completed
+#  CI stabilisation: https://issues.redhat.com/browse/RHCEPHQE-19549
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -221,7 +221,7 @@ tests:
       desc: Verification of mon connection scores in different scenarios
       module: test_mon_connection_scores.py
       polarion-id: CEPH-83602911
-      comments: Active bug 2357894
+      comments: Intermittent bug 2357894
 
   - test:
       name: Verify config values via cephadm-ansible

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -188,28 +188,29 @@ tests:
                 - mon_osd_down_out_subtree_limit
                 - host
 
-  - test:
-      name: EC pool 8+6@4 with MSR LC
-      module: test_ec_86.py
-      polarion-id: CEPH-83590733
-      config:
-        profile_name: ec86_0
-        pool_name: ec86_pool0
-        k: 8
-        m: 6
-        force: true
-        plugin: jerasure
-        create_rule: false
-        modify_threshold: true
-        pre_create_rule: false
-        crush-failure-domain: host
-        change_subtree_limit: host
-        crush-osds-per-failure-domain: 4
-        crush-num-failure-domains: 4
-        delete_pools:
-          - ec86_pool0
-      desc: 8+6@4 MSR EC pool life cycle with serviceability scenarios
-      comments: "Bug with OSD down scenario 2305520"
+# Commenting test due to BZ - https://bugzilla.redhat.com/show_bug.cgi?id=2305520
+#  - test:
+#      name: EC pool 8+6@4 with MSR LC
+#      module: test_ec_86.py
+#      polarion-id: CEPH-83590733
+#      config:
+#        profile_name: ec86_0
+#        pool_name: ec86_pool0
+#        k: 8
+#        m: 6
+#        force: true
+#        plugin: jerasure
+#        create_rule: false
+#        modify_threshold: true
+#        pre_create_rule: false
+#        crush-failure-domain: host
+#        change_subtree_limit: host
+#        crush-osds-per-failure-domain: 4
+#        crush-num-failure-domains: 4
+#        delete_pools:
+#          - ec86_pool0
+#      desc: 8+6@4 MSR EC pool life cycle with serviceability scenarios
+#      comments: "Bug with OSD down scenario 2305520"
 
   - test:
       name: Upgrade cluster to latest 8.x ceph version

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -185,7 +185,20 @@ tests:
                 - "1099511627776"
 
   - test:
-      name: EC pool 2=2@4 LC
+      name: Upgrade cluster to latest 8.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 1,2
       module: test_four_node_ecpool.py
       polarion-id: CEPH-83575858
       abort-on-fail: true
@@ -201,6 +214,53 @@ tests:
         remove_host: true
         delete_pools:
           - test_ec_pool
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
+          - scenario-3
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 3
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-4
+          - scenario-5
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 4
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-6
       desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
 
   - test:

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -9,6 +9,7 @@ Tests included:
 """
 
 import datetime
+import json
 import math
 import random
 import time
@@ -85,6 +86,11 @@ def run(ceph_cluster, **kw):
                 try:
                     while counter < 5:
                         pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+                        log_info_msg = (
+                            f"Pool stats of {pool_name} post object creation:"
+                            f"\n{json.dumps(pool_stat, indent=4)}"
+                        )
+                        log.info(log_info_msg)
                         ceph_df_obj = pool_stat["stats"]["objects"]
                         if ceph_df_obj == obj_num:
                             log.info(
@@ -121,6 +127,11 @@ def run(ceph_cluster, **kw):
                     counter = 1
                     while counter < 5:
                         pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+                        log_info_msg = (
+                            f"Pool stats of {pool_name} post objects deletion:"
+                            f"\n{json.dumps(pool_stat, indent=4)}"
+                        )
+                        log.info(log_info_msg)
                         ceph_df_obj = pool_stat.get("stats")["objects"]
                         if ceph_df_obj == 0:
                             log.info(f"ceph df stats display 0 objects for {pool_name}")


### PR DESCRIPTION
PR includes below:- 
(1) Upgrade 7.x to latest versions in **suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml**
(2) Upgrade 8.x to latest versions in **suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml**
(3) Comments **ceph-objectstore-tool utility** in **suites/reef/rados/tier-2_rados_test-brownfield.yaml**
(4) Splits **EC pool 2=2@4** into 6 scenarios:- 
        scenario-1: Test the effects of bulk flag and no IO stoppage
        scenario-2: Perform rolling reboot of all the OSDs on a particular host.
        scenario-3: OSD operations
        scenario-4: Stopping 1 OSD from each host
        scenario-5: Stopping all OSDs of 1 host
        scenario-6: Remove 1 OSD from 1 host
(5) Adds pool stats logging for 'ceph df'

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
