### PR TITLE
Specify cluster site to be used in case of multisite setup

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -357,10 +357,14 @@ tests:
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
+
   - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw_multisite.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -382,7 +386,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_object_versioninig_enabled.yaml
       desc: test_sse_s3_per_object_with_versioning


### PR DESCRIPTION
# Description

[TFA]:  while analyzing the failure 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-334/rgw/70/tier-2_rgw_ms_async_data_notification/sse_s3_per_bucket_enc_multipart_upload_0.log

its found that in the multisite setup, there were no mention of cluster site to be used for  testcase execution.

hence same testcase was executing twice on both the sites.

In that case intermittently we were seeing, BucketNotEmpty error when test case executed from secondary site.
when tried manually via boto script no issue seen.
also automation run was also got passed in couple of instances.

currently keeping execution bind to primary site.
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-OITC2Y/sse_s3_per_bucket_enc_multipart_upload_0.log


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
