### PR TITLE
[RHCEPHQE-19842]: TFA: Move from diff to rsync

### DIFF
--- a/tests/cephfs/cephfs_nfs/2_node_nfs.py
+++ b/tests/cephfs/cephfs_nfs/2_node_nfs.py
@@ -138,7 +138,7 @@ def run(ceph_cluster, **kw):
         log.info("Waiting for 30 seconds for nfs mount to be ready for validation")
         time.sleep(30)
         commands = [
-            f"diff -r {nfs_mounting_dir_1} {nfs_mounting_dir_2}",
+            rf"rsync -ani {nfs_mounting_dir_1} {nfs_mounting_dir_2} | grep -qv '^\.'",
             f"mkdir {nfs_mounting_dir_2}/dir3 {nfs_mounting_dir_2}/dir4",
             f"for n in {{1..5}}; do     dd if=/dev/zero of={nfs_mounting_dir_2}/dir3"
             f"/file$(printf %03d $n) bs=500k count=500; done",
@@ -154,7 +154,7 @@ def run(ceph_cluster, **kw):
         time.sleep(30)
         client1.exec_command(
             sudo=True,
-            cmd=f"diff -r {nfs_mounting_dir_1} {nfs_mounting_dir_2}",
+            cmd=rf"rsync -ani {nfs_mounting_dir_1} {nfs_mounting_dir_2} | grep -qv '^\.'",
             long_running=True,
         )
         return 0


### PR DESCRIPTION
# Description

Diff command consumes more time and hangs up at certain point which fails the subsequent test run

## Changes

- Replace `diff` with `rsync` equivalent which takes approx 10 sec to complete
- Even if it hangs, handled the clean up to forcefully un-mount

## Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-19842/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
