### PR TITLE
Automation of CEPH-83617545

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -357,3 +357,34 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate NVMeoFTooManySubsystems alert
       polarion-id: CEPH-83617622
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node5
+          - node6
+        rbd_pool: nvme_of_pool
+        time_to_fire: 60
+        gw_group: gw_group1
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            max_ns: 1024
+            bdevs:
+              - count: 1024
+                size: 1G
+                lb_group: node5
+            listener_port: 4420
+            listeners:
+              - node5
+              - node6
+            allow_host: "*"
+        test_case: CEPH-83617545
+        cleanup:
+          - pool
+          - gateway
+      desc: Prometheus alert for number of namespaces defined to the gateway exceeds supported values
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate NVMeoFTooManyNamespaces alert
+      polarion-id: CEPH-83617545


### PR DESCRIPTION
# Description

Polarian test case link https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83617545

```
2025-05-22 13:30:58,083 - cephci - run:964 - INFO -
All test logs located here: /Users/pjayaprakash/logs/CEPH_83617545
2025-05-22 13:30:58,083 - cephci - xunit:81 - INFO - Creating xUnit tier-2_nvmeof-alerts_health-checks-events for test run-id RHCS-8-1-tier-2_nvmeof-alerts_health-checks-events-DLI3U5
2025-05-22 13:30:58,095 - cephci - xunit:133 - INFO - xUnit result file created: /Users/pjayaprakash/logs/CEPH_83617545/xunit.xml

All test logs located here: /Users/pjayaprakash/logs/CEPH_83617545

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate NVMeoFTooManyNamespac   Prometheus alert for number of namespaces defined to the gat   0:07:48.256962                   Pass
2025-05-22 13:30:58,164 - cephci - run:1092 - INFO - final rc of test run 0
```
