### PR TITLE
CEPH-83617622 test

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -355,5 +355,5 @@ tests:
       desc: Prometheus alert for number of subsystems defined to the gateway exceeds supported values
       destroy-cluster: false
       module: test_ceph_nvmeof_alerts_events.py
-      name: Validate NVMeoFTooManySubsystems alert when user created more than 128 subsystems in group
+      name: Validate NVMeoFTooManySubsystems alert
       polarion-id: CEPH-83617622

--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -336,3 +336,24 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate NVMeoFMaxGatewayGroups alert when created more than 4 gateway groups
       polarion-id: CEPH-83617404
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node5
+          - node6
+        rbd_pool: rbd
+        time_to_fire: 60
+        gw_group: gw_group1
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+        test_case: CEPH-83617622
+        cleanup:
+          - pool
+          - gateway
+      desc: Prometheus alert for number of subsystems defined to the gateway exceeds supported values
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate NVMeoFTooManySubsystems alert when user created more than 128 subsystems in group
+      polarion-id: CEPH-83617622

--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -970,7 +970,7 @@ def test_ceph_83617622(ceph_cluster, config):
     nvmegwcl1 = ha.gateways[0]
     created_subsystems = list()
     for i in range(0, 128):
-        subsystem = nqn_name + "." + str(i)
+        subsystem = f"{nqn_name}.{i}"
         sub_args = {"subsystem": subsystem}
         nvmegwcl1.subsystem.add(**{"args": {**sub_args, **{"no-group-append": True}}})
         created_subsystems.append(subsystem)
@@ -997,9 +997,9 @@ def test_ceph_83617622(ceph_cluster, config):
         alert, timeout=time_to_fire, state="inactive", interval=intervel
     )
 
-    # Add the deleted nqns and check the alert is in firning state or not
+    # Add the deleted nqns and check the alert is in firing state or not
     LOG.info(
-        "Add 128 susbystems and check NVMeoFTooManySubsystems alert is in firning state"
+        "Add 128 susbystems and check NVMeoFTooManySubsystems alert is in firing state"
     )
     for nqn in selected_nqs_to_delete:
         sub_args = {"subsystem": nqn}

--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -990,9 +990,7 @@ def test_ceph_83617622(ceph_cluster, config):
     selected_nqs_to_delete = created_subsystems[-9:]
     for nqn in selected_nqs_to_delete:
         sub_args = {"subsystem": nqn}
-        nvmegwcl1.subsystem.delete(
-            **{"args": {**sub_args}}
-        )
+        nvmegwcl1.subsystem.delete(**{"args": {**sub_args}})
 
     # Check for alert and it should be in inactive state
     events.monitor_alert(


### PR DESCRIPTION
# Description

Polarian link for test case:- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83617622

```
2025-05-21 11:40:08,109 - cephci - run:964 - INFO -
All test logs located here: /Users/pjayaprakash/logs/CEPH_83617622
2025-05-21 11:40:08,110 - cephci - xunit:81 - INFO - Creating xUnit tier-2_nvmeof-alerts_health-checks-events for test run-id RHCS-8-1-tier-2_nvmeof-alerts_health-checks-events-DRH3BB
2025-05-21 11:40:08,124 - cephci - xunit:133 - INFO - xUnit result file created: /Users/pjayaprakash/logs/CEPH_83617622/xunit.xml

All test logs located here: /Users/pjayaprakash/logs/CEPH_83617622

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate NVMeoFTooManySubsyste   Prometheus alert for number of subsystems defined to the gat   0:07:14.977551                   Pass
2025-05-21 11:40:08,219 - cephci - run:1092 - INFO - final rc of test run 0
```
