### PR TITLE
[LibFix] Add mon bootstrap configs to interop tests

### DIFF
--- a/suites/quincy/interop/test-ceph-sanity.yaml
+++ b/suites/quincy/interop/test-ceph-sanity.yaml
@@ -41,6 +41,12 @@ tests:
                 all-available-devices: true
           - config:
               command: apply
+              service: mon
+              args:
+                placement:
+                label: mon
+          - config:
+              command: apply
               service: rgw
               pos_args:
                 - rgw.1

--- a/suites/reef/interop/test-ceph-sanity.yaml
+++ b/suites/reef/interop/test-ceph-sanity.yaml
@@ -41,6 +41,12 @@ tests:
                 all-available-devices: true
           - config:
               command: apply
+              service: mon
+              args:
+                placement:
+                label: mon
+          - config:
+              command: apply
               service: rgw
               pos_args:
                 - rgw.1

--- a/suites/squid/interop/test-ceph-sanity.yaml
+++ b/suites/squid/interop/test-ceph-sanity.yaml
@@ -41,6 +41,12 @@ tests:
                 all-available-devices: true
           - config:
               command: apply
+              service: mon
+              args:
+                placement:
+                label: mon
+          - config:
+              command: apply
               service: rgw
               pos_args:
                 - rgw.1


### PR DESCRIPTION
RCA:
  Steps to add mon to specific node is missing from bootstrap configs and it's causing to add mon on all available nodes. Ceph FS test `cephfs-basics` fails to validate IPs as it's expects node configs present in global-conf.
