### PR TITLE
[TFA-sanityfix]changed pre upgrade version from 8.0 to 8.1 in sanity upgrade suites

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -25,7 +25,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 8.1
+                    rhcs-version: 8.0
                     release: sanity
                     registry-url: registry.redhat.io
                     mon-ip: node1

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -18,7 +18,7 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 8.1
+                rhcs-version: 8.0
                 release: sanity
                 registry-url: registry.redhat.io
                 mon-ip: node1


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

The sanity suite was failing for 8.0 because the pre-upgrade version was set to 8.1. We had changed this to 8.1 because sanity was failing in 8.1, since there were no 8.0 sanity builds available at that time.

Now that we are running sanity for 8.0, the upgrade path is invalid as it tries to upgrade from a higher version (8.1 to 8.0).

This PR changes the pre-upgrade version to 8.0 to fix the issue for now.

JIRA: https://issues.redhat.com/browse/RHCEPHQE-19916
failed logs: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Sanity/19.2.0-134/323/tier-2_rgw_upgrade_8xsanity_to_8xlatest/

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Sanity/19.2.0-134/323/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest/?C=M;O=A

