### PR TITLE
Automation of CEPH-83616916 test case

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -278,3 +278,30 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate Warning at Max gateways within a gateway group exceeded on cluster
       polarion-id: CEPH-83617544
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node5
+          - node6
+        rbd_pool: rbd
+        time_to_fire: 300
+        gw_group: gw_group1
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            listener_port: 4420
+            listeners:
+              - node5
+            allow_host: "*"
+        test_case: CEPH-83616916
+        host: node10
+        cleanup:
+          - pool
+          - gateway
+      desc: Warning at subsystem defined without host level security on cluster
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate NVMeoFGatewayOpenSecurity alert helps user to add host security to the subsystem
+      polarion-id: CEPH-83616916

--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -305,3 +305,34 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate NVMeoFGatewayOpenSecurity alert helps user to add host security to the subsystem
       polarion-id: CEPH-83616916
+
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        time_to_fire: 60
+        gw_groups:
+          - gw_group: group1
+            gw_nodes:
+              - node2
+          - gw_group: group2
+            gw_nodes:
+              - node3
+          - gw_group: group3
+            gw_nodes:
+              - node4
+          - gw_group: group4
+            gw_nodes:
+              - node5
+          - gw_group: group5
+            gw_nodes:
+              - node6
+        test_case: CEPH-83617404
+        cleanup:
+          - pool
+          - gateway
+      desc: Warning at when created more than 4 gateway groups
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate NVMeoFMaxGatewayGroups alert when created more than 4 gateway groups
+      polarion-id: CEPH-83617404

--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -22,6 +22,7 @@ from tests.nvmeof.test_ceph_nvmeof_high_availability import (
     get_node_by_id,
     teardown,
 )
+from tests.nvmeof.workflows.nvme_utils import delete_nvme_service
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.retry import retry
@@ -867,6 +868,80 @@ def test_ceph_83616916(ceph_cluster, config):
     LOG.info("CEPH-83616916 - NVMeoFGatewayOpenSecurity validated successfully.")
 
 
+def test_ceph_83617404(ceph_cluster, config):
+    """[CEPH-83617404] Warning at when created more than 4 gateway groups
+
+    NVMeoFMaxGatewayGroups alert users to notify when user created
+    more than 4 gateway groups per cluster
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        config: test case config
+    """
+
+    time_to_fire = config["time_to_fire"]
+    intervel = 60
+    rbd_pool = config["rbd_pool"]
+    alert = "NVMeoFMaxGatewayGroups"
+    msg = "Max gateway groups exceeded on cluster "
+    svcs = list()
+    gw_groups = deepcopy(config.get("gw_groups"))
+
+    # Deploy nvmeof service
+    LOG.info("deploy nvme service")
+    # Deploy Services
+    for svc in config["gw_groups"]:
+        svc.update({"rbd_pool": rbd_pool})
+        deploy_nvme_service(ceph_cluster, svc)
+        svcs.append(HighAvailability(ceph_cluster, svc["gw_nodes"], **svc))
+    ha1 = svcs[0]
+    # Check for alert
+    # NVMeoFMaxGatewayGroups prometheus alert should be firing
+    events = PrometheusAlerts(ha1.orch)
+
+    LOG.info("Check NVMeoFMaxGatewayGroups should be firing")
+    events.monitor_alert(
+        alert,
+        timeout=time_to_fire,
+        msg=msg,
+        interval=intervel,
+    )
+
+    # Remove one gateway and NVMeoFMaxGatewayGroups alert should be in inactive state
+    LOG.info(
+        "Remove one gateway group and NVMeoFMaxGatewayGroups alert should be in inactive state"
+    )
+    rm_add_gw_grp = gw_groups[0:1]
+    config.update({"gw_groups": rm_add_gw_grp})
+    delete_nvme_service(ceph_cluster, config)
+    events.monitor_alert(
+        alert, timeout=time_to_fire, state="inactive", interval=intervel
+    )
+
+    # Add more than 4 gateway groups and NVMeoFMaxGatewayGroups alert should be in firing state
+    LOG.info(
+        "Add more than 4 gateway groups and NVMeoFMaxGatewayGroups alert should be in firing state"
+    )
+    # Deploy Services
+    config.update({"gw_groups": rm_add_gw_grp})
+    for svc in config["gw_groups"]:
+        svc.update({"rbd_pool": rbd_pool})
+        deploy_nvme_service(ceph_cluster, svc)
+        HighAvailability(ceph_cluster, svc["gw_nodes"], **svc)
+
+    events.monitor_alert(
+        alert,
+        timeout=time_to_fire,
+        msg=msg,
+        interval=intervel,
+    )
+
+    # Delete all gateway groups
+    config.update({"gw_groups": gw_groups})
+    delete_nvme_service(ceph_cluster, config)
+    LOG.info("CEPH-83617404 - NVMeoFMaxGatewayGroups validated successfully.")
+
+
 testcases = {
     "CEPH-83610948": test_ceph_83610948,
     "CEPH-83610950": test_ceph_83610950,
@@ -877,6 +952,7 @@ testcases = {
     "CEPH-83616917": test_CEPH_83616917,
     "CEPH-83617544": test_ceph_83617544,
     "CEPH-83616916": test_ceph_83616916,
+    "CEPH-83617404": test_ceph_83617404,
 }
 
 


### PR DESCRIPTION
# Description

Test case link:- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83616916

```
All test logs located here: /Users/pjayaprakash/logs/ceph_83616916
2025-05-12 15:42:22,601 - cephci - xunit:81 - INFO - Creating xUnit tier-2_nvmeof-alerts_health-checks-events for test run-id RHCS-8-1-tier-2_nvmeof-alerts_health-checks-events-ECP2BE
2025-05-12 15:42:22,613 - cephci - xunit:133 - INFO - xUnit result file created: /Users/pjayaprakash/logs/ceph_83616916/xunit.xml

All test logs located here: /Users/pjayaprakash/logs/ceph_83616916

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate NVMeoFGatewayOpenSecu   Warning at subsystem defined without host level security on    0:15:43.822261                   Pass
2025-05-12 15:42:22,696 - cephci - run:1092 - INFO - final rc of test run 0
pjayaprakash@Ps-MacBook-Pro cephci %
```