### PR TITLE
[RHCEPHQE-19990]:[TFA]: Fix placement flags

### DIFF
--- a/suites/squid/cephfs/regression_suite.yaml
+++ b/suites/squid/cephfs/regression_suite.yaml
@@ -610,6 +610,7 @@ tests:
       polarion-id: CEPH-83573870
       desc: Create 2 Filesystem with default values on different MDS daemons
       abort-on-fail: false
+      comments: BZ-2368774
   - test:
       name: creation of multiple file systems
       module: multifs.multifs_multiplefs.py


### PR DESCRIPTION
# Description

Failed due to placement flags identifying the same host and failed error handling for wait_for_mds_process

## Changes

- Add BZ in the suite
- Fixed to pick up the right set of node for placement whereas earlier it was hardcoded
- Fixed to check the return statement for wait_mds_process to catch the issue at the right place

## Logs

- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-19990/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
