### PR TITLE
tfa fix for snap sched

### DIFF
--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -843,6 +843,7 @@ def snap_sched_multi_fs(snap_test_params):
     log.info("Perform ceph fs ls to get the list")
     total_fs = fs_util.get_fs_details(client)
     fs_cnt = len(total_fs)
+    fs_to_rm = None
     for i in range(0, fs_cnt):
         fs_name = total_fs[i]["name"]
         cmd = f"ceph fs status {fs_name}"
@@ -852,7 +853,8 @@ def snap_sched_multi_fs(snap_test_params):
         )
         if "failed" in str(out):
             fs_to_rm = i
-    total_fs.pop(fs_to_rm)
+    if fs_to_rm is not None:
+        total_fs.pop(fs_to_rm)
     log.info(total_fs)
     log.info(
         "Verify fs-name is prompted when snap-schedule is tried to create without fs-name"


### PR DESCRIPTION
# Description

snap sched multi-fs : Script failed as it didnt find any failed FS that had to be removed from list of FS and default code had a variable to remove failed FS which was not initalized in this case.
Failed log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5PQFOM/snap_sched_multi_fs_0.log

Initialized variable to None, so that failed FS pop-out happens only when valid index for failed FS from FS list is defined.

This code, checking for failed FS and remove them, exists in two places, had fixed in one section in previous PR, but not the other. Am fixing the other section too with this PR.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
