### PR TITLE
[TFA][RADOS] RHCEPHQE-19754: Change test case order to avoid false failure in ISA plugin for EC

### DIFF
--- a/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -127,6 +127,60 @@ tests:
       abort-on-fail: true
       comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
 
+  # Below test is added for ISA erasure code plugin
+
+  - test:
+      name: EC pool with ISA plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83606527
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_isa_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_isa_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_isa_ec_pool
+      desc: Creation, modification & deletion of ISA EC pools and run IO
+
+  - test:
+      name: ISA plugin for EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83606782
+      config:
+        ec_pool:
+          create: true
+          pool_name: isa_ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: isa
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: isa_re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - isa_ec_pool_overwrite
+          - isa_re_pool_overwrite
+      desc: ISA EC pool with Overwrites & create RBD pool
+
   - test:
       name: EC Pool Recovery Improvement
       module: pool_tests.py
@@ -314,57 +368,3 @@ tests:
           - rpool_2
           - rpool_3
           - ecpool_test_2
-
-  # Below test is added for ISA erasure code plugin
-
-  - test:
-      name: EC pool with ISA plugin
-      module: rados_prep.py
-      polarion-id: CEPH-83606527
-      config:
-        ec_pool:
-          create: true
-          pool_name: test_isa_ec_pool
-          pg_num: 64
-          k: 2
-          m: 2
-          plugin: isa
-          disable_pg_autoscale: true
-          max_objs: 300
-          rados_read_duration: 10
-        set_pool_configs:
-          pool_name: test_isa_ec_pool
-          configurations:
-            pg_num: 32
-            pgp_num: 32
-            pg_autoscale_mode: 'on'
-            compression_mode: force
-            compression_algorithm: snappy
-        delete_pools:
-          - test_isa_ec_pool
-      desc: Creation, modification & deletion of ISA EC pools and run IO
-
-  - test:
-      name: ISA plugin for EC pool with Overwrites
-      module: rados_prep.py
-      polarion-id: CEPH-83606782
-      config:
-        ec_pool:
-          create: true
-          pool_name: isa_ec_pool_overwrite
-          app_name: rbd
-          pg_num: 32
-          erasure_code_use_overwrites: "true"
-          k: 2
-          m: 2
-          plugin: isa
-          max_objs: 300
-          rados_read_duration: 10
-          test_overwrites_pool: true
-          metadata_pool: isa_re_pool_overwrite
-          image_name: image_ec_pool
-          image_size: 100M
-        delete_pools:
-          - isa_ec_pool_overwrite
-          - isa_re_pool_overwrite
-      desc: ISA EC pool with Overwrites & create RBD pool


### PR DESCRIPTION
During recent CI upgrade pipeline runs, it was observed that test to verify ISA EC pool with Overwrites & create RBD pool would consistently fail with socket timeout.

Investigation around this issue revealed that the command works perfectly in greenfield and brownfield scenarios if run without the preceding tests. As an immediate fix, the order of test case execution in the test suite has been changed.

For closure, the failure will be investigated separately to find out the root cause behind the rbd device map command getting stuck.

Logs:
Initial failure log from pipeline: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Upgrade/19.2.1-188/97/tier-2_rados_ec-pool_recovery/

Pass log when test is executed immediately after upgrade: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZWG59A/

Fail log in rhos-d: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CYOBV9/

Pass log after changing test case execution order: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JPQHAB/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>