### PR TITLE
Fix fetching build artifacts w/o custom config

### DIFF
--- a/run.py
+++ b/run.py
@@ -449,6 +449,7 @@ def run(args):
     kernel_repo = args.get("--kernel-repo")
     custom_config = args.get("--custom-config")
     custom_config_file = args.get("--custom-config-file")
+    ibm_build = False
 
     if custom_config:
         for _config in custom_config:


### PR DESCRIPTION
Follow up PR for #4862

A regression has been introduced due the changes made in PR #4862

It has been observed that in the scenario where custom config has not been provided and image and repo details have also not provided in run.py, `fetch_build_artifacts` method complains above not being able to reference unrecognized/un-initialized parameter `ibm_build`

```hyelloji@magna002:~/snapdiff_temp/cephci$ python run.py --osp-cred /home/hyelloji/hkumar_sys.yaml --cloud openstack --rhbuild 7.1 --platform rhel-9 --instances-name hk_81 --global-conf conf/reef/cephfs/tier-0_fs.yaml --suite suites/reef/cephfs/tier-0_fs.yaml --inventory conf/inventory/rhel-9.5-server-x86_64.yaml --log-level DEBUG --build latest --store
Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
log directory - /ceph/cephci-jenkins/cephci-run-GU8GN6
2025-06-09 02:59:37,332 - cephci - log:125 - INFO - Test logfile: /ceph/cephci-jenkins/cephci-run-GU8GN6/startup.log
Traceback (most recent call last):
  File "/home/hyelloji/snapdiff_temp/cephci/run.py", line 1096, in <module>
    rc = run(args)
  File "/home/hyelloji/snapdiff_temp/cephci/run.py", line 461, in run
    build, rhbuild, platform, upstream_build, ibm_build
UnboundLocalError: local variable 'ibm_build' referenced before assignment
```

This PR fixes the issue by initializing the variable `ibm_build` with default value `False` regardless of whether custom config is provided with run.py invocation or not

Signed-off-by: Harsh Kumar <hakumar@redhat.com>