### PR TITLE
Fixing the upgrade suite

### DIFF
--- a/conf/squid/cephfs/tier-1_cephfs_mirror.yaml
+++ b/conf/squid/cephfs/tier-1_cephfs_mirror.yaml
@@ -24,12 +24,14 @@ globals:
         role:
           - osd
           - mds
+          - nfs
         no-of-volumes: 4
         disk-size: 15
       node5:
         role:
           - osd
           - mds
+          - nfs
         no-of-volumes: 4
         disk-size: 15
       node6:
@@ -62,12 +64,14 @@ globals:
         role:
           - osd
           - mds
+          - nfs
         no-of-volumes: 4
         disk-size: 15
       node5:
         role:
           - osd
           - mds
+          - nfs
         no-of-volumes: 4
         disk-size: 15
       node6:

--- a/tests/cephfs/cephfs_tier1_ops.py
+++ b/tests/cephfs/cephfs_tier1_ops.py
@@ -85,7 +85,7 @@ def run(ceph_cluster, **kw):
             "ceph osd pool set cephfs-data-ec allow_ec_overwrites true",
             "ceph fs new cephfs-ec cephfs-metadata cephfs-data-ec --force",
         ]
-        if fs_util.get_fs_info(clients[0], "cephfs-ec"):
+        if not fs_util.get_fs_info(clients[0], "cephfs-ec"):
             for cmd in list_cmds:
                 clients[0].exec_command(sudo=True, cmd=cmd)
 

--- a/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
@@ -85,7 +85,7 @@ def run(ceph_cluster, **kw):
         pass
 
 
-def wait_for_two_active_mds(client1, fs_name, max_wait_time=180, retry_interval=10):
+def wait_for_two_active_mds(client1, fs_name, max_wait_time=600, retry_interval=20):
     """
     Wait until two active MDS (Metadata Servers) are found or the maximum wait time is reached.
 


### PR DESCRIPTION
# Description
Fixing the upgrade suite

Problem : 
NFS role was not present in mirror suites. because of this the suites are failing with "No NFS server"

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Upgrade/19.2.0-136/103/tier-0_cephfs_upgrade_7x_to_8x



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
