### PR TITLE
[RADOS] RHCEPHQE-19872: Include additional scenarios in 'Scrubbing with mClock' tests

### DIFF
--- a/tests/rados/test_scrub_deepscrub_timecheck.py
+++ b/tests/rados/test_scrub_deepscrub_timecheck.py
@@ -18,6 +18,10 @@ log = Log(__name__)
 
 def run(ceph_cluster, **kw):
     """
+    # CEPH-83605026
+    Bugzilla tracker:
+    Reef - 2330755
+    Squid - 2292517
     Bug Verfication steps:
     1. Create a replicate pool with single PG
     2. Push the data into the pool
@@ -37,8 +41,6 @@ def run(ceph_cluster, **kw):
     rados_object = RadosOrchestrator(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_object)
     pool_obj = PoolFunctions(node=cephadm)
-    ceph_nodes = kw.get("ceph_nodes")
-    osd_list = []
     # Customer faced the issue with the low "osd_mclock_max_capacity_iops_hdd" values.The same values
     # are picked for the testing.
     mclock_max_capacity_values = ["2.985434", "0.198044", "0.198104"]
@@ -48,13 +50,10 @@ def run(ceph_cluster, **kw):
         method_should_succeed(rados_object.create_pool, **config)
         rados_object.bench_write(pool_name=pool_name, max_objs=75000)
         # Get the OSD list
-        for node in ceph_nodes:
-            if node.role == "osd":
-                node_osds = rados_object.collect_osd_daemon_ids(node)
-                osd_list = osd_list + node_osds
-            log.info(f"The OSDs in the cluster are-{osd_list}")
+        osd_list = rados_object.get_osd_list(status="up")
+        log.info(f"The OSDs in the cluster are-{osd_list}")
 
-            # Get the osd_mclock_max_capacity_iops_hdd values for all OSDs
+        # Get the osd_mclock_max_capacity_iops_hdd values for all OSDs
         for osd_id in osd_list:
             capacity_iops_value = mon_obj.show_config(
                 daemon="osd", id=osd_id, param="osd_mclock_max_capacity_iops_hdd"
@@ -72,6 +71,30 @@ def run(ceph_cluster, **kw):
             "Customer faced the deep-scrub issue when the osd_mclock_max_capacity_iops_hdd was low."
             "For verification setting the acting set OSDs with the low values "
         )
+
+        # perform deep-scrub with default value of osd_mclock_max_capacity_iops_hdd
+        init_pool_pg_dump = rados_object.get_ceph_pg_dump(pg_id=pg_id)
+
+        init_deep_scrub_stamp = datetime.datetime.strptime(
+            init_pool_pg_dump["last_deep_scrub_stamp"], "%Y-%m-%dT%H:%M:%S.%f%z"
+        )
+        log.info(
+            f"The deep scrub time stamp before deep-scrub -{init_deep_scrub_stamp}"
+        )
+        rados_object.run_deep_scrub(pgid=pg_id)
+        scrub_wait_time = 30
+        status, init_scrub_time = is_deep_scrub_complete(
+            rados_object, pg_id, init_deep_scrub_stamp, scrub_wait_time
+        )
+
+        if not status:
+            err_msg = (
+                f"Unable to completed deep-scrub on PG {pg_id} within {scrub_wait_time}"
+            )
+            log.error(err_msg)
+            raise Exception(err_msg)
+
+        time.sleep(10)
         for osd_id, value in zip(acting_set, mclock_max_capacity_values):
             section_id = f"osd.{osd_id}"
             mon_obj.set_config(
@@ -94,16 +117,21 @@ def run(ceph_cluster, **kw):
             f"The deep scrub time stamp before deep-scrub -{init_deep_scrub_stamp}"
         )
         rados_object.run_deep_scrub(pgid=pg_id)
-        # wait for deep-scrub to complete in  40 minutes
-        deep_scrub_time = 40
-        if is_deep_scrub_complete(
-            rados_object, pg_id, init_deep_scrub_stamp, deep_scrub_time
-        ):
+        # wait for deep-scrub to complete in 10 minutes + initial scrub time
+        scrub_wait_time = init_scrub_time + 10
+        status, upd_scrub_time = is_deep_scrub_complete(
+            rados_object, pg_id, init_deep_scrub_stamp, scrub_wait_time
+        )
+        if status:
             log.error(
-                f"Cannot able to reproduce the issue after waiting the {deep_scrub_time} time"
+                f"Unable to reproduce the issue after waiting for {scrub_wait_time} time"
             )
             return 1
         log.info("The bug is reproduced and verifying the bug fix")
+        log.info(
+            "Deep scrub time with default osd_mclock_max_capacity_iops_hdd: "
+            + str(init_scrub_time)
+        )
 
         mon_obj.set_config(
             section="osd",
@@ -128,7 +156,7 @@ def run(ceph_cluster, **kw):
             if float(capacity_iops_value) < 50 or float(capacity_iops_value) > 500:
                 log.error(
                     f"The osd_mclock_max_capacity_iops_hdd parameter value for the osd.{osd_id} is "
-                    f"{capacity_iops_value}. The value range is in between 50 and 500"
+                    f"{capacity_iops_value}. Should lie between 50 and 500"
                 )
                 return 1
             time.sleep(60)
@@ -137,17 +165,37 @@ def run(ceph_cluster, **kw):
         init_deep_scrub_stamp = datetime.datetime.strptime(
             init_pool_pg_dump["last_deep_scrub_stamp"], "%Y-%m-%dT%H:%M:%S.%f%z"
         )
-        deep_scrub_time = 20
+        scrub_wait_time = init_scrub_time + 10
         rados_object.run_deep_scrub(pgid=pg_id)
-        deep_result = is_deep_scrub_complete(
-            rados_object, pg_id, init_deep_scrub_stamp, deep_scrub_time
+        status, final_scrub_time = is_deep_scrub_complete(
+            rados_object, pg_id, init_deep_scrub_stamp, scrub_wait_time
         )
-        if not deep_result:
-            log.error(f"The deep-scrub not completed within {deep_scrub_time} minutes")
+        if not status:
+            log.error("deep-scrub not completed within %s minutes" % scrub_wait_time)
             return 1
         log.info(
-            f"The deep-scrub completed within {deep_scrub_time} and osd_mclock_max_capacity_iops_hdd value is "
-            f"in between 50 and 500.The verification of bug fix is completed "
+            "Deep scrub for PG %s too %s time to complete" % (pg_id, final_scrub_time)
+        )
+        log.info(
+            "Deep scrub time with default osd_mclock_max_capacity_iops_hdd: "
+            + str(init_scrub_time)
+        )
+
+        # As after OSD restart, the osd_mclock_max_capacity_iops_hdd should get restored to
+        # previous default value, it is expected that second round of deep scrub time
+        # with restored values remains within 10% deviation
+        if float(final_scrub_time) > init_scrub_time * 1.1:
+            err_msg = (
+                f"Time taken to Deep scrub PG {pg_id} after reseting osd_mclock_max_capacity_iops_hdd"
+                f" is more than 10% of initial deep scrub time {init_scrub_time}: {final_scrub_time}"
+            )
+            log.error(err_msg)
+            raise Exception(err_msg)
+
+        log.info(
+            "The deep-scrub completed within %s and osd_mclock_max_capacity_iops_hdd value is "
+            "in between 50 and 500. The verification of bug fix is completed"
+            % scrub_wait_time
         )
     except Exception as e:
         log.info(e)
@@ -173,7 +221,7 @@ def run(ceph_cluster, **kw):
 
 
 def is_deep_scrub_complete(rados_object, pg_id, old_deep_scrub_stamp, wait_time):
-
+    deep_scrub_difference = 0
     end_time = datetime.datetime.now() + datetime.timedelta(minutes=wait_time)
     while end_time > datetime.datetime.now():
         init_pool_pg_dump = rados_object.get_ceph_pg_dump(pg_id=pg_id)
@@ -186,7 +234,7 @@ def is_deep_scrub_complete(rados_object, pg_id, old_deep_scrub_stamp, wait_time)
             log.info(
                 f"The deep-scrub operation took -{deep_scrub_difference} time to complete the operation"
             )
-            return True
+            return True, deep_scrub_difference
         time.sleep(40)
         log.info("The deep-scrub is in progress")
-    return False
+    return False, deep_scrub_difference


### PR DESCRIPTION
Follow up PR for #4437 

Adds the following:
- Check to determine time taken to complete deep-scrub with default/unaltered values of `osd_mclock_max_capacity_iops_hdd`
- Uses relative scrub time instead of blind wait to ensure scrubbing is not completed after reducing 
`osd_mclock_max_capacity_iops_hdd`
- Checks if deep-scrub time after restoring `osd_mclock_max_capacity_iops_hdd` is close to original value

Test cases modified:
- `tests/rados/test_scrub_deepscrub_timecheck.py`

Logs:
Squid -
Reef -

Signed-off-by: Harsh Kumar <hakumar@redhat.com>