### PR TITLE
[TFA] fix ceph mgr crash and intermittent issue with crc check

### DIFF
--- a/tests/rados/test_node_drain_customer_bug.py
+++ b/tests/rados/test_node_drain_customer_bug.py
@@ -143,6 +143,7 @@ def run(ceph_cluster, **kw):
         # Re-producing the bug by running  mgr start and removing OSD parallely
         time.sleep(10)
         mgr_daemon.start()
+        host_labels = rados_obj.get_host_label(drain_host)
         if bug_exists:
             log.info("Reproducing  the bug")
             rm_host = utils.get_node_by_id(ceph_cluster, drain_host)
@@ -175,7 +176,6 @@ def run(ceph_cluster, **kw):
             "--unmanaged=true.Once the node is added back to the cluster the OSDs get configured automatically"
         )
         # Check if labels exist for the node
-        host_labels = rados_obj.get_host_label(drain_host)
         for label_name in host_labels:
             if label_name == "_no_schedule" or label_name == "_no_conf_keyring":
                 log.error(
@@ -298,6 +298,8 @@ def verify_mgr_traceback_log(
     host = None
     log.info("Checking log lines")
     fsid = rados_obj.run_ceph_command(cmd="ceph fsid")["fsid"]
+    log_info_message = f"The MGR daemons list are - {mgr_daemon_list}"
+    log.info(log_info_message)
     for mgr_daemon in mgr_daemon_list:
         systemctl_name = f"ceph-{fsid}@mgr.{mgr_daemon}.service"
         host_name = mgr_daemon.split(".")[0]


### PR DESCRIPTION
PR addresses below issues:- 

PR includes below fixes:- 

(1) **Verification of Ceph mgr crash bug**
Issue log:- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-124/rados/95/tier-2_rados_test-drain-customer-issue/Verification_of_Ceph_mgr_crash_bug_0.log 
Issue:- 
```
2025-03-30 14:04:14,540 - cephci - test_node_drain_customer_bug:255 - ERROR - Could not add host : ceph-regression-7gttem-jhlv4e-node4 into the cluster and deploy OSDs. **Error : list index out of range**
2025-03-30 14:04:14,541 - cephci - test_node_drain_customer_bug:260 - INFO - 
 ************** Execution of finally block begins here *************** 
```

RUN logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_7.1_tfa_4_node_ecpools_25_05_08_07_59_01/ 
**NOTE:-** Currently the test fails due to Active Bug https://bugzilla.redhat.com/show_bug.cgi?id=2328605 
```
2025-05-08 09:39:33,771 - cephci - test_node_drain_customer_bug:181 - ERROR -  The _no_schedule  not removed from the ceph-vipin-tfa-testing-7rqha2-node4.This is the product bug(BZ#2328605)
2025-05-08 09:39:33,771 - cephci - test_node_drain_customer_bug:260 - INFO - 
 ************** Execution of finally block begins here *************** 
```





(2) **Intermittent issue observed in Verify read crc error message**
Issue log:- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-131/rados/100/tier-2_rados_test-bugfixes/Verify_read_crc_error_message_0.log 
Issue:- 
```
2025-04-16 18:58:17,950 - cephci - ceph:1632 - ERROR - awk '$1 >= "2025-04-16T18:50:08.187+0000" && $1 <= "2025-04-16T18:52:46.413+0000"' /var/log/ceph/a8596e40-1ab6-11f0-810b-fa163e9f2d42/ceph-osd.12.log failed to execute within 300s.
2025-04-16 18:58:17,951 - cephci - test_crc_check_logs:125 - INFO - Command exceed the allocated execution time.
```


**Tested with 2 scenarios Pass and Fail**

**Positive scenario: String "full-object read crc" should not be present in OSD logs.**
Tested for log line : "full-object read crc"
Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_7.1_tfa_4_node_ecpools_25_05_08_10_30_14/ 

**Failure scenario: Simulated a failing scenario by testing with a dummy string which will be present in OSD logs.**
Tested for log line : "empty local-lis/les=499/500 n=0 ec=57/33 lis/c=499/499 les/c/f=500/500/0"
Logs for failure scenario:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_7.1_tfa_4_node_ecpools_25_05_08_10_50_56/ 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
