### PR TITLE
[TFA] fix issue with upgrade suite

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -428,11 +428,11 @@ tests:
         ceph-pri:
           config:
             script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
-      desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload pre upgarde
-      module: sanity_rgw_multisite.py
-      name:  pre upgarde test encryption with multipart
-      polarion-id: CEPH-83592485
+            config-file-name: test_sse_s3_per_object.yaml
+      desc: test_sse_s3_per_object pre upgarde
+      module: sanity_rgw.py
+      name: sse-s3 per object encryption test pre upgarde
+      polarion-id: CEPH-83575153
 
   - test:
       name: NFS export delete
@@ -489,12 +489,12 @@ tests:
             config-file-name: test_sync_policy_state_change.yaml
 
   - test:
-      name: S3CMD object download on secondary post upgarde
+      name: S3CMD object download post upgarde
       desc: S3CMD object download or GET post upgarde
       polarion-id: CEPH-83575477
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
@@ -517,11 +517,11 @@ tests:
         ceph-pri:
           config:
             script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_kms_kmip_gklm_per_object.yaml
-      desc: test_sse_kms_kmip_gklm_per_object post upgrade
-      module: sanity_rgw_multisite.py
-      name: test_sse_kms_kmip_gklm_per_object post upgrade
-      polarion-id: CEPH-83592485
+            config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+      desc: test sse-s3 per bucket encryption post upgrade
+      module: sanity_rgw.py
+      name: sse-s3 per bucket encryption test post upgrade
+      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
 
   - test:
       name: Test NFS cluster and export create


### PR DESCRIPTION
# Description
issue : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Upgrade/19.2.1-188/98/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest/ 
1. s3cmd : user craetion from secondary failed
2. gklm should not be part of this suite

pass log : 
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-FM6DCP/ 
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-19G3DL/ 


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
