### PR TITLE
fix: handle subscription-manager release failures with clean and re-register fallback

### DIFF
--- a/cli/utilities/repos.py
+++ b/cli/utilities/repos.py
@@ -1,0 +1,52 @@
+from cli.utilities.packages import Repos, SubscriptionManager
+
+
+def enable_rhel_rpms(ceph, distro_ver):
+    """
+    Enable required RHEL repositories based on the distro version.
+
+    Args:
+        ceph: The node or context to run commands on.
+        distro_ver (str): The major RHEL version (e.g., '7', '8', '9')
+    """
+    repos = {
+        "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
+        "8": ["rhel-8-for-x86_64-appstream-rpms", "rhel-8-for-x86_64-baseos-rpms"],
+        "9": ["rhel-9-for-x86_64-appstream-rpms", "rhel-9-for-x86_64-baseos-rpms"],
+    }
+
+    sm = SubscriptionManager(ceph)
+    repos = Repos(ceph)
+
+    sm.set(distro_ver)
+
+    for repo in repos.get(distro_ver[0]):
+        repos.enable(repos=repo)
+
+
+def enable_rhel_eus_rpms(ceph, distro_ver):
+    """
+    Enable Extended Update Support (EUS) repositories for RHEL 7.
+
+    Args:
+        ceph: The node or object to run commands on.
+        distro_ver (str): The major RHEL version (e.g., '7').
+
+    Raises:
+        NotImplementedError: If the version is not supported for EUS.
+    """
+
+    sm = SubscriptionManager(ceph)
+    repos = Repos(ceph)
+
+    eus_repos = {"7": ["rhel-7-server-eus-rpms", "rhel-7-server-extras-rpms"]}
+    for repo in eus_repos.get(distro_ver[0]):
+        repos.enable(repos=repo)
+
+    if distro_ver[0] == "7":
+        release = "7.7"
+    else:
+        raise NotImplementedError(f"Cannot set EUS repos for {distro_ver[0]}")
+
+    sm.set(release)
+    ceph.exec_command(sudo=True, cmd="yum clean all", long_running=True)

--- a/cli/utilities/subscription_manager.py
+++ b/cli/utilities/subscription_manager.py
@@ -1,0 +1,102 @@
+import re
+
+from cli.exceptions import ConfigError
+from cli.utilities.packages import SubscriptionManager, SubscriptionManagerError
+from utility.log import Log
+from utility.utils import get_cephci_config
+
+log = Log(__name__)
+
+
+def setup_subscription_manager(ceph, server):
+    """
+    Set up the subscription manager on a Ceph node with provided credentials.
+
+    This includes:
+    - Unregistering the system if already registered
+    - Cleaning all local subscription data using `subscription-manager clean`
+    - Removing any residual certificate or identity files
+    - Registering to the specified subscription server
+
+    Args:
+        ceph: Ceph node object where subscription-manager is to be configured.
+        server: Name of the subscription server, used to fetch credentials from config.
+
+    Returns:
+        bool: True if subscription is successful, False otherwise.
+
+    Raises:
+        ConfigError: if credentials for the given server are not found.
+    """
+    configs = get_cephci_config()
+    creds = configs.get(f"{server}_credentials")
+    if not creds:
+        raise ConfigError(f"{server} credentials are not provided")
+
+    sm = SubscriptionManager(ceph)
+
+    # Clean all local subscription data: entitlements, certs, identity
+    try:
+        sm.unregister()
+    except SubscriptionManagerError as e:
+        log.warning(f"Unregister failed (possibly already unregistered): {e}")
+
+    try:
+        sm.clean()
+    except SubscriptionManagerError as e:
+        log.warning(f"Subscription clean failed; stale entitlements may remain: {e}")
+
+    try:
+        cleanup_subscription_files(ceph)
+    except SubscriptionManagerError as e:
+        log.warning(f"Residual subscription file cleanup failed (certs/identity): {e}")
+
+    # Registration
+    try:
+        sm.register(
+            username=creds.get("username"),
+            password=creds.get("password"),
+            serverurl=creds.get("serverurl"),
+            baseurl=creds.get("baseurl"),
+            force=True,
+        )
+        log.info(f"Subscribed to {server} server successfully")
+        return True
+    except SubscriptionManagerError as e:
+        log.error(f"Failed to subscribe to {server} server: {e}")
+        return False
+
+
+def subscription_manager_status(ceph):
+    """
+    Returns the current status of subscription-manager on the Ceph node.
+
+    Args:
+        ceph: Ceph node object
+
+    Returns:
+        str: Status string (e.g., "Subscribed", "Unknown", etc.)
+
+    Raises:
+        SubscriptionManagerError: if parsing the status fails.
+    """
+    expr = ".*Overall Status:(.*).*"
+    status = SubscriptionManager(ceph).status()
+    match = re.search(expr, status)
+    if not match:
+        raise SubscriptionManagerError("Unexpected subscription manager status")
+    return match.group(0)
+
+
+def cleanup_subscription_files(ceph):
+    """
+    Remove residual subscription-related certificate and identity files.
+
+    Args:
+        ceph: Ceph node object.
+
+    Raises:
+        SubscriptionManagerError: if the file cleanup command fails.
+    """
+    cmd = "rm -rf /etc/pki/consumer /etc/pki/product"
+    ceph.exec_command(sudo=True, long_running=True, cmd=cmd)


### PR DESCRIPTION
Refactored subscription manager workflow as suggested.

- Introduced clean() and cleanup_subscription_files() as separate methods.
- unregister() is now called explicitly before clean() to maintain clear separation of concerns.
- Residual subscription-related files (/etc/pki/consumer, /etc/pki/product) are removed in a dedicated method (cleanup_subscription_files) without modifying core CLI behavior.
- Confirmed that exec_command already handles exit codes via check_ec, so no additional status checks are used.

All subscription-manager logic is moved into a new subscription_manager.py module for better organization.

setup_subscription_manager() is updated to follow this clean and modular flow:
   unregister → clean → cleanup files → register

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
