### PR TITLE
[RHCEPHQE-19477][TFA]: Fix the long running job in case of failure

### DIFF
--- a/tests/cephfs/mds_rm_add.py
+++ b/tests/cephfs/mds_rm_add.py
@@ -75,8 +75,9 @@ def mds_rm_add(fs_util, mdss, client, fs_name="cephfs"):
         stop_flag = True
 
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
+        stop_flag = True
         raise CommandFailed
 
 
@@ -143,14 +144,12 @@ def run(ceph_cluster, get_fs_info=None, **kw):
                 fs_util,
                 client1,
                 kernel_mount_dir + "/kernel_1",
-                timeout=0,
             )
             p.spawn(
                 start_io_time,
                 fs_util,
                 client1,
                 fuse_mount_dir + "/fuse_1",
-                timeout=0,
             )
         return 0
 


### PR DESCRIPTION
# Description

Long running job identified as part of Jenkins run in case of failure. 

## Fix:

- Remove the no-timeout logic for the parallel job
- Set the flag to True to forcefully stop the parallel job in case of failure as well

## Logs:
<In-progress for the whole regression suite>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
