### PR TITLE
Add owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - veera-raghava-reddy
+  - cephci-admins
+
+reviewers:
+  - ceph-ci-team
+  - ceph-infra-team
+  - ceph-block-team
+  - ceph-rgw-team
+  - ceph-rados-team
+  - ceph-fs-team
+  - ceph-dmfg-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,74 @@
+---
+# Based on the information reference from
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+aliases:
+
+# Complete ownership of the repository
+  cephci-admins:
+    - sunilkumarn417
+    - AmarnatReddy
+    - psathyan
+
+  # Members of Ceph Infra team
+  ceph-infra-team:
+    - krishnaramaswamy
+
+  # members of RBD team
+  ceph-block-team:
+    - Manohar-Murthy
+    - sunilangadi2
+    - manasagowri
+    - rahullepakshi
+    - HaruChebrolu
+    - jprakash-redhat
+    - sunilkumarn417
+    - krishnaramaswamy
+
+  # Members of CI team
+  ceph-ci-team:
+    - pavankumarag
+    - vdas-redhat
+    - vamahaja
+    - obannak
+    - tintumathew10
+    - Adarsha1999
+    - deepssin
+
+  # Members of DMFG
+  ceph-dmfg-team:
+    - vdas-redhat
+    - sayaleeraut
+    - adityaramteke
+    - vinpapnoi
+    - msainiRedhat
+    - MohitBis
+    - pranavprakash20
+
+  # Members of FS
+  ceph-fs-team:
+    - neha-gangadhar
+    - sumabai
+    - hkadam134
+    - Manimaran-MM
+    - AmarnatReddy
+
+  # Members of rados
+  ceph-rados-team:
+    - neha-gangadhar
+    - pdhiran
+    - SrinivasaBharath
+    - harshkumarRH
+    - Divya-78
+    - s-vipin
+
+  # Members of RGW
+  ceph-rgw-team:
+    - mkasturi18
+    - viduship
+    - TejasC88
+    - ckulal
+    - anrao19
+    - hmaheswa
+    - Sohan-Singh
+    - manisha-reddem

--- a/api/OWNERS
+++ b/api/OWNERS
@@ -1,0 +1,18 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - pranavprakash20
+  - vdas-redhat
+
+reviewers:
+  - sayaleeraut
+  - adityaramteke
+  - vinpapnoi
+  - msainiRedhat
+  - MohitBis
+
+labels:
+  - "RESTful API"
+  - DMFG

--- a/ceph/ceph_admin/OWNERS
+++ b/ceph/ceph_admin/OWNERS
@@ -1,0 +1,17 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - ceph-ci-team
+  - pranavprakash20
+
+reviewers:
+  - sayaleeraut
+  - adityaramteke
+  - vinpapnoi
+  - msainiRedhat
+  - MohitBis
+
+labels:
+  - DMFG

--- a/ceph/iscsi/OWNERS
+++ b/ceph/iscsi/OWNERS
@@ -1,0 +1,18 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - Manohar-Murthy
+  - HaruChebrolu
+
+reviewers:
+  - sunilangadi2
+  - manasagowri
+  - rahullepakshi
+  - jprakash-redhat
+  - krishnaramaswamy
+
+labels:
+  - isci
+  - RBD

--- a/ceph/nvmegw_cli/OWNERS
+++ b/ceph/nvmegw_cli/OWNERS
@@ -1,0 +1,18 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - Manohar-Murthy
+  - HaruChebrolu
+
+reviewers:
+  - sunilangadi2
+  - manasagowri
+  - rahullepakshi
+  - jprakash-redhat
+  - krishnaramaswamy
+
+labels:
+  - nvmeof
+  - RBD

--- a/ceph/nvmeof/OWNERS
+++ b/ceph/nvmeof/OWNERS
@@ -1,0 +1,18 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - Manohar-Murthy
+  - HaruChebrolu
+
+reviewers:
+  - sunilangadi2
+  - manasagowri
+  - rahullepakshi
+  - jprakash-redhat
+  - krishnaramaswamy
+
+labels:
+  - nvmeof
+  - RBD

--- a/ceph/rados/OWNERS
+++ b/ceph/rados/OWNERS
@@ -1,0 +1,16 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - neha-gangadhar
+  - pdhiran
+
+reviewers:
+  - SrinivasaBharath
+  - harshkumarRH
+  - Divya-78
+  - s-vipin
+
+labels:
+  - RADOS

--- a/ceph/rbd/OWNERS
+++ b/ceph/rbd/OWNERS
@@ -1,0 +1,17 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - Manohar-Murthy
+  - HaruChebrolu
+
+reviewers:
+  - sunilangadi2
+  - manasagowri
+  - rahullepakshi
+  - jprakash-redhat
+  - krishnaramaswamy
+
+labels:
+  - RBD

--- a/cephci/OWNERS
+++ b/cephci/OWNERS
@@ -1,0 +1,17 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+reviewers:
+  - pavankumarag
+  - vdas-redhat
+  - obannak
+  - Adarsha1999
+  - deepssin
+
+labels:
+  - ceph-ci-review

--- a/cli/OWNERS
+++ b/cli/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/compute/OWNERS
+++ b/compute/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/conf/OWNERS
+++ b/conf/OWNERS
@@ -1,0 +1,11 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - ceph-infra-team
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/conf/inventory/OWNERS
+++ b/conf/inventory/OWNERS
@@ -1,0 +1,9 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - ceph-infra-team
+
+labels:
+  - ceph-ci-review

--- a/pipeline/OWNERS
+++ b/pipeline/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/rest/OWNERS
+++ b/rest/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/suites/OWNERS
+++ b/suites/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/templates/OWNERS
+++ b/templates/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/unittests/OWNERS
+++ b/unittests/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review

--- a/utility/OWNERS
+++ b/utility/OWNERS
@@ -1,0 +1,10 @@
+---
+# Based on the information found 
+# https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+approvers:
+  - vamahaja
+  - tintumathew10
+
+labels:
+  - ceph-ci-review


### PR DESCRIPTION
# Description

As part of this commit, `owners` file has been added to most top level directories. This file allows Prow to control checkins and reviews.

With mergify reliability wavering in past few weeks, moving to RH provided Prow would be a good choice.

- [x] Review the automation design
