### PR TITLE
[TFA] Add more logging information for debugging and volumes for no space devices available.

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3192,7 +3192,7 @@ EOF"""
         pool_id = out["pools"][pool_names.index(pool)]["id"]
 
         cmd = f" ceph pg ls {pool_id}"
-        out = self.run_ceph_command(cmd=cmd)
+        out = self.run_ceph_command(cmd=cmd, client_exec=True)
         for ele in out["pg_stats"]:
             if any(key in disallowed_states for key in ele["state"].split("+")):
                 log.error(

--- a/conf/reef/rados/13-node-cluster.yaml
+++ b/conf/reef/rados/13-node-cluster.yaml
@@ -20,6 +20,9 @@ globals:
           - mgr
           - mds
           - nfs
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
       node3:
         role:
           - osd
@@ -41,6 +44,7 @@ globals:
           - mgr
           - mds
           - nfs
+          - osd
         no-of-volumes: 4
         disk-size: 15
       node7:
@@ -50,6 +54,7 @@ globals:
         role:
           - mon
           - rgw
+          - osd
         no-of-volumes: 4
         disk-size: 15
       node9:
@@ -66,6 +71,9 @@ globals:
         role:
           - mon
           - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
       node12:
         role:
           - osd-bak

--- a/conf/squid/rados/13-node-cluster.yaml
+++ b/conf/squid/rados/13-node-cluster.yaml
@@ -21,22 +21,22 @@ globals:
           - mds
           - nfs
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node3:
         role:
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node4:
         role:
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node5:
         role:
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node6:
         role:
@@ -45,7 +45,7 @@ globals:
           - mds
           - nfs
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node7:
         role:
@@ -55,32 +55,32 @@ globals:
           - mon
           - rgw
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node9:
         role:
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node10:
         role:
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node11:
         role:
           - mon
           - rgw
           - osd
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node12:
         role:
           - osd-bak
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15
       node13:
         role:
           - osd-bak
-        no-of-volumes: 3
+        no-of-volumes: 4
         disk-size: 15

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -119,12 +119,22 @@ def run(ceph_cluster, **kw):
             out = bluestore_obj.add_wal_device(osd_id=osd_id, new_device=wal_target)
             log.info(out)
             assert "WAL device added" in out
-            osd_metadata = ceph_cluster.get_osd_metadata(
-                osd_id=int(osd_id), client=client
-            )
-            log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
 
-            if not int(osd_metadata["bluefs_dedicated_wal"]) == 1:
+            for _ in range(3):
+                osd_metadata = ceph_cluster.get_osd_metadata(
+                    osd_id=int(osd_id), client=client
+                )
+                log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
+
+                if int(osd_metadata["bluefs_dedicated_wal"]) == 1:
+                    log_info_msg = "'bluefs_dedicated_wal' entry in OSD metadata is 1"
+                    log.info(log_info_msg)
+                    break
+
+                log_info_msg = "'bluefs_dedicated_wal' entry in OSD metadata is not 1. Retrying after 30 seconds."
+                log.info(log_info_msg)
+                time.sleep(30)
+            else:
                 log.error("'bluefs_dedicated_wal' entry in OSD metadata is not 1")
                 raise AssertionError(
                     "'bluefs_dedicated_wal' entry in OSD metadata is not 1"
@@ -166,12 +176,22 @@ def run(ceph_cluster, **kw):
             )
             log.info(out)
             assert "DB device added" in out
-            osd_metadata = ceph_cluster.get_osd_metadata(
-                osd_id=int(osd_id), client=client
-            )
-            log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
 
-            if not int(osd_metadata["bluefs_dedicated_db"]) == 1:
+            for _ in range(3):
+                osd_metadata = ceph_cluster.get_osd_metadata(
+                    osd_id=int(osd_id), client=client
+                )
+                log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
+
+                if int(osd_metadata["bluefs_dedicated_db"]) == 1:
+                    log_info_msg = "'bluefs_dedicated_db' entry in OSD metadata is 1"
+                    log.info(log_info_msg)
+                    break
+
+                log_info_msg = "'bluefs_dedicated_db' entry in OSD metadata is not 1. Retrying after 30 seconds."
+                log.info(log_info_msg)
+                time.sleep(30)
+            else:
                 log.error("'bluefs_dedicated_db' entry in OSD metadata is not 1")
                 raise AssertionError(
                     "'bluefs_dedicated_db' entry in OSD metadata is not 1"

--- a/tests/rados/test_osd_full.py
+++ b/tests/rados/test_osd_full.py
@@ -196,14 +196,20 @@ def run(ceph_cluster, **kw):
 
                 # perform rados bench to trigger nearfull warning
                 nearfull_config = {
-                    "seconds": 150,
-                    "b": f"{bench_obj_size_kb}KB",
-                    "no-cleanup": True,
-                    "max-objects": max_obj_nearfull,
+                    "rados_write_duration": 150,
+                    "byte_size": f"{bench_obj_size_kb}KB",
+                    "nocleanup": True,
+                    "max_objs": max_obj_nearfull,
                 }
-                bench_obj.write(
-                    client=client_node, pool_name=pool_name, **nearfull_config
-                )
+
+                if (
+                    rados_obj.bench_write(
+                        pool_name=pool_name, **nearfull_config, verify_stats=False
+                    )
+                    is False
+                ):
+                    err_msg = f"Error running rados bench using nearfull_config: {nearfull_config}"
+                    raise Exception(err_msg)
 
                 assert rados_obj.verify_pool_stats(
                     pool_name=pool_name, exp_objs=max_obj_nearfull
@@ -222,14 +228,20 @@ def run(ceph_cluster, **kw):
 
                 # perform rados bench to trigger backfill-full warning
                 backfillfull_config = {
-                    "seconds": 80,
-                    "b": f"{bench_obj_size_kb}KB",
-                    "no-cleanup": True,
-                    "max-objects": subseq_obj_backfillfull,
+                    "rados_write_duration": 80,
+                    "byte_size": f"{bench_obj_size_kb}KB",
+                    "nocleanup": True,
+                    "max_objs": subseq_obj_backfillfull,
                 }
-                bench_obj.write(
-                    client=client_node, pool_name=pool_name, **backfillfull_config
-                )
+
+                if (
+                    rados_obj.bench_write(
+                        pool_name=pool_name, **backfillfull_config, verify_stats=False
+                    )
+                    is False
+                ):
+                    err_msg = f"Error running rados bench using backfillfull_config: {backfillfull_config}"
+                    raise Exception(err_msg)
 
                 _exp_objs = max_obj_nearfull + subseq_obj_backfillfull
                 assert rados_obj.verify_pool_stats(
@@ -250,14 +262,19 @@ def run(ceph_cluster, **kw):
 
                 # perform rados bench to trigger osd full warning
                 osdfull_config = {
-                    "seconds": 80,
-                    "b": f"{bench_obj_size_kb}KB",
-                    "no-cleanup": True,
-                    "max-objects": subseq_obj_full,
+                    "rados_write_duration": 80,
+                    "byte_size": f"{bench_obj_size_kb}KB",
+                    "nocleanup": True,
+                    "max_objs": subseq_obj_full,
                 }
-                bench_obj.write(
-                    client=client_node, pool_name=pool_name, **osdfull_config
-                )
+                if (
+                    rados_obj.bench_write(
+                        pool_name=pool_name, **osdfull_config, verify_stats=False
+                    )
+                    is False
+                ):
+                    err_msg = f"Error running rados bench using osdfull_config: {osdfull_config}"
+                    raise Exception(err_msg)
 
                 assert rados_obj.verify_pool_stats(
                     pool_name=pool_name, exp_objs=total_objs


### PR DESCRIPTION
PR addresses below :- 

(1) Add back 4 volumes for **conf/squid/rados/13-node-cluster.yaml** Since we observed below error in http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-138/rados/101/tier-2_rados_test_cot_cbt/ceph-bluestore-tool_utility_non-collocated_0.log 

`ERROR - No spare disks available on OSD host ceph-regression-6zb6sd-41exwy-node10`

In attached pass log test fails due to bz https://bugzilla.redhat.com/show_bug.cgi?id=2309610  after adding dedicated WAL
Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_test_cot_cbt_25_05_06_21_19_46/ceph-bluestore-tool_utility_non-collocated_0.log 

(2) Add more debugging information for **tier-2_rados_test-bugfixes	Verify read crc error message** 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-131/rados/100/tier-2_rados_test-bugfixes/Verify_read_crc_error_message_0.log 
`ERROR - awk '$1 >= "2025-04-16T18:50:08.187+0000" && $1 <= "2025-04-16T18:52:46.413+0000"' /var/log/ceph/a8596e40-1ab6-11f0-810b-fa163e9f2d42/ceph-osd.12.log failed to execute within 300s.`

Logs are getting truncated , to discuss with team
Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_customer_drain_issue_25_05_06_22_18_36/Verify_read_crc_error_message_0.log 

(3) Updates the **tier-2_rados_test-osd-rebalance	Cluster behaviour when OSDs are full** 
rados bench method to Rados FG inhouse rados bench write method
->  Rados FG inhouse rados bench write method provides verbose output information
->  Rados FG inhouse rados bench write method provides more configurable options
Tried by providing different threads but default 16 thread provided better performance
Pass logs with verbose output:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_customer_drain_issue_25_05_06_22_27_00/Cluster_behaviour_when_OSDs_are_full_0.log 

(4) Fix  issue in **tier-2_rados_test-pg-split-merge | Test Reads Balancer ( offline )**  :- 
Issue:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_test_pg_split_25_05_06_16_33_40/ 
`ERROR - cephadm shell --  ceph pg ls 8 -f json failed to execute within 300 seconds.`
-> Tried with 600 seconds timeout
-> Tried the command in CLI "ceph pg ls 8 -f json" executed within seconds
-> Tried the command execution with client node and command passed.
Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_test_pg_split_25_05_06_22_16_17/Test_Reads_Balancer_0.log 

(5) Addresses intermittent issue we have observed with 'ceph osd metadata' in **tier-2_rados_test_cot_cbt  ceph-bluestore-tool utility non-collocated**
Fixed by adding 3 retries with 30 seconds sleep




# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
