### PR TITLE
Fix for removing file after md5sum using boolean flag

### DIFF
--- a/ceph/rbd/utils.py
+++ b/ceph/rbd/utils.py
@@ -62,6 +62,7 @@ def get_md5sum_rbd_image(**kw):
         "client": <client_node>
     }
     """
+
     if kw.get("image_spec"):
         export_spec = {
             "source-image-or-snap-spec": kw.get("image_spec"),
@@ -71,11 +72,19 @@ def get_md5sum_rbd_image(**kw):
         if "100% complete...done" not in out + err:
             log.error(f"Export failed for image {kw.get('image_spec')}")
             return None
-    return exec_cmd(
+
+    md5sum_hash = exec_cmd(
         output=True,
-        cmd=f"md5sum {kw['file_path']} && rm -f {kw['file_path']}",
+        cmd=f"md5sum {kw['file_path']}",
         node=kw.get("client"),
     ).split()[0]
+    if kw.get("remove_file") or "remove_file" not in kw.keys():
+        exec_cmd(
+            output=True,
+            cmd=f"rm -f {kw['file_path']}",
+            node=kw.get("client"),
+        )
+    return md5sum_hash
 
 
 def check_data_integrity(**kw):

--- a/ceph/rbd/workflows/encryption.py
+++ b/ceph/rbd/workflows/encryption.py
@@ -516,6 +516,11 @@ def test_encryption_between_image_and_clone(**kw):
         "first": {"file_path": kw["parent_file_path"], "rbd": rbd, "client": client},
         "second": {"file_path": kw["clone_file_path"], "rbd": rbd, "client": client},
     }
+
+    if "remove_file" in kw.keys():
+        data_check_config["first"]["remove_file"] = kw.get("remove_file")
+        data_check_config["second"]["remove_file"] = kw.get("remove_file")
+
     if check_data_integrity(**data_check_config):
         log.error(f"Data inconsistency found between {image_spec} and {clone_spec}")
         return None
@@ -628,6 +633,10 @@ def mount_image_and_mirror_and_check_data(**kw):
             "client": mirror_client,
         },
     }
+    if "remove_file" in kw.keys():
+        data_check_config["first"]["remove_file"] = kw.get("remove_file")
+        data_check_config["second"]["remove_file"] = kw.get("remove_file")
+
     if check_data_integrity(**data_check_config):
         log.error(f"Data inconsistency found between {image_spec} and its mirror")
         return 1

--- a/tests/rbd_mirror/test_encryption_on_mirrored_image.py
+++ b/tests/rbd_mirror/test_encryption_on_mirrored_image.py
@@ -218,6 +218,7 @@ def test_rbd_encryption(mirror_obj, pool, image, format, **kw):
             "clone_file_path": clone_file_path,
             "size": size,
             "format": format,
+            "remove_file": False,
         }
 
         encryption_config = test_encryption_between_image_and_clone(**test_config)
@@ -281,6 +282,7 @@ def test_rbd_encryption(mirror_obj, pool, image, format, **kw):
             "size": size,
             "file_path": parent_file_path,
             "encryption_config": parent_encryption_config,
+            "remove_file": False,
         }
 
         if mount_image_and_mirror_and_check_data(**mirror_config):


### PR DESCRIPTION
Description of problem: get_md5sum_rbd_image in utils.py uses "cmd=f"md5sum {kw['file_path']} && rm -f {kw['file_path']}

Failure log without fix: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-128/rbd/25/tier-3_rbd_mirror_encrypted_image/Verify_the_luks_encryption_functionality_for_a_mirrored_image_0.log

Pass log after fix: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YPBMC8
