### PR TITLE
[RADOS] Create IBM specific test suites for Upgrade pipeline

### DIFF
--- a/suites/quincy/rados/tier-2_rados_ec-pool_recovery_ibm.yaml
+++ b/suites/quincy/rados/tier-2_rados_ec-pool_recovery_ibm.yaml
@@ -1,0 +1,195 @@
+# Suite contains tier-2 rados test: EC Pool recovery
+# CLuster should have atleast 6 OSD hosts for testing.
+# Suited best for BM pipeline.
+# Can be run on RHOS-d env as well.
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                # IBM 6.1 GA
+                custom_image: "cp.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+
+  - test:
+      name: EC Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_ec_pool
+      desc: Create, modify & delete EC pools and run IO
+
+  - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool
+

--- a/suites/quincy/rados/tier-2_rados_test-brownfield_ibm.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-brownfield_ibm.yaml
@@ -1,0 +1,266 @@
+# Suite contains tests to be run after upgrade [brownfield deployment]
+# Use cluster-conf file: conf/quincy/rados/7-node-cluster.yaml
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                # IBM 6.1 z6
+                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:6-24"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/\
+                  IBM-CEPH-6.1-202404162311.ci.0/IBM-CEPH-6.1-202404162311.ci.0-rhel9.repo"
+                mon-ip: node1
+                orphan-initial-daemons: true
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: "issue repro: obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
+
+  - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      config:
+        cluster_conf_path: "conf/squid/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  - test:
+      name: "verify fix: obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: prometheus metadata
+      module: test_brownfield.py
+      desc: Fetch and verify ceph version for various daemons post upgrade
+      polarion-id: CEPH-83581346
+      config:
+       prometheus_metrics:
+         daemons:
+           - mon
+           - osd
+           - mgr
+
+# cot and cbt tests are blocked due to BZ-2258542]
+#  - test:
+#      name: ceph-bluestore-tool utility
+#      module: test_bluestoretool_workflows.py
+#      polarion-id: CEPH-83571692
+#      desc: Verify ceph-bluestore-tool functionalities
+#
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade_ibm.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade_ibm.yaml
@@ -1,0 +1,277 @@
+# Suite contains tests related to election strategy and Stretched mode
+# Use cluster-conf file: conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+# Stretch mode tests performing upgrade
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          # IBM 5.3 GA
+          custom_image: "cp.icr.io/cp/ibm-ceph/ceph-5-rhel9:latest"
+          custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-5-rhel-9.repo"
+          mon-ip: node1
+          orphan-initial-daemons: true
+          skip-monitoring-stack: true
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+                - node4
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node5
+                - node6
+                - node7
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=tiebreaker
+                  node2:
+                    - datacenter=DC1
+                  node3:
+                    - datacenter=DC1
+                  node5:
+                    - datacenter=DC2
+                  node6:
+                    - datacenter=DC2
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node8:
+              release: 5
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 300
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false

--- a/suites/reef/rados/tier-2_rados_ec-pool_recovery_ibm.yaml
+++ b/suites/reef/rados/tier-2_rados_ec-pool_recovery_ibm.yaml
@@ -1,0 +1,283 @@
+# Suite contains tier-2 rados test: EC Pool recovery
+# CLuster should have atleast 6 OSD hosts for testing.
+# Suited best for BM pipeline.
+# Can be run on RHOS-d env as well.
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              orphan-initial-daemons: true
+              skip-monitoring-stack: true
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                # IBM 5.3 GA
+                custom_image: "cp.icr.io/cp/ibm-ceph/ceph-5-rhel9:latest"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-5-rhel-9.repo"
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Upgrade cluster to IBM 7.1z3 ceph version
+      desc: Upgrade cluster to IBM 7.1z3 version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        args:
+          # IBM 7.1 z3
+          custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:7-113"
+          custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/\
+            IBM-CEPH-7.1-202502180027.ci.0/IBM-CEPH-7.1-202502180027.ci.0-rhel9.repo"
+      abort-on-fail: false
+
+  - test:
+      name: Upgrade cluster to latest 7.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: EC Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_ec_pool
+      desc: Create, modify & delete EC pools and run IO
+
+  - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool
+
+# below tests have been moved here from - tier-2_rados_test-clay-ecpool.yaml
+  - test:
+      name: EC pool with clay profile for RBD
+      module: test_clay_ecpool.py
+      polarion-id: CEPH-83574881
+      config:
+        clay_pool:
+          profile_name: clay_profile1
+          pool_name: clay_ec_pool1
+          k: 4
+          m: 3
+          d: 6
+          plugin: clay
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          crush-failure-domain: osd
+          force: true
+          test_overwrites_pool: true
+          delete_pools: true
+          image_name: test_clay_image1
+          image_size: 50G
+          metadata_pool: clay_meta_pool1
+      desc: Create and delete CLAY profile EC pool with RBD Images
+
+  - test:
+      name: Pool tests with clay profile for RBD Images
+      module: test_clay_ecpool.py
+      polarion-id: CEPH-83574880
+      config:
+        clay_pool:
+          profile_name: clay_profile2
+          pool_name: clay_ec_pool2
+          k: 4
+          m: 2
+          d: 5
+          plugin: clay
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          crush-failure-domain: osd
+          force: true
+          test_overwrites_pool: true
+          delete_pools: true
+          image_name: test_clay_image2
+          image_size: 50G
+          metadata_pool: clay_meta_pool2
+          test_tier3_system_tests: true
+          test_compression:
+            configurations:
+              - config-1:
+                  compression_mode: force
+                  compression_algorithm: snappy
+                  compression_required_ratio: 0.3
+                  compression_min_blob_size: 1B
+                  byte_size: 10KB
+              - config-2:
+                  compression_mode: passive
+                  compression_algorithm: zlib
+                  compression_required_ratio: 0.7
+                  compression_min_blob_size: 10B
+                  byte_size: 100KB
+              - config-3:
+                  compression_mode: aggressive
+                  compression_algorithm: zstd
+                  compression_required_ratio: 0.5
+                  compression_min_blob_size: 1KB
+                  byte_size: 100KB
+      desc: Perform tests on EC pools having a RBD Image

--- a/suites/reef/rados/tier-2_rados_test-brownfield_ibm.yaml
+++ b/suites/reef/rados/tier-2_rados_test-brownfield_ibm.yaml
@@ -1,0 +1,321 @@
+# Suite contains tests to be run after upgrade [brownfield deployment]
+# Use cluster-conf file: conf/reef/rados/7-node-cluster.yaml
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                # IBM 6.1 z6
+                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:6-24"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/\
+                  IBM-CEPH-6.1-202404162311.ci.0/IBM-CEPH-6.1-202404162311.ci.0-rhel9.repo"
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: "issue repro-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: setup osd failure due to allocator file corruption
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           issue_reproduction: true
+        pool_config:
+           pool_name: osd-alloc-pool
+           pg_num: 1
+           pg_num_max: 1
+           pool_type: replicated
+
+  - test:
+      name: Upgrade cluster to IBM 7.1z2 ceph version
+      desc: Upgrade cluster to IBM 7.1z2 version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        args:
+          # IBM 7.1 z2
+          custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:7-96"
+          custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/\
+            IBM-CEPH-7.1-202411010109.ci.0/IBM-CEPH-7.1-202411010109.ci.0-rhel9.repo"
+      abort-on-fail: false
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: OSD fails with ceph_assert post upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           check_assert: true
+        pool_config:
+           pool_name: osd-alloc-pool
+
+  - test:
+      name: Upgrade cluster to latest 7.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: "verify fix-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+          verify_fix: true
+
+  - test:
+      name: "verify fix-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
+
+  - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      config:
+        cluster_conf_path: "conf/reef/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: prometheus metadata
+      module: test_brownfield.py
+      desc: Fetch and verify ceph version for various daemons post upgrade
+      polarion-id: CEPH-83581346
+      config:
+       prometheus_metrics:
+         daemons:
+           - mon
+           - osd
+           - mgr
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+#  Uncomment test case once stabilisation is completed
+#  CI stabilisation: https://issues.redhat.com/browse/RHCEPHQE-19549
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade_ibm.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade_ibm.yaml
@@ -1,0 +1,282 @@
+# Suite contains tests related to election strategy and Stretched mode
+# Use cluster-conf file: conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+# Stretch mode tests performing upgrade
+
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/reef/rados/deploy-stretch-cluster-mode.yaml
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          # upgrade bug from 6.x to 7.x wrt warning : 2243570
+          # IBM 6.1 GA
+          custom_image: "cp.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
+          custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+          mon-ip: node1
+          orphan-initial-daemons: true
+          skip-monitoring-stack: true
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+                - node4
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node5
+                - node6
+                - node7
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=tiebreaker
+                  node2:
+                    - datacenter=DC1
+                  node3:
+                    - datacenter=DC1
+                  node5:
+                    - datacenter=DC2
+                  node6:
+                    - datacenter=DC2
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node8:
+              release: 5
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 300
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_older_version_warn: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false

--- a/suites/squid/rados/tier-2_rados_ec-pool_recovery_ibm.yaml
+++ b/suites/squid/rados/tier-2_rados_ec-pool_recovery_ibm.yaml
@@ -1,0 +1,370 @@
+# Suite contains tier-2 rados test: EC Pool recovery
+# CLuster should have atleast 6 OSD hosts for testing.
+# Suited best for BM pipeline.
+# Can be run on RHOS-d env as well.
+# RHOS-d run duration: 60 mins (clay-ecpool tests)
+# Suite contains ISA erasure code plugin
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              orphan-initial-daemons: true
+              skip-monitoring-stack: true
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                # IBM 6.1 GA
+                custom_image: "cp.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                mon-ip: node1
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
+
+  # Below test is added for ISA erasure code plugin
+
+  - test:
+      name: EC pool with ISA plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83606527
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_isa_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_isa_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_isa_ec_pool
+      desc: Creation, modification & deletion of ISA EC pools and run IO
+
+  - test:
+      name: ISA plugin for EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83606782
+      config:
+        ec_pool:
+          create: true
+          pool_name: isa_ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: isa
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: isa_re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - isa_ec_pool_overwrite
+          - isa_re_pool_overwrite
+      desc: ISA EC pool with Overwrites & create RBD pool
+
+  - test:
+      name: EC Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_ec_pool
+      desc: Create, modify & delete EC pools and run IO
+
+  - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool
+
+# below tests have been moved here from - tier-2_rados_test-clay-ecpool.yaml
+  - test:
+      name: EC pool with clay profile for RBD
+      module: test_clay_ecpool.py
+      polarion-id: CEPH-83574881
+      config:
+        clay_pool:
+          profile_name: clay_profile1
+          pool_name: clay_ec_pool1
+          k: 4
+          m: 3
+          d: 6
+          plugin: clay
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          crush-failure-domain: osd
+          force: true
+          test_overwrites_pool: true
+          delete_pools: true
+          image_name: test_clay_image1
+          image_size: 50G
+          metadata_pool: clay_meta_pool1
+      desc: Create and delete CLAY profile EC pool with RBD Images
+
+  - test:
+      name: Pool tests with clay profile for RBD Images
+      module: test_clay_ecpool.py
+      polarion-id: CEPH-83574880
+      config:
+        clay_pool:
+          profile_name: clay_profile2
+          pool_name: clay_ec_pool2
+          k: 4
+          m: 2
+          d: 5
+          plugin: clay
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          crush-failure-domain: osd
+          force: true
+          test_overwrites_pool: true
+          delete_pools: true
+          image_name: test_clay_image2
+          image_size: 50G
+          metadata_pool: clay_meta_pool2
+          test_tier3_system_tests: true
+          test_compression:
+            configurations:
+              - config-1:
+                  compression_mode: force
+                  compression_algorithm: snappy
+                  compression_required_ratio: 0.3
+                  compression_min_blob_size: 1B
+                  byte_size: 10KB
+              - config-2:
+                  compression_mode: passive
+                  compression_algorithm: zlib
+                  compression_required_ratio: 0.7
+                  compression_min_blob_size: 10B
+                  byte_size: 100KB
+              - config-3:
+                  compression_mode: aggressive
+                  compression_algorithm: zstd
+                  compression_required_ratio: 0.5
+                  compression_min_blob_size: 1KB
+                  byte_size: 100KB
+      desc: Perform tests on EC pools having a RBD Image
+
+# Pool scale down tests commented until fix for 2302230
+  - test:
+      name: Test Online Reads Balancer Read
+      module: test_online_reads_balancer.py
+      desc: Testing Online reads balancer tool via balancer module | read
+      polarion-id: CEPH-83590731
+      config:
+        balancer_mode: read
+        negative_scenarios: true
+        scale_up: true
+        scale_down: false
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_2

--- a/suites/squid/rados/tier-2_rados_test-brownfield_ibm.yaml
+++ b/suites/squid/rados/tier-2_rados_test-brownfield_ibm.yaml
@@ -1,0 +1,323 @@
+# Suite contains tests to be run after upgrade [brownfield deployment]
+# Use cluster-conf file: conf/squid/rados/7-node-cluster.yaml
+# RHOS-d run duration: 100 mins
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                # IBM 7.1 z1
+                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:7-78"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/\
+                  IBM-CEPH-7.1-202407312217.ci.0/IBM-CEPH-7.1-202407312217.ci.0-rhel9.repo"
+                # deploying old build to verify obj snap deletion
+                mon-ip: node1
+                orphan-initial-daemons: true
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: "issue repro-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: setup osd failure due to allocator file corruption
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           issue_reproduction: true
+        pool_config:
+           pool_name: osd-alloc-pool
+           pg_num: 1
+           pg_num_max: 1
+           pool_type: replicated
+      comments: "8.1 bug-2338097"
+
+  - test:
+      name: Upgrade cluster to 7.1z2 ceph version
+      desc: Upgrade cluster to 7.1z2 version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        args:
+          # IBM 7.1 z2
+          custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:7-96"
+          custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/\
+            IBM-CEPH-7.1-202411010109.ci.0/IBM-CEPH-7.1-202411010109.ci.0-rhel9.repo"
+      abort-on-fail: false
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: OSD fails with ceph_assert post upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           check_assert: true
+        pool_config:
+           pool_name: osd-alloc-pool
+
+  - test:
+      name: Upgrade cluster to latest 8.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: "verify fix-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+          verify_fix: true
+
+  - test:
+      name: "verify fix-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
+
+  - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      config:
+        cluster_conf_path: "conf/squid/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: prometheus metadata
+      module: test_brownfield.py
+      desc: Fetch and verify ceph version for various daemons post upgrade
+      polarion-id: CEPH-83581346
+      config:
+       prometheus_metrics:
+         daemons:
+           - mon
+           - osd
+           - mgr
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+#  Uncomment test case once stabilisation is completed
+#  CI stabilisation: https://issues.redhat.com/browse/RHCEPHQE-19549
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade_ibm.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade_ibm.yaml
@@ -1,0 +1,279 @@
+# Suite contains tests related to election strategy and Stretched mode
+# Use cluster-conf file: conf/squid/rados/stretch-mode-host-location-attrs.yaml
+# Stretch mode tests performing upgrade
+
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/squid/rados/deploy-stretch-cluster-mode.yaml
+# RHOS-d run duration: 80 mins
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          # IBM 8 GA
+          custom_image: "cp.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
+          custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+          mon-ip: node1
+          orphan-initial-daemons: true
+          skip-monitoring-stack: true
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+                - node4
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node5
+                - node6
+                - node7
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=tiebreaker
+                  node2:
+                    - datacenter=DC1
+                  node3:
+                    - datacenter=DC1
+                  node5:
+                    - datacenter=DC2
+                  node6:
+                    - datacenter=DC2
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes: node8
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 300
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_older_version_warn: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false


### PR DESCRIPTION
Recently it was observed that the below test suite would fail in the IBM upgrade pipeline as their initial deployment was pointing to RHCS versions and builds.

- `tier-2_rados_ec-pool_recovery.yaml`
- `tier-2_rados_test-brownfield.yaml`
- `tier-2_rados_test-stretch-mode-upgrade.yaml`

This PR adds equivalent test suites that map to similar IBM builds during bootstrap.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>