### PR TITLE
[LibFix] Increate command execution default timeout to 600 sec

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1604,7 +1604,7 @@ class CephNode(object):
             timeout = None if kw["timeout"] == "notimeout" else kw["timeout"]
         else:
             # Set defaults if long_running then 1h else 5m
-            timeout = 3600 if kw.get("long_running", False) else 300
+            timeout = 3600 if kw.get("long_running", False) else 600
 
         try:
             channel = ssh().get_transport().open_session(timeout=timeout)


### PR DESCRIPTION
Many tests are failing with `CommandTimeout` error when executed in bulk. Increase default command timeout to `600` and monitor the results.