### PR TITLE
[TFA] skip elapsed_time in test case Bluefs DB utilization and Osd Compaction based on release

### DIFF
--- a/suites/squid/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/squid/rados/tier-2_rados_test_bluestore.yaml
@@ -177,8 +177,11 @@ tests:
       config:
         scenarios_to_run:
           - scenario-1
-          - scenario-2
-          - scenario-3
+          # To be uncommented after behaviour is clarified
+          # by dev. Task to uncomment
+          # https://issues.redhat.com/browse/RHCEPHQE-20207
+          # - scenario-2
+          # - scenario-3
           - scenario-4
 
   - test:

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -351,8 +351,9 @@ tests:
         netsplit_site: DC1
         tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
+        set_debug: true
       desc: Test stretch Cluster netsplit scenario between data sites
-      comments: Active bug with netsplit scenarios - 2318975
+      comments: Intermittent Active bug with netsplit scenarios - 2318975
 
   - test:
       name: Netsplit Scenarios data-tiebreaker sites
@@ -363,7 +364,6 @@ tests:
         netsplit_site: tiebreaker
         tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-        set_debug: true
       desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:

--- a/tests/rados/test_bluefs_space.py
+++ b/tests/rados/test_bluefs_space.py
@@ -38,6 +38,7 @@ def run(ceph_cluster, **kw):
     bluestore_obj = BluestoreToolWorkflows(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
     omap_config = config["omap_config"]
+    rhbuild = config.get("rhbuild")
 
     log.info("Running test case to verify bluefs space utilization is under control")
 
@@ -114,7 +115,11 @@ def run(ceph_cluster, **kw):
             args=[f"ceph tell osd.{primary_osd} compact"], timeout=1200
         )
         log.info(out)
-        assert "elapsed_time" in out, "OSD Compaction output not as expected"
+
+        # "ceph tell osd.1 compact" does not print elapsed_time
+        # in 8.1. BZ https://bugzilla.redhat.com/show_bug.cgi?id=2351352
+        if float(rhbuild.split("-")[0]) < 8.1:
+            assert "elapsed_time" in out, "OSD Compaction output not as expected"
         time.sleep(5)
 
         # log ceph tell osd.# perf dump bluefs

--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -191,7 +191,7 @@ def run(ceph_cluster, **kw):
 
         # "ceph tell osd.1 compact" does not print elapsed_time
         # in 8.1. BZ https://bugzilla.redhat.com/show_bug.cgi?id=2351352
-        if rhbuild.split("-")[0] != "8.1":
+        if float(rhbuild.split("-")[0]) < 8.1:
             assert "elapsed_time" in out
         time.sleep(10)
 
@@ -229,7 +229,7 @@ def run(ceph_cluster, **kw):
 
         # "ceph tell osd.1 compact" does not print elapsed_time
         # in 8.1. BZ https://bugzilla.redhat.com/show_bug.cgi?id=2351352
-        if rhbuild.split("-")[0] != "8.1":
+        if float(rhbuild.split("-")[0]) < 8.1:
             assert "elapsed_time" in out
         time.sleep(10)
 


### PR DESCRIPTION
TFA fix addresses below:- 
1) skip elapsed_time in test case Bluefs DB utilization and Osd Compaction based on release 
Squid Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_cot_25_05_30_12_04_08/ 

2) Adds debug_true for **Netsplit Scenarios data-data sites** and updates comment with intermittent bug

3) Comments bluestore compression scenarios until the tests are clarified by dev:- 
Task to uncomment - https://issues.redhat.com/browse/RHCEPHQE-20207

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
