### PR TITLE
[TFA]:Fix issue related to reef s3test due to python library change

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -511,7 +511,7 @@ def _s3test_req_py3(node: CephNode) -> None:
         "python3 -m venv s3-tests/virtualenv",
         "s3-tests/virtualenv/bin/python -m pip install --upgrade pip setuptools",
         "s3-tests/virtualenv/bin/python -m pip install -r s3-tests/requirements.txt",
-        "s3-tests/virtualenv/bin/python s3-tests/setup.py develop",
+        "s3-tests/virtualenv/bin/python -m pip install --editable s3-tests/.",
     ]
     node.exec_command(
         sudo=True, check_ec=False, cmd=f"yum install -y {' '.join(packages)}"
@@ -547,7 +547,7 @@ def _s3tests_req_install(node: CephNode, os_ver: str) -> None:
         f"{venv_cmd} -p python2 --no-site-packages --distribute s3-tests/virtualenv",
         "s3-tests/virtualenv/bin/pip install --upgrade pip setuptools",
         "s3-tests/virtualenv/bin/pip install -r s3-tests/requirements.txt",
-        "s3-tests/virtualenv/bin/python s3-tests/setup.py develop",
+        "s3-tests/virtualenv/bin/python -m pip install --editable s3-tests/.",
     ]
     for cmd in commands:
         node.exec_command(cmd=cmd)


### PR DESCRIPTION
# Description

Issue was due to depricated setup.py develop coommand,
https://github.com/pypa/setuptools/pull/4955/files

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-S3K9AL/execute_s3tests_0.log

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-GDTAAE/execute_s3tests_0.log

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
