### PR TITLE
[RBD] Removed intermittent tests

### DIFF
--- a/suites/quincy/rbd/tier-1_rbd.yaml
+++ b/suites/quincy/rbd/tier-1_rbd.yaml
@@ -113,15 +113,6 @@ tests:
       module: test_rbd.py
       name: 2_rbd_cli_import_export
       polarion-id: CEPH-83574240
-  -
-    test:
-      config:
-        script: cli_migration.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD CLI Migration scenarios"
-      module: test_rbd.py
-      name: 4_rbd_cli_migration
-      polarion-id: CEPH-83574243
   - test:
       config:
         script_path: qa/workunits/rbd

--- a/suites/quincy/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/quincy/rbd/tier-1_rbd_mirror.yaml
@@ -184,16 +184,6 @@ tests:
       polarion-id: CEPH-83573619,CEPH-83573620
       desc: Create RBD mirrored images and run IOs
   - test:
-      name: test_rbd_mirror_rename_image
-      module: test_rbd_mirror_rename_image.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-83573614
-      desc: Rename primary image and check on secondary for this change
-  - test:
       name: test_rbd_mirror_daemon_status
       module: test_rbd_mirror_daemon_status.py
       clusters:

--- a/suites/reef/rbd/tier-1_rbd.yaml
+++ b/suites/reef/rbd/tier-1_rbd.yaml
@@ -123,15 +123,6 @@ tests:
       module: test_rbd.py
       name: 2_rbd_cli_import_export
       polarion-id: CEPH-83574240
-  -
-    test:
-      config:
-        script: cli_migration.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD CLI Migration scenarios"
-      module: test_rbd.py
-      name: 4_rbd_cli_migration
-      polarion-id: CEPH-83574243
   - test:
       config:
         script_path: qa/workunits/rbd

--- a/suites/reef/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/reef/rbd/tier-1_rbd_mirror.yaml
@@ -184,16 +184,6 @@ tests:
       polarion-id: CEPH-83573619,CEPH-83573620
       desc: Create RBD mirrored images and run IOs
   - test:
-      name: test_rbd_mirror_rename_image
-      module: test_rbd_mirror_rename_image.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-83573614
-      desc: Rename primary image and check on secondary for this change
-  - test:
       name: test_rbd_mirror_daemon_status
       module: test_rbd_mirror_daemon_status.py
       clusters:

--- a/suites/squid/rbd/tier-1_rbd.yaml
+++ b/suites/squid/rbd/tier-1_rbd.yaml
@@ -123,15 +123,7 @@ tests:
       module: test_rbd.py
       name: 2_rbd_cli_import_export
       polarion-id: CEPH-83574240
-  -
-    test:
-      config:
-        script: cli_migration.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD CLI Migration scenarios"
-      module: test_rbd.py
-      name: 4_rbd_cli_migration
-      polarion-id: CEPH-83574243
+
   - test:
       config:
         script_path: qa/workunits/rbd

--- a/suites/squid/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/squid/rbd/tier-1_rbd_mirror.yaml
@@ -184,16 +184,6 @@ tests:
       polarion-id: CEPH-83573619,CEPH-83573620
       desc: Create RBD mirrored images and run IOs
   - test:
-      name: test_rbd_mirror_rename_image
-      module: test_rbd_mirror_rename_image.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-83573614
-      desc: Rename primary image and check on secondary for this change
-  - test:
       name: test_rbd_mirror_daemon_status
       module: test_rbd_mirror_daemon_status.py
       clusters:


### PR DESCRIPTION
# Description
In RBD sanity below tests are inconsistent due to timeout issue, also these tests are part of regression 
hence removed these tests to make RBD sanity stable 

> 4_rbd_cli_migration
> test_rbd_mirror_rename_image

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
