### PR TITLE
Addition of RADOS suite & conf files in tentacle folder

### DIFF
--- a/conf/tentacle/rados/11-node-cluster.yaml
+++ b/conf/tentacle/rados/11-node-cluster.yaml
@@ -1,0 +1,83 @@
+# Rados tier-2 test configuration
+# Deployment for all the ceph daemons , with 5 mon's, 3 mgr's, and 20 OSD daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - alertmanager
+          - crash
+          - nfs
+      node3:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node6:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - crash
+          - nfs
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - mon
+          - rgw
+          - node-exporter
+          - crash
+      node9:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node10:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node11:
+        role:
+          - mon
+          - rgw
+          - node-exporter
+          - crash

--- a/conf/tentacle/rados/11-node-replica1-cluster.yaml
+++ b/conf/tentacle/rados/11-node-replica1-cluster.yaml
@@ -1,0 +1,84 @@
+# Rados test configuration for replica-1 pool
+# Deployment for all the ceph daemons , with 5 mon's, 3 mgr's, and 6 OSD daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - alertmanager
+          - crash
+      node3:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 15
+      node6:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - crash
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - mon
+          - rgw
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 15
+      node9:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 15
+      node10:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 15
+      node11:
+        role:
+          - mon
+          - rgw
+          - node-exporter
+          - crash

--- a/conf/tentacle/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/tentacle/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -1,0 +1,139 @@
+# Test Suite to test CIDR blocklisting of clients + every other generic rados test suite
+# Deployment for all the ceph daemons , with 5 mon's, 5 mgr's, 36 OSD daemons & 4 Client nodes
+# 12 x OSD hosts: 10 standard, 2 backup
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_15
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        networks:
+          - provider_net_cci_15
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        networks:
+          - provider_net_cci_15
+        role:
+          - mon
+          - mgr
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        networks:
+          - provider_net_cci_16
+        role:
+          - client
+      node8:
+        networks:
+          - provider_net_cci_15
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+          - mon
+          - mgr
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node11:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node12:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node13:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node14:
+        networks:
+          - provider_net_cci_15
+        role:
+          - rgw
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node15:
+        networks:
+          - provider_net_cci_16
+        role:
+          - client
+      node16:
+        networks:
+          - provider_net_cci_13
+        role:
+          - client
+      node17:
+        networks:
+          - provider_net_cci_13
+        role:
+          - client

--- a/conf/tentacle/rados/13-node-cluster-4-clients.yaml
+++ b/conf/tentacle/rados/13-node-cluster-4-clients.yaml
@@ -1,0 +1,139 @@
+# Test Suite to test CIDR blocklisting of clients + every other generic rados test suite
+# Deployment for all the ceph daemons , with 5 mon's, 5 mgr's, 36 OSD daemons & 4 Client nodes
+# 12 x OSD hosts: 10 standard, 2 backup
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - shared_net_15
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        networks:
+          - shared_net_15
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        networks:
+          - shared_net_15
+        role:
+          - mon
+          - mgr
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        networks:
+          - shared_net_2
+        role:
+          - client
+      node8:
+        networks:
+          - shared_net_15
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+          - mon
+          - mgr
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node11:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node12:
+        networks:
+          - shared_net_15
+        role:
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node13:
+        networks:
+          - shared_net_15
+        role:
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node14:
+        networks:
+          - shared_net_15
+        role:
+          - rgw
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node15:
+        networks:
+          - shared_net_2
+        role:
+          - client
+      node16:
+        networks:
+          - shared_net_5
+        role:
+          - client
+      node17:
+        networks:
+          - shared_net_5
+        role:
+          - client

--- a/conf/tentacle/rados/13-node-cluster.yaml
+++ b/conf/tentacle/rados/13-node-cluster.yaml
@@ -1,0 +1,86 @@
+# Rados tier-4 test configuration
+# Used for testing pools with OSD addition, deletion , start, stop & restart.
+# Suite also contains spare OSD hosts with label "osd-bak" for OSD deployment as required
+# Contains 12 RHCS Cluster hosts and 1 RHCS Client.
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - nfs
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - mon
+          - mgr
+          - mds
+          - nfs
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - mon
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node11:
+        role:
+          - mon
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node12:
+        role:
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node13:
+        role:
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15

--- a/conf/tentacle/rados/3AZ-cluster-rhos-1.yaml
+++ b/conf/tentacle/rados/3AZ-cluster-rhos-1.yaml
@@ -1,0 +1,106 @@
+# Test Suite that deploys 3 AZs in different subnets
+# Deployment for all the ceph daemons , with 9 mon's, 6 mgr's, 28 OSD daemons
+
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - shared_net_15
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node2:
+        networks:
+          - shared_net_15
+        role:
+          - mon
+          - mgr
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        networks:
+          - shared_net_15
+        role:
+          - osd
+          - mon
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        networks:
+          - shared_net_2
+        role:
+          - _admin
+          - mon
+          - mgr
+          - osd
+          - alertmanager
+          - grafana
+          - prometheus
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        networks:
+          - shared_net_2
+        role:
+          - mon
+          - mgr
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        networks:
+          - shared_net_2
+        role:
+          - osd
+          - mon
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        networks:
+          - shared_net_5
+        role:
+          - _admin
+          - mon
+          - mgr
+          - osd
+          - alertmanager
+          - grafana
+          - prometheus
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        networks:
+          - shared_net_5
+        role:
+          - mon
+          - mgr
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        networks:
+          - shared_net_5
+        role:
+          - osd
+          - mon
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        role:
+          - client

--- a/conf/tentacle/rados/3AZ-cluster-rhos-d.yaml
+++ b/conf/tentacle/rados/3AZ-cluster-rhos-d.yaml
@@ -1,0 +1,106 @@
+# Test Suite that deploys 3 AZs in different subnets
+# Deployment for all the ceph daemons , with 9 mon's, 6 mgr's, 28 OSD daemons
+
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_15
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node2:
+        networks:
+          - provider_net_cci_15
+        role:
+          - mon
+          - mgr
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        networks:
+          - provider_net_cci_15
+        role:
+          - osd
+          - mon
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        networks:
+          - provider_net_cci_13
+        role:
+          - _admin
+          - mon
+          - mgr
+          - osd
+          - alertmanager
+          - grafana
+          - prometheus
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        networks:
+          - provider_net_cci_13
+        role:
+          - mon
+          - mgr
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        networks:
+          - provider_net_cci_13
+        role:
+          - osd
+          - mon
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        networks:
+          - provider_net_cci_16
+        role:
+          - _admin
+          - mon
+          - mgr
+          - osd
+          - alertmanager
+          - grafana
+          - prometheus
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        networks:
+          - provider_net_cci_16
+        role:
+          - mon
+          - mgr
+          - rgw
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        networks:
+          - provider_net_cci_16
+        role:
+          - osd
+          - mon
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        role:
+          - client

--- a/conf/tentacle/rados/4-node-ec-cluster-1-client.yaml
+++ b/conf/tentacle/rados/4-node-ec-cluster-1-client.yaml
@@ -1,0 +1,53 @@
+# Test Suite to test EC 8+6 MSR pool on 4 nodes
+# Deployment for all the ceph daemons , with 3 mon, 3 mgr, 24 OSD, 3 MDS, 3 RGW daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+          role:
+            - _admin
+            - installer
+            - osd
+            - mon
+            - mgr
+            - rgw
+          no-of-volumes: 6
+          disk-size: 15
+      node2:
+          role:
+            - mgr
+            - rgw
+            - mon
+            - osd
+            - mds
+            - _admin
+          no-of-volumes: 6
+          disk-size: 15
+      node3:
+          role:
+            - mds
+            - mon
+            - mgr
+            - osd
+          no-of-volumes: 6
+          disk-size: 15
+      node4:
+          role:
+            - osd
+            - rgw
+            - mds
+            - node-exporter
+            - alertmanager
+            - grafana
+            - prometheus
+          no-of-volumes: 6
+          disk-size: 15
+      node5:
+        role:
+          - _admin
+          - osd-bak
+        no-of-volumes: 6
+        disk-size: 15
+      node6:
+        role:
+          - client

--- a/conf/tentacle/rados/7-node-cluster.yaml
+++ b/conf/tentacle/rados/7-node-cluster.yaml
@@ -1,0 +1,59 @@
+# Rados tier-2 test configuration, small test config for basic tests
+# Deployment for all the ceph daemons , with 3 mon's, 3 mgr's, and 15 OSD daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - nfs
+          - rgw
+          - node-exporter
+          - alertmanager
+          - crash
+      node3:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 5
+        disk-size: 25
+      node4:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 5
+        disk-size: 25
+      node5:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 5
+        disk-size: 25
+      node6:
+        role:
+          - mon
+          - mgr
+          - mds
+          - nfs
+          - rgw
+          - node-exporter
+          - crash
+      node7:
+        role:
+          - client

--- a/conf/tentacle/rados/7node-1client-stretch-mode-rhos-d.yaml
+++ b/conf/tentacle/rados/7node-1client-stretch-mode-rhos-d.yaml
@@ -1,0 +1,92 @@
+# Test Suite for deploying and testing Stretch mode.
+
+# Example of the cluster taken from the MDR deployment guide for ODF.
+# ref: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/
+# configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/metro-dr-solution#hardware_requirements
+
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_16
+        role:
+          - _admin
+          - installer
+          - mon
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        networks:
+          - provider_net_cci_15
+        role:
+          - mon
+          - mgr
+          - _admin
+          - osd
+          - osd-bak
+          - alertmanager
+          - grafana
+          - prometheus
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        networks:
+          - provider_net_cci_15
+        role:
+          - mon
+          - mgr
+          - nfs
+          - osd
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        networks:
+          - provider_net_cci_15
+        role:
+          - rgw
+          - osd
+          - mds
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        networks:
+          - provider_net_cci_13
+        role:
+          - mon
+          - _admin
+          - mgr
+          - osd
+          - osd-bak
+          - alertmanager
+          - grafana
+          - prometheus
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        networks:
+          - provider_net_cci_13
+        role:
+          - mon
+          - mgr
+          - osd
+          - nfs
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        networks:
+          - provider_net_cci_13
+        role:
+          - osd
+          - rgw
+          - mds
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role:
+          - client

--- a/conf/tentacle/rados/depressa-cluster.yaml
+++ b/conf/tentacle/rados/depressa-cluster.yaml
@@ -1,0 +1,128 @@
+# 7 node cluster with 1 client
+# baremetal config for depressa Octo lab machines
+---
+globals:
+  - ceph-cluster:
+      name: ceph-depressa
+      networks:
+        public:
+          - 10.1.172.0/23
+        cluster:
+          - 172.20.0.0/16
+      nodes:
+        - hostname: depressa002
+          id: node1
+          ip: 10.1.172.202
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - rgw
+            - osd
+            - node-exporter
+            - alertmanager
+            - grafana
+            - prometheus
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa003
+          id: node2
+          ip: 10.1.172.203
+          root_password: passwd
+          role:
+            - _admin
+            - mon
+            - mgr
+            - rgw
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+
+        - hostname: depressa004
+          id: node3
+          ip: 10.1.172.204
+          root_password: passwd
+          role:
+            - _admin
+            - mon
+            - mgr
+            - osd
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa005
+          id: node4
+          ip: 10.1.172.205
+          root_password: passwd
+          role:
+            - _admin
+            - mds
+            - rgw
+            - osd
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa006
+          id: node5
+          ip: 10.1.172.206
+          root_password: passwd
+          role:
+            - nfs
+            - rgw
+            - osd
+            - node-exporter
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa011
+          id: node6
+          ip: 10.1.172.211
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+            - crash
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa012
+          id: node7
+          ip: 10.1.172.212
+          root_password: passwd
+          role:
+            - osd
+            - rgw
+            - client
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1

--- a/conf/tentacle/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/tentacle/rados/stretch-mode-host-location-attrs.yaml
@@ -1,0 +1,77 @@
+# Test Suite for deploying and testing Stretch mode.
+
+# Example of the cluster taken from the MDR deployment guide for ODF.
+# ref: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/
+# configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/metro-dr-solution#hardware_requirements
+
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+# Keeping the mgr daemon in the tiebreaker node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+          - mgr
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        role:
+          - mon
+          - mgr
+          - _admin
+          - osd
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - mon
+          - mgr
+          - nfs
+          - osd
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - rgw
+          - osd
+          - mds
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - mon
+          - _admin
+          - mgr
+          - osd
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - mon
+          - mgr
+          - osd
+          - nfs
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - osd
+          - rgw
+          - mds
+          - osd-bak
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+#        image-name:
+#          openstack: RHEL-9.4.0-x86_64-ga-latest
+#          ibmc: rhel-91-server-released
+        role:
+          - client

--- a/conf/tentacle/rados/test-confs/cluster-configs
+++ b/conf/tentacle/rados/test-confs/cluster-configs
@@ -1,0 +1,13 @@
+
+[mon]
+mon_cluster_log_to_syslog = true
+
+[osd]
+debug_osd = 5/5
+
+[mgr]
+mgr_stats_period = 10
+debug_mgr = 5/5
+
+[mds]
+mds_op_history_size = 40

--- a/conf/tentacle/rados/test-confs/pool-configurations.yaml
+++ b/conf/tentacle/rados/test-confs/pool-configurations.yaml
@@ -1,0 +1,61 @@
+# yaml containing the configurations for pools
+replicated:
+  sample-pool-1:
+    pool_type: replicated
+    pool_name: re_pool_10
+  sample-pool-2:
+    pool_type: replicated
+    pool_name: re_pool_20
+    pg_num: 32
+  sample-pool-3:
+    pool_type: replicated
+    pool_name: re_pool_30
+    pg_num: 128
+erasure:
+  sample-pool-1:
+    pool_name: ec_pool_10
+    pool_type: erasure
+    k: 4
+    m: 3
+    crush-failure-domain: host
+  sample-pool-2:
+    pool_name: ec_pool_20
+    pool_type: erasure
+    k: 4
+    m: 2
+    crush-failure-domain: host
+  sample-pool-3:
+    profile_name: ec86_profile
+    pool_name: ec86_msr_pool
+    pool_type: erasure
+    k: 8
+    m: 6
+    create_rule: false
+    crush-osds-per-failure-domain: 4
+    crush-num-failure-domains: 4
+    plugin: jerasure
+    crush-failure-domain: host
+  sample-pool-4:
+    profile_name: ec86_profile1
+    pool_name: ec86_msr_pool1
+    pool_type: erasure
+    k: 8
+    m: 6
+    create_rule: false
+    crush-osds-per-failure-domain: 4
+    crush-num-failure-domains: 4
+    plugin: jerasure
+    crush-failure-domain: host
+  sample-pool-5:
+    pool_name: ec_pool_22
+    pool_type: erasure
+    k: 2
+    m: 2
+    plugin: jerasure
+    crush-failure-domain: host
+  sample-pool-6:
+    pool_name: ec_pool_22_1
+    pool_type: erasure
+    k: 2
+    m: 2
+    crush-failure-domain: host

--- a/conf/tentacle/rados/test-confs/rados_config_parameters.ini
+++ b/conf/tentacle/rados/test-confs/rados_config_parameters.ini
@@ -1,0 +1,41 @@
+#MSG version 2 parameters
+[MSGRV2]
+   ms_compress_secure = false
+   ms_osd_compress_mode = none
+   ms_osd_compress_min_size = 1024
+   ms_osd_compression_algorithm = snappy
+
+# Mclock parameters  check
+[Mclock_sleep]
+    osd_recovery_sleep = 0.000000
+    osd_recovery_sleep_hdd = 0.000000
+    osd_recovery_sleep_ssd = 0.000000
+    osd_recovery_sleep_hybrid = 0.000000
+    osd_scrub_sleep = 0.000000
+    osd_delete_sleep = 0.000000
+    osd_delete_sleep_hdd = 0.000000
+    osd_delete_sleep_ssd = 0.000000
+    osd_delete_sleep_hybrid = 0.000000
+    osd_snap_trim_sleep = 0.000000
+    osd_snap_trim_sleep_hdd = 0.000000
+    osd_snap_trim_sleep_ssd = 0.000000
+    osd_snap_trim_sleep_hybrid = 0.000000
+
+#Check the default values in the mclock
+[Mclock_default]
+    osd_max_backfills = 1
+    osd_recovery_max_active = 0
+    osd_recovery_max_active_hdd = 3
+    osd_recovery_max_active_ssd = 10
+
+# Mclock paramter setting check
+[Mclock_paramert_set]
+   osd_mclock_scheduler_client_res = .1
+   osd_mclock_scheduler_client_wgt = 1
+   osd_mclock_scheduler_client_lim = .1
+   osd_mclock_scheduler_background_recovery_res = .1
+   osd_mclock_scheduler_background_recovery_wgt = 1
+   osd_mclock_scheduler_background_recovery_lim = .1
+   osd_mclock_scheduler_background_best_effort_res = .1
+   osd_mclock_scheduler_background_best_effort_wgt = 1
+   osd_mclock_scheduler_background_best_effort_lim = .1

--- a/suites/tentacle/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/tentacle/rados/deploy-stretch-cluster-mode.yaml
@@ -1,0 +1,196 @@
+# Suite is to be used to deploy Stretched mode on the given set of nodes
+# Some keys need to be replaced in the suite
+# 1. In Test: "cluster deployment" -> Modify config for
+#       - "mon-ip" param in cephadm bootstrap section # shortname of the bootstrap mon host
+#
+# 2. In Test: "OSD deployment" -> Modify config for
+#				placement:
+#                    nodes:
+#                      - <host1-shortname>            # shortname of the OSD host1
+#                      - <host2-shortname>            # shortname of the OSD host2
+#					   - ...                          # shortname of the OSD host-n
+#
+# 3. In Test: "Configure client admin" -> Modify config for
+#       - "nodes" param in client section             # shortname of the Client host
+#
+# 1. In Test: "Deploy stretch Cluster" -> Modify config for
+#       - stretch_rule_name: "stretch_rule"         # Name of the crush rule with which stretched mode would be deployed
+#       - site1:
+#              name: "DC1"                           # Name of the datacenter-1 to be added in crush map
+#              hosts: ["<host1-shortname>", ... ]    # List of hostnames present in datacenter-1
+#       - site2:
+#              name: "DC2"                           # Name of the datacenter-2 to be added in crush map
+#              hosts: ["<host3-shortname>", ... ]    # List of hostnames present in datacenter-2
+#       - site3:
+#              name: "DC3"                           # Name of the tiebreaker location to be added in crush map
+#              hosts: ["<host5-shortname>"]          # List of hostname present in tiebreaker
+# Added to BM pipeline
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: mero001
+                orphan-initial-daemons: true
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: stretch_osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    nodes:
+                      - mero005
+                      - mero007
+                      - mero009
+                      - mero011
+                      - mero013
+                      - mero014
+                      - mero017
+                      - mero018
+                      - mero019
+                      - mero020
+                  spec:
+                    data_devices:
+                      paths:
+                        - /dev/sdc
+                        - /dev/sdd
+                        - /dev/sde
+                        - /dev/sdf
+                        - /dev/sdg
+                        - /dev/sdh
+                    db_devices:
+                      paths:
+                        - /dev/nvme0n1
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure clients
+      desc: Configures multiple client nodes on cluster
+      module: test_parallel.py
+      parallel:
+        - test:
+            name: Configure client 1
+            desc: Configures client.1 admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.1                      # client Id (<type>.<Id>)
+              nodes:
+                  - node10:
+                      release: 7
+                  - node11:
+                      release: 7
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+
+  - test:
+      name: Deploy stretch Cluster
+      module: test_deploy_stretch_cluster_baremetal.py
+      polarion-id: CEPH-83573621
+      config:
+        stretch_rule_name: "stretch_rule"
+        site1:
+          name: "DC1"
+          hosts: ["mero001"]
+        site2:
+          name: "DC2"
+          hosts: ["mero003", "mero004", "mero013", "mero011", "mero009", "mero007", "mero005" ]
+        site3:
+          name: "DC3"
+          hosts: ["mero017", "mero018", "mero014", "mero019", "mero020"]
+      desc: Enables connectivity mode, deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true

--- a/suites/tentacle/rados/mero_4_node_rados_db_wal_conf.yaml
+++ b/suites/tentacle/rados/mero_4_node_rados_db_wal_conf.yaml
@@ -1,0 +1,185 @@
+# Suite contains  tier-2 rados tests which adds DB and wal to the OSD
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#-----      Tier-2 Add DB & Wal LVM path to the existing OSD                         ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/baremetal/mero_4_node_4_client_conf.yaml
+#
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_hdd
+                  placement:
+                    host_pattern: '*'
+                  spec:
+                    data_devices:
+                      rotational: 1
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - cephadm
+        node: node4
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      name: DB and WAL configuration
+      desc: Add DB and WAL to the existing OSD
+      module: test_osd_db_wal_configuration.py
+      polarion-id: CEPH-83574885
+      abort-on-fail: true
+  -
+    test:
+      name:  Testing bluestore
+      desc: Testing bluestore pinned
+      module: test_bluestore_features.py
+      polarion-id: CEPH-83575438
+      config:
+          execution-time: 30
+          cache_trim_max_skip_pinned:
+            configurations:
+               pool-1:
+                 pool_type: replicated
+                 pool_name: blustore_pinned
+                 pg_num: 64
+                 pg_num_min: 32
+                 max_objs: 300
+                 rados_read_duration: 10
+                 byte_size: 64MB
+               pool-2:
+                 pool_name: bluestore_ec_pool
+                 pool_type: erasure
+                 pg_num: 32
+                 k: 8
+                 m: 4
+                 plugin: jerasure
+                 max_objs: 300
+                 rados_read_duration: 10
+          desc: Verification of the bluestore pinned tests

--- a/suites/tentacle/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/tentacle/rados/tier-2-rados-basic-regression.yaml
@@ -1,0 +1,447 @@
+# Suite contains basic tier-2 rados tests
+# RHOS-d run duration: 70 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Configure email alerts
+      module: rados_prep.py
+      polarion-id: CEPH-83574472
+      config:
+        email_alerts:
+          smtp_host: smtp.corp.redhat.com
+          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
+          smtp_port: 25
+          interval: 10
+          smtp_destination:
+            - pdhiran@redhat.com
+          smtp_from_name: Rados Sanity Cluster Alerts
+      desc: Configure email alerts on ceph cluster
+
+# RHOS-d run duration: 2 mins
+# env: VM + BM
+  - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      comments: RFE - 2277761
+      config:
+        cluster_conf_path: "conf/tentacle/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+# RHOS-d run duration: 6 mins
+# env: VM only
+  - test:
+      name: Verify osd heartbeat no reply
+      desc: heartbeat_check log entries should contain hostname:port
+      polarion-id: CEPH-10839
+      module: test_osd_heartbeat.py
+      destroy-cluster: false
+
+# RHOS-d run duration: 6 mins
+# env: VM only
+  - test:
+      name: Monitor configuration - section and masks changes
+      module: rados_prep.py
+      polarion-id: CEPH-83573477
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "osd"
+                name: "osd_max_backfills"
+                value: "8"
+                location_type: "class"
+                location_value: "hdd"
+            - config-2:
+                section: "osd"
+                name: "osd_recovery_max_active"
+                value: "8"
+                location_type: "host"
+                location_value: "host"
+            - config-3:
+                section: "global"
+                name: "debug_mgr"
+                value: "10/10"
+            - config-4:
+                section: "osd"
+                name: "osd_max_scrubs"
+                value: "5"
+            - config-5:
+                section: "osd.1"
+                name: "osd_max_scrubs"
+                value: "3"
+            - config-6:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+            - config-7:
+                section: "client.rgw"
+                name: "rgw_lc_debug_interval"
+                value: "1"
+            - config-8:
+                section: "global"
+                name: "debug_mgr"
+                value: "10/10"
+            - config-9:
+                section: "osd.2"
+                name: "debug_ms"
+                value: "10/10"
+      desc: Verify config changes for section & masks like device class, host etc
+
+# RHOS-d run duration: 4 mins
+# env: VM + BM
+  - test:
+      name: Monitor configuration - msgrv2 compression modes
+      module: rados_prep.py
+      polarion-id: CEPH-83574961
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "force"
+            - config-2:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "512"
+            - config-3:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "none"
+            - config-4:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "1024"
+      desc: Verify the health status of the cluster by randomly changing the compression configuration values
+
+# RHOS-d run duration: 3 mins
+# env: VM + BM
+  - test:
+      name: Replicated pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        replicated_pool:
+          create: true
+          pool_name: test_re_pool
+          pg_num: 16
+          size: 2
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_re_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: aggressive
+            compression_algorithm: zlib
+        delete_pools:
+          - test_re_pool
+      desc: Create replicated pools and run IO
+
+# RHOS-d run duration: 8 mins
+# env: VM + BM
+  - test:
+      name: Compression algorithms
+      module: rados_prep.py
+      polarion-id: CEPH-83571669
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 300
+          rados_read_duration: 10
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+        delete_pools:
+          - re_pool_compress
+      desc: Enable/disable different compression algorithms.
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Ceph balancer plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83573247
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: crush-compat
+          target_max_misplaced_ratio: 0.04
+          sleep_interval: 30
+      desc: Ceph balancer plugins CLI validation in crush-compat mode
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Ceph balancer test
+      module: rados_prep.py
+      polarion-id: CEPH-83573251
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: upmap
+          target_max_misplaced_ratio: 0.05
+          sleep_interval: 60
+      desc: Ceph balancer plugins CLI validation in upmap mode
+
+# RHOS-d run duration: 3 mins
+# env: VM + BM
+  - test:
+      name: Ceph PG Autoscaler
+      module: rados_prep.py
+      polarion-id: CEPH-83573412
+      config:
+        replicated_pool:
+          create: true
+          pool_name: rep_test_pool
+          max_objs: 300
+          rados_read_duration: 10
+          pg_num: 32
+        configure_pg_autoscaler:
+          default_mode: warn
+          mon_target_pg_per_osd: 128
+          pool_config:
+            pool_name: rep_test_pool
+            pg_autoscale_mode: "on"
+            pg_num_min: 16
+            target_size_ratio: 0.4
+        delete_pools:
+          - rep_test_pool
+      desc: Ceph PG autoscaler CLI validation
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Config checks
+      module: rados_prep.py
+      polarion-id: CEPH-83574529
+      config:
+        cluster_configuration_checks:
+          configure: true
+          disable_check_list:
+            - osd_mtu_size
+            - osd_linkspeed
+            - kernel_security
+          enable_check_list:
+            - kernel_security
+            - osd_linkspeed
+      desc: Enable Cluster Configuration checks
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: config source changes log
+      module: test_mon_config_history.py
+      polarion-id: CEPH-83573479
+      desc: Config sources - Verify config source changes in the log
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: config source changes reset
+      module: test_mon_config_reset.py
+      polarion-id: CEPH-83573478
+      desc: Config sources - Verify config source changes and reset config
+
+# RHOS-d run duration: 8 mins
+  - test:
+      name: autoscaler flags
+      module: test_pg_autoscale_flag.py
+      polarion-id: CEPH-83574794
+      config:
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+        create_ec_pool: true
+        create_re_pool: true
+      desc: verify autoscaler flags functionality
+      comments: active bug 2361441
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Mon election strategies
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      desc: Change Mon election strategies and verify status
+
+# RHOS-d run duration: 6 min
+# env: VM + BM
+  - test:
+      name: EC Profile tests
+      module: pool_tests.py
+      polarion-id: CEPH-83596295
+      config:
+        Verify_ec_profile:
+          name: test
+          profile_name: test_profile
+          pool_name: ec_profile_test
+          k: 2
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          crush-failure-domain: host
+      desc: Verify the behaviour of EC profiles in ceph
+
+# RHOS-d run duration: 8 mins
+  - test:
+      name: MGR regression test
+      module: test_mgr_daemon.py
+      polarion-id: CEPH-83586116
+      desc: MGR regression testing
+

--- a/suites/tentacle/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
+++ b/suites/tentacle/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
@@ -1,0 +1,167 @@
+# Suite contains  tier-2 rados tests which adds DB and wal to the OSD
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#-----      Tier-2- Using bluestore-tool add DB & Wal  to the existing OSD          ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/baremetal/mero_4_node_4_client_conf.yaml
+# Requirements:  Minimum one SSD and NVME is required to verify this testcase.In Mero nodes
+#                initially configuring the OSD's on HDD devices.On test OSD adding DB using SSD
+#                and adding WAL using NVME device.
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_hdd
+                  placement:
+                    host_pattern: '*'
+                  spec:
+                    data_devices:
+                      rotational: 1
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - cephadm
+        node: node4
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      name: Using Bluestore-tool add DB and WAL to existing OSD
+      desc: Using Bluestore-tool add DB and WAL to existing OSD
+      module: test_add_db_wal_cbt.py
+      polarion-id: CEPH-83584018
+      abort-on-fail: true
+
+  - test:
+      name: Verification of recovery from Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat-baremetal: true
+      polarion-id: CEPH-83590688
+      desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -1,0 +1,412 @@
+# Suite contains tier-2 rados test: EC Pool recovery
+# Test suite covers N-2 -> 9.0 Upgrade path
+# CLuster should have atleast 6 OSD hosts for testing.
+# Suited best for BM pipeline.
+# Can be run on RHOS-d env as well.
+# RHOS-d run duration: 60 mins (clay-ecpool tests)
+# Suite contains ISA erasure code plugin
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              rhcs-version: 7.1
+              release: rc
+              command: bootstrap
+              orphan-initial-daemons: true
+              skip-monitoring-stack: true
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: false
+      abort-on-fail: true
+
+# LC , recovery & Owerwrites test for ISA Profile.
+  - test:
+      name: EC pool with ISA plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83606527
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_isa_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_isa_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_isa_ec_pool
+      desc: Creation, modification & deletion of ISA EC pools and run IO
+
+  - test:
+      name: ISA plugin for EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83606782
+      config:
+        ec_pool:
+          create: true
+          pool_name: isa_ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: isa
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: isa_re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - isa_ec_pool_overwrite
+          - isa_re_pool_overwrite
+      desc: ISA EC pool with Overwrites & create RBD pool
+
+  - test:
+      name: EC Pool Recovery Improvement with ISA profile
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available with ISA profile
+
+# LC , recovery & Owerwrites test for Jerasure Profile.
+  - test:
+      name: EC pool LC with jerasure profile
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_ec_pool
+      desc: Create, modify & delete EC pools and run IO with jerasure profile
+
+  - test:
+      name: EC pool with Overwrites with jerasure profile
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool with jerasure profile
+
+
+  - test:
+      name: EC Pool Recovery Improvement with jerasure profile
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available with jerasure profile
+
+# below tests have been moved here from - tier-2_rados_test-clay-ecpool.yaml
+# LC and Owerwrites test for CLAY Profile.
+  - test:
+      name: EC pool with clay profile for RBD
+      module: test_clay_ecpool.py
+      polarion-id: CEPH-83574881
+      config:
+        clay_pool:
+          profile_name: clay_profile1
+          pool_name: clay_ec_pool1
+          k: 4
+          m: 3
+          d: 6
+          plugin: clay
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          crush-failure-domain: osd
+          force: true
+          test_overwrites_pool: true
+          delete_pools: true
+          image_name: test_clay_image1
+          image_size: 50G
+          metadata_pool: clay_meta_pool1
+      desc: Create and delete CLAY profile EC pool with RBD Images
+
+  - test:
+      name: EC Pool Recovery Improvement with Clay profile
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 4
+          m: 3
+          d: 6
+          plugin: clay
+          pg_num: 32
+          max_objs: 300
+          crush-failure-domain: osd
+          force: true
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available with Clay profile
+
+  - test:
+      name: Pool tests with clay profile for RBD Images
+      module: test_clay_ecpool.py
+      polarion-id: CEPH-83574880
+      config:
+        clay_pool:
+          profile_name: clay_profile2
+          pool_name: clay_ec_pool2
+          k: 4
+          m: 2
+          d: 5
+          plugin: clay
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          crush-failure-domain: osd
+          force: true
+          test_overwrites_pool: true
+          delete_pools: true
+          image_name: test_clay_image2
+          image_size: 50G
+          metadata_pool: clay_meta_pool2
+          test_tier3_system_tests: true
+          test_compression:
+            configurations:
+              - config-1:
+                  compression_mode: force
+                  compression_algorithm: snappy
+                  compression_required_ratio: 0.3
+                  compression_min_blob_size: 1B
+                  byte_size: 10KB
+              - config-2:
+                  compression_mode: passive
+                  compression_algorithm: zlib
+                  compression_required_ratio: 0.7
+                  compression_min_blob_size: 10B
+                  byte_size: 100KB
+              - config-3:
+                  compression_mode: aggressive
+                  compression_algorithm: zstd
+                  compression_required_ratio: 0.5
+                  compression_min_blob_size: 1KB
+                  byte_size: 100KB
+      desc: Perform tests on EC pools having a RBD Image
+
+# Online reads balancer test case
+# Pool scale down tests commented until fix for 2302230
+  - test:
+      name: Test Online Reads Balancer Read
+      module: test_online_reads_balancer.py
+      desc: Testing Online reads balancer tool via balancer module | read
+      polarion-id: CEPH-83590731
+      config:
+        balancer_mode: read
+        negative_scenarios: true
+        scale_up: true
+        scale_down: false
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_2

--- a/suites/tentacle/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-brownfield.yaml
@@ -1,0 +1,334 @@
+# Suite contains tests to be run after upgrade [brownfield deployment]
+# Use cluster-conf file: conf/tentacle/rados/7-node-cluster.yaml
+# RHOS-d run duration: 100 mins
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                rhcs-version: 7.1
+                release: z1     # deploying old build to verify obj snap deletion
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      name: "issue repro-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: setup osd failure due to allocator file corruption
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           issue_reproduction: true
+        pool_config:
+           pool_name: osd-alloc-pool
+           pg_num: 1
+           pg_num_max: 1
+           pool_type: replicated
+      comments: "8.1 bug-2338097"
+
+  - test:
+      name: Upgrade cluster to 7.1z2 ceph version
+      desc: Upgrade cluster to 7.1z2 version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        args:
+          rhcs-version: 7.1
+          release: z2
+      abort-on-fail: false
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: OSD fails with ceph_assert post upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           check_assert: true
+        pool_config:
+           pool_name: osd-alloc-pool
+
+  - test:
+      name: Upgrade cluster to latest 8.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        args:
+          rhcs-version: 8.0
+          release: rc
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Upgrade cluster to latest 9.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: "verify fix-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+          verify_fix: true
+
+  - test:
+      name: "verify fix-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
+
+  - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      config:
+        cluster_conf_path: "conf/tentacle/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: prometheus metadata
+      module: test_brownfield.py
+      desc: Fetch and verify ceph version for various daemons post upgrade
+      polarion-id: CEPH-83581346
+      config:
+       prometheus_metrics:
+         daemons:
+           - mon
+           - osd
+           - mgr
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+#  Uncomment test case once stabilisation is completed
+#  CI stabilisation: https://issues.redhat.com/browse/RHCEPHQE-19549
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/tentacle/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-bugfixes.yaml
@@ -1,0 +1,276 @@
+# Suite contains  tier-2 rados bug verification automation
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 - Bug verification  automation   ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/rados/7-node-cluster.yaml
+# Bugs:
+#     1. https://bugzilla.redhat.com/show_bug.cgi?id=2233800
+#     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
+#     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
+#     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
+#     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264053
+#     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
+#     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
+#     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
+#     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
+#     10.https://bugzilla.redhat.com/show_bug.cgi?id=1892173
+#     11.https://bugzilla.redhat.com/show_bug.cgi?id=2174954
+#     12.https://bugzilla.redhat.com/show_bug.cgi?id=2151501
+#     13.https://bugzilla.redhat.com/show_bug.cgi?id=2315595
+#     14.https://bugzilla.redhat.com/show_bug.cgi?id=2326179
+#     15.https://bugzilla.redhat.com/show_bug.cgi?id=2213766
+#     16.https://bugzilla.redhat.com/show_bug.cgi?id=2336885
+#     17.https://bugzilla.redhat.com/show_bug.cgi?id=2336886
+#
+#===============================================================================================
+# RHOS-d run duration: 330 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verification of the Mon ballooning
+      module: test_rados_ballooning_client.py
+      polarion-id: CEPH-83584004
+      desc: Verify MON ballooning client
+
+# moved prior to Inconsistent object test due to chances of an OSD being down
+  - test:
+      name: OSD restart when bluefs_shared_alloc_size is lower than bluestore_min_alloc_size
+      module: test_bug_fixes.py
+      config:
+        lower_bluefs_shared_alloc_size: true
+      polarion-id: CEPH-83591092
+      desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
+
+  - test:
+      name: Verification the recovery flag functionality
+      desc: Verify the pg_num and recovery status
+      module: test_norecovery_flag_functionality.py
+      polarion-id: CEPH-83591783
+      config:
+        replicated_pool:
+          create: true
+          pool_name: recovery_pool
+      delete_pool:
+        - recovery_pool
+
+  - test:
+      name: Inconsistent objects in  EC pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          pool_name: ecpool
+          pg_num: 1
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - ecpool
+      comments:  Intermittent active bug 2277111
+
+  - test:
+      name: Inconsistent objects in replicated pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        replicated_pool:
+          create: true
+          pool_name: replicated_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - replicated_pool
+      comments: Active bug 2316244
+
+  - test:
+      name: Verification of ceph config show & get
+      module: test_bug_fixes.py
+      config:
+        test-config-show-get: true
+      polarion-id: CEPH-83590689
+      desc: Verify ceph config show & get outputs
+
+  - test:
+      name: Verification of Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat: true
+      polarion-id: CEPH-83590688
+      desc: Generate Slow OSD heartbeats by inducing network delay
+
+  - test:
+      name: Client connection over v1 port
+      module: test_v1client.py
+      polarion-id: CEPH-83594645
+      desc: Ensure client connection over v1 port does not crash
+
+  - test:
+      name: Mon connection scores testing
+      desc: Verification of mon connection scores in different scenarios
+      module: test_mon_connection_scores.py
+      polarion-id: CEPH-83602911
+      comments: Intermittent bug 2357894
+
+  - test:
+      name: Verify config values via cephadm-ansible
+      module: test_cephadm_ansible.py
+      polarion-id: CEPH-83602686
+      desc: Ensure configuration values are accessible via cephadm-ansible module
+
+  - test:
+      name: Verify read crc error message
+      module: test_crc_check_logs.py
+      desc: Verify read crc error message in the osd logs
+      polarion-id: CEPH-83612766
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: replicated_pool
+              pool_type: replicated
+              pg_num: 1
+              pg_num_max: 1
+
+          - create_pool:
+              pool_name: ec_pool
+              pool_type: erasure
+              pg_num: 1
+              pg_num_max: 1
+              k: 3
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: osd
+
+  - test:
+      name: Verify that there are no 'defunct' ssh connections after the manager is redeployed
+      module: test_defunct_ssh_connections.py
+      polarion-id: CEPH-83602699
+      desc: ceph-mgr cephadm ssh connections 'defunct' after the manager is redeployed
+
+  - test:
+      name: Verify that there are no CEPHADM_STRAY_DAEMON warning while replacing the osd
+      module: test_bug_fixes.py
+      config:
+        stray_daemon_warning: true
+      polarion-id: CEPH-83615076
+      desc: No CEPHADM_STRAY_DAEMON warning while replacing the osd
+
+  - test:
+      name: Verify that OSDs can be added-moved to new spec
+      module: test_bug_fixes.py
+      config:
+        test_osd_spec_update: true
+      polarion-id: CEPH-83615839
+      desc: Verify that OSDs can be added-moved to new spec

--- a/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -1,0 +1,159 @@
+# Suite contains  tier-2 rados bug verification automation
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 - Bug verification  automation   ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/rados/11-node-cluster.yaml
+# Bugs:
+#     1. https://bugzilla.redhat.com/show_bug.cgi?id=2305677
+#===============================================================================================
+# RHOS-d run duration: 80 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                rhcs-version: 7.1
+                release: z0
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  # RHOS-d run duration: 8 mins
+  - test:
+      name: MGR regression test
+      module: test_mgr_daemon.py
+      polarion-id: CEPH-83586116
+      desc: MGR regression testing
+
+  - test:
+      name: Reproducing the Ceph mgr crash bug
+      module: test_node_drain_customer_bug.py
+      polarion-id: CEPH-83595932
+      abort-on-fail: true
+      config:
+        replicated_pool:
+          create: true
+          pool_name: mgr_test_pool
+          delete_pool: mgr_test_pool
+      desc: Reproducing the Ceph mgr crashed after a mgr failover
+
+  - test:
+      name: Upgrade cluster to latest 9.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Verification of Ceph mgr crash bug
+      module: test_node_drain_customer_bug.py
+      polarion-id: CEPH-83595932
+      config:
+        replicated_pool:
+          create: true
+          pool_name: mgr_test_pool
+          delete_pool: mgr_test_pool
+      comments: Active bug 2328605
+      desc: Ceph mgr crashed after a mgr failover with the message mgr operator

--- a/suites/tentacle/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -1,0 +1,290 @@
+# Suite contains tests related to osd re-balance upon OSD addition / removal
+# Can be run on RHOS-d env pipeline or BM pipeline.
+# RHOS-d run duration: 220 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args: # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+# RHOS-d run duration: 6 min
+# env: VM + BM
+  - test:
+      name: EC Profile tests
+      module: pool_tests.py
+      polarion-id: CEPH-83596295
+      config:
+        Verify_ec_profile:
+          name: test
+          profile_name: test_profile
+          pool_name: ec_profile_test
+          k: 2
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          crush-failure-domain: host
+      desc: Verify the behaviour of EC profiles in ceph
+
+  - test:
+      name: Robust rebalancing in ecpool - osd replacement
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration in ec pool
+      polarion-id: CEPH-9212
+      config:
+        create_pools:
+          - create_pool:
+              create: true
+              pool_name: ec_pool_9212
+              pool_type: erasure
+              rados_put: true
+              pg_num: 32
+              pgp_num: 32
+              k: 3
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec_pool_9212
+
+  - test:
+      name: Taking snaps during rebalance
+      module: test_osd_rebalance_snap.py
+      desc: Taking snaps while data migration is in progress
+      polarion-id: CEPH-9235
+      config:
+        create_pools:
+          - create_pool:
+              snapshot: true
+              num_snaps: 2
+              pool_name: repool_1
+              pg_num: 1
+              rados_put: true
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+
+        delete_pools:
+          - repool_1
+
+  - test:
+      name: Robust rebalancing - osd replacement
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration
+      polarion-id: CEPH-9205
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool_p1
+              pg_num: 64
+              max_objs: 300
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+        delete_pools:
+          - pool_p1
+
+  - test:
+      name: Robust rebalancing - in progress osd replacement
+      module: test_osd_inprogress_rebalance.py
+      desc: Add osd while data migration from the pools are in progress
+      polarion-id: CEPH-9228
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: repool_1
+              pg_num: 32
+              rados_put: true
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              pool_name: repool_2
+              pg_num: 32
+              pool_type: replicated
+              size: 2
+              min_size: 2
+              rados_put: true
+              byte_size: 1024
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              create: true
+              pool_name: ercpool_1
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 3
+              plugin: jerasure
+              rados_put: true
+          - create_pool:
+              create: true
+              pool_name: ercpool_2
+              pool_type: erasure
+              rados_put: true
+              pg_num: 32
+              pgp_num: 32
+              k: 8
+              m: 4
+              plugin: jerasure
+
+        delete_pools:
+          - repool_1
+          - repool_2
+          - ercpool_1
+          - ercpool_2
+
+  - test:
+      name: Robust rebalancing - osd replacement with many pools
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration from the pools which have different replica and pg count
+      polarion-id: CEPH-9210
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 32
+              max_objs: 300
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 32
+              pool_type: replicated
+              size: 2
+              min_size: 2
+              max_objs: 300
+              byte_size: 1024
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 300
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              disable_pg_autoscale: true
+          - create_pool:
+              create: true
+              pool_name: ecpool_1
+              pool_type: erasure
+              pg_num: 32
+              k: 4
+              m: 2
+              plugin: jerasure
+              max_objs: 300
+              rados_read_duration: 10
+          - create_pool:
+              create: true
+              pool_name: ecpool_2
+              pool_type: erasure
+              pg_num: 32
+              k: 4
+              m: 2
+              l: 3
+              plugin: lrc
+              max_objs: 300
+              rados_read_duration: 10
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_1
+          - ecpool_2

--- a/suites/tentacle/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -1,0 +1,288 @@
+# Suite contains tests related to mon db trimmings
+# Note: the test cannot be run on a cluster that is just created as the DB size increases with
+# new mappings for around next hour or so.. This test needs to be run on cluster who's age is at least 1 hour.
+# Suited best for BM pipeline.
+# Can be run on RHOS-d env as well.
+
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+# env: VM only
+  - test:
+      name: Monitor configuration - section and masks changes
+      module: rados_prep.py
+      polarion-id: CEPH-83573477
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "osd"
+                name: "osd_max_backfills"
+                value: "8"
+                location_type: "class"
+                location_value: "hdd"
+            - config-2:
+                section: "osd"
+                name: "osd_recovery_max_active"
+                value: "8"
+                location_type: "host"
+                location_value: "host"
+            - config-3:
+                section: "global"
+                name: "debug_mgr"
+                value: "10/10"
+            - config-4:
+                section: "osd"
+                name: "osd_max_scrubs"
+                value: "5"
+            - config-5:
+                section: "osd.1"
+                name: "osd_max_scrubs"
+                value: "3"
+            - config-6:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+            - config-7:
+                section: "client.rgw"
+                name: "rgw_lc_debug_interval"
+                value: "1"
+            - config-8:
+                section: "global"
+                name: "debug_mgr"
+                value: "10/10"
+            - config-9:
+                section: "osd.2"
+                name: "debug_ms"
+                value: "10/10"
+      desc: Verify config changes for section & masks like device class, host etc
+
+# RHOS-d run duration: 4 mins
+# env: VM + BM
+  - test:
+      name: Monitor configuration - msgrv2 compression modes
+      module: rados_prep.py
+      polarion-id: CEPH-83574961
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "force"
+            - config-2:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "512"
+            - config-3:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "none"
+            - config-4:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "1024"
+      desc: Verify the health status of the cluster by randomly changing the compression configuration values
+
+# RHOS-d run duration: 3 mins
+# env: VM + BM
+  - test:
+      name: Replicated pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        replicated_pool:
+          create: true
+          pool_name: test_re_pool
+          pg_num: 16
+          size: 2
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_re_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: aggressive
+            compression_algorithm: zlib
+        delete_pools:
+          - test_re_pool
+      desc: Create replicated pools and run IO
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      desc: Create EC pools and run IO
+      config:
+        ec_pool:
+          pool_name: test_ec_pool
+          pg_num: 32
+          k: 2
+          byte_size: 200KB
+          m: 2
+          max_objs: 300
+          rados_read_duration: 10
+        replicated_pool:
+          pool_name: delete_pool
+          pg_num: 32
+          byte_size: 1024
+          max_objs: 300
+          rados_read_duration: 10
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        io-total: 500M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 600
+      desc: Perform rgw tests
+
+  - test:
+      name: Compression test - EC pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
+      config:
+        Compression_tests:
+          pool_type: erasure
+          pool_config:
+            pool-1: test_compression_ecpool-1
+            pool-2: test_compression_ecpool-2
+            max_objs: 300
+            byte_size: 10KB
+            pg_num: 32
+            k: 2
+            m: 2
+            plugin: jerasure
+            crush-failure-domain: host
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.7
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on erasure coded pools
+
+  - test:
+      name: Automatic trimming of Mon DB
+      module: customer_scenarios.py
+      polarion-id: CEPH-83574466
+      config:
+        mondb_trim_config:
+          paxos_service_trim_min: 10
+          paxos_service_trim_max: 100
+          osd_op_complaint_time: 0.000001
+          osd_max_backfills: 10
+          osd_recovery_max_active: 10
+      desc: Verification of mon DB trimming during various cluster operations

--- a/suites/tentacle/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -1,0 +1,183 @@
+# Suite contains tests related to osd re-balance upon OSD addition / removal
+# conf - conf/tentacle/rados/11-node-cluster.yaml
+# RHOS-d run duration: 60 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args: # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+  - test:
+      name: Cluster behaviour when OSDs are full
+      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
+      module: test_osd_full.py
+      polarion-id: CEPH-83571715
+      config:
+        pg_autoscaling:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool_3
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
+  - test:
+      name: osd_memory_target param set at OSD level
+      module: test_osd_memory_target.py
+      desc: Verification of osd_memory_target parameter set at OSD level
+      polarion-id: CEPH-83580882
+      config:
+        osd_level: true
+
+  - test:
+      name: osd_memory_target param set at host level
+      module: test_osd_memory_target.py
+      desc: Verification of osd_memory_target parameter set at host level
+      polarion-id: CEPH-83580881
+      config:
+        host_level: true
+
+  - test:
+      name: ObjectStore block stats verification
+      module: test_objectstore_block.py
+      desc: Reduce data from an object and verify the decrease in blocks
+      polarion-id: CEPH-83571714
+      config:
+        create_pool: true
+        pool_name: test-objectstore
+        write_iteration: 3
+        delete_pool: true
+
+  - test:
+      name: ceph osd df stats
+      module: test_osd_df.py
+      desc: Mark osd out and inspect stats change in ceph osd df
+      polarion-id: CEPH-10787
+      config:
+        run_iteration: 3
+        create_pool: true
+        pool_name: test-osd-df
+        write_iteration: 10
+        delete_pool: true
+
+  # Below test is currently failing, BZ raised #2214864
+  # will be un-commented once fix is available
+#  - test:
+#      name: Perform IOPS on a Cluster with full OSDs
+#      desc: Verify posibility of IOPS on a Cluster with full OSDs
+#      module: test_osd_full.py
+#      polarion-id: CEPH-83572758
+#      config:
+#        iops_with_full_osds:
+#          pool-1:
+#            pool_name: "pool_full_osds"
+#            pool_type: replicated
+#            pg_num: 1
+#            disable_pg_autoscale: true
+#          pool-2:
+#            pool_name: "re_pool_test"
+#            pool_type: replicated
+#            pg_num: 1
+#            disable_pg_autoscale: true
+#          pool-3:
+#            pool_name: "test_ec_pool"
+#            pool_type: erasure
+#            pg_num: 1
+#            k: 4
+#            m: 2
+#            plugin: jerasure
+#            disable_pg_autoscale: true

--- a/suites/tentacle/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -1,0 +1,217 @@
+# Suite is to be used to verify the dups trimming scenario on all NVMe cluster
+# Conf file to be used : conf/tentacle/baremetal/mero_conf.yaml
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574887
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                rhcs-version: 8.0
+                release: rc
+                mon-ip: mero001
+                allow-fqdn-hostname: true
+                yes-i-know: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: true
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:  CEPH-83573758
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: mero015                     # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure email alerts
+      module: rados_prep.py
+      polarion-id: CEPH-83574472
+      config:
+        email_alerts:
+          smtp_host: smtp.corp.redhat.com
+          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
+          smtp_port: 25
+          interval: 10
+          smtp_destination:
+            - pdhiran@redhat.com
+          smtp_from_name: CM Scenarios - Dups trimming Cluster Alerts
+      desc: Configure email alerts on ceph cluster
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Upgrade cluster to latest 9.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+          io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      name: Decreasing the replica count
+      module: rados_prep.py
+      polarion-id: CEPH-9261
+      config:
+        replicated_pool:
+          create: true
+          pool_name: test_re_pool-1
+          pg_num: 16
+          size: 3
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: test_re_pool-1
+          configurations:
+            size: 2
+            pg_num: 32
+            pgp_num: 32
+      desc: Decreasing the replica count of the pool and observe the behaviour
+
+  - test:
+      name: Verify dups trimming
+      module: test_pg_dups_trimming.py
+      polarion-id: CEPH-83575116
+      config:
+        pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: replicated
+              conf: sample-pool-2
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+        verify_inflation: false
+      desc: Verify that the duplicates in the PG log entries are trimmed regularly
+      abort-on-fail: true

--- a/suites/tentacle/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -1,0 +1,303 @@
+# Suite contains tests related pg split and merge scenario
+# RHOS-d run duration: 290 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573713
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args: # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Test Reads Balancer
+      module: test_reads_balancer.py
+      desc: Testing reads balancer online tool functionality in RHCS
+      polarion-id: CEPH-83576078
+      config:
+        negative_scenarios: true
+        online_command_verification: true
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_1
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_1
+
+  - test:
+      name: Test Reads Balancer
+      module: test_reads_balancer.py
+      desc: Testing reads balancer offline tool functionality in RHCS
+      polarion-id: CEPH-83576079
+      config:
+        offline_command_verification: true
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_2
+
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+  - test:
+      name: verify mon parameter 'mon_pg_warn_max_object_skew'
+      polarion-id: CEPH-83575440
+      module: test_mon_pg_warn.py
+      desc: verify auto-increment of 'mon_pg_warn_max_object_skew' MON parameter
+
+  - test:
+      name: Verify PG split and merge
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging
+      polarion-id: CEPH-11674
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool1
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool1
+
+  - test:
+      name: Verify restart osd during PG split
+      module: test_pg_split.py
+      desc: Verify restart osd when PG split in progress
+      polarion-id: CEPH-11667
+      config:
+        create_pools:
+          - create_pool:
+              restart_osd: true
+              pool_name: pool2
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool2
+
+  - test:
+      name: Verify PG split and merge with network delay
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool5
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        add_network_delay: true
+        delete_pools:
+          - pool5
+
+  - test:
+      name: Verify delete object during PG split
+      module: test_pg_split.py
+      desc: Verify delete object when PG split in progress
+      polarion-id: CEPH-11671
+      config:
+        create_pools:
+          - create_pool:
+              del_obj: true
+              pool_name: pool3
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              objs_to_del: 20
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool3
+
+  - test:
+      name: Verify add remove osd during PG split
+      module: test_pg_split.py
+      desc: Verify osd removal and addition when PG split in progress
+      polarion-id: CEPH-11677
+      config:
+        create_pools:
+          - create_pool:
+              remove_add_osd: true
+              pool_name: pool4
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool4
+
+  - test:
+      name: Verify premerge PGS during PG split
+      module: test_pg_split.py
+      desc: Verify if there are premerge PGs when split is in progress
+      polarion-id: CEPH-83573526
+      config:
+        create_pools:
+          - create_pool:
+              check_premerge_pgs: true
+              pool_name: pool3
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool3

--- a/suites/tentacle/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -1,0 +1,482 @@
+# Suite contains tests to verify and test ceph pools
+# RHOS-d run duration: 290 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Ceph balancer plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83573247
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: crush-compat
+          target_max_misplaced_ratio: 0.04
+          sleep_interval: 30
+      desc: Ceph balancer plugins CLI validation in crush-compat mode
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: Ceph balancer test
+      module: rados_prep.py
+      polarion-id: CEPH-83573251
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: upmap
+          target_max_misplaced_ratio: 0.05
+          sleep_interval: 60
+      desc: Ceph balancer plugins CLI validation in upmap mode
+
+# RHOS-d run duration: 3 mins
+# env: VM + BM
+  - test:
+      name: Ceph PG Autoscaler
+      module: rados_prep.py
+      polarion-id: CEPH-83573412
+      config:
+        replicated_pool:
+          create: true
+          pool_name: rep_test_pool
+          max_objs: 300
+          rados_read_duration: 10
+          pg_num: 32
+        configure_pg_autoscaler:
+          default_mode: warn
+          mon_target_pg_per_osd: 128
+          pool_config:
+            pool_name: rep_test_pool
+            pg_autoscale_mode: "on"
+            pg_num_min: 16
+            target_size_ratio: 0.4
+        delete_pools:
+          - rep_test_pool
+      desc: Ceph PG autoscaler CLI validation
+
+  - test:
+      name: Verify scrub logs
+      module: test_scrub_log.py
+      polarion-id: CEPH-83575403
+      config:
+        # After the implementation of BZ#2320860 set the verify_log to true
+        verify_log: false
+        pool_configs:
+            - type: replicated
+              conf: sample-pool-2
+            - type: erasure
+              conf: sample-pool-2
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Verify that scrub & deep-scrub logs are captured in OSD logs
+
+  - test:
+      name: Verify pool behaviour at min_size
+      module: pool_tests.py
+      polarion-id: CEPH-9167
+      config:
+        Verify_pool_min_size_behaviour:
+          pool_name: test-pool-3
+      desc: Verify that Clients can read and write data into pools with min_size OSDs
+
+  - test:
+      name: Autoscaler test - pool target size ratio
+      module: pool_tests.py
+      polarion-id: CEPH-83573424
+      config:
+        verify_pool_target_ratio:
+          configurations:
+            pool-1:
+              pool_name: ec_pool_1
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: osd
+              target_size_ratio: 0.8
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+            pool-2:
+              pool_type: replicated
+              pool_name: re_pool_1
+              pg_num: 32
+              target_size_ratio: 0.8
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+  - test:
+      name: Verify Ceph df stats
+      desc: Verify Ceph df stats after creating and deleting objects from a pool
+      module: test_cephdf.py
+      polarion-id: CEPH-83571666
+      config:
+        verify_cephdf_stats:
+          create_pool: true
+          pool_name: test-ceph-df
+          obj_nums:
+            - 5
+            - 20
+            - 50
+          delete_pool: true
+      destroy-cluster: false
+
+  - test:
+      name: Mon target for PG num
+      module: pool_tests.py
+      polarion-id: CEPH-83573423
+      desc: Verification of mon_target_pg_per_osd option globally
+      config:
+        verify_mon_target_pg_per_osd:
+          section: "global"
+          name: "mon_target_pg_per_osd"
+          value: "150"
+
+  - test:
+      name: Autoscaler test - pool pg_num_min
+      module: pool_tests.py
+      polarion-id: CEPH-83573425
+      config:
+        verify_pg_num_min:
+          configurations:
+            pool-1:
+              pool_name: ec_pool_2
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 3
+              plugin: jerasure
+              crush-failure-domain: osd
+              pg_num_min: 16
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+            pool-2:
+              pool_type: replicated
+              pool_name: re_pool_2
+              pg_num: 64
+              pg_num_min: 32
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+
+  - test:
+      name: client pg access
+      module: test_client_pg_access.py
+      polarion-id: CEPH-83571713
+      config:
+        verify_client_pg_access:
+          num_snapshots: 20
+          configurations:
+            pool-1:
+              pool_name: ec_pool_4
+              pool_type: erasure
+              pg_num: 1
+              k: 8
+              m: 3
+              disable_pg_autoscale: true
+            pool-2:
+              pool_type: replicated
+              pool_name: re_pool_4
+              pg_num: 1
+              disable_pg_autoscale: true
+      desc: many clients clients accessing same PG with bluestore as backend
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-2
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-1. RE -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-2. RE -> EC
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-3
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-3. EC -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-2
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-4. Ec -> EC
+
+  - test:
+      name: Pg autoscaler bulk flag
+      module: pool_tests.py
+      polarion-id: CEPH-83573412
+      desc: Ceph PG autoscaler bulk flag tests
+      config:
+        test_autoscaler_bulk_feature: true
+        pool_name: test_bulk_features
+        delete_pool: true
+
+  - test:
+      name: PG number maximum limit check
+      module: pool_tests.py
+      desc: Check the pg_num maximut limit is <=128
+      polarion-id: CEPH-83574909
+      config:
+        verify_pg_num_limit:
+          pool_name: pool_num_chk
+          delete_pool: true
+
+  - test:
+      name: OSD min-alloc size and fragmentation checks
+      module: rados_prep.py
+      polarion-id: CEPH-83573808
+      config:
+        Verify_osd_alloc_size:
+          allocation_size: 4096
+      desc: Verify the minimum allocation size for OSDs along with fragmentation scores.
+
+  - test:
+      name: Compression test - replicated pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571673
+      config:
+        Compression_tests:
+          verify_compression_ratio_set: true          # TC : CEPH-83571672
+          pool_type: replicated
+          pool_config:
+            pool-1: test_compression_repool-1
+            pool-2: test_compression_repool-2
+            max_objs: 300
+            byte_size: 400KB
+            pg_num: 32
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.6
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on replicated pools
+
+# Blocked due to BZ 2172795. Bugzilla fixed.
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
+  - test:
+      name: Verify autoscaler scales up pool to pg_num_min
+      module: pool_tests.py
+      polarion-id:  CEPH-83592793
+      config:
+        verify_pool_min_pg_count:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Verify if PG Autoascler will autoscale pools to pg_num_min size
+
+  - test:
+      name: Verify degraded pool behaviour at min_size
+      module: pool_tests.py
+      polarion-id: CEPH-9185
+      config:
+        Verify_degraded_pool_min_size_behaviour:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: pool_degraded_test
+              pg_num: 1
+              disable_pg_autoscale: true
+      desc: On a degraded cluster verify that clients can read and write data into pools with min_size OSDs
+      abort-on-fail: false
+
+  - test:
+      name: OSD behaviour when marked Out
+      module: pool_tests.py
+      polarion-id: CEPH-83591786
+      config:
+        Verify_osd_in_out_behaviour: true
+      desc: Verify OSD behaviour when it is marked in and out of cluster
+
+# Pool scale down tests commented until fix for 2302230
+  - test:
+      name: Test Online Reads Balancer Upmap-read
+      module: test_online_reads_balancer.py
+      desc: Testing Online reads balancer tool via balancer module | upmap-read
+      polarion-id: CEPH-83590731
+      config:
+        balancer_mode: upmap-read
+        negative_scenarios: true
+        scale_up: true
+        scale_down: false
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_2

--- a/suites/tentacle/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-scrubbing.yaml
@@ -1,0 +1,244 @@
+# Suite contains tests for replica-1 non-resilient pool
+# conf: conf/tentacle/rados/7-node-cluster.yaml
+# RHOS-d run duration: 200 mins
+# move from tier-2 to tier-3 and move to weekly
+tests:
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: verify scrub chunk max
+      polarion-id: CEPH-10792
+      module: test_scrub_chunk_max.py
+      config:
+        delete_pool: true
+      desc: Scrub Chunk max validation
+
+  - test:
+      name: Scrub enhancement
+      module: test_scrub_enhancement.py
+      desc: Verify scrub enhancement feature
+      polarion-id: CEPH-83575885
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scrub_pool
+              pg_num: 1
+              pg_num_max: 1
+              pool_type: replicated
+        delete_pools:
+          - scrub_pool
+  - test:
+      name: CPU and Memory check during scheduled scrub
+      module: test_scrub_cpu_memory_usage.py
+      desc: Verify CPU and Memory check during scheduled scrub
+      polarion-id: CEPH-9369
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scheduled_scrub
+              pg_num: 32
+              pg_num_min: 32
+              pool_type: replicated
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 1KB
+        delete_pools:
+          - scheduled_scrub
+
+  - test:
+      name: Default scheduled scrub
+      polarion-id: CEPH-9361
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "default"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin Time = End Time
+      polarion-id: CEPH-9362
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "begin_end_time_equal"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin time > End time
+      polarion-id: CEPH-9363
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "beginTime gt endTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin Time >End time<current
+      polarion-id: CEPH-9365
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "beginTime gt endTime lt currentTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin Time & End time > current
+      polarion-id: CEPH-9368
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "beginTime and endTime gt currentTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Decrease scrub time
+      polarion-id: CEPH-9371
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "decreaseTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Unsetting scrubbing
+      polarion-id: CEPH-9374
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "unsetScrub"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Verification of the scrub and deep-scrub time check
+      desc: BZ#2292517deep scrub taking too long under mclock I/O scheduler
+      module: test_scrub_deepscrub_timecheck.py
+      polarion-id: CEPH-83605026
+      config:
+        pool_name: scrub_pool
+        pg_num: 1
+        pg_num_max: 1
+      delete_pool:
+        - scrub_pool
+
+  - test:
+      name: Verification of the scrub and deep-scrub functionality on PG
+      desc: BZ#2241025- Verification of Scrub and Deep-Scrub Operations on Placement Groups
+      module: test_noscrub_nodeepscrub_check.py
+      polarion-id: CEPH-83594004
+      config:
+        pool_name: scrub_pool
+      delete_pool:
+        - scrub_pool

--- a/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -1,0 +1,295 @@
+# Suite contains tests related to election strategy and Stretched mode
+# Use cluster-conf file: conf/tentacle/rados/stretch-mode-host-location-attrs.yaml
+# Stretch mode tests performing upgrade
+
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/tentacle/rados/deploy-stretch-cluster-mode.yaml
+# RHOS-d run duration: 80 mins
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          rhcs-version: 7.1
+          release: rc
+          mon-ip: node1
+          orphan-initial-daemons: true
+          registry-url: registry.redhat.io
+          skip-monitoring-stack: true
+          registry-json: registry.redhat.io
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+                - node4
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node5
+                - node6
+                - node7
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=tiebreaker
+                  node2:
+                    - datacenter=DC1
+                  node3:
+                    - datacenter=DC1
+                  node5:
+                    - datacenter=DC2
+                  node6:
+                    - datacenter=DC2
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes: node8
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: Upgrade cluster to 8.0 ceph version
+      desc: Upgrade cluster to 8.0 version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        args:
+          rhcs-version: 8.0
+          release: rc
+      abort-on-fail: false
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 300
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: Upgrade ceph cluster to 9.0
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_older_version_warn: true
+        verify_cluster_usage: true
+      abort-on-fail: true
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false

--- a/suites/tentacle/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_bluestore.yaml
@@ -1,0 +1,222 @@
+# Suite contains basic tier-2 rados tests
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 - To check Bluestore features   ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/rados/7-node-cluster.yaml
+#
+#===============================================================================================
+# RHOS-d run duration: 120 mins
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verify osd heartbeat no reply
+      desc: heartbeat_check log entries should contain hostname:port
+      polarion-id: CEPH-10839
+      module: test_osd_heartbeat.py
+      destroy-cluster: false
+
+  - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms
+
+  - test:
+      name: BlueStore cache size tuning
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571675
+      config:
+        bluestore_cache: true
+      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
+      name: BlueStore Superblock redundancy
+      module: test_bluestore_superblock.py
+      polarion-id: CEPH-83590892
+      desc: Verify OSD recovery when Bluestore superblock is corrupted
+
+  - test:
+      name: OSD Superblock redundancy
+      module: test_osd_superblock.py
+      polarion-id: CEPH-83593841
+      desc: Verify OSD recovery when OSD superblock is corrupted
+
+  - test:
+      name: Bluefs DB utilization
+      desc: DB utilization is under check - bluefs files are not inflated
+      module: test_bluefs_space.py
+      polarion-id: CEPH-83600867
+      config:
+        omap_config:
+          pool_name: re_pool_bluefs_db
+          pg_num: 1
+          pg_num_max: 1
+          obj_start: 0
+          obj_end: 15
+          normal_objs: 400
+          num_keys_obj: 200001
+
+  - test:
+      name: Bluestore data compression - set 1
+      module: test_bluestore_data_compression.py
+      desc: Positive workflows for bluestore data compression
+      polarion-id: CEPH-83611889
+      config:
+        scenarios_to_run:
+          - scenario-1
+          # To be uncommented after behaviour is clarified
+          # by dev. Task to uncomment
+          # https://issues.redhat.com/browse/RHCEPHQE-20207
+          # - scenario-2
+          # - scenario-3
+          - scenario-4
+
+  - test:
+      name: Bluestore data compression - set 2
+      module: test_bluestore_data_compression.py
+      desc: Positive workflows for bluestore data compression
+      polarion-id: CEPH-83611889
+      config:
+        scenarios_to_run:
+          - scenario-5
+          - scenario-6
+          - scenario-7
+
+  - test:
+      name: Bluestore data compression - set 3
+      module: test_bluestore_data_compression.py
+      desc: Positive workflows for bluestore data compression
+      polarion-id: CEPH-83611889
+      config:
+        scenarios_to_run:
+          - scenario-8
+          - scenario-9
+
+  - test:
+      name: Ceph Volume utility zap test with destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id: CEPH-83603694
+      desc: verify ceph-volume lvm zap functionality with destroy flag
+      config:
+        zap_with_destroy_flag: true
+
+  - test:
+      name: Ceph Volume utility zap test without destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id: CEPH-83603694
+      desc: verify ceph-volume lvm zap functionality without destroy flag
+      config:
+        zap_without_destroy_flag: true

--- a/suites/tentacle/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,0 +1,207 @@
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 test to verify all functionalities of COT and CBT tool ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/rados/13-node-cluster.yaml
+# Test suite is targeted only for OpenStack
+#===============================================================================================
+# RHOS-d run duration: 170 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574887
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
+      comments: regression Bug in 8.1 - 2309610
+
+  - test:
+      name: cbt utility bluefs spillover
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83595766
+      config:
+        bluefs-spillover: true
+      desc: Verify BlueFS Spillover warning with dedicated wal/db
+
+  - test:
+      name: ceph-objectstore-tool utility
+      module: test_objectstoretool_workflows.py
+      polarion-id: CEPH-83581811
+      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/tentacle/rados/tier-2_rados_test_omap.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_omap.yaml
@@ -1,0 +1,216 @@
+# Suite contains basic tier-2 rados tests
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 To check OSD status during OMAP,scrub and deep-scrub tasks in progress ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/rados/7-node-cluster.yaml
+#
+#===============================================================================================
+# RHOS-d run duration: 190 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: OMAP feature
+      desc: Testing omap features
+      module: test_scrub_omap.py
+      polarion-id: CEPH-83572661
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Test
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 200
+            num_keys_obj: 300000
+        verify_cluster_health: true
+
+  - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
+      name: Inconsistent OSD epoch
+      desc: list-inconsistent requires the correct epoch
+      module: test_inconsistency_osd_epoch.py
+      polarion-id: CEPH-9947
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool_name: test_pool_4
+            pool_type: replicated
+          omap_config:
+            obj_start: 0
+            obj_end: 50
+            num_keys_obj: 100
+        delete_pool: true
+
+  - test:
+      name: Preempt scrub messages checks
+      desc: Checking preempt messages in the OSDs
+      module: test_rados_preempt_scrub.py
+      polarion-id: CEPH-83572916
+      config:
+        pool_name: preempt_pool
+        pg_num: 1
+        delete_pool: true
+
+  - test:
+      name: Omap creations on objects
+      module: test_omap_entries.py
+      polarion-id: CEPH-83571702
+      config:
+        # Pool created to  verify the Bug#2249003
+        crash_config:
+          pool_name: re_pool_crash
+        # EC pool config is commented out because omaps can be written only on RE pools
+        omap_config:
+          small_omap:
+            pool_name: re_pool_small_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: false
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200000
+          large_omap:
+            pool_name: re_pool_large_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: true
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200001
+      desc: Large number of omap creation on objects and OSD resiliency
+
+  - test:
+      name: Verification of dump scrub parameters
+      desc: Verification of forced and scheduled time flags
+      module: test_scrub_parameters.py
+      polarion-id: CEPH-83593830
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_rp_pool
+          pg_num: 1
+        ec_pool:
+          pool_name: scrub_ec_pool
+          k: 2
+          m: 2
+          pg_num: 1
+          plugin: jerasure

--- a/suites/tentacle/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_parameters.yaml
@@ -1,0 +1,225 @@
+#################################################################################
+# Checking various parameters in RHCS7
+#--------------------------------------------------------------------------------
+# Cluster Configuration: conf/tentacle/rados/7-node-cluster.yaml
+#--------------------------------------------------------------------------------
+# Test Steps:
+#--------------------------------------------------------------------------------
+# - Deploy RHCS 8 cluster in RHEL 9
+# - Check the MSGRV2 parameters
+# - Check the MSGRV2 paramters and Mclock parameters
+#--------------------------------------------------------------------------------
+#################################################################################
+# RHOS-d run duration: 190 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size before OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        pre_deployment_config_changes: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size After OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        post_deployment_config_verification: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: Ceph MSGRV2 paramter check in 9.x
+      desc: MSGRV2 parameter check in 9.x
+      polarion-id: CEPH-83574890
+      module: test_config_parameter_chk.py
+      config:
+        scenario: msgrv2_6x
+        ini-file: conf/tentacle/rados/test-confs/rados_config_parameters.ini
+
+  - test:
+      name: Mclock sleep parameter check
+      desc: Mclock sleep parameter check
+      polarion-id: CEPH-83574903
+      module: test_config_parameter_chk.py
+      config:
+        scenario: mclock_sleep
+        ini-file: conf/tentacle/rados/test-confs/rados_config_parameters.ini
+
+  - test:
+      name: Mclock default,reservation,limit and weight parameter check
+      desc: Mclock default,reservation,limit and weight parameter check
+      polarion-id: CEPH-83574902
+      module: test_config_parameter_chk.py
+      config:
+        scenario: mclock_chg_chk
+        ini-file: conf/tentacle/rados/test-confs/rados_config_parameters.ini
+
+  - test:
+      name: Check RocksDB compression default value
+      desc: Check that RocksDB compression value is kLZ4Compression
+      polarion-id: CEPH-83582326
+      module: test_config_parameter_chk.py
+      config:
+        scenario: rocksdb_compression
+
+  - test:
+      name: replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83575297
+      config:
+       replica-1: true
+      desc: Test replica-1 non-resilient pools
+
+# test should run in succession with previous test(replica-1 non-resilient pools)
+# as it needs replica-1 pools to be present on the cluster
+  - test:
+      name: EIO flag on replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83582009, CEPH-83582010
+      config:
+        eio: true
+      desc: Test EIO flag on replica-1 non-resilient pools

--- a/suites/tentacle/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/tentacle/rados/tier-2_rados_trim_tests.yaml
@@ -1,0 +1,198 @@
+# Suite contains basic Tier-2,Tier-3 and Tier-4 rados tests
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2, Tier-3 and Tier-4 tests to verify the trim,PG and compaction verification ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/tentacle/rados/7-node-cluster.yaml
+#
+#===============================================================================================
+# RHOS-d run duration: 120 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Automatic trimming of osdmaps
+      desc: check for periodic trimming of osdmaps
+      module: test_osdmap_trim.py
+      polarion-id: CEPH-10046
+
+  - test:
+      name: Trimming of onodes
+      desc: check for the onode trimming in the cluster
+      module: test_osd_onode_trimming.py
+      polarion-id: CEPH-83575269
+
+  - test:
+      name: Inconsistent object pg check
+      desc: Inconsistent object pg check
+      module: test_osd_inconsistency_pg.py
+      polarion-id: CEPH-9924
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: Inconsistent object pg check using pool snapshot for RE pools
+      desc: Inconsistent object pg check using pool snapshot for RE pools
+      module: test_osd_snap_inconsistency_pg.py
+      polarion-id: CEPH-9942
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_snap_pool_re
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: Inconsistent object secondary pg check using pool snapshot
+      desc: Inconsistent object pg check using pool snapshot for RE pools for secondary OSD in PG
+      module: test_osd_snap_inconsistency_pg.py
+      polarion-id: CEPH-83571452
+      config:
+        test_secondary: true
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_snap_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: OSD compaction with failures
+      module: test_osd_compaction.py
+      polarion-id: CEPH-11681
+      config:
+        omap_config:
+          pool_name: re_pool_large_omap
+          large_warn: true
+          obj_start: 0
+          obj_end: 5
+          normal_objs: 400
+          num_keys_obj: 200001
+        bench_config:
+          pool_name: re_pool_bench
+          pg_num: 128
+          pgp_num: 128
+      desc: Perform OSD compaction with & without failures

--- a/suites/tentacle/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/tentacle/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,0 +1,220 @@
+# Suite contains tests related to CIDR blocklisting of ceph clients
+# This is Openstack only test suite.
+# conf: 13-node-cluster-4-clients.yaml
+# RHOS-d run duration: 50 mins + 50 min (slow_ops) + 20 min (recovery_tests)
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client 1
+      desc: Configures client.1 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node15:
+              release: 7
+          - node7:
+              release: 7
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 2
+      desc: Configures client.2 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2                     # client Id (<type>.<Id>)
+        nodes:
+          - node16:
+              release: 8
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 3
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3                      # client Id (<type>.<Id>)
+        node: node17                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: CIDR Blocklisting.
+      module: test_cidr_blocklisting.py
+      polarion-id: CEPH-83575008
+      config:
+        pool_configs:
+          pool-1:
+            type: replicated
+            conf: sample-pool-1
+          pool-2:
+            type: replicated
+            conf: sample-pool-2
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: CIDR Blocklisting of ceph rbd clients
+
+  - test:
+      name: Database reopening by libcephsqlite
+      module: test_libcephsqlite.py
+      polarion-id: CEPH-83583664
+      desc: libcephsqlite reopens database connection upon blocklisting
+
+# below tests have been moved from: tier-3_rados-recovery_tests.yaml
+# commented until a definite method to
+# trigger Async recovery is found
+#  - test:
+#        name: Testing async recovery
+#        desc: Testing async recovery
+#        module: test_osd_async_recovery.py
+#        polarion-id: CEPH-83574487
+#        config:
+#          async_recovery:
+#            configurations:
+#              pool-1:
+#                pool_type: replicated
+#                pool_name: async_recover
+#                pg_num: 16
+#          desc: Verification of the async recovery
+
+  - test:
+      name: Change Mon weight for Mgr
+      polarion-id: CEPH-83588304
+      module: test_mon_mgr_weight.py
+      desc: Verify Mgr stability when mon-weight is modified
+
+# below test has been moved from: tier-2_rados_test-slow-op-requests.yaml
+  - test:
+      name: Limit slow request details to cluster log
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        pool_name: slow-ops
+        pg_num: 64
+        byte_size: 1024
+        pool_type: replicated
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        check_ec: False
+
+# PG log limit parameter cannot be unset,
+# this test should always run at the last
+  - test:
+      name: Limit PG log size
+      polarion-id: CEPH-83573252
+      module: test_pg_log_limit.py
+      desc: Verify PG log growth limit using pglog_hardlimit flag

--- a/suites/tentacle/rados/tier-3_rados_ssd-tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_ssd-tests.yaml
@@ -1,0 +1,222 @@
+# Suite contains tests related to OSD(s) on SSDs
+# Picking mero since it has SSDs, HDDs and NVmes
+# - ADD SSD OSDs
+# - Perform IO with replicated and EC pool
+# - ADD or remove OSDs.
+# - Remove replicated EC pool and verify the re-balance
+# - ADD HDD OSDs and perform IOS
+# configuration file loaction: conf/tentacle/baremetal/mero_conf.yaml
+tests:
+  - test:
+      name: setup install pre-requisites
+      desc: deploy pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment on SSDs with spec
+      desc: Add OSD services on SSDs using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-11686
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: ssd_nodes
+                  placement:
+                    nodes:
+                      - node4
+                      - node5
+                      - node6
+                      - node7
+                      - node8
+                      - node9
+                      - node12
+                      - node13
+                  spec:
+                    data_devices:
+                      rotational: 0
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node10
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node11
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+
+  - test:
+      name: SSDs OSDs replacement with replicated and EC pools
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration from the pools
+      polarion-id: CEPH-9269
+      abort-on-fail: true
+      config:
+        mclock_profile: high_recovery_ops
+        timeout: unlimited                # provide "unlimited" or "<time in seconds>"
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 16
+              pool_type: replicated
+              size: 2
+              min_size: 2
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+          - create_pool:
+              create: true
+              pool_name: ecpool_1
+              pool_type: erasure
+              pg_num: 16
+              byte_size: 256
+              k: 4
+              m: 2
+              plugin: jerasure
+              max_objs: 300
+              rados_read_duration: 10
+              crush-failure-domain: osd
+        delete_pools:
+          - ecpool_1
+          - rpool_1
+
+  - test:
+      name: OSD deployment on SSDs and HDDs with spec
+      desc: Add OSD on SSDs and HDDs using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-9264
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: hdd_nodes
+                  placement:
+                    nodes:
+                      - node4
+                      - node5
+                      - node6
+                      - node7
+                      - node8
+                      - node9
+                      - node12
+                      - node13
+                  spec:
+                    data_devices:
+                      rotational: 1
+
+  - test:
+      name: Rebalancing on SSDs HDDs osd with replicate pools
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration
+      polarion-id: CEPH-9210
+      abort-on-fail: true
+      config:
+        timeout: unlimited
+        mclock_profile: high_recovery_ops
+        create_pools:
+          - create_pool:
+              pool_name: rpool_01
+              pg_num: 16
+              max_objs: 300
+              rados_read_duration: 10
+              byte_size: 256
+              pool_type: replicated
+        delete_pools:
+          - rpool_01
+
+  - test:
+      name: OSD deployment on single SSD
+      desc: Add OSD services on single SSD.
+      polarion-id: CEPH-9268
+      module: test_add_osd_ssd.py
+      config:
+        add:
+          - config:
+              node_name: node14
+          - config:
+              node_name: node15
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id:
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 16
+          k: 4
+          m: 2
+          plugin: jerasure
+          max_objs: 300
+          rados_read_duration: 10
+          crush-failure-domain: osd
+      desc: Create pools and run IO

--- a/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -1,0 +1,301 @@
+# Use cluster-conf file: conf/tentacle/rados/3AZ-cluster-rhos-1.yaml
+# 3 AZ cluster deployment tests
+# can be part of regression/weekly
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83609796
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          mon-ip: node1
+          rhcs-version: 8.0
+          release: rc
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+                - node2
+                - node3
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node4
+                - node5
+                - node6
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node7
+                - node8
+                - node9
+              location:
+                root: default
+                datacenter: DC3
+            - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=DC1
+                  node2:
+                    - datacenter=DC1
+                  node3:
+                    - datacenter=DC1
+                  node4:
+                    - datacenter=DC2
+                  node5:
+                    - datacenter=DC2
+                  node6:
+                    - datacenter=DC2
+                  node7:
+                    - datacenter=DC3
+                  node8:
+                    - datacenter=DC3
+                  node9:
+                    - datacenter=DC3
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+        name: MDS Service deployment with spec
+        desc: Add MDS services using spec file
+        module: test_cephadm.py
+        polarion-id: CEPH-83574728
+        config:
+          steps:
+            - config:
+                command: shell
+                args: # arguments to ceph orch
+                  - ceph
+                  - fs
+                  - volume
+                  - create
+                  - cephfs
+            - config:
+                command: apply_spec
+                service: orch
+                validate-spec-services: true
+                specs:
+                  - service_type: mds
+                    service_id: cephfs
+                    placement:
+                      label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node10
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Config checks
+      module: rados_prep.py
+      polarion-id: CEPH-83574529
+      config:
+        cluster_configuration_checks:
+          configure: true
+          disable_check_list:
+            - osd_mtu_size
+            - osd_linkspeed
+            - kernel_security
+          enable_check_list:
+            - kernel_security
+            - osd_linkspeed
+      desc: Enable Cluster Configuration checks
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: config source changes log
+      module: test_mon_config_history.py
+      polarion-id: CEPH-83573479
+      desc: Config sources - Verify config source changes in the log
+
+# RHOS-d run duration: 1 min
+# env: VM + BM
+  - test:
+      name: config source changes reset
+      module: test_mon_config_reset.py
+      polarion-id: CEPH-83573478
+      desc: Config sources - Verify config source changes and reset config
+
+# RHOS-d run duration: 8 mins
+  - test:
+      name: autoscaler flags
+      module: test_pg_autoscale_flag.py
+      polarion-id: CEPH-83574794
+      config:
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+        create_ec_pool: true
+        create_re_pool: true
+      desc: verify autoscaler flags functionality
+      comments: "Active bug 2361441"
+
+  - test:
+      name: Enable Stretch mode on pools
+      module: pool_tests.py
+      polarion-id: CEPH-83609796
+      config:
+        enable_3AZ_stretch_pools:
+          pool_name: test-pool-11
+          stretch_bucket: datacenter
+          rule_name: 3az_rule
+      desc: Enable 3 AZ stretch mode on all pools of the cluster
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83609797
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: false
+      abort-on-fail: true
+
+  - test:
+      name: Enable Stretch mode on pool post upgrade
+      module: pool_tests.py
+      polarion-id: CEPH-83609796
+      config:
+        enable_3AZ_stretch_pools:
+          pool_name: test-pool-12
+          stretch_bucket: datacenter
+          rule_name: 3az_rule
+          pool_list:
+            - test-pool-12
+      desc: Enable 3 AZ stretch mode on new pools of the cluster post upgrade
+
+  - test:
+      name: Site-down Scenarios
+      module: test_stretch_n_az_site_down_scenarios.py
+      polarion-id: CEPH-83609869
+      config:
+        pool_name: test_stretch_pool6
+        stretch_bucket: datacenter
+        rule_name: 3az_rule
+      desc: Test stretch site down scenarios in 3 AZ cluster
+
+  - test:
+      name: Maintenance mode Scenarios
+      module: test_stretch_n_az_site_down_scenarios.py
+      polarion-id: CEPH-83609871
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        rule_name: 3az_rule
+        scenarios_to_run:
+          - scenario-8
+          - scenario-9
+          - scenario-10
+      desc: Test stretch site maintenance mode scenarios in 3 AZ cluster
+
+  - test:
+      name: Negative Scenarios
+      module: test_stretch_n_az_negative_scenarios.py
+      polarion-id: CEPH-83609872
+      config:
+        stretch_bucket: datacenter
+        rule_name: 3az_rule
+      desc: negative scenarios with stretch pool enable command
+
+  - test:
+      name: Netsplit Scenarios data-data sites
+      module: test_stretch_n-az_netsplit_scenarios.py
+      polarion-id: CEPH-83609870
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        netsplit_site_1: DC1
+        netsplit_site_2: DC3
+        delete_pool: true
+        rule_name: 3az_rule
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
+      comments: Bugzilla for feature 2318936, 2316900

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -1,0 +1,673 @@
+# Suite is to be used to verify the EC 8+6 with MSR config on 4 nodes
+# to be run in regression conf: 4-node-ec-cluster-1-client.yaml
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                rhcs-version: 8.0
+                release: rc
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:  CEPH-83573758
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                     # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure email alerts
+      module: rados_prep.py
+      polarion-id: CEPH-83574472
+      config:
+        email_alerts:
+          smtp_host: smtp.corp.redhat.com
+          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
+          smtp_port: 25
+          interval: 10
+          smtp_destination:
+            - pdhiran@redhat.com
+          smtp_from_name: EC 8+6@4 MSR rules cluster alerts
+      desc: Configure email alerts on ceph cluster
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+
+# Commenting test due to BZ - https://bugzilla.redhat.com/show_bug.cgi?id=2305520
+#  - test:
+#      name: EC pool 8+6@4 with MSR LC
+#      module: test_ec_86.py
+#      polarion-id: CEPH-83590733
+#      config:
+#        profile_name: ec86_0
+#        pool_name: ec86_pool0
+#        k: 8
+#        m: 6
+#        force: true
+#        plugin: jerasure
+#        create_rule: false
+#        modify_threshold: true
+#        pre_create_rule: false
+#        crush-failure-domain: host
+#        change_subtree_limit: host
+#        crush-osds-per-failure-domain: 4
+#        crush-num-failure-domains: 4
+#        delete_pools:
+#          - ec86_pool0
+#      desc: 8+6@4 MSR EC pool life cycle with serviceability scenarios
+#      comments: "Bug with OSD down scenario 2305520"
+
+  - test:
+      name: Upgrade cluster to latest 9.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+
+#  - test:
+#      name: EC Pool Recovery Improvement
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573852
+#      config:
+#        ec_pool_recovery_improvement:
+#          create: true
+#          profile_name: ec86_1
+#          pool_name: ec86_pool1
+#          k: 8
+#          m: 6
+#          pg_num: 32
+#          plugin: jerasure
+#          create_rule: false
+#          crush-osds-per-failure-domain: 4
+#          crush-num-failure-domains: 4
+#          crush-failure-domain: host
+#          max_objs: 300
+#          rados_read_duration: 10
+#          osd_max_backfills: 16
+#          osd_recovery_max_active: 16
+#          delete_pool: true
+#      desc: Verify Recovery of EC pool with only "k" shards available
+#      comments: "Bug with OSD down scenario 2305520"
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec86_2
+          pool_name: ec86_pool2
+          pg_num: 64
+          k: 8
+          m: 6
+          create_rule: false
+          crush-osds-per-failure-domain: 4
+          crush-num-failure-domains: 4
+          plugin: jerasure
+          crush-failure-domain: host
+          disable_pg_autoscale: true
+          max_objs: 300
+          rados_read_duration: 10
+        set_pool_configs:
+          pool_name: ec86_pool2
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - ec86_pool2
+      desc: Create, modify & delete EC pools and run IO
+
+  - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec86_3
+          pool_name: ec86_pool3
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 8
+          m: 6
+          create_rule: false
+          crush-osds-per-failure-domain: 4
+          crush-num-failure-domains: 4
+          plugin: jerasure
+          crush-failure-domain: host
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec86_pool3
+          - re_pool_overwrite
+      comments: "RBD support RFE : 2305966"
+      desc: EC pool with Overwrites & create RBD pool
+
+#  - test:
+#      name: Inconsistent objects in  EC pool functionality check
+#      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+#      module: test_osd_ecpool_inconsistency_scenario.py
+#      polarion-id: CEPH-83586175
+#      config:
+#        ec_pool:
+#          create: true
+#          profile_name: ec86_4
+#          pool_name: ec86_pool4
+#          pg_num: 1
+#          k: 8
+#          m: 6
+#          create_rule: false
+#          crush-failure-domain: host
+#          crush-osds-per-failure-domain: 4
+#          crush-num-failure-domains: 4
+#          plugin: jerasure
+#          disable_pg_autoscale: true
+#        inconsistent_obj_count: 4
+#        delete_pool:
+#          - ec86_pool4
+
+  - test:
+      name: Compression test - EC pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
+      config:
+        Compression_tests:
+          pool_type: erasure
+          pool_config:
+            pool-1: ec86_pool5
+            pool-2: ec86_pool6
+            max_objs: 300
+            byte_size: 10KB
+            pg_num: 32
+            k: 8
+            m: 6
+            create_rule: false
+            crush-osds-per-failure-domain: 4
+            crush-num-failure-domains: 4
+            plugin: jerasure
+            crush-failure-domain: host
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.7
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on erasure coded pools
+
+  - test:
+      name: Autoscaler test - pool target size ratio
+      module: pool_tests.py
+      polarion-id: CEPH-83573424
+      config:
+        verify_pool_target_ratio:
+          configurations:
+            pool-1:
+              profile_name: ec86_7
+              pool_name: ec86_pool7
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              target_size_ratio: 0.8
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+  - test:
+      name: ceph-objectstore-tool utility
+      module: test_objectstoretool_workflows.py
+      polarion-id: CEPH-83581811
+      desc: Verify ceph-objectstore-tool functionalities
+
+#  - test:
+#      name: Verify premerge PGS during PG split
+#      module: test_pg_split.py
+#      desc: Verify if there are premerge PGs when split is in progress
+#      polarion-id: CEPH-83573526
+#      config:
+#        create_pools:
+#          - create_pool:
+#              check_premerge_pgs: true
+#              profile_name: ec86_8
+#              pool_name: ec86_pool8
+#              pg_num: 32
+#              rados_put: true
+#              num_objs: 200
+#              byte_size: 1024
+#              pool_type: erasure
+#              k: 8
+#              m: 6
+#              create_rule: false
+#              crush-failure-domain: host
+#              crush-osds-per-failure-domain: 4
+#              crush-num-failure-domains: 4
+#              plugin: jerasure
+#        delete_pools:
+#          - ec86_pool8
+
+#  - test:
+#      name: Verify PG split and merge with network delay
+#      module: test_pg_split.py
+#      desc: Verify PG splitting and merging with network delay
+#      polarion-id: CEPH-83571705
+#      config:
+#        create_pools:
+#          - create_pool:
+#              profile_name: ec86_9
+#              pool_name: ec86_pool9
+#              pg_num: 32
+#              rados_put: true
+#              num_objs: 200
+#              byte_size: 1024
+#              pool_type: erasure
+#              k: 8
+#              m: 6
+#              create_rule: false
+#              crush-failure-domain: host
+#              crush-osds-per-failure-domain: 4
+#              crush-num-failure-domains: 4
+#              plugin: jerasure
+#        add_network_delay: true
+#        delete_pools:
+#          - ec86_pool9
+
+  - test:
+      name: Verify scrub logs
+      module: test_scrub_log.py
+      polarion-id: CEPH-83575403
+      config:
+        # After the implementation of BZ#2320860 set the verify_log to true
+        verify_log: true
+        pool_configs:
+            - type: erasure
+              conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Verify that scrub & deep-scrub logs are captured in OSD logs
+
+  - test:
+      name: Autoscaler test - pool target size ratio
+      module: pool_tests.py
+      polarion-id: CEPH-83573424
+      config:
+        verify_pool_target_ratio:
+          configurations:
+            pool-1:
+              profile_name: ec86_10
+              pool_name: ec86_pool10
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              target_size_ratio: 0.8
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+  - test:
+      name: Autoscaler test - pool pg_num_min
+      module: pool_tests.py
+      polarion-id: CEPH-83573425
+      config:
+        verify_pg_num_min:
+          configurations:
+            pool-1:
+              profile_name: ec86_11
+              pool_name: ec86_pool11
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              pg_num_min: 16
+              max_objs: 300
+              rados_read_duration: 10
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+
+  - test:
+      name: client pg access
+      module: test_client_pg_access.py
+      polarion-id: CEPH-83571713
+      config:
+        verify_client_pg_access:
+          num_snapshots: 20
+          configurations:
+            pool-1:
+              profile_name: ec86_12
+              pool_name: ec86_pool12
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              disable_pg_autoscale: true
+      desc: many clients clients accessing same PG with bluestore as backend
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-2. RE -> EC
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-3
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-3. EC -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-4
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-4. Ec -> EC
+
+# Blocked due to BZ 2172795. Bugzilla fixed.
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: erasure
+              conf: sample-pool-3
+          pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
+  - test:
+      name: Scrub enhancement
+      module: test_scrub_enhancement.py
+      desc: Verify scrub enhancement feature
+      polarion-id: CEPH-83575885
+      config:
+        create_pools:
+          - create_pool:
+              pg_num: 1
+              pg_num_max: 1
+              profile_name: ec86_13
+              pool_name: ec86_pool13
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool13
+
+  - test:
+      name: Limit slow request details to cluster log
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        profile_name: ec86_14
+        pool_name: ec86_pool14
+        pool_type: erasure
+        k: 8
+        m: 6
+        create_rule: false
+        crush-osds-per-failure-domain: 4
+        crush-num-failure-domains: 4
+        plugin: jerasure
+        crush-failure-domain: host
+        pg_num: 64
+        max_objs: 300
+        byte_size: 1024
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        delete_pools:
+          - ec86_pool14
+
+# to be run only where OSDs are directly created on top of disks.
+# user created LVM based OSDs cannot run the below test
+  - test:
+      name: Robust rebalancing - in progress osd replacement
+      module: test_osd_inprogress_rebalance.py
+      desc: Add osd while data migration from the pools are in progress
+      polarion-id: CEPH-9228
+      abort-on-fail: true
+      config:
+        create_pools:
+          - create_pool:
+              create: true
+              profile_name: ec86_15
+              pool_name: ec86_pool15
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              rados_put: true
+          - create_pool:
+              create: true
+              profile_name: ec86_16
+              pool_name: ec86_pool16
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool15
+          - ec86_pool16

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -1,0 +1,662 @@
+# Suite is to be used to verify the EC 2+2 config on 4 nodes
+# to be run in regression conf: 4-node-ec-cluster-1-client.yaml
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                rhcs-version: 8.0
+                release: rc
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:  CEPH-83573758
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                     # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - osd
+                - osd_async_recovery_min_cost
+                - "1099511627776"
+
+  - test:
+      name: Upgrade cluster to latest 9.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 1,2
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
+          - scenario-3
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 3
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-4
+          - scenario-5
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC pool 2=2@4 LC - scenarios 4
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      abort-on-fail: true
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+        scenarios_to_run:
+          - scenario-6
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
+
+  - test:
+      name: EC Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          crush-failure-domain: host
+          max_objs: 300
+          rados_read_duration: 10
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+
+#  - test:
+#      name: EC pool LC
+#      module: rados_prep.py
+#      polarion-id: CEPH-83571632
+#      config:
+#        ec_pool:
+#          create: true
+#          pool_name: test_ec_pool
+#          pg_num: 64
+#          k: 2
+#          m: 2
+#          plugin: jerasure
+#          crush-failure-domain: host
+#          disable_pg_autoscale: true
+#          rados_write_duration: 50
+#          rados_read_duration: 10
+#        set_pool_configs:
+#          pool_name: test_ec_pool
+#          configurations:
+#            pg_num: 32
+#            pgp_num: 32
+#            pg_autoscale_mode: 'on'
+#            compression_mode: force
+#            compression_algorithm: snappy
+#        delete_pools:
+#          - test_ec_pool
+#      desc: Create, modify & delete EC pools and run IO
+
+  - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          max_objs: 300
+          rados_read_duration: 10
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool
+
+
+#  - test:
+#      name: Inconsistent objects in  EC pool functionality check
+#      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+#      module: test_osd_ecpool_inconsistency_scenario.py
+#      polarion-id: CEPH-83586175
+#      config:
+#        ec_pool:
+#          create: true
+#          profile_name: ec86_4
+#          pool_name: ec86_pool4
+#          pg_num: 1
+#          k: 2
+#          m: 2
+#          plugin: jerasure
+#          disable_pg_autoscale: true
+#          crush-failure-domain: host
+#        inconsistent_obj_count: 4
+#        delete_pool:
+#          - ec86_pool4
+#
+#  - test:
+#      name: Compression test - EC pool
+#      module: pool_tests.py
+#      polarion-id: CEPH-83571674
+#      config:
+#        Compression_tests:
+#          pool_type: erasure
+#          pool_config:
+#            pool-1: ec86_pool5
+#            pool-2: ec86_pool6
+#            max_objs: 300
+#            byte_size: 10KB
+#            pg_num: 32
+#            k: 2
+#            m: 2
+#            plugin: jerasure
+#            crush-failure-domain: host
+#          compression_config:
+#            compression_mode: aggressive
+#            compression_algorithm: snappy
+#            compression_required_ratio: 0.7
+#            compression_min_blob_size: 1B
+#            byte_size: 10KB
+#      desc: Verification of the effect of compression on erasure coded pools
+
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_7
+#              pool_name: ec86_pool7
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 10
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+#  - test:
+#      name: ceph-bluestore-tool utility
+#      module: test_bluestoretool_workflows.py
+#      polarion-id: CEPH-83571692
+#      desc: Verify ceph-bluestore-tool functionalities
+#
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
+
+  - test:
+      name: Verify premerge PGS during PG split
+      module: test_pg_split.py
+      desc: Verify if there are premerge PGs when split is in progress
+      polarion-id: CEPH-83573526
+      config:
+        create_pools:
+          - create_pool:
+              check_premerge_pgs: true
+              profile_name: ec86_8
+              pool_name: ec86_pool8
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool8
+
+  - test:
+      name: Verify PG split and merge with network delay
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              profile_name: ec86_9
+              pool_name: ec86_pool9
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: erasure
+              k: 2
+              m: 2
+              crush-failure-domain: host
+              plugin: jerasure
+        add_network_delay: true
+        delete_pools:
+          - ec86_pool9
+
+  - test:
+      name: Verify scrub logs
+      module: test_scrub_log.py
+      polarion-id: CEPH-83575403
+      config:
+        # After the implementation of BZ#2320860 set the verify_log to true
+        verify_log: false
+        pool_configs:
+            - type: erasure
+              conf: sample-pool-5
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Verify that scrub & deep-scrub logs are captured in OSD logs
+
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_10
+#              pool_name: ec86_pool10
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              crush-failure-domain: host
+#              plugin: jerasure
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 10
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+#  - test:
+#      name: Autoscaler test - pool pg_num_min
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573425
+#      config:
+#        verify_pg_num_min:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_11
+#              pool_name: ec86_pool11
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num_min: 16
+#              rados_write_duration: 50
+#              rados_read_duration: 10
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+
+#  - test:
+#      name: client pg access
+#      module: test_client_pg_access.py
+#      polarion-id: CEPH-83571713
+#      config:
+#        verify_client_pg_access:
+#          num_snapshots: 20
+#          num_objects: 250
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_12
+#              pool_name: ec86_pool12
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              disable_pg_autoscale: true
+#      desc: many clients clients accessing same PG with bluestore as backend
+
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-5
+#        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+#      desc: Migrating data between different pools. Scenario-2. RE -> EC
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-5
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-3. EC -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-6
+        pool-2-conf: sample-pool-5
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-4. Ec -> EC
+
+## Blocked due to BZ 2172795. Bugzilla fixed.
+#  - test:
+#      name: Verify cluster behaviour during PG autoscaler warn
+#      module: pool_tests.py
+#      polarion-id:  CEPH-83573413
+#      config:
+#        verify_pool_warnings:
+#          pool_configs:
+#            - type: erasure
+#              conf: sample-pool-5
+#          pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
+#  - test:
+#      name: Scrub enhancement
+#      module: test_scrub_enhancement.py
+#      desc: Verify scrub enhancement feature
+#      polarion-id: CEPH-83575885
+#      config:
+#        create_pools:
+#          - create_pool:
+#              pg_num: 1
+#              pg_num_max: 1
+#              profile_name: ec86_13
+#              pool_name: ec86_pool13
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#        delete_pools:
+#          - ec86_pool13
+
+#  - test:
+#      name: Limit slow request details to cluster log
+#      module: test_slow_op_requests.py
+#      desc: Limit slow request details to cluster log
+#      polarion-id: CEPH-83574884
+#      config:
+#        profile_name: ec86_14
+#        pool_name: ec86_pool14
+#        pool_type: erasure
+#        k: 2
+#        m: 2
+#        plugin: jerasure
+#        crush-failure-domain: host
+#        pg_num: 64
+#        rados_write_duration: 1000
+#        byte_size: 1024
+#        osd_max_backfills: 16
+#        osd_recovery_max_active: 16
+#        delete_pools:
+#          - ec86_pool14
+
+  - test:
+      name: Robust rebalancing - in progress osd replacement
+      module: test_osd_inprogress_rebalance.py
+      desc: Add osd while data migration from the pools are in progress
+      polarion-id: CEPH-9228
+      abort-on-fail: true
+      config:
+        create_pools:
+          - create_pool:
+              create: true
+              profile_name: ec86_15
+              pool_name: ec86_pool15
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+              rados_put: true
+          - create_pool:
+              create: true
+              profile_name: ec86_16
+              pool_name: ec86_pool16
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool15
+          - ec86_pool16
+

--- a/suites/tentacle/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -1,0 +1,406 @@
+# Stretch mode tests performing site down scenarios
+# conf: 13-node-cluster-4-clients.yaml
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/tentacle/rados/deploy-stretch-cluster-mode.yaml
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          registry-json: registry.redhat.io
+          mon-ip: node1
+          orphan-initial-daemons: true
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+                - node4
+                - node5
+                - node6
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node8
+                - node9
+                - node10
+                - node11
+                - node14
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node7
+          - node15
+          - node16
+          - node17
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+# RHOS-d run duration: 18 min
+# env: VM + BM
+  - test:
+      name: Mon election strategies
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      desc: Change Mon election strategies and verify status
+
+  - test:
+      name: Deploy stretch Cluster
+      module: test_stretch_deployment_with_placement.py
+      polarion-id: CEPH-83573621
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+        negative_scenarios: False
+      comments: Pre-deployment -ve scenarios commented due to bug - 2293147
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: Mon election strategies in stretch mode
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      config:
+        stretch_mode: True
+      desc: Run Mon election strategies workflow for a stretch cluster
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 300
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
+      name: test stretch Cluster site down - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83574975
+      config:
+        pool_name: test_stretch_pool6
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site down with delay - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83571705
+      config:
+        pool_name: test_stretch_pool9
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        add_network_delay: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site down - tiebreaker site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83574974
+      config:
+        pool_name: test_stretch_pool5
+        shutdown_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is shut down
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - tiebreaker site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool2
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site reboot - Data site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool3
+        affected_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the data site is rebooted
+
+  - test:
+      name: test stretch Cluster site reboot - tiebreaker site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool4
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is rebooted
+
+  - test:
+      name: Mon replacement on Data site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool5
+        replacement_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        add_mon_without_location: true
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - Data site
+
+  - test:
+      name: Mon replacement on tiebreaker site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool6
+        replacement_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - tiebreaker site
+
+  - test:
+      name: Netsplit Scenarios data-data sites
+      module: test_stretch_netsplit_scenarios.py
+      polarion-id: CEPH-83574979
+      config:
+        pool_name: test_stretch_pool8
+        netsplit_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        set_debug: true
+      desc: Test stretch Cluster netsplit scenario between data sites
+      comments: Intermittent Active bug with netsplit scenarios - 2318975
+
+  - test:
+      name: Netsplit Scenarios data-tiebreaker sites
+      module: test_stretch_netsplit_scenarios.py
+      polarion-id: CEPH-83574979
+      config:
+        pool_name: test_stretch_pool7
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
+
+  - test:
+      name: test stretch Cluster maintenance mode - data site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool1
+        affected_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the Data site is moved to maintenance mode
+
+  - test:
+      name: Negative scenarios - post-deployment
+      module: test_stretch_negative_scenarios.py
+      polarion-id: CEPH-83584499
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Perform post-deployment negative tests on stretch mode
+
+  - test:
+      name: OSD and host replacement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
+      desc: Test stretch Cluster osd and Host replacement
+
+  - test:
+      name: OSD replacement enhancement - 1
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-3
+          - scenario-4
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD replacement enhancement - 2
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-5
+          - scenario-6
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD Host replacement enhancement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-7
+      desc: Test stretch Cluster Host replacement

--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -1,0 +1,604 @@
+# Use cluster-conf file: conf/baremetal/rados_extensa_1admin_5node_1client.yaml
+# Stretch mode tests performing site down scenarios
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          registry-json: registry.redhat.io
+          mon-ip: node1
+          orphan-initial-daemons: true
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node5
+                - node4
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure OSD
+      module: homogenous_osd_cluster.py
+      desc: Deploy OSDs on specifc devices on the node.
+      abort-on-fail: true
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Mon election strategies
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      desc: Change Mon election strategies and verify status
+
+  - test:
+      name: Deploy stretch Cluster
+      module: test_stretch_deployment_with_placement.py
+      polarion-id: CEPH-83573621
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+        negative_scenarios: false
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: Verify osd heartbeat no reply
+      desc: heartbeat_check log entries should contain hostname:port
+      polarion-id: CEPH-10839
+      module: test_osd_heartbeat.py
+      destroy-cluster: false
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 300
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: Compression test - replicated pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571673
+      config:
+        Compression_tests:
+          verify_compression_ratio_set: true          # TC : CEPH-83571672
+          pool_type: replicated
+          pool_config:
+            pool-1: test_compression_repool-1
+            pool-2: test_compression_repool-2
+            max_objs: 300
+            byte_size: 100KB
+            pg_num: 32
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.6
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on replicated pools
+
+  - test:
+      name: Compression algorithms
+      module: rados_prep.py
+      polarion-id: CEPH-83571669
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 300
+          rados_read_duration: 10
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+        delete_pools:
+          - re_pool_compress
+      desc: Enable/disable different compression algorithms.
+
+  - test:
+      name: Ceph balancer test
+      module: rados_prep.py
+      polarion-id: CEPH-83573251
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: upmap
+          target_max_misplaced_ratio: 0.05
+          sleep_interval: 60
+      desc: Ceph balancer plugins CLI validation in upmap mode
+
+  - test:
+      name: Ceph PG Autoscaler
+      module: rados_prep.py
+      polarion-id: CEPH-83573412
+      config:
+        replicated_pool:
+          create: true
+          pool_name: rep_test_pool
+          max_objs: 300
+          rados_read_duration: 10
+          pg_num: 32
+        configure_pg_autoscaler:
+          default_mode: warn
+          mon_target_pg_per_osd: 128
+          pool_config:
+            pool_name: rep_test_pool
+            pg_autoscale_mode: "on"
+            pg_num_min: 16
+            target_size_ratio: 0.4
+        delete_pools:
+          - rep_test_pool
+      desc: Ceph PG autoscaler CLI validation
+
+  - test:
+      name: ObjectStore block stats verification
+      module: test_objectstore_block.py
+      desc: Reduce data from an object and verify the decrease in blocks
+      polarion-id: CEPH-83571714
+      config:
+        create_pool: true
+        pool_name: test-objectstore
+        write_iteration: 3
+        delete_pool: true
+
+  - test:
+      name: Trimming of onodes
+      desc: check for the onode trimming in the cluster
+      module: test_osd_onode_trimming.py
+      polarion-id: CEPH-83575269
+
+  - test:
+      name: Inconsistent object pg check
+      desc: Inconsistent object pg check
+      module: test_osd_inconsistency_pg.py
+      polarion-id: CEPH-9924
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: Inconsistent object pg check using pool snapshot for RE pools
+      desc: Inconsistent object pg check using pool snapshot for RE pools
+      module: test_osd_snap_inconsistency_pg.py
+      polarion-id: CEPH-9942
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_snap_pool_re
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: PG number maximum limit check
+      module: pool_tests.py
+      desc: Check the pg_num maximut limit is <=128
+      polarion-id: CEPH-83574909
+      config:
+        verify_pg_num_limit:
+          pool_name: pool_num_chk
+          delete_pool: true
+
+  - test:
+      name: OSD min-alloc size and fragmentation checks
+      module: rados_prep.py
+      polarion-id: CEPH-83573808
+      config:
+        Verify_osd_alloc_size:
+          allocation_size: 4096
+      desc: Verify the minimum allocation size for OSDs along with fragmentation scores.
+
+  - test:
+      name: osd_memory_target param set at OSD level
+      module: test_osd_memory_target.py
+      desc: Verification of osd_memory_target parameter set at OSD level
+      polarion-id: CEPH-83580882
+      config:
+        osd_level: true
+
+  - test:
+      name: osd_memory_target param set at host level
+      module: test_osd_memory_target.py
+      desc: Verification of osd_memory_target parameter set at host level
+      polarion-id: CEPH-83580881
+      config:
+        host_level: true
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-2
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-1. RE -> RE
+
+# Cannot run site down tests in BM as of now as the methods use openstack drivers in code.
+# Need to improve code coverage in rados/infra test to use IPMI commands to start/stop/restart BM hosts
+# CEPH-83574975 Test commented in BM
+#  - test:
+#      name: test stretch Cluster site down - Data site
+#      module: test_stretch_site_down.py
+#      polarion-id: CEPH-83574975
+#      config:
+#        pool_name: test_stretch_pool6
+#        shutdown_site: DC1
+#        tiebreaker_mon_site_name: tiebreaker
+#        delete_pool: true
+#      desc: Test the cluster when we have only 1 of 2 DC's surviving
+#      abort-on-fail: true
+#
+#  - test:
+#      name: test stretch Cluster site down with delay - Data site
+#      module: test_stretch_site_down.py
+#      polarion-id: CEPH-83571705
+#      config:
+#        pool_name: test_stretch_pool9
+#        shutdown_site: DC1
+#        tiebreaker_mon_site_name: tiebreaker
+#        delete_pool: true
+#        add_network_delay: true
+#      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+#      abort-on-fail: true
+#
+#  - test:
+#      name: test stretch Cluster site down - tiebreaker site
+#      module: test_stretch_site_down.py
+#      polarion-id: CEPH-83574974
+#      config:
+#        pool_name: test_stretch_pool5
+#        shutdown_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
+#        delete_pool: true
+#      desc: Test the cluster when the tiebreaker site is shut down
+#      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - tiebreaker site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool2
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site reboot - Data site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool3
+        affected_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the data site is rebooted
+
+  - test:
+      name: test stretch Cluster site reboot - tiebreaker site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool4
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is rebooted
+
+  - test:
+      name: Mon replacement on Data site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool5
+        replacement_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - Data site
+
+# No free host without any mon daemon on the cluster.
+# tiebreaker site Mon replacement test commented as of now
+#  - test:
+#      name: Mon replacement on tiebreaker site
+#      module: test_stretch_mon_replacements.py
+#      polarion-id: CEPH-83574971
+#      config:
+#        pool_name: test_stretch_pool6
+#        replacement_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
+#        delete_pool: true
+#      desc: Test stretch Cluster mon replacement - tiebreaker site
+
+# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+# New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
+#  - test:
+#      name: Netsplit Scenarios data-data sites
+#      module: test_stretch_netsplit_scenarios.py
+#      polarion-id: CEPH-83574979
+#      config:
+#        pool_name: test_stretch_pool8
+#        netsplit_site: DC1
+#        tiebreaker_mon_site_name: tiebreaker
+#        delete_pool: true
+#      desc: Test stretch Cluster netsplit scenario between data sites
+#
+# Commenting this test to make changes in the test case in the way OSds are added/removed.
+# Need to use the same spec file used for cluster deployment
+#  - test:
+#      name: OSD and host replacement
+#      module: test_stretch_osd_serviceability_scenarios.py
+#      polarion-id: CEPH-83575474
+#      config:
+#        pool_name: test_stretch_pool7
+#        stretch_bucket: datacenter
+#        tiebreaker_mon_site_name: tiebreaker
+#        delete_pool: true
+#        add_network_delay: true
+#      desc: Test stretch Cluster osd and Host replacement
+
+  - test:
+      name: Netsplit Scenarios data-tiebreaker sites
+      module: test_stretch_netsplit_scenarios.py
+      polarion-id: CEPH-83574979
+      config:
+        pool_name: test_stretch_pool7
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
+
+  - test:
+      name: Negative scenarios - post-deployment
+      module: test_stretch_negative_scenarios.py
+      polarion-id: CEPH-83584499
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Perform post-deployment negative tests on stretch mode
+
+  - test:
+      name: test stretch Cluster maintenance mode - data site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool1
+        affected_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the Data site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts
+
+  - test:
+      name: Pg autoscaler bulk flag
+      module: pool_tests.py
+      polarion-id: CEPH-83573412
+      desc: Ceph PG autoscaler bulk flag tests
+      config:
+        test_autoscaler_bulk_feature: true
+        pool_name: test_bulk_features
+        delete_pool: true
+
+  - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        pool_type : replicated
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms
+
+# Bug : https://bugzilla.redhat.com/show_bug.cgi?id=2279839
+#  - test:
+#      name: BlueStore cache size tuning
+#      module: test_bluestore_configs.py
+#      polarion-id: CEPH-83571675
+#      config:
+#        pool_type : replicated
+#        bluestore_cache: true
+#      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
+      name: Verification of recovery from Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat-baremetal: true
+      polarion-id: CEPH-83590688
+      desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/tentacle/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/tentacle/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -1,0 +1,251 @@
+# Suite contains tier-4 tests to verify and test ceph pools upon OSD changes
+# This suite is to be run with conf : conf/tentacle/rados/13-node-cluster.yaml
+# RHOS-d run duration: 200 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+            - node5
+            - node6
+            - node8
+            - node9
+            - node10
+            - node11
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  # Running basic rbd and rgw tests after deployment of cluster
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Crushtool to change crush maps
+      module: test_crushtool_workflows.py
+      polarion-id: CEPH-83572695
+      config:
+        add_buckets:
+          DC1: datacenter
+          DC2: datacenter
+          tiebreaker: datacenter
+          test-host-1: host
+          test-host-2: host
+        bin_tests:
+          - show-statistics
+          - show-mappings
+          - show-utilization-all
+      desc: Verify Crushtool to change crush maps ( -ve Tests )
+
+  - test:
+      name: Failure recovery on Replicated & EC
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-11032
+      config:
+        pool_configs:
+          - type: replicated
+            conf: sample-pool-2
+          - type: erasure
+            conf: sample-pool-2
+          - type: replicated
+            conf: sample-pool-1
+          - type: erasure
+            conf: sample-pool-1
+        pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+        remove_host : node13
+      desc: Failure recovery on Replicated & EC pools upon OSD changes
+
+  - test:
+      name: pg rebalancing upon addition of new OSD
+      desc: Test PG rebalancing upon addition of new OSDs when Cluster is in full state
+      module: test_osd_full.py
+      polarion-id: CEPH-9232
+      config:
+        osd_addition:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
+  - test:
+      name: crash warning upon daemon crash
+      module: test_crash_daemon.py
+      polarion-id: CEPH-83573855
+      desc: Verify crash warning in ceph health upon crashing a daemon
+      comments: Intermittent Active BZ-2253394

--- a/suites/tentacle/rados/tier-4_rados_tests.yaml
+++ b/suites/tentacle/rados/tier-4_rados_tests.yaml
@@ -1,0 +1,315 @@
+# Suite contains basic tier-4 rados tests
+# conf - conf/tentacle/rados/13-node-cluster.yaml
+# RHOS-d run duration: 170 mins
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+            - node5
+            - node6
+            - node8
+            - node9
+            - node10
+            - node11
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: OSD addition on an unavailable disk
+      desc: Add new OSD on an pre-occupied OSD disk
+      module: test_add_new_osd.py
+      polarion-id: CEPH-83574780
+
+  - test:
+      name: replacement of OSD
+      module: test_osd_replacement.py
+      polarion-id: CEPH-83572702
+      desc: Replace an OSD by retaining its ID
+
+  - test:
+      name: Test ceph osd command arguments
+      desc: Provide invalid values as argument to different ceph osd commands
+      module: test_osd_args.py
+      polarion-id: CEPH-10417
+      config:
+        cmd_list:
+          - "reweight-by-pg"
+          - "reweight-by-utilization"
+          - "test-reweight-by-pg"
+          - "test-reweight-by-utilization"
+
+  - test:
+      name: Verify Ceph df MAX_AVAIL
+      desc: MAX_AVAIL value should not change to 0 upon addition of OSD with weight 0
+      module: test_cephdf.py
+      polarion-id: CEPH-10312
+      config:
+        verify_cephdf_max_avail:
+          create_pool: true
+          pool_name: test-max-avail
+          obj_nums: 5
+          delete_pool: true
+
+  - test:
+      name: Verify MAX_AVAIL variance with OSD size change
+      desc: MAX_AVAIL value update correctly when OSD size changes
+      module: test_cephdf.py
+      polarion-id: CEPH-83595780
+      config:
+        cephdf_max_avail_osd_expand: true
+
+  - test:
+      name: Verify MAX_AVAIL variance when OSDs are removed
+      desc: MAX_AVAIL value update correctly when OSDs are removed
+      module: test_cephdf.py
+      polarion-id: CEPH-83604474
+      config:
+        cephdf_max_avail_osd_rm: true
+      comments: Intermittent Active BZ-2275995
+
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 300
+          rados_read_duration: 10
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571671
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 300
+          rados_read_duration: 10
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.
+
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts
+
+  - test:
+      name: Replacement of a failed OSD host
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-9408
+      config:
+        osd_host_fail: True
+      desc: Replacement of a failed OSD host with a healthy host
+
+  - test:
+      name: mon replacement test
+      polarion-id: CEPH-9407
+      module: test_mon_addition_removal.py
+      desc: Replace a Healthy Mon with a new MON
+
+  - test:
+      name: mon system tests
+      polarion-id: CEPH-9388
+      module: test_mon_system_operations.py
+      desc: Performing system tests with mon daemons
+
+  - test:
+      name: OSD Fragmentation tests
+      polarion-id: CEPH-83607852
+      module: test_fragmentation_warnings.py
+      desc: Generate Fragmentation on OSDs and verify health warning + logs


### PR DESCRIPTION
Addition of conf and suite files for RADOS -> Tentacle release.

All test suites present in squid have been moved to tentacle, with updates in config as needed for Tentacle.

Upgrade suites :
tier-2_rados_ec-pool_recovery.yaml -> 7.1 RC -> 9.0
tier-2_rados_test-brownfield.yaml -> 7.1z1 -> 7.1z2 -> 8.0z5 -> 9.0
tier-2_rados_test-drain-customer-issue.yaml -> 7.1z0 -> 9.0
tier-2_rados_test-pg-dups-trimming.yaml -> 8.0 rc -> 9.0
tier-2_rados_test-stretch-mode-upgrade.yaml -> 7.1 RC -> 8.1 RC -> 9.0
tier-3_rados_test-3-AZ-Cluster.yaml -> 8.0 RC -> 9.0
tier-3_rados_test-4-node-8+6-msr-ecpools.yaml -> 8.0RC -> 9.0
tier-3_rados_test-4-node-ecpools.yaml -> 8.0 rc -> 9.0