### PR TITLE
[RADOS] TFA fixes for concurrent-parallel ops | OSD start false failure | Slow ops request test

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-slow-op-requests.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-slow-op-requests.yaml
@@ -92,32 +92,10 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool2
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool3
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -214,6 +214,18 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
       name: test stretch Cluster site down - Data site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574975

--- a/suites/quincy/rados/tier-2_rados_test-slow-op-requests.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-slow-op-requests.yaml
@@ -92,32 +92,10 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              rmax_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool2
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool3
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False

--- a/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -524,20 +524,18 @@ tests:
 #      desc: Limit slow request details to cluster log
 #      polarion-id: CEPH-83574884
 #      config:
-#        create_pools:
-#          - create_pool:
-#              profile_name: ec86_14
-#              pool_name: ec86_pool14
-#              pool_type: erasure
-#              k: 2
-#              m: 2
-#              plugin: jerasure
-#              crush-failure-domain: host
-#              pg_num: 64
-#              max_objs: 300
-#              byte_size: 1024
-#              osd_max_backfills: 16
-#              osd_recovery_max_active: 16
+#        profile_name: ec86_14
+#        pool_name: ec86_pool14
+#        pool_type: erasure
+#        k: 2
+#        m: 2
+#        plugin: jerasure
+#        crush-failure-domain: host
+#        pg_num: 64
+#        max_objs: 300
+#        byte_size: 1024
+#        osd_max_backfills: 16
+#        osd_recovery_max_active: 16
 #        delete_pools:
 #          - ec86_pool14
 

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -222,6 +222,18 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
       name: test stretch Cluster site down - Data site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574975

--- a/suites/reef/rados/test_rados_all_generic_features.yaml
+++ b/suites/reef/rados/test_rados_all_generic_features.yaml
@@ -1390,35 +1390,13 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool2
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool3
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False
 
   - test:
       name: BlueStore Checksum algorithms

--- a/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -203,38 +203,13 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-          - create_pool:
-              pool_name: pool2
-              pg_num: 128
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-          - create_pool:
-              pool_name: pool3
-              pg_num: 256
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False
 
 # PG log limit parameter cannot be unset,
 # this test should always run at the last

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -615,20 +615,18 @@ tests:
 #      desc: Limit slow request details to cluster log
 #      polarion-id: CEPH-83574884
 #      config:
-#        create_pools:
-#          - create_pool:
-#              profile_name: ec86_14
-#              pool_name: ec86_pool14
-#              pool_type: erasure
-#              k: 2
-#              m: 2
-#              plugin: jerasure
-#              crush-failure-domain: host
-#              pg_num: 64
-#              rados_write_duration: 1000
-#              byte_size: 1024
-#              osd_max_backfills: 16
-#              osd_recovery_max_active: 16
+#        profile_name: ec86_14
+#        pool_name: ec86_pool14
+#        pool_type: erasure
+#        k: 2
+#        m: 2
+#        plugin: jerasure
+#        crush-failure-domain: host
+#        pg_num: 64
+#        rados_write_duration: 1000
+#        byte_size: 1024
+#        osd_max_backfills: 16
+#        osd_recovery_max_active: 16
 #        delete_pools:
 #          - ec86_pool14
 

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -238,6 +238,18 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
       name: test stretch Cluster site down - Data site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574975

--- a/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
+++ b/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
@@ -647,23 +647,21 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              profile_name: ec86_14
-              pool_name: ec86_pool14
-              pool_type: erasure
-              k: 8
-              m: 6
-              create_rule: false
-              crush-osds-per-failure-domain: 4
-              crush-num-failure-domains: 4
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num: 64
-              max_objs: 5000
-              byte_size: 1024
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
+        profile_name: ec86_14
+        pool_name: ec86_pool14
+        pool_type: erasure
+        k: 8
+        m: 6
+        create_rule: false
+        crush-osds-per-failure-domain: 4
+        crush-num-failure-domains: 4
+        plugin: jerasure
+        crush-failure-domain: host
+        pg_num: 64
+        max_objs: 5000
+        byte_size: 1024
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
         delete_pools:
           - ec86_pool14
 

--- a/suites/squid/common/regression/rados/rados_pool-functionalities.yaml
+++ b/suites/squid/common/regression/rados/rados_pool-functionalities.yaml
@@ -458,38 +458,13 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              max_objs: 5000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-          - create_pool:
-              pool_name: pool2
-              pg_num: 128
-              max_objs: 5000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-          - create_pool:
-              pool_name: pool3
-              pg_num: 256
-              max_objs: 5000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False
 
   - test:
       name: Verify Ceph df MAX_AVAIL

--- a/suites/squid/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/squid/rados/tier-2-rados-basic-regression.yaml
@@ -409,6 +409,7 @@ tests:
         create_ec_pool: true
         create_re_pool: true
       desc: verify autoscaler flags functionality
+      comments: active bug 2361441
 
 # RHOS-d run duration: 1 min
 # env: VM + BM

--- a/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -203,38 +203,13 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-          - create_pool:
-              pool_name: pool2
-              pg_num: 128
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-          - create_pool:
-              pool_name: pool3
-              pg_num: 256
-              max_objs: 300
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-              check_ec: False
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False
 
 # PG log limit parameter cannot be unset,
 # this test should always run at the last

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -615,23 +615,21 @@ tests:
       desc: Limit slow request details to cluster log
       polarion-id: CEPH-83574884
       config:
-        create_pools:
-          - create_pool:
-              profile_name: ec86_14
-              pool_name: ec86_pool14
-              pool_type: erasure
-              k: 8
-              m: 6
-              create_rule: false
-              crush-osds-per-failure-domain: 4
-              crush-num-failure-domains: 4
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num: 64
-              max_objs: 300
-              byte_size: 1024
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
+        profile_name: ec86_14
+        pool_name: ec86_pool14
+        pool_type: erasure
+        k: 8
+        m: 6
+        create_rule: false
+        crush-osds-per-failure-domain: 4
+        crush-num-failure-domains: 4
+        plugin: jerasure
+        crush-failure-domain: host
+        pg_num: 64
+        max_objs: 300
+        byte_size: 1024
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
         delete_pools:
           - ec86_pool14
 

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -614,20 +614,18 @@ tests:
 #      desc: Limit slow request details to cluster log
 #      polarion-id: CEPH-83574884
 #      config:
-#        create_pools:
-#          - create_pool:
-#              profile_name: ec86_14
-#              pool_name: ec86_pool14
-#              pool_type: erasure
-#              k: 2
-#              m: 2
-#              plugin: jerasure
-#              crush-failure-domain: host
-#              pg_num: 64
-#              rados_write_duration: 1000
-#              byte_size: 1024
-#              osd_max_backfills: 16
-#              osd_recovery_max_active: 16
+#        profile_name: ec86_14
+#        pool_name: ec86_pool14
+#        pool_type: erasure
+#        k: 2
+#        m: 2
+#        plugin: jerasure
+#        crush-failure-domain: host
+#        pg_num: 64
+#        rados_write_duration: 1000
+#        byte_size: 1024
+#        osd_max_backfills: 16
+#        osd_recovery_max_active: 16
 #        delete_pools:
 #          - ec86_pool14
 

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -237,6 +237,18 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
       name: test stretch Cluster site down - Data site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574975

--- a/tests/rados/test_osd_replacement.py
+++ b/tests/rados/test_osd_replacement.py
@@ -63,8 +63,15 @@ def run(ceph_cluster, **kw):
         log.debug(destroyed_osd)
         if len(destroyed_osd) != 0:
             raise AssertionError("Cluster still has OSD(s) with destroyed status")
-        time.sleep(5)
-        assert rados_obj.fetch_osd_status(_osd_id=osd_id) == "up"
+
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=100)
+        while datetime.datetime.now() < endtime:
+            if rados_obj.fetch_osd_status(_osd_id=osd_id) == "up":
+                break
+            time.sleep(10)
+        else:
+            log.error("OSD.%s is not up even after 100 secs" % osd_id)
+            raise
 
         # set unmanaged to False for OSD
         log.info("Set OSD service unmanaged to false")

--- a/tests/rados/test_slow_op_requests.py
+++ b/tests/rados/test_slow_op_requests.py
@@ -1,10 +1,12 @@
+import datetime
+import re
+import time
 import traceback
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
-from tests.rados.rados_test_util import create_pools, get_slow_requests_log
+from tests.rados.monitor_configurations import MonConfigMethods
 from utility.log import Log
-from utility.utils import method_should_succeed, should_not_be_empty
 
 log = Log(__name__)
 
@@ -12,56 +14,127 @@ log = Log(__name__)
 def run(ceph_cluster, **kw):
     """
     Verify slow op requests
-    - Capture the node time to start reading the logs - format %Y-%m-%d %H:%M:%S
-    - Add pools to the cluster and write data to these pools
-    - Capture the node time to stop reading the logs - format %Y-%m-%d %H:%M:%S
-    - Query slow requests in the logs for the given time interval
+    Steps:
+    1. Set the parameter osd_op_complaint_time to 0.01 at Global level
+    2. Initialize rados bench write in the background
+    3. Sleep for 10 secs and initialize rados bench random read in the background
+    4. Observe ceph health detail for 240 secs, there should be reports of Slow ops
     """
     log.info(run.__doc__)
     config = kw["config"]
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
-    client_node = ceph_cluster.get_nodes(role="client")[0]
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
     installer = ceph_cluster.get_nodes(role="installer")[0]
 
     try:
         log.info("Running slow op requests tests")
-        rados_obj.enable_file_logging()
-        installer.exec_command(cmd="sudo timedatectl set-timezone UTC")
+        _pool_name = config.pop("pool_name", "slow-op-pool")
+        assert rados_obj.create_pool(pool_name=_pool_name, **config)
+
+        mon_obj.set_config(
+            section="global", name="osd_op_complaint_time", value="0.01"
+        ), "osd_op_complaint_time could not be set correctly"
+
         start_time, err = installer.exec_command(
             cmd="sudo date -u '+%Y-%m-%d %H:%M:%S'"
         )
-        osd_nodes = ceph_cluster.get_nodes(role="osd")
+        rados_obj.bench_write(
+            pool_name=_pool_name,
+            verify_stats=False,
+            background=True,
+            rados_write_duration=300,
+            byte_size=config["byte_size"],
+        )
+        time.sleep(10)
+        rados_obj.bench_read(
+            pool_name=_pool_name, rados_read_duration=300, background=True
+        )
 
-        pool = create_pools(config, rados_obj, client_node)
-        should_not_be_empty(pool, "Failed to retrieve pool details")
-        pools = config.get("create_pools")
-        for each_pool in pools:
-            cr_pool = each_pool["create_pool"]
-            osd_services = rados_obj.list_orch_services(service_type="osd")
-            for service in osd_services:
-                client_node.exec_command(cmd=f"ceph orch restart {service}", sudo=True)
-            for node in osd_nodes:
-                log.info(f"Rebooting node : {node.hostname}")
-                node.exec_command(sudo=True, cmd="reboot", check_ec=False)
-            method_should_succeed(rados_obj.bench_write, **cr_pool)
-        rados_obj.change_recovery_threads(config=pool, action="set")
+        slow_ops_frequency = {}
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=240)
+        while datetime.datetime.now() < endtime:
+            health_detail = rados_obj.run_ceph_command(
+                cmd="ceph health detail", client_exec=True
+            )
+            slow_ops_msg = None
+            slow_ops_dict = health_detail.get("checks").get("SLOW_OPS")
+            if slow_ops_dict:
+                log.info("Slow Ops request found in ceph health detail")
+                log.info("Proceeding to update OSD list with frequency")
+                slow_ops_msg = slow_ops_dict.get("summary").get("message")
+                log.info(slow_ops_msg)
+            if slow_ops_msg:
+                daemon_str = re.search(r"daemons \[([^\]]+)\]", slow_ops_msg)
+                if daemon_str:
+                    daemon_list = daemon_str.group(1).split(",")
+                    log.info("Slow Ops daemons: %s" % daemon_list)
+                    for _id in daemon_list:
+                        slow_ops_frequency[_id] = (
+                            slow_ops_frequency[_id] + 1
+                            if slow_ops_frequency.get(_id)
+                            else 1
+                        )
+            time.sleep(10)
 
         end_time, err = installer.exec_command(cmd="sudo date -u '+%Y-%m-%d %H:%M:%S'")
-        logs = get_slow_requests_log(installer, start_time.strip(), end_time.strip())
-        log.info(f"logs --- {logs}")
+        if not slow_ops_frequency:
+            log.error(
+                "Slow Ops warning was NOT generated/captured during the 240 secs smart wait"
+            )
+            raise Exception(
+                "Slow Ops warning was NOT generated/captured during the 120 secs smart wait"
+            )
 
-        return 0
+        log.info("Slow Ops request frequency: %s" % slow_ops_frequency)
+        max_osd = max(slow_ops_frequency, key=slow_ops_frequency.get)
+        log.info("OSD with highest count of Slow Ops: %s" % max_osd)
+
+        init_logs = rados_obj.get_journalctl_log(
+            start_time=start_time,
+            end_time=end_time,
+            daemon_type="osd",
+            daemon_id=max_osd.split(".")[-1],
+        )
+        slow_ops_log_list = []
+        for line in init_logs.splitlines():
+            if "slow ops" in line:
+                slow_ops_log_list.append(line)
+                # check slow op count
+                count = re.search(r"\b(\d+)\s+slow ops\b", line)
+                if not count:
+                    log.error("Slow Ops count not found in log line: " + line)
+                    raise Exception("Slow Ops count not found in log line: " + line)
+                log.info("Slow Ops count: %s" % count.group(1))
+
+        if not slow_ops_log_list:
+            log.error("No 'Slow Ops' entry found in the OSD log for OSD." + max_osd)
+            raise Exception(
+                "No 'Slow Ops' entry found in the OSD log for OSD." + max_osd
+            )
+
+        slow_op_logs = "\n".join(slow_ops_log_list)
+
+        log.info(
+            "\n ==========================================================================="
+            "\n SLOW OPS entries in %s log: \n %s"
+            "\n ==========================================================================="
+            % (max_osd, slow_op_logs)
+        )
+
+        log.info("Generation of Slow Ops request warning has been verified")
     except Exception as e:
         log.info(e)
         log.error(traceback.format_exc())
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(
             "\n \n ************** Execution of finally block begins here *************** \n \n"
         )
-        rados_obj.change_recovery_threads(config=pool, action="rm")
-
+        # remove "osd_op_complaint_time" parameter
+        mon_obj.remove_config(section="global", name="osd_op_complaint_time")
         # removal of rados pools
         rados_obj.rados_pool_cleanup()
 
@@ -71,3 +144,4 @@ def run(ceph_cluster, **kw):
         if rados_obj.check_crash_status():
             log.error("Test failed due to crash at the end of test")
             return 1
+    return 0


### PR DESCRIPTION
Jira trackers:
- [RHCEPHQE-18559](https://issues.redhat.com/browse/RHCEPHQE-18559)
- [RHCEPHQE-17018](https://issues.redhat.com/browse/RHCEPHQE-17018)
- [RHCEPHQE-19350](https://issues.redhat.com/browse/RHCEPHQE-19350)

TFA fixes provided:
- Concurrent and parallel ops
The test used to fail when run in conjuncture with test omaps. Although the test execution has stabilized over the previous two pipeline runs, it was decided the move this test to another test suite - location-stretch-mode
For the time being, the test is present in two test suites:
- `tier-3_rados_test-location-stretch-mode.yaml`
- `tier-2_rados_test_omap.yaml`

Depending upon the result of next few pipeline runs, a decision will be made to find the final single place for the test.

- Slow Ops request
The test was initially designed in such a way to overload the VM cluster and organically generate the "Slow Ops request" warning. However, this was done keeping in mind the then popular VM instance type - medium. Gradually we moved away from medium VM instance to a higher one - large or x-large. The workflow designed for medium instance was not enough to bring the cluster to a state where the warning would get generated due to OSD flapping. Even after increasing the load on the cluster, it was found that the environment in rhos-d and rhos-01 were too different to design a scenario were OSDs would flap organically and consistently in each run.
Finally, it was decided to no longer chase the organic generation this warning and reduce the value of `osd_op_complaint_time` parameter instead to capture "Slow ops request" warning easily.

- Smart wait to let OSD be reported as UP
At times it was seen that a recently added OSD is up and running but needs a small amount of time to reported as UP in the `ceph osd tree up` output. Changes have been made to wait for the state of OSD to get updated.

Logs:
Reef - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C440FI
Squid - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WZ1Z06

Signed-off-by: Harsh Kumar <hakumar@redhat.com>