### PR TITLE
Automation of CEPH-83617544 test case

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -221,3 +221,60 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate Gateway in DELETING state healthcheck warning
       polarion-id: CEPH-83611306
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node5
+          - node6
+        rbd_pool: rbd
+        time_to_fire: 60
+        gw_group: gw_group1
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            max_ns: 10
+            serial: 1
+            bdevs:
+            - count: 10
+              size: 5G
+              lb_group: node5
+            listener_port: 4420
+            listeners:
+              - node5
+            allow_host: "*"
+        test_case: CEPH-83616917
+        cleanup:
+          - pool
+          - gateway
+      desc: Warning at maximum number of namespaces reached at subsystem.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate Warning at maximum number of namespaces reached at subsystem.
+      polarion-id: CEPH-83616917
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node2
+          - node3
+          - node4
+          - node5
+          - node6
+          - node7
+          - node8
+          - node9
+          - node10
+        time_to_fire: 60
+        rbd_pool: nvme_of_pool
+        gw_group: gw_group1
+        test_case: CEPH-83617544
+        cleanup:
+          - pool
+          - gateway
+      desc: Warning at Max gateways within a gateway group exceeded on cluster.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate Warning at Max gateways within a gateway group exceeded on cluster
+      polarion-id: CEPH-83617544

--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -1,5 +1,5 @@
 # NVMeoF alerts and testing
-# cluster configuration file: conf/squid/nvmeof/ceph_nvmeof_functional.yaml
+# cluster configuration file: conf/squid/nvmeof/ceph_nvmeof_4-nvmeof-gwgroup_2gw_cluster.yaml
 # Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml or later versions
 
 tests:
@@ -56,7 +56,7 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node10
+          - node14
         install_packages:
           - ceph-common
         copy_admin_keyring: true

--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -677,6 +677,130 @@ def test_ceph_83611306(ceph_cluster, config):
     )
 
 
+def test_CEPH_83616917(ceph_cluster, config):
+    """[CEPH-83616917] - Warning at maximum number of namespaces reached at subsystem.
+
+    NVMeoFSubsystemNamespaceLimit alert indicates to user to maximum number of
+    namespaces reached at subsystem
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        config: test case config
+    """
+
+    time_to_fire = config["time_to_fire"]
+    rbd_pool = config["rbd_pool"]
+    rbd_obj = config["rbd_obj"]
+    nqn_name = config["subsystems"][0]["nqn"]
+    intervel = 60
+    alert = "NVMeoFSubsystemNamespaceLimit"
+    msg = "{nqn} subsystem has reached its maximum number of namespaces on cluster "
+
+    # Deploy nvmeof service
+    LOG.info("deploy nvme service")
+    deploy_nvme_service(ceph_cluster, config)
+    ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
+    # Configure subsystems, --max-namespaces is 10 and we are creating 10 namesapces
+    with parallel() as p:
+        for subsys_args in config["subsystems"]:
+            subsys_args["ceph_cluster"] = ceph_cluster
+            p.spawn(configure_subsystems, rbd_pool, ha, subsys_args)
+
+    # Check for alert
+    # NVMeoFSubsystemNamespaceLimit prometheus alert should be firing
+    events = PrometheusAlerts(ha.orch)
+    LOG.info("Check NVMeoFSubsystemNamespaceLimit should be firing")
+    events.monitor_alert(
+        alert,
+        timeout=time_to_fire,
+        msg=msg.format(nqn=nqn_name),
+        interval=intervel,
+    )
+
+    nvmegwcli = ha.gateways[0]
+    sub1_args = {"subsystem": nqn_name}
+    # Delete an namespace and check alert should be in inactive state
+    LOG.info("Delete an namespace and check alert should be in inactive state")
+    nvmegwcli.namespace.delete(**{"args": {**sub1_args, **{"nsid": 1}}})
+    events.monitor_alert(
+        alert, timeout=time_to_fire, state="inactive", interval=intervel
+    )
+
+    # Add namespace back and check alert should be in active state
+    LOG.info("Add namespace back and check alert should be in active state")
+    image = f"image-{generate_unique_id(4)}"
+    rbd_obj.create_image(rbd_pool, image, "10G")
+    img_args = {"rbd-pool": rbd_pool, "rbd-image": image, "nsid": 1}
+    nvmegwcli.namespace.add(**{"args": {**sub1_args, **img_args}})
+    events.monitor_alert(
+        alert,
+        timeout=time_to_fire,
+        msg=msg.format(nqn=nqn_name),
+        interval=intervel,
+    )
+
+    LOG.info("CEPH-83616917 - NVMeoFSubsystemNamespaceLimit validated successfully.")
+
+
+def test_ceph_83617544(ceph_cluster, config):
+    """[CEPH-83617544] Warning at Max gateways within a gateway group exceeded on cluster.
+
+    NVMeoFMaxGatewayGroupSize alert users to notify when user created
+    more than 8 gateways within a group per cluster
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        config: test case config
+    """
+
+    time_to_fire = config["time_to_fire"]
+    intervel = 60
+    alert = "NVMeoFMaxGatewayGroupSize"
+    msg = "Max gateways within a gateway group ({gw_group}) exceeded on cluster "
+
+    # Deploy nvmeof service
+    LOG.info("deploy nvme service")
+    gateway_nodes = deepcopy(config.get("gw_nodes"))
+    deploy_nvme_service(ceph_cluster, config)
+    ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
+    # Check for alert
+    # NVMeoFMaxGatewayGroupSize prometheus alert should be firing
+    events = PrometheusAlerts(ha.orch)
+
+    LOG.info("Check NVMeoFMaxGatewayGroupSize should be firing")
+    events.monitor_alert(
+        alert,
+        timeout=time_to_fire,
+        msg=msg.format(gw_group=config["gw_group"]),
+        interval=intervel,
+    )
+
+    # Deploy 8 gateways in group and NVMeoFMaxGatewayGroupSize alert should be in inactive state
+    LOG.info(
+        "Deploy 8 gateways in group and NVMeoFMaxGatewayGroupSize alert should be in inactive state"
+    )
+    config.update({"gw_nodes": gateway_nodes[0:8]})
+    deploy_nvme_service(ceph_cluster, config)
+    events.monitor_alert(
+        alert, timeout=time_to_fire, state="inactive", interval=intervel
+    )
+
+    # Add more than 8 gateways and NVMeoFMaxGatewayGroupSize alert should be in firing state
+    LOG.info(
+        "Add more than 8 gateways and NVMeoFMaxGatewayGroupSize alert should be in firing state"
+    )
+    config.update({"gw_nodes": gateway_nodes})
+    deploy_nvme_service(ceph_cluster, config)
+    events.monitor_alert(
+        alert,
+        timeout=time_to_fire,
+        msg=msg.format(gw_group=config["gw_group"]),
+        interval=intervel,
+    )
+
+    LOG.info("CEPH-83617544 - NVMeoFMaxGatewayGroupSize validated successfully.")
+
+
 testcases = {
     "CEPH-83610948": test_ceph_83610948,
     "CEPH-83610950": test_ceph_83610950,
@@ -684,6 +808,8 @@ testcases = {
     "CEPH-83611098": test_ceph_83611098,
     "CEPH-83611099": test_ceph_83611099,
     "CEPH-83611306": test_ceph_83611306,
+    "CEPH-83616917": test_CEPH_83616917,
+    "CEPH-83617544": test_ceph_83617544,
 }
 
 


### PR DESCRIPTION
Automation of CEPH-83616917 test case

Polarian test link:- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83617544

Logs:- 

```
2025-05-08 17:26:25,200 - cephci - xunit:133 - INFO - xUnit result file created: /Users/pjayaprakash/logs/ceph_83617544/xunit.xml

All test logs located here: /Users/pjayaprakash/logs/ceph_83617544

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate Warning at Max gatewa   Warning at Max gateways within a gateway group exceeded on c   0:13:05.841757                   Pass
2025-05-08 17:26:25,289 - cephci - run:1092 - INFO - final rc of test run 0
```
