### PR TITLE
Add fscrypt to test-clients, enable for fuse mount, change fscrypt in…

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -3897,13 +3897,12 @@ os.system('sudo systemctl start  network')
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(3))
         )
-        fs_util = mount_params["fs_util"]
 
         if mnt_type == "kernel":
             mounting_dir = f"/mnt/cephfs_kernel_{mount_suffix}/"
             client.exec_command(sudo=True, cmd=f"mkdir -p {mounting_dir}")
-            mon_node_ips = fs_util.get_mon_node_ips()
-            retry_mount = retry(CommandFailed, tries=3, delay=30)(fs_util.kernel_mount)
+            mon_node_ips = self.get_mon_node_ips()
+            retry_mount = retry(CommandFailed, tries=3, delay=30)(self.kernel_mount)
             retry_mount(
                 [client],
                 mounting_dir,
@@ -3914,7 +3913,7 @@ os.system('sudo systemctl start  network')
         if mnt_type == "fuse":
             mounting_dir = f"/mnt/cephfs_fuse_{mount_suffix}/"
             client.exec_command(sudo=True, cmd=f"mkdir -p {mounting_dir}")
-            fs_util.fuse_mount(
+            self.fuse_mount(
                 [client],
                 mounting_dir,
                 extra_params=f" -r {fs_vol_path} --client_fs {mount_params['fs_name']}",
@@ -3928,7 +3927,7 @@ os.system('sudo systemctl start  network')
                     f"{mount_params['nfs_export_name']} {mount_params['fs_name']} path={fs_vol_path}",
                 )
                 mount_params["export_created"] = 1
-            fs_util.cephfs_nfs_mount(
+            self.cephfs_nfs_mount(
                 client,
                 mount_params["nfs_server"],
                 mount_params["nfs_export_name"],

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -147,7 +147,7 @@ class CephFSCommonUtils(FsUtils):
                    }}}
         """
         try:
-            client = clients.pop(0)
+            client = clients[0]
 
             mounting_dir = "".join(
                 random.choice(string.ascii_lowercase + string.digits)
@@ -155,7 +155,6 @@ class CephFSCommonUtils(FsUtils):
             )
 
             mnt_type_list = ["kernel", "fuse", "nfs"]
-            mnt_type_list = ["kernel"]
             mount_details = {}
             sv_list = setup_params["sv_list"]
             fs_name = setup_params["fs_name"]
@@ -172,7 +171,6 @@ class CephFSCommonUtils(FsUtils):
                 )
 
                 mnt_path = subvol_path.strip()
-                mnt_path = subvol_path
                 nfs_export_name = f"/export_{sv_name}_" + "".join(
                     random.choice(string.digits) for i in range(3)
                 )


### PR DESCRIPTION
…stall source

# Description

Jira: https://issues.redhat.com/browse/RHCEPHQE-19450

Fix description:
2. Enable fscrypt basic tests to run on fuse mount and change clients config
3. Use alternate fscrypt install source suggested by Dev
4. In fscrypt_utilsV1, remove the need to use fsutil object in mount_ceph method

Files:
	modified:   tests/cephfs/cephfs_fscrypt/test_fscrypt_basic.py
	modified:   tests/cephfs/cephfs_utilsV1.py
	modified:   tests/cephfs/lib/cephfs_common_lib.py
	modified:   tests/cephfs/lib/fscrypt_utils.py

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CMVAF2

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
