### PR TITLE
TFA fixes for upgrade suite

### DIFF
--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_8GA_to_81x_latest.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_8GA_to_81x_latest.yaml
@@ -112,7 +112,7 @@ tests:
         install_packages:
           - ceph-common
         node: node9
-      desc: "Configure the Cephfs client system 1"
+      desc: "Configure the Cephfs client system 2"
       destroy-cluster: false
       module: test_client.py
       name: "configure client"
@@ -141,7 +141,7 @@ tests:
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
-            name: "creation of Prerequisites for Upgrade"
+            name: "Run IOs in parallel to upgrade"
             polarion-id: CEPH-83575315
 
         - test:
@@ -177,9 +177,9 @@ tests:
       polarion-id: CEPH-83575313
   - test:
       abort-on-fail: false
-      desc: Validates nfs after upgrade
+      desc: Post upgrade CephFS validation
       module: cephfs_upgrade.cephfs_post_upgrade_validation.py
-      name: "Validates NFS after upgrade"
+      name: "Post upgrade CephFS validation"
       polarion-id: CEPH-83575098
   - test:
       name: cephfs_volume_management

--- a/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
@@ -37,10 +37,10 @@ def run(ceph_cluster, **kw):
         # while True:
         start_time = time.time()
         while time.time() - start_time < 1800:
-            cmd = "ceph orch upgrade status --format json"
+            cmd = "ceph orch upgrade status"
             out, rc = client1.exec_command(cmd=cmd, sudo=True)
-            output = json.loads(out)
-            if not output["in_progress"]:
+            exp_msg = "There are no upgrades in progress currently."
+            if exp_msg in out:
                 log.info("Upgrade Complete...")
                 break
             mds_ls = fs_util.get_active_mdss(client1, fs_name=fs_name)

--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -235,8 +235,18 @@ def snap_sched_test(snap_req_params):
         mnt_pt = sv_snap[sv]["mnt_pt"]
         mnt_client_name = sv_snap[sv]["mnt_client"]
         mnt_client = [i for i in clients if i.node.hostname == mnt_client_name][0]
-        cmd = f"ls {mnt_pt}/.snap/*{sv_snap[sv]['snap_list'][0]}*/*"
-        out, rc = mnt_client.exec_command(sudo=True, cmd=cmd)
+        try:
+            cmd = f"ls {mnt_pt}/.snap/_{sv_snap[sv]['snap_list'][0]}*/*"
+            out, _ = mnt_client.exec_command(sudo=True, cmd=cmd)
+        except CommandFailed as ex:
+            log.info(ex)
+            if "No such file or directory" in str(ex):
+                cmd = f"cd {mnt_pt}/.snap/;ls -l ./*"
+                out1, _ = mnt_client.exec_command(sudo=True, cmd=cmd)
+                log.info(out1)
+                cmd = f"ls {mnt_pt}/.snap/_{sv_snap[sv]['snap_list'][0]}*/dd_test_file"
+                out, _ = mnt_client.exec_command(sudo=True, cmd=cmd)
+                log.info(out)
         file_path = out.strip()
         cmd = f"dd if={file_path} count=10 bs=1M > read_dd"
         out, rc = mnt_client.exec_command(sudo=True, cmd=cmd)


### PR DESCRIPTION
# Description

Jira : https://issues.redhat.com/browse/RHCEPHQE-19454

Fix Description : TFA fix for 2 suite failures,
1. Snapshot_Clone suite : Failure in snap_schedule_retention_subvol test script due to mismatch in expected v/s actual snapshots retained.Added retry logic to check for deletion of oldest snapshots and maintain retention count as expected until 300secs
2. Upgrade suite : MDS failover during upgrade test script failed while checking for upgrade status in json format. Due to recent design changes there is no json output for this command when upgrade completed. Removed json format and added check for expected string upon upgrade completion.
3. Upgrade suite : Post upgrade test failed during snapshot validation due to non-linking of snapshot directories in .snap when cmd as 'ls <mnt_pt>/.snap/*snap_name*/*' is invoked. Added try-except and in except block added alternate cmds to confirm snapshots exists in .snap and then rerun ls cmd.

Latest logs with comments addressed: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U5E59A
Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3ICPZM
Logs with simulated failure:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5W7NKG 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
