### PR TITLE
[TFA] add set_debug flag for 4 node ec pool test

### DIFF
--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -129,17 +129,19 @@ tests:
             num_keys_obj: 300000
         verify_cluster_health: true
 
-  - test:
-      name: concurrent and parallel IOPS on an object
-      desc: Perform concurrent and parallel IOPs on one object
-      module: test_object_ops.py
-      config:
-        obj_sizes:
-          - 45
-          - 80
-          - 23
-          - 107
-      polarion-id: CEPH-83571710
+  # Commenting Test case due to performance related
+  # intermittent issue observed in 6.x
+  # - test:
+  #     name: concurrent and parallel IOPS on an object
+  #     desc: Perform concurrent and parallel IOPs on one object
+  #     module: test_object_ops.py
+  #     config:
+  #       obj_sizes:
+  #         - 45
+  #         - 80
+  #         - 23
+  #         - 107
+  #     polarion-id: CEPH-83571710
 
   - test:
       name: Inconsistent OSD epoch

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -227,6 +227,7 @@ tests:
       polarion-id: CEPH-83575858
       abort-on-fail: true
       config:
+        set_debug: true
         ec_pool:
           profile_name: ec22_profile
           pool_name: test_ec_pool

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -352,12 +352,11 @@ def run(ceph_cluster, **kw) -> int:
 
             # workflow to fail the host and make it offline
             # Blocks all incoming traffic on selected OSD node, except for SSH
-            out, _ = installer_node.exec_command(
-                sudo=True, cmd=f"iptables -A INPUT -d {fail_host.ip_address} -j REJECT"
-            )
-            out, _ = installer_node.exec_command(
-                sudo=True, cmd=f"iptables -A OUTPUT -d {fail_host.ip_address} -j REJECT"
-            )
+            cluster_nodes = ceph_cluster.get_nodes()
+            for node in cluster_nodes:
+                rados_obj.block_in_out_packets_on_host(
+                    source_host=node, target_host=fail_host
+                )
 
             # smart wait to check the status of osd host
             end_time = datetime.datetime.now() + datetime.timedelta(seconds=400)


### PR DESCRIPTION
PR includes :- 

**NOTE:-** FS command error in pass logs for test MDS_Service_deployment_with_spec

**(1)  Tier 4 rados tests:- Intermittent issue observed.** 
Adds REJECT for host under removal on All hosts.
Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_tfa_rados_tests_25_05_07_22_17_13

**(2) Adds set_debug flag for 4 node ec pools** 

**(3) Adds set_debug for scenario 5 for 4 node ec pools where issue was observed**

**(4) Adds check_ec as False for host reboot scenario in 4 node ec pools**
Pass logs for 2,3,4:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_8.1_tfa_rados_tests_25_05_07_22_17_1/

**(5) Comment concurrent and parallel IOPS test from quincy**
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
