### PR TITLE
Automation of CEPH-83617640

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -388,3 +388,35 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate NVMeoFTooManyNamespaces alert
       polarion-id: CEPH-83617545
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node6
+          - node5
+        nvme_diff_version: cp.stg.icr.io/cp/ibm-ceph/nvmeof-rhel9:1.4.11-2
+        rbd_pool: nvme_of_pool
+        time_to_fire: 3600
+        gw_group: gw_group1
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            max_ns: 1024
+            bdevs:
+              - count: 5
+                size: 1G
+                lb_group: node5
+            listener_port: 4420
+            listeners:
+              - node6
+              - node5
+            allow_host: "*"
+        test_case: CEPH-83617640
+        cleanup:
+          - pool
+          - gateway
+      desc: Prometheus alert for having different nvme-of gateway releases active on cluster
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate NVMeoFVersionMismatch alert
+      polarion-id: CEPH-83617640

--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -1082,7 +1082,7 @@ def test_ceph_83617545(ceph_cluster, config):
 def test_ceph_83617640(ceph_cluster, config):
     """[CEPH-83617640] - Warning at maximum number of namespaces reached in group
 
-    NVMeoFVersionMismatch alert will notify the user when user is having 
+    NVMeoFVersionMismatch alert will notify the user when user is having
     different nvme-of gateway releases active on cluster
 
     Args:
@@ -1111,9 +1111,7 @@ def test_ceph_83617640(ceph_cluster, config):
 
     # Check for alert
     # NVMeoFVersionMismatch prometheus alert should be in inactive state
-    LOG.info(
-        "NVMeoFVersionMismatch should in inactive state"
-    )
+    LOG.info("NVMeoFVersionMismatch should in inactive state")
     events = PrometheusAlerts(ha.orch)
     events.monitor_alert(
         alert, timeout=time_to_fire, state="inactive", interval=intervel
@@ -1122,7 +1120,7 @@ def test_ceph_83617640(ceph_cluster, config):
     # Get the image version of nvmeof daemon
     LOG.info("Get the current nvmeof image version")
     get_version, _ = ha.orch.shell(
-        args=["ceph", "config",  "get", "mgr", "mgr/cephadm/container_image_nvmeof"]
+        args=["ceph", "config", "get", "mgr", "mgr/cephadm/container_image_nvmeof"]
     )
 
     initial_verions_of_nvme = get_version.strip()
@@ -1130,9 +1128,18 @@ def test_ceph_83617640(ceph_cluster, config):
 
     # Set the different nvmeof version so that alert will be active
     # ceph config set mgr mgr/cephadm/container_image_nvmeof  < container image >
-    LOG.info(f"Set ceph config set mgr mgr/cephadm/container_image_nvmeof  {nvme_diff_version}")
+    LOG.info(
+        f"Set ceph config set mgr mgr/cephadm/container_image_nvmeof  {nvme_diff_version}"
+    )
     output, _ = ha.orch.shell(
-        args=["ceph", "config", "set", "mgr", "mgr/cephadm/container_image_nvmeof", f"{nvme_diff_version}"]
+        args=[
+            "ceph",
+            "config",
+            "set",
+            "mgr",
+            "mgr/cephadm/container_image_nvmeof",
+            f"{nvme_diff_version}",
+        ]
     )
 
     # Redeploy NVMeOF daemon
@@ -1146,14 +1153,21 @@ def test_ceph_83617640(ceph_cluster, config):
     # Set the initial version of nvmeof image
     LOG.info("Set the initial version of nvmeof image")
     output, _ = ha.orch.shell(
-        args=["ceph", "config", "set", "mgr", "mgr/cephadm/container_image_nvmeof", f"{initial_verions_of_nvme}"]
+        args=[
+            "ceph",
+            "config",
+            "set",
+            "mgr",
+            "mgr/cephadm/container_image_nvmeof",
+            f"{initial_verions_of_nvme}",
+        ]
     )
 
     # Redeploy all the nvme daemons
     LOG.info("Redeploy all the nvme daemons")
     for gateway in ha.gateways:
         ha.daemon_redeploy(gateway)
-    
+
     # Check alert is in inactive state or not
     LOG.info("Check alert is in inactive state or not")
     events.monitor_alert(


### PR DESCRIPTION
# Description

Polarian test link:- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83617640

```
All test logs located here: /Users/pjayaprakash/logs/CEPH_83617640
2025-05-28 16:52:31,149 - cephci - xunit:81 - INFO - Creating xUnit tier-2_nvmeof-alerts_health-checks-events for test run-id RHCS-8-1-tier-2_nvmeof-alerts_health-checks-events-OKB10R
2025-05-28 16:52:31,163 - cephci - xunit:133 - INFO - xUnit result file created: /Users/pjayaprakash/logs/CEPH_83617640/xunit.xml

All test logs located here: /Users/pjayaprakash/logs/CEPH_83617640

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate NVMeoFVersionMismatch   Prometheus alert for having different nvme-of gateway releas   1:07:31.059126                   Pass
2025-05-28 16:52:31,253 - cephci - run:1092 - INFO - final rc of test run 0
```
