### PR TITLE
[TFA] Rearrange testcase due for granular sync as intermittent issue seen

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -257,6 +257,30 @@ tests:
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
 
   - test:
+      name: bucket granular sync policy with sync from differnt bucket
+      desc: Test bucket granular sync with sync from differnt bucket
+      polarion-id: CEPH-83575140
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_bucket_granular_sync_policy.py
+            config-file-name: test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
+            timeout: 5500
+
+  - test:
+      name: bucket granular sync policy with sync to differnt bucket
+      desc: Test bucket granular sync with sync to differnt bucket
+      polarion-id: CEPH-83575141
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_bucket_granular_sync_policy.py
+            config-file-name: test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
+            timeout: 5500
+
+  - test:
       name: Test Max Bucket generations
       desc: Test Max Bucket generations
       module: sanity_rgw_multisite.py
@@ -355,30 +379,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: Manual Resharding tests on Primary cluster
       polarion-id: CEPH-83574434
-
-  - test:
-      name: bucket granular sync policy with sync from differnt bucket
-      desc: Test bucket granular sync with sync from differnt bucket
-      polarion-id: CEPH-83575140
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_bucket_granular_sync_policy.py
-            config-file-name: test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
-            timeout: 5500
-
-  - test:
-      name: bucket granular sync policy with sync to differnt bucket
-      desc: Test bucket granular sync with sync to differnt bucket
-      polarion-id: CEPH-83575141
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_bucket_granular_sync_policy.py
-            config-file-name: test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
-            timeout: 5500
 
   - test:
       clusters:


### PR DESCRIPTION
# Description
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-188/rgw/104/tier-2_rgw_ms_regression_test/bucket_granular_sync_policy_with_sync_from_differnt_bucket_0.log
issue is sync is taking bit longer , intermittent issue

pass log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-204POA/ 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
