### PR TITLE
Increased timeout value

### DIFF
--- a/tests/rbd/test_rbd.py
+++ b/tests/rbd/test_rbd.py
@@ -147,6 +147,6 @@ def run(ceph_cluster, **kwargs) -> int:
         if script == "*":
             cmd = f"cd ceph/{script_dir}; for test in $(ls); do sudo bash $test; done"
 
-        node.exec_command(cmd=cmd, check_ec=True, timeout=1200)
+        node.exec_command(cmd=cmd, check_ec=True, timeout=1800)
 
     return 0


### PR DESCRIPTION
Test fails if running time is more than 1200 sec(20min). Sometimes due to network lags, the sript "cli_migration.sh" takes more than 20 min and the test is considered failed.
Increased the timeout value to 1800

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F8KL7S/
