### PR TITLE
[TFA-fix] Update RGW SSL certificate commands Ceph 8.0

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -171,7 +171,7 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt"
+              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
               - "sudo yum install -y sshpass"
               - "sleep 20"
               - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
@@ -193,7 +193,7 @@ tests:
               - "ceph orch restart {service_name:shared.sec}"
               - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt"
+              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
               - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
               - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node6}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
jira: 
https://issues.redhat.com/browse/RHCEPHQE-20143

pass logs : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.5/Test/19.2.1-218/532/tier-2_rgw_ssl_cephadm_gen_cert 8.1

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9.5/Test/19.2.0-139/533/tier-2_rgw_ssl_cephadm_gen_cert 8.0 

Updated the certificate retrieval steps support both Ceph 8.0 and 8.1.
The script now checks the Ceph version and uses the appropriate command to fetch the cephadm_root_ca_cert certificate.
This ensures that the test runs correctly regardless of the Ceph version being used.


