### PR TITLE
TFA fixes for regression tests

### DIFF
--- a/suites/squid/cephfs/regression_suite.yaml
+++ b/suites/squid/cephfs/regression_suite.yaml
@@ -677,11 +677,20 @@ tests:
       desc: Tests the file and byte attributes on the directory
       abort-on-fail: false
   - test:
-      name: Concurrent-clone-test
-      module: snapshot_clone.clone_threads.py
-      polarion-id: CEPH-83574592
-      desc: Concurrent-clone-test
+      name: snapshot_flag
+      module: snapshot_clone.snapshot_flag.py
+      polarion-id: CEPH-83573415
+      desc: Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
       abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+       ENABLE_LOGS : 1
+       daemon_list : ['mds','mgr','client']
+       daemon_dbg_level : {'mds':10,'mgr':10,'client':10}
   - test:
       name: Clone_status
       module: snapshot_clone.clone_status.py
@@ -701,16 +710,42 @@ tests:
       desc: Retains the snapshots after deletig the subvolume
       abort-on-fail: false
   - test:
-      name: snapshot_flag
-      module: snapshot_clone.snapshot_flag.py
-      polarion-id: CEPH-83573415
-      desc: Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
-      abort-on-fail: false
-  - test:
       name: Remove_Subvolume_clone
       module: snapshot_clone.clone_remove_subvol.py
       polarion-id: CEPH-83573499
       desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: subvolume_full_vol
+      module: snapshot_clone.clone_subvolume_full_vol.py
+      polarion-id: CEPH-83574724
+      desc: Clone a subvolume with full data in the subvolume
+      abort-on-fail: false
+  - test:
+      name: cancel the subvolume snapshot cloning
+      module: snapshot_clone.clone_cancel_in_progress.py
+      polarion-id: CEPH-83574681
+      desc: Try to cancel the snapshot while clonning is operating
+      abort-on-fail: false
+  - test:
+      name: Clone_attributes
+      module: snapshot_clone.clone_attributes.py
+      polarion-id: CEPH-83573524
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+       DISABLE_LOGS : 1
+       daemon_list : ['mds','mgr','client']
+  - test:
+      name: Concurrent-clone-test
+      module: snapshot_clone.clone_threads.py
+      polarion-id: CEPH-83574592
+      desc: Concurrent-clone-test
       abort-on-fail: false
   - test:
       name: Test Max Snapshot limit
@@ -731,12 +766,6 @@ tests:
       desc: Try writing the data to snap directory
       abort-on-fail: false
   - test:
-      name: Clone_attributes
-      module: snapshot_clone.clone_attributes.py
-      polarion-id: CEPH-83573524
-      desc: Retains the snapshots after deletig the subvolume
-      abort-on-fail: false
-  - test:
       name: cross_platform_snaps
       module: snapshot_clone.cross_platform_snaps.py
       polarion-id: CEPH-11319
@@ -755,22 +784,10 @@ tests:
       desc: Create a Snapshot, reboot the node and rollback the snapshot
       abort-on-fail: false
   - test:
-      name: subvolume_full_vol
-      module: snapshot_clone.clone_subvolume_full_vol.py
-      polarion-id: CEPH-83574724
-      desc: Clone a subvolume with full data in the subvolume
-      abort-on-fail: false
-  - test:
       name: snapshot_metadata
       module: snapshot_clone.snapshot_metadata.py
       polarion-id: CEPH-83575038
       desc: verify CRUD operation on metadata of subvolume's snapshot
-      abort-on-fail: false
-  - test:
-      name: cancel the subvolume snapshot clonning
-      module: snapshot_clone.clone_cancel_in_progress.py
-      polarion-id: CEPH-83574681
-      desc: Try to cancel the snapshot while clonning is operating
       abort-on-fail: false
   - test:
       name: snap_schedule_test

--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -1207,13 +1207,14 @@ def run(ceph_cluster, **kw):
         if test_status == 1:
             assert False, "CG quiesce post upgrade validation failed"
         log.info(" CG quiesce post upgrade validation succeeded \n")
-        # Upgrade all clients
-        for client in clients:
-            cmd = "yum install -y --nogpgcheck ceph-common ceph-fuse"
-            client.exec_command(sudo=True, cmd=cmd)
         return 0
 
     except Exception as e:
         log.info(traceback.format_exc())
         log.error(e)
         return 1
+    finally:
+        log.info("Upgrade all clients")
+        for client in clients:
+            cmd = "yum upgrade -y --nogpgcheck ceph-common ceph-fuse"
+            client.exec_command(sudo=True, cmd=cmd)

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -186,6 +186,19 @@ def run(ceph_cluster, **kw):
             if "multi_fs" in test_case_name:
                 log.info("Verify that setup has atleast 2 Ceph FS")
                 total_fs = fs_util_v1.get_fs_details(client1)
+                fs_cnt = len(total_fs)
+                log.info(total_fs)
+                log.info(f"fs_cnt:{fs_cnt}")
+                for i in range(0, fs_cnt):
+                    fs_name = total_fs[i]["name"]
+                    cmd = f"ceph fs status {fs_name}"
+                    out, _ = client1.exec_command(
+                        sudo=True,
+                        cmd=cmd,
+                    )
+                    if "failed" in str(out):
+                        fs_to_rm = i
+                total_fs.pop(fs_to_rm)
                 if len(total_fs) == 1:
                     log.info("We need atleast two ceph FS to perform this test")
                     for i in range(1, 3):
@@ -827,6 +840,17 @@ def snap_sched_multi_fs(snap_test_params):
     mnt_path_fs = []
     log.info("Perform ceph fs ls to get the list")
     total_fs = fs_util.get_fs_details(client)
+    fs_cnt = len(total_fs)
+    for i in range(0, fs_cnt):
+        fs_name = total_fs[i]["name"]
+        cmd = f"ceph fs status {fs_name}"
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=cmd,
+        )
+        if "failed" in str(out):
+            fs_to_rm = i
+    total_fs.pop(fs_to_rm)
     log.info(total_fs)
     log.info(
         "Verify fs-name is prompted when snap-schedule is tried to create without fs-name"


### PR DESCRIPTION
# Description

Jira: https://issues.redhat.com/browse/RHCEPHQE-19788

1.Client caps validate - Replace local health check with cephfs_common_utils.wait_for_healthy_ceph module from testlib
Also, as cluster could be multiFS due to compaction, run ceph tell cmds on cephfs specific mds instead of generic mds.0
Remove nfs mount as ceph tell output for client caps from nfs mnt pt is not straightforward, will explore further on this.
Failed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DFRJZO/client_caps_update_validation_0.log
Passed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8YWUTH

2.CG quiesce interop_1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DFRJZO/cg_snap_interop_workflow_1_0.log
As the tests across suites are combined, due to improper cleanup, we will FS volume 'cephfs' with standby-replay  mds too, at this test was not aware and is just looking for standby type.
Updated to use either standby or standby-replay.
Also, deleting existing cephfs volumes and creating new cephfs for the tests.
Passed log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4JYAEX/cg_snap_interop_workflow_1_0.log

3.snap_sched_with_multi_fs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DFRJZO/snap_sched_multi_fs_0.log
Kernel mount failed when tried on one of the existing FS volumes because it was in failed state
When looking for available FS volumes for the test, remove the FS volume in failed state to avoid above issue.
Passed logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GZYER4

4. Post upgrade validation script: In a suite config where upgrade with lower version of ceph-fuse and ceph-common is being validated, after post upgrade tests, all client tools are to be upgraded. This code exists but in execution block, so if test script fails, client upgrade is missed causing next set of tests to fail.

Move the client upgrade post validations to finally block.
Failed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YD2M2S/

5.test_defer_client_evict_on_laggy_osd.py:

As cluster could be multiFS due to compaction, run ceph tell cmds on cephfs specific mds instead of generic mds.0

Also net-tools was not available on client, adding it through setup in this script, as its required for netstat cmd in network_failure bash script

failed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DFRJZO/Client_eviction_deferred_if_OSD_is_laggy_0.log
Passed log:http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3OF68Q

6. 5 clone scripts failed with ETIMEDOUT during clone create
A clone system style test just before them has passed, could be a slowness was induced.
Moving clone system test to run after these 5 functional tests and added DBG logs enable before  and DBG logs disable after clone functional tests

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
