### PR TITLE
[CephFS] Inclusion of suites and conf file for tentacle

### DIFF
--- a/conf/tentacle/cephfs/tier-0_fs.yaml
+++ b/conf/tentacle/cephfs/tier-0_fs.yaml
@@ -1,0 +1,39 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - osd
+          - mon
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - nfs
+          - mds
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - nfs
+          - mds
+      node7:
+        role:
+          - client

--- a/conf/tentacle/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/conf/tentacle/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -1,0 +1,55 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - osd
+          - installer
+        no-of-volumes: 4
+        disk-size: 30
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 30
+      node3:
+        role:
+          - mon
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 30
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 30
+      node5:
+        role: client
+      node6:
+        role: client
+      node7:
+        role: client
+      node8:
+        role: client
+      node9:
+        role: client
+      node10:
+        role: client
+      node11:
+        role: client
+      node12:
+        role: client
+      node13:
+        role: client
+      node14:
+        role: client
+      node15:
+        role: client

--- a/conf/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/conf/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -1,0 +1,78 @@
+globals:
+  - ceph-cluster:
+      name: ceph1
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - mds
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+      node3:
+        role:
+          - mon
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - cephfs-mirror
+          - mds
+      node7:
+          role: client
+  - ceph-cluster:
+      name: ceph2
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+      node3:
+        role:
+          - mon
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: client

--- a/conf/tentacle/cephfs/tier-1_cephfs_smb_nfs.yaml
+++ b/conf/tentacle/cephfs/tier-1_cephfs_smb_nfs.yaml
@@ -1,0 +1,60 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - smb
+      node2:
+        role:
+          - mon
+          - mgr
+          - smb
+      node3:
+        role:
+          - mon
+          - mds
+          - osd
+          - smb
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - osd
+          - mds
+          - smb
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - osd
+          - mds
+          - smb
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - osd
+          - nfs
+          - mds
+        no-of-volumes: 4
+        disk-size: 20
+      node7:
+        role:
+          - mds
+          - nfs
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client
+      node10:
+        role:
+          - client
+      node11:
+        role:
+          - client

--- a/conf/tentacle/cephfs/tier-1_fs.yaml
+++ b/conf/tentacle/cephfs/tier-1_fs.yaml
@@ -1,0 +1,55 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - osd
+          - nfs
+          - mds
+        no-of-volumes: 4
+        disk-size: 20
+      node7:
+        role:
+          - mds
+          - nfs
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client
+      node10:
+        role:
+          - client
+      node11:
+        role:
+          - client

--- a/conf/tentacle/cephfs/tier-2_cephfs_7-node-cluster.yaml
+++ b/conf/tentacle/cephfs/tier-2_cephfs_7-node-cluster.yaml
@@ -1,0 +1,57 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - mds
+      node4:
+        role:
+          - osd
+          - mds
+          - smb
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+          - smb
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - osd
+          - nfs
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - mds
+          - nfs
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client
+      node10:
+        role:
+          - client
+      node11:
+        role:
+          - client

--- a/conf/tentacle/cephfs/tier-2_cephfs_8mds-cluster.yaml
+++ b/conf/tentacle/cephfs/tier-2_cephfs_8mds-cluster.yaml
@@ -1,0 +1,73 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - mds
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - mds
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        role:
+          - mds
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node11:
+        role:
+          - client
+      node12:
+        role:
+          - client
+      node13:
+        role:
+          - client
+      node14:
+        role:
+          - client

--- a/conf/tentacle/cephfs/tier-2_cephfs_mirror_ha.yaml
+++ b/conf/tentacle/cephfs/tier-2_cephfs_mirror_ha.yaml
@@ -1,0 +1,82 @@
+globals:
+  - ceph-cluster:
+      name: ceph1
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - mds
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+      node3:
+        role:
+          - mon
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - cephfs-mirror
+          - mds
+      node7:
+        role:
+          - cephfs-mirror
+          - mds
+      node8:
+          role: client
+  - ceph-cluster:
+      name: ceph2
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+      node3:
+        role:
+          - mon
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: client

--- a/conf/tentacle/cephfs/tier-2_cephfs_upgrade.yaml
+++ b/conf/tentacle/cephfs/tier-2_cephfs_upgrade.yaml
@@ -1,0 +1,51 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - mds
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - osd
+          - nfs
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - mds
+          - nfs
+          - osd
+          - grafana
+        no-of-volumes: 4
+        disk-size: 15
+
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client

--- a/conf/tentacle/cephfs/tier-3_cephfs_4clients_4osd.yaml
+++ b/conf/tentacle/cephfs/tier-3_cephfs_4clients_4osd.yaml
@@ -1,0 +1,58 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - mds
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - osd
+          - nfs
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - mds
+          - nfs
+      node8:
+        role:
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - client
+      node10:
+        role:
+          - client
+      node11:
+        role:
+          - client
+      node12:
+        role:
+          - client
+

--- a/conf/tentacle/cephfs/tier-3_cephfs_system_test.yaml
+++ b/conf/tentacle/cephfs/tier-3_cephfs_system_test.yaml
@@ -1,0 +1,182 @@
+# Cluster for System test on Baremetal environment.
+# The below defined cluster has 11 nodes.
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.8.128.0/21']
+      nodes:
+        -
+          hostname: magna021
+          id: node1
+          ip: 10.8.128.21
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna022
+          id: node2
+          ip: 10.8.128.22
+          root_password: passwd
+          role:
+            - mgr
+            - mon
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna023
+          id: node3
+          ip: 10.8.128.23
+          root_password: passwd
+          role:
+            - mon
+            - osd
+            - mds
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna024
+          id: node4
+          ip: 10.8.128.24
+          root_password: passwd
+          role:
+            - mds
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna025
+          id: node5
+          ip: 10.8.128.25
+          root_password: passwd
+          role:
+            - mds
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna026
+          id: node6
+          ip: 10.8.128.26
+          root_password: passwd
+          role:
+            - mds
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: magna027
+          id: node7
+          ip: 10.8.128.27
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdd
+        -
+          hostname: magna028
+          id: node8
+          ip: 10.8.128.28
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: rhel94client1
+          id: node101
+          ip: 10.8.131.201
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client2
+          id: node102
+          ip: 10.8.131.202
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client3
+          id: node103
+          ip: 10.8.131.203
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client4
+          id: node104
+          ip: 10.8.131.204
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client5
+          id: node105
+          ip: 10.8.131.205
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client6
+          id: node106
+          ip: 10.8.131.206
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client7
+          id: node107
+          ip: 10.8.131.207
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client8
+          id: node108
+          ip: 10.8.131.208
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client9
+          id: node109
+          ip: 10.8.131.209
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client10
+          id: node110
+          ip: 10.8.131.210
+          root_password: passwd
+          role:
+            - client

--- a/suites/tentacle/cephfs/8_1_features_suite.yaml
+++ b/suites/tentacle/cephfs/8_1_features_suite.yaml
@@ -1,0 +1,178 @@
+---
+tests:
+  ######################################################################################################################
+  # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml
+  # Features Covered - case-insensitive,fscrypt
+  # Pre-Requisites
+  # Cluster Deployment
+  # Configure 4 Cephfs clients
+  ######################################################################################################################
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+
+  ######################################################################################################################
+  # Suite file : suites/squid/cephfs/tier-1_cephfs_case_sensitivity.yaml
+  # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml
+  # Features Covered
+  # case-insensitive feature
+  ######################################################################################################################
+  - test:
+      name: test cephfs attributes - functional
+      module: cephfs_case_sensitivity.case_sensitivity_functional.py
+      polarion-id: CEPH-83606639
+      desc: Test fs attributes for functional use case
+      abort-on-fail: false
+  - test:
+      name: test cephfs attributes - negative
+      module: cephfs_case_sensitivity.case_sensitivity_negative.py
+      polarion-id: CEPH-83611927
+      desc: Test fs attributes for negative use case
+      abort-on-fail: false
+  - test:
+      name: test cephfs attributes - disruptive
+      module: cephfs_case_sensitivity.case_sensitivity_disruptive.py
+      polarion-id: CEPH-83611928
+      desc: Test fs attributes for disruptive use case
+      abort-on-fail: false
+  - test:
+      name: test cephfs attributes - subvolume
+      module: cephfs_case_sensitivity.case_sensitivity_subvolume.py
+      polarion-id: CEPH-83617010
+      desc: Test fs attributes for functional use case
+      abort-on-fail: false
+
+  ######################################################################################################################
+  # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml
+  # Features Covered
+  # fscrypt basic,functional,negative tests
+  ######################################################################################################################
+  - test:
+      abort-on-fail: false
+      desc: "Verify fscrypt basic tests - lifecycle,non_empty_path and metadata validation"
+      destroy-cluster: false
+      module: cephfs_fscrypt.test_fscrypt_basic.py
+      name: "fscrypt_basic"
+      polarion-id: CEPH-83607378
+  - test:
+      abort-on-fail: false
+      desc: "Verify fscrypt functional tests - fscrypt_enctag,fscrypt_datapath,fscrypt_xttrs,fscrypt_file_types"
+      destroy-cluster: false
+      module: cephfs_fscrypt.test_fscrypt_functional.py
+      name: "fscrypt_functional"
+      polarion-id: CEPH-83619943
+  - test:
+      abort-on-fail: false
+      desc: "Verify fscrypt negative tests - filename_len,key_remove,key_remove_diff_clients,wrong_key_msg_validate"
+      destroy-cluster: false
+      module: cephfs_fscrypt.test_fscrypt_negative.py
+      name: "fscrypt_negative"
+      polarion-id: CEPH-83607406

--- a/suites/tentacle/cephfs/9_0_features_suite.yaml
+++ b/suites/tentacle/cephfs/9_0_features_suite.yaml
@@ -1,0 +1,120 @@
+---
+tests:
+  ######################################################################################################################
+  # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml
+  # Features Covered - <TBD>
+  # Pre-Requisites
+  # Cluster Deployment
+  # Configure 4 Cephfs clients
+  ######################################################################################################################
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"

--- a/suites/tentacle/cephfs/kernel_post_verification.yaml
+++ b/suites/tentacle/cephfs/kernel_post_verification.yaml
@@ -1,0 +1,230 @@
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Deploy cluster with enforcing mode(default mode).
+      module: test_cephadm.py
+      polarion-id: CEPH-83573740
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            node: node8
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.2
+            node: node9
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 2
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.3
+            node: node10
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 3
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.4
+            node: node11
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 4
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573445
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83571366
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+        name: cephfs_tier1_ops
+        module: cephfs_tier1_ops.py
+        polarion-id: CEPH-83573447
+        desc: cephfs tier1 operations
+        abort-on-fail: false
+  - test:
+        name: cephfs_client_authorize
+        module: client_authorize.py
+        polarion-id: CEPH-83574483
+        desc: client authorize test for cephfs
+        abort-on-fail: false
+  - test:
+      name: cephfs-mdsfailover-pinning-io
+      module: dir_pinning.py
+      config:
+        num_of_dirs: 200
+      polarion-id: CEPH-11227
+      desc: MDSfailover on active-active mdss,performing client IOs with no pinning at the first,later pin 10 dirs with IOs
+      abort-on-fail: false
+  - test:
+      name: cephfs subvolume authorize test
+      desc: Test cephfs subvolume client authorize
+      module: subvolume_authorize.py
+      polarion-id: CEPH-83574596
+      abort-on-fail: false
+  - test:
+      name: no recover session mount
+      module: no_recover_session_mount.py
+      polarion-id: CEPH-11260
+      desc: test no recover session mount by blocking the client node
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Run fsstress on kernel and fuse mounts
+      module: cephfs_bugs.test_fsstress_on_kernel_and_fuse.py
+      polarion-id: CEPH-83575623
+      desc: Run fsstress on kernel and fuse mounts
+      abort-on-fail: false
+  - test:
+      name: Run xfs test on kernel
+      module: xfs_test.py
+      polarion-id: CEPH-83575623
+      desc: Run xfs test on kernel
+      abort-on-fail: false
+

--- a/suites/tentacle/cephfs/regression_mirror_suite.yaml
+++ b/suites/tentacle/cephfs/regression_mirror_suite.yaml
@@ -1,0 +1,107 @@
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_mirror.yaml
+# Test-Case: Configure CephFS Mirror setup and run IOs
+
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: "CEPH-83574099"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring modification of source and target cluster"
+      clusters:
+        ceph1:
+          config:
+            name: Configure CephFS Mirroring modification of source and target cluster
+      module: cephfs_mirroring.validate_file_dir_stats_modification_on_mirrored_cluster.py
+      name: validate_file_dir_stats_modification_on_mirrored_cluster
+      polarion-id: "CEPH-83575625"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring on multiple FS"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Mirroring is successful upon enabling fs mirroring on multiple FS from source to same destinatio
+      module: cephfs_mirroring.test_cephfs_mirroring_validate_cephfs-mirroring_on_multifs_setup.py
+      name: Validate the Mirroring is successful upon enabling fs mirroring on multiple FS from source to same destination
+      polarion-id: "CEPH-83574107"
+  - test:
+      abort-on-fail: false
+      desc: "modify User caps and validate the mirroring sync."
+      clusters:
+        ceph1:
+          config:
+            name: "modify User caps and validate the mirroring sync."
+      module: cephfs_mirroring.test_cephfs_mirror_auth_caps.py
+      name: modify User caps and validate the mirroring sync.
+      polarion-id: "CEPH-83574109"
+  - test:
+      abort-on-fail: false
+      desc: "Modify the Remote Snap Directories"
+      clusters:
+        ceph1:
+          config:
+            name: Modify the Remote Snap Directories
+      module: cephfs_mirroring.test_cephfs_mirroring_modify_remote_snapshots.py
+      name: Modify the Remote Snap Directories
+      polarion-id: "CEPH-83574120"
+  - test:
+      abort-on-fail: false
+      desc: "Convert single node to HA configuration"
+      clusters:
+        ceph1:
+          config:
+            name: Convert single node to HA configuration
+      module: cephfs_mirroring.test_cephfs_mirror_ha_conversion.py
+      name: Convert single node to HA configuration
+      polarion-id: "CEPH-83575340"
+  - test:
+      abort-on-fail: false
+      desc: "Validate all failure scenarios to disconnect the mirroring"
+      clusters:
+        ceph1:
+          config:
+            name: Validate all failure scenarios to disconnect the mirroring
+      module: cephfs_mirroring.test_cephfs_mirror_disconnect.py
+      name: Validate all failure scenarios to disconnect the mirroring
+      polarion-id: "CEPH-83574100"
+  - test:
+      abort-on-fail: false
+      desc: "Validate multiple snapshots Synchronization on Mirror setup"
+      clusters:
+        ceph1:
+          config:
+            name: Validate multiple snapshots Synchronization on Mirror setup
+      module: cephfs_mirroring.test_cephfs_mirroring_multiple_snapshots.py
+      name: Validate multiple snapshots Synchronization on Mirror setup
+      polarion-id: "CEPH-83580026"
+  - test:
+      abort-on-fail: false
+      desc: "Validate Snapshot Sync status using asok file"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation Status using asok file
+      module: cephfs_mirroring.test_cephfs_mirroring_snap_status_using_asok.py
+      name: Validate the Synchronisation Status using asok file
+      polarion-id: "CEPH-83593134"
+  - test:
+      abort-on-fail: false
+      desc: "Validate snapshot synchronisation using SnapSchedule"
+      clusters:
+        ceph1:
+          config:
+            name: Validate snapshot synchronisation using SnapSchedul
+      module: cephfs_mirroring.test_cephfs_mirroring_with_snap_schedule.py
+      name: Validate snapshot synchronisation using SnapSchedul
+      polarion-id: "CEPH-83598968"

--- a/suites/tentacle/cephfs/regression_suite.yaml
+++ b/suites/tentacle/cephfs/regression_suite.yaml
@@ -1,0 +1,1170 @@
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args: # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  ######################################################################################################################
+  # Suite file : tier-2_file-dir-lay_vol-mgmt_nfs.yaml
+  # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml
+  # Features Covered
+  # File Directory Layout
+  # CephFS Volume management
+  # NFS
+  ######################################################################################################################
+  - test:
+      name: File and Dir Layout Lifecycle Operations
+      module: cephfs_file_and_dir_layout.file_dir_layout_lifecycle_ops.py
+      polarion-id: CEPH-11334
+      desc: File and Directory Layout Lifecycle Operations
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export path"
+      module: cephfs_nfs.nfs_export_path.py
+      name: "cephfs nfs export path"
+      polarion-id: "CEPH-83574028"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs snapshot clone operations"
+      module: cephfs_nfs.nfs_snaphshot_clone.py
+      name: "cephfs nfs snapshot clone operations"
+      polarion-id: "CEPH-83574024"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs subvolume & subvolumegroup operations"
+      module: cephfs_nfs.nfs_subvolume_subvolumegroup.py
+      name: "cephfs nfs subvolume & subvolumegroup operations"
+      polarion-id: "CEPH-83574027"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs read only export"
+      module: cephfs_nfs.read_only_nfs_export.py
+      name: "cephfs nfs read only export"
+      polarion-id: "CEPH-83574003"
+  - test:
+      abort-on-fail: false
+      desc: "test recreation of cephfs nfs cluster with same name"
+      module: cephfs_nfs.recreate_same_name_nfs.py
+      name: "recreate same name nfs cluster"
+      polarion-id: "CEPH-83574015"
+  - test:
+      abort-on-fail: false
+      desc: "test creation of 2 node nfs cluster"
+      module: cephfs_nfs.2_node_nfs.py
+      name: "2 node nfs cluster"
+      polarion-id: "CEPH-83574022"
+  - test:
+      abort-on-fail: false
+      desc: "test zipping & unzipping files on nfs export continuously"
+      module: cephfs_nfs.zip_unzip_files_nfs.py
+      name: "zipping & unzipping files on nfs export"
+      polarion-id: "CEPH-83574026"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export for cephfs subvolume"
+      module: cephfs_nfs.subvolume_export.py
+      name: "cephfs nfs export for subvolume"
+      polarion-id: "CEPH-83573993"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on non-existing directory"
+      module: cephfs_nfs.nfs_non_exist_export_path.py
+      name: "Create cephfs nfs export on non-existing directory"
+      polarion-id: "CEPH-83573669"
+  - test:
+      abort-on-fail: false
+      desc: "Export and import data between NFS and CephFS"
+      module: cephfs_nfs.move_data_bw_nfs_and_cephfs_mounts.py
+      name: "Move Data bw nfs and cephfs exports"
+      polarion-id: "CEPH-11309"
+  - test:
+      abort-on-fail: false
+      desc: "Test data integrity between cephfs & nfs mounts"
+      module: cephfs_nfs.test_data_integrity_nfs_cephfs_mounts.py
+      name: "data integrity between cephfs & nfs mounts"
+      polarion-id: "CEPH-11312"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on existing path"
+      module: cephfs_nfs.existing_path_nfs_export.py
+      name: "existing path cephfs nfs export"
+      polarion-id: "CEPH-83573995"
+  - test:
+      abort-on-fail: false
+      desc: "Run IOs by mounting same subvolume with all the three mounts"
+      module: cephfs_nfs.nfs_fuse_kernel_same_subvolume.py
+      name: "Mount same volume on fuse,kernel and nfs and runIOs"
+      polarion-id: "CEPH-11310"
+  - test:
+      abort-on-fail: false
+      desc: "Backup and restore data using existing NFS backup tools"
+      module: cephfs_nfs.data_backup_restore_bw_nfs_and_local_mounts.py
+      name: "backup and restore data bw nfs exports and local dir"
+      polarion-id: "CEPH-11314"
+  - test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
+  - test:
+      abort-on-fail: false
+      desc: "Apply various number of hosts to nfs cluster and verify the changes"
+      module: cephfs_nfs.nfs_update_cluster_node_changes.py
+      name: "nfs cluster host changes and verification"
+      polarion-id: "CEPH-83574013"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs with io and network failures"
+      module: cephfs_nfs.nfs_io_network_failures.py
+      name: "cephfs nfs with io and network failures"
+      polarion-id: "CEPH-83574020"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs mount with fstab entry"
+      module: cephfs_nfs.nfs_mount_with_fstab.py
+      name: "cephfs nfs mount with fstab entry"
+      polarion-id: "CEPH-83574025"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_ro_rw_access.py
+      name: "cephfs nfs RO and RW export"
+      polarion-id: "CEPH-83574001"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_export_config.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83574008"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs config reset"
+      module: cephfs_nfs.nfs_config_reset.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83573999"
+  - test:
+      abort-on-fail: false
+      desc: "modifying_nfs_cluster_invalid_value"
+      module: cephfs_nfs.modifying_nfs_cluster_invalid_value.py
+      name: "modifying_nfs_cluster_invalid_value"
+      polarion-id: "CEPH-83574014"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_transfer_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+      name: "nfs_file_transfer_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575825"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_file_attributes_retention.py
+      name: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575937"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_multiple_export_using_single_conf"
+      module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
+      name: "nfs_multiple_export_using_single_conf"
+      polarion-id: "CEPH-83575082"
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  #cephfs_vol_management
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Create a subvolume in a non-existent subvolume group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: Create a subvolume in a non-existent subvolume group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false
+  - test:
+      name: CephFS Volume Operations
+      module: cephfs_vol_management.cephfs_vol_mgmt_test_volume.py
+      polarion-id: CEPH-83604097
+      desc: Test for validating all CephFS Volume Operations
+      abort-on-fail: false
+  - test:
+      name: volume rename, subvolume earmark, subvolumegroup idempotence scenarios
+      module: cephfs_vol_management.cephfs_vol_mgmt_rename_earmark_subvolume.py
+      polarion-id: CEPH-83604978
+      desc: volume rename, subvolume earmark, subvolumegroup idempotence scenarios
+      abort-on-fail: false
+  - test:
+      name: vol_info
+      module: cephfs_vol_management.cephfs_vol_info.py
+      polarion-id: CEPH-83606764
+      desc: Validate the volume info command and ensure the output is accurate.
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  ######################################################################################################################
+  # Tier-1_fs
+  ######################################################################################################################
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: cephfs_client_authorize
+      module: client_authorize.py
+      polarion-id: CEPH-83574483
+      desc: client authorize test for cephfs
+      abort-on-fail: false
+  - test:
+      name: cephfs-mdsfailover-pinning-io
+      module: dir_pinning.py
+      config:
+        num_of_dirs: 200
+      polarion-id: CEPH-11227
+      desc: MDSfailover on active-active mdss,performing client IOs with no pinning at the first,later pin 10 dirs with IOs
+      abort-on-fail: false
+  - test:
+      name: cephfs subvolume authorize test
+      desc: Test cephfs subvolume client authorize
+      module: subvolume_authorize.py
+      polarion-id: CEPH-83574596
+      abort-on-fail: false
+  - test:
+      name: no recover session mount
+      module: no_recover_session_mount.py
+      polarion-id: CEPH-11260
+      desc: test no recover session mount by blocking the client node
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Ensure kernel mounts works with all available options and validate the functionality of each option"
+      module: fs_kernel_mount_options.py
+      name: fs_kernel_mount_options
+      polarion-id: "CEPH-83575389"
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  ######################################################################################################################
+  # Suite File Name : tier-2_fs_mutlifs_quota_snaphost.yaml
+  # Features Covered
+  # Multi FS
+  # Quota
+  # Snapshot
+  ######################################################################################################################
+  - test:
+      abort-on-fail: false
+      desc: "Fill the cluster with specific percentage"
+      module: test_io.py
+      name: Fill_Cluster
+      config:
+        cephfs:
+          "fill_data": 60
+          "io_tool": "smallfile"
+          "mount": "fuse"
+          "filesystem": "cephfs"
+          "mount_dir": ""
+  - test:
+      name: Stanby-replay mds
+      module: stand_by_replay_mds.py
+      polarion-id: CEPH-83573269
+      desc: Stanby-replay mds testt
+      abort-on-fail: false
+  - test:
+      name: mds service add removal test
+      module: mds_rm_add.py
+      polarion-id: CEPH-11259
+      desc: mds service add removal test
+      abort-on-fail: false
+  - test:
+      name: mon service add removal test
+      module: mon_rm_add.py
+      polarion-id: CEPH-11345
+      desc: mon service add removal test
+      abort-on-fail: false
+  - test:
+      name: mds service stop & start test
+      module: mon_rm_add.py
+      polarion-id: CEPH-83574339
+      desc: mds service stop & start test
+      abort-on-fail: false
+  - test:
+      name: multifs flag
+      module: multifs.multifs_flag.py
+      polarion-id: CEPH-83573878
+      desc: Tests the multifs flag functionality
+      abort-on-fail: false
+  - test:
+      name: multifs same pool
+      module: multifs.multifs_same_pool.py
+      polarion-id: CEPH-83573873
+      desc: Tests the file system with same pools
+      abort-on-fail: false
+  - test:
+      name: multifs reboot with fstab
+      module: multifs.multifs_kernelmounts.py
+      polarion-id: CEPH-83573872
+      desc: Tests the file system with fstab entries with multiple file systems and reboots using kernel mount
+      abort-on-fail: false
+  - test:
+      name: multifs reboot with fstab fuse
+      module: multifs.multifs_fusemounts.py
+      polarion-id: CEPH-83573871
+      desc: Tests the file system with fstab entries with multiple file systems and reboots using fuse mount
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems wtih different MDS daemons
+      module: multifs.multifs_default_values.py
+      polarion-id: CEPH-83573870
+      desc: Create 2 Filesystem with default values on different MDS daemons
+      abort-on-fail: false
+      comments: BZ-2368774
+  - test:
+      name: creation of multiple file systems
+      module: multifs.multifs_multiplefs.py
+      polarion-id: CEPH-83573867
+      desc: Create 4-5 Filesystem randomly on different MDS daemons
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-increase-test
+      module: quota.quota_files_increase.py
+      polarion-id: CEPH-83573400
+      desc: Tests the increase of file attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-decrease-test
+      module: quota.quota_files_decrease.py
+      polarion-id: CEPH-83573403
+      desc: Tests the increase of file attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-remove-test
+      module: quota.quota_files_remove.py
+      polarion-id: CEPH-83573405
+      desc: Tests the remove of file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573402
+      desc: Tests the Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-increase-test
+      module: quota.quota_bytes_increase.py
+      polarion-id: CEPH-83573401
+      desc: Tests the increase of Byte attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-decrease-test
+      module: quota.quota_bytes_decrease.py
+      polarion-id: CEPH-83573407
+      desc: Tests the decrease of Byte attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-remove-test
+      module: quota.quota_bytes_remove.py
+      polarion-id: CEPH-83573409
+      desc: Tests the remove of Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Quota-Reboot-test
+      module: quota.quota_reboot.py
+      polarion-id: CEPH-83573408
+      desc: Tests the remove of Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Quota-file-byte-test
+      module: quota.quota_files_bytes.py
+      polarion-id: CEPH-83573406
+      desc: Tests the file and byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  - test:
+      name: snapshot_flag
+      module: snapshot_clone.snapshot_flag.py
+      polarion-id: CEPH-83573415
+      desc: Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+       ENABLE_LOGS : 1
+       daemon_list : ['mds','mgr','client']
+       daemon_dbg_level : {'mds':10,'mgr':10,'client':10}
+  - test:
+      name: Clone_status
+      module: snapshot_clone.clone_status.py
+      polarion-id: CEPH-83573501
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Clone_cancel_status
+      module: snapshot_clone.clone_cancel_status.py
+      polarion-id: CEPH-83573502
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Retain_Snapshots
+      module: snapshot_clone.retain_snapshots.py
+      polarion-id: CEPH-83573521
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: Remove_Subvolume_clone
+      module: snapshot_clone.clone_remove_subvol.py
+      polarion-id: CEPH-83573499
+      desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: subvolume_full_vol
+      module: snapshot_clone.clone_subvolume_full_vol.py
+      polarion-id: CEPH-83574724
+      desc: Clone a subvolume with full data in the subvolume
+      abort-on-fail: false
+  - test:
+      name: cancel the subvolume snapshot cloning
+      module: snapshot_clone.clone_cancel_in_progress.py
+      polarion-id: CEPH-83574681
+      desc: Try to cancel the snapshot while clonning is operating
+      abort-on-fail: false
+  - test:
+      name: Clone_attributes
+      module: snapshot_clone.clone_attributes.py
+      polarion-id: CEPH-83573524
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+       DISABLE_LOGS : 1
+       daemon_list : ['mds','mgr','client']
+  - test:
+      name: Concurrent-clone-test
+      module: snapshot_clone.clone_threads.py
+      polarion-id: CEPH-83574592
+      desc: Concurrent-clone-test
+      abort-on-fail: false
+  - test:
+      name: Test Max Snapshot limit
+      module: snapshot_clone.max_snapshot_limit.py
+      polarion-id: CEPH-83573520
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: Snapshot reboot
+      module: snapshot_clone.snapshot_reboot.py
+      polarion-id: CEPH-83573418
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: Snapshot write
+      module: snapshot_clone.snapshot_write.py
+      polarion-id: CEPH-83573420
+      desc: Try writing the data to snap directory
+      abort-on-fail: false
+  - test:
+      name: cross_platform_snaps
+      module: snapshot_clone.cross_platform_snaps.py
+      polarion-id: CEPH-11319
+      desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: rename snap directory
+      module: snapshot_clone.rename_snap_dir.py
+      polarion-id: CEPH-83573255
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: subvolume_info_retain
+      module: snapshot_clone.subvolume_info_retain.py
+      polarion-id: CEPH-83573522
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: snapshot_metadata
+      module: snapshot_clone.snapshot_metadata.py
+      polarion-id: CEPH-83575038
+      desc: verify CRUD operation on metadata of subvolume's snapshot
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_test
+      module: snapshot_clone.snap_schedule.py
+      polarion-id: CEPH-83575569
+      desc: snap_schedule_test
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_retention_vol_subvol
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83579271
+      desc: snap schedule and retention functional test on vol and subvol
+      abort-on-fail: false
+      config:
+        test_name: functional
+  - test:
+      name: snap_sched_multi_fs
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83581235
+      desc: snap schedule and retention functional test on multi-fs setup
+      abort-on-fail: false
+      config:
+        test_name: systemic
+  - test:
+      name: snapshot_nfs_mount
+      module: snapshot_clone.snapshot_nfs_mount.py
+      polarion-id: CEPH-83592018
+      desc: Validate Snapshot mount through NFS suceeds and snapshot data is accessible
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_with_mds_restart
+      module: snapshot_clone.snap_schedule_with_mds_restart.py
+      polarion-id: CEPH-83600860
+      desc: Validate Verify Kernel and FUSE Mount Behavior with Snapshot Scheduling and MDS Restarts
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  ######################################################################################################################
+  # Suite File Name : tier-2_cephfs_test-clients.yaml
+  # Features Covered
+  # Fs Clients
+  ######################################################################################################################
+  - test:
+      name: multiple clients run IO's on same directory from each clients and exersize POSIX locks
+      module: clients.multiple_clients_posix_calls.py
+      polarion-id: CEPH-10529
+      desc: multiple clients exersizing POSIX locks
+      abort-on-fail: false
+  - test:
+      name: smallfile IO on multiple clients with diff operations
+      module: clients.smallfiles_with_different_operations.py
+      polarion-id: CEPH-10625
+      desc: smallfiles with different operations
+      abort-on-fail: false
+  - test:
+      name: Mount single directory and perform IO ops from multiple clients
+      module: clients.multiclients_io_on_same_directory.py
+      polarion-id: CEPH-11224
+      desc: multiple clients performing IO on same directory
+      abort-on-fail: false
+  - test:
+      name: rsync tests bw fs and other location and vice versa
+      module: clients.rsync_bw_fs_and_other_location.py
+      polarion-id: CEPH-11298
+      desc: rsync bw filesystem and other location and vice versa
+      abort-on-fail: false
+  - test:
+      name: scp bw fs and remote path and vice versa
+      module: clients.mirgate_data_bw_fs_and_remote_using_scp.py
+      polarion-id: CEPH-11299
+      desc: scp bw filesystem and remote directory and vice versa
+      abort-on-fail: false
+  - test:
+      name: Running basic bash commands on fuse,Kernel and NFS mounts
+      module: clients.fs_basic_bash_cmds.py
+      polarion-id: CEPH-11300
+      desc: Running basic bash commands on fuse,Kernel and NFS mounts
+      abort-on-fail: false
+      config:
+        no_of_files: 1000
+        size_of_files: 1
+        num_dir: 100
+  - test:
+      name: Client File locking on mounts
+      module: clients.file_lock_on_mounts.py
+      polarion-id: CEPH-11304
+      desc: Test File locking on mounts
+      abort-on-fail: false
+  - test:
+      name: Client eviction
+      module: clients.client_evict.py
+      polarion-id: CEPH-11335
+      desc: Test Filesystem client eviction
+      abort-on-fail: false
+  - test:
+      name: Filesystem mount with fstab entry and reboot the client
+      module: clients.client_fstab_auto_mount.py
+      polarion-id: CEPH-11336
+      desc: Update fstab and reboot client to check auto mount of FS works
+      abort-on-fail: false
+  - test:
+      name: Mount and unmount CephFS repeatedly in interval of 30 min & check data integrity
+      module: clients.integrity_check_after_remount.py
+      polarion-id: CEPH-11337
+      desc: Mount and unmount CephFS repeatedly in interval of 30 min & check data integrity
+      abort-on-fail: false
+  - test:
+      name: Filesystem information restriction for client
+      module: clients.multiclient_cephx_restrict_fs.py
+      polarion-id: CEPH-11338
+      desc: Test Filesystem information restriction for client for multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: multi client file and dir ops
+      module: clients.multiclient_file_dir_ops.py
+      polarion-id: CEPH-83573529
+      desc: multi client file and dir ops
+      abort-on-fail: false
+  - test:
+      name: cross delete operations
+      module: clients.cross_delete_ops_bw_fuse_and_kernel_clients.py
+      polarion-id: CEPH-83573532
+      desc: Cross Delete Ops b/w Fuse and Kernel mounts
+      abort-on-fail: false
+  - test:
+      name: mds restriction for client for multifs
+      module: clients.client_mds_restriction.py
+      polarion-id: CEPH-83573869
+      desc: Test mds restriction for client for multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: Filesystem information restriction for client
+      module: clients.client_fs_information_restriction.py
+      polarion-id: CEPH-83573875
+      desc: Test Filesystem information restriction for client for multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: No data sharing between multifs
+      module: clients.test_no_data_sharing_multifs.py
+      polarion-id: CEPH-83573876
+      desc: Test no data sharing between multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: Mount multifs with same client
+      module: clients.multifs_mount_same_client.py
+      polarion-id: CEPH-83573877
+      desc: Test mounting multiple cephfs with same client
+      abort-on-fail: false
+  - test:
+      name: Create users with permissions
+      module: clients.create_user_with_permissions.py
+      polarion-id: CEPH-83574327
+      desc: Create users with permissions and verify the permissions
+      abort-on-fail: false
+  - test:
+      name: ceph auth caps change permission and check
+      module: clients.ceph_auth_caps_modifying_permissions.py
+      polarion-id: CEPH-83574328
+      desc: generate all the possible permissions and verify the permissions
+      abort-on-fail: false
+  - test:
+      name: multi client unlink file
+      module: clients.file_unlink_on_clients.py
+      polarion-id: CEPH-83575042
+      desc: multi client unlink file
+      abort-on-fail: false
+  - test:
+      name: verify user read and write permissions
+      module: clients.verify_user_read_write_permissions.py
+      polarion-id: CEPH-83575574
+      desc: verify user read and write permissions
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "MDS failover while IO is going on each client"
+      module: clients.MDS_failover_while_client_IO.py
+      polarion-id: CEPH-11242
+      config:
+        num_of_file_dir: 1000
+      name: "MDS failover whi client IO"
+  - test:
+      name: Test important MDS Configuration Settings
+      module: clients.mds_conf_modifying.py
+      polarion-id: CEPH-11329
+      desc: Test important MDS Configuration Settings
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "multiple clients permission in mounted directory"
+      module: clients.multiple_clients_permission_mounted_directories.py
+      name: multiple clients permission in mounted directory
+      polarion-id: "CEPH-11340"
+  - test:
+      abort-on-fail: false
+      desc: "mds journal value conf verification"
+      module: clients.mds_journal_value_conf_verification.py
+      name: mds journal value conf verification
+      polarion-id: "CEPH-11331"
+  - test:
+      abort-on-fail: false
+      desc: "mds scrub only with one mds after failover"
+      module: clients.mds_scrub_after_failover.py
+      name: mds scrub only with one mds after failover
+      polarion-id: "CEPH-83573489"
+  - test:
+      abort-on-fail: false
+      desc: "Verify root_squash cap works in multiFS"
+      module: clients.verify_root_squash_in_caps.py
+      name: verify root_squash cap works in multiFS
+      polarion-id: "CEPH-83573868"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client eviction is deferred if OSD was laggy"
+      module: cephfs_bugs.test_defer_client_evict_on_laggy_osd.py
+      name: Client eviction deferred if OSD is laggy
+      polarion-id: "CEPH-83581592"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client is blocklisted if session metadata is bloated"
+      module: cephfs_bugs.test_client_blocklist_large_session_metadata.py
+      name: Verify Client is blocklisted if session metadata is bloated
+      polarion-id: "CEPH-83581613"
+  - test:
+      abort-on-fail: false
+      desc: "Validate Root Sqaush operations on Cephfs"
+      module: clients.validate_root_squash.py
+      name: Validate Root Sqaush operations on Cephfs
+      comments: "BZ-2293943"
+      polarion-id: "CEPH-83591419"
+  - test:
+      abort-on-fail: false
+      desc: "Client Caps Validation during quiesce,mds failover and evict"
+      module: clients.client_caps_update_validation.py
+      name: client_caps_update_validation
+      polarion-id: "CEPH-83597462"
+  - test:
+      abort-on-fail: false
+      desc: "Validate directory creation with non root user with root_squash"
+      module: clients.client_root_squash_non_root_user.py
+      name: client_root_squash_non_root_user
+      polarion-id: "CEPH-83602912"
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_clean_up.py
+      name: "setup Cleanup after the test suite"
+  ######################################################################################################################
+  # Suite File Name : tier-1_cephfs_cg_quiesce.yaml
+  # Features Covered
+  # FS CG Quiesce
+  ######################################################################################################################
+  - test:
+      abort-on-fail: false
+      desc: "Verify quiesce release with if-version, repeat with exclude and include prior to release"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_2"
+      polarion-id: CEPH-83581470
+      config:
+        test_name: cg_snap_func_workflow_2
+  - test:
+      abort-on-fail: false
+      desc: "Verify restore suceeds from snapshot taken when subvolume was quiesced"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_4"
+      polarion-id: CEPH-83590254
+      config:
+        test_name: cg_snap_func_workflow_4
+  - test:
+      abort-on-fail: false
+      desc: "Verify quiesce release response when quiesce-timeout and quiesce-expire time is reached"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_5"
+      polarion-id: CEPH-83590255
+      config:
+        test_name: cg_snap_func_workflow_5
+  - test:
+      abort-on-fail: false
+      desc: "Verify state transitions suceed during quiescing,quiesced and releasing state"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_6"
+      polarion-id: CEPH-83590256
+      config:
+        test_name: cg_snap_func_workflow_6
+  - test:
+      abort-on-fail: false
+      desc: "Verify quiesce suceeds with IO from nfs,fuse and kernel mounts"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_interop_workflow_2"
+      polarion-id: CEPH-83591508
+      config:
+        test_name: cg_snap_interop_workflow_2
+  - test:
+      abort-on-fail: false
+      desc: "Verify parallel quiesce calls to same quiesce set members"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_neg_workflow_1"
+      polarion-id: CEPH-83591512
+      config:
+        test_name: cg_snap_neg_workflow_1
+  - test:
+      abort-on-fail: false
+      desc: "Verify CG quiesce on pre-provisioned quiesce set"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_3"
+      polarion-id: CEPH-83590253
+      config:
+        test_name: cg_snap_func_workflow_3
+  - test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+        ENABLE_LOGS: 1
+        daemon_list: ["mds", "client"]
+        daemon_dbg_level: { "mds": 20, "client": 20 }
+  - test:
+      abort-on-fail: false
+      desc: "Verify quiesce lifecycle with and without --await"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_1"
+      polarion-id: CEPH-83581467
+      config:
+        test_name: cg_snap_func_workflow_1
+  - test:
+      abort-on-fail: false
+      desc: "Verify quiesce ops in parallel to multi-MDS failover"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_interop_workflow_1"
+      polarion-id: CEPH-83581472
+      config:
+        test_name: cg_snap_interop_workflow_1
+      comments: product bug bz-2273569
+  - test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+        DISABLE_LOGS: 1
+        daemon_list: ["mds", "client"]

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_9x.yaml
@@ -1,0 +1,399 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 7.1
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 7.1
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node7"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: false
+
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_81x_latest_to_9x_latest.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_81x_latest_to_9x_latest.yaml
@@ -1,0 +1,399 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 8.1
+                    release: latest
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 8.1
+                    release: latest
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node7"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_8x_to_9x.yaml
@@ -1,0 +1,399 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 8.0
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 8.0
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node7"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "openstack"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_9x.yaml
@@ -1,0 +1,399 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
+                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    registry-url: registry.redhat.io
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
+                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    registry-url: registry.redhat.io
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node7"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_81x_latest_to_9x_latest.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_81x_latest_to_9x_latest.yaml
@@ -1,0 +1,396 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:8-154"
+                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/IBM-CEPH-8.1-202506100026.ci.0/IBM-CEPH-8.1-202506100026.ci.0-rhel9.repo"
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    registry-url: registry.redhat.io
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:8-154"
+                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/IBM-CEPH-8.1-202506100026.ci.0/IBM-CEPH-8.1-202506100026.ci.0-rhel9.repo"
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    registry-url: registry.redhat.io
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node7"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_8x_to_9x.yaml
@@ -1,0 +1,399 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
+                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    registry-url: registry.redhat.io
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
+                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    registry-url: registry.redhat.io
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Pre-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node7"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: false
+
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on  1MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 1MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_1mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 1
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 1MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 10 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_10files_v8_1.csv"
+            num_of_files: 10
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 10 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Post-upgrade validate snapdiff perf on 10MB X 100 Files"
+      clusters:
+        ceph1:
+          config:
+            name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+            cloud_type: "ibmc"
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_10mb_100files_v8_1.csv"
+            num_of_files: 100
+            file_size: 10
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Post-upgrade validate snapdiff perf on 10MB X 100 Files
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 1MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_1mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_1mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 1MB X 100 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 10 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_10files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_10files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration of 10MB X 10 Files by comparing between 2 releases
+      polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration of 10MB X 100 Files by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
+            result_file_v_n_1: "snapshot_sync_info_10mb_100files_v8_0.csv"
+            result_file_v_n: "snapshot_sync_info_10mb_100files_v8_1.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_seq_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_seq_7x_to_9x.yaml
@@ -1,0 +1,301 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 7.1
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 7.1
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: false
+      desc: "Validate snapshot synchronisation perf improvements"
+      clusters:
+        ceph1:
+          config:
+            name: Validate snapshot synchronisation perf improvements
+            source_fs: "cephfs_snapdiff_pre"
+            target_fs: "cephfs_rem_snapdiff_pre"
+            result_file: "snapshot_sync_info_v7.csv"
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Validate snapshot synchronisation perf improvements
+      polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade of primary cluster
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade of primary cluster
+            clean_up: false
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      clusters:
+        ceph2:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph2:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade of second cluster
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade of second cluster
+            clean_up: true
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336
+  - test:
+      abort-on-fail: false
+      desc: "Validate snapshot synchronisation perf improvements"
+      clusters:
+        ceph1:
+          config:
+            name: Validate snapshot synchronisation perf improvements
+            source_fs: "cephfs_snapdiff_post"
+            target_fs: "cephfs_rem_snapdiff_post"
+            result_file: "snapshot_sync_info_v8.csv"
+      module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
+      name: Validate snapshot synchronisation perf improvements
+      polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: false
+      desc: "Validate sync duration results by comparing between 2 releases"
+      clusters:
+        ceph1:
+          config:
+            name: Validate sync duration results by comparing between 2 releases
+            result_filev7: "snapshot_sync_info_v7.csv"
+            result_filev8: "snapshot_sync_info_v8.csv"
+      module: cephfs_mirroring.validate_snapdiff_perf_results.py
+      name: Validate sync duration results by comparing between 2 releases
+      polarion-id: "CEPH-83595260"

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
@@ -1,0 +1,223 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 6.x with below options,
+#       - rhcs-version: 6.1 in this suite, but it can be changed to 6.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                rhcs-version: 7.1
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata validation for Upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
@@ -1,0 +1,224 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - rhcs-version: 5.3 in this suite, but it can be changed to 5.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                rhcs-version: 8.1
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_8GA_to_81x_latest.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_8GA_to_81x_latest.yaml
@@ -1,0 +1,224 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - rhcs-version: 5.3 in this suite, but it can be changed to 5.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                rhcs-version: 8.0
+                release: z0
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "Run IOs in parallel to upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Post upgrade CephFS validation
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Post upgrade CephFS validation"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_8x_latest_to_81x_latest.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_8x_latest_to_81x_latest.yaml
@@ -1,0 +1,224 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - rhcs-version: 5.3 in this suite, but it can be changed to 5.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                rhcs-version: 8.0
+                release: latest
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_8x_to_9x.yaml
@@ -1,0 +1,228 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - rhcs-version: 5.3 in this suite, but it can be changed to 5.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                rhcs-version: 8.0
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        nodes:
+          - node8:
+              release: 7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        nodes:
+          - node9:
+              release: 6
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_7x_to_9x.yaml
@@ -1,0 +1,222 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+# - Deploy IBM 6 cluster in RHEL 9, Deploy CephFS config
+# - Upgrade cluster from IBM 6 to IBM 7 with IO in-progress
+# - Validate cluster status
+# - Verify CephFS existing config, Run I/O's
+# - Run new CephFS workflows
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection for Upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              cleint_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata validation after Upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_81x_latest_to_9x_latest.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_81x_latest_to_9x_latest.yaml
@@ -1,0 +1,220 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+# Test Steps:
+# - Deploy IBM 5 cluster in RHEL 8, Deploy CephFS config
+# - Upgrade cluster from IBM 5 to IBM 7 with IO in-progress
+# - Validate cluster status
+# - Verify CephFS existing config, Run I/O's
+# - Run new CephFS workflows
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:8-154"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/IBM-CEPH-8.1-202506100026.ci.0/IBM-CEPH-8.1-202506100026.ci.0-rhel9.repo"
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata validation After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_8x_to_9x.yaml
@@ -1,0 +1,220 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+# Test Steps:
+# - Deploy IBM 5 cluster in RHEL 8, Deploy CephFS config
+# - Upgrade cluster from IBM 5 to IBM 7 with IO in-progress
+# - Validate cluster status
+# - Verify CephFS existing config, Run I/O's
+# - Run new CephFS workflows
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
+                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata validation After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr

--- a/suites/tentacle/cephfs/tier-0_fs.yaml
+++ b/suites/tentacle/cephfs/tier-0_fs.yaml
@@ -1,0 +1,132 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Deploy MDS with default values using cephadm"
+      module: mds_default_values.py
+      name: cephfs default values for mds
+      polarion-id: "CEPH-83574284"
+  -
+    test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  -
+    test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+  - test:
+      name: Increase and Decrease of MDS
+      module: mds_inc_dec.py
+      desc: Deploy mds using cephadm and increase & decrease number of mds.
+      polarion-id: CEPH-83574286
+      abort-on-fail: false
+  -
+    test:
+      desc: "generate sosreport"
+      module: sosreport.py
+      name: "generate sosreport"

--- a/suites/tentacle/cephfs/tier-0_fs_kernel.yaml
+++ b/suites/tentacle/cephfs/tier-0_fs_kernel.yaml
@@ -1,0 +1,144 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      desc: "kernel update for CephFS kernel bugs"
+      module: kernel_update.py
+      name: kernel update
+      polarion-id: "CEPH-83575404"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Deploy MDS with default values using cephadm"
+      module: mds_default_values.py
+      name: cephfs default values for mds
+      polarion-id: "CEPH-83574284"
+  -
+    test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  -
+    test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+  - test:
+      name: Increase and Decrease of MDS
+      module: mds_inc_dec.py
+      desc: Deploy mds using cephadm and increase & decrease number of mds.
+      polarion-id: CEPH-83574286
+      abort-on-fail: false
+  - test:
+      name: Run fsstress on kernel and fuse mounts
+      module: cephfs_bugs.test_fsstress_on_kernel_and_fuse.py
+      polarion-id: CEPH-83575623
+      desc: Run fsstress on kernel and fuse mounts
+      abort-on-fail: false
+  -
+    test:
+      desc: "generate sosreport"
+      module: sosreport.py
+      name: "generate sosreport"

--- a/suites/tentacle/cephfs/tier-1_cephfs_case_sensitivity.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_case_sensitivity.yaml
@@ -1,0 +1,144 @@
+---
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_case_sensitivity
+# Conf file : conf/squid/cephfs/tier-1_cephfs_smb_nfs.yaml
+# Test-Case Covered:
+# CEPH-83606639 Verify Case Sensitivity Functionality
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - samba-client
+          - cifs-utils
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: test cephfs attributes - functional
+      module: cephfs_case_sensitivity.case_sensitivity_functional.py
+      polarion-id: CEPH-83606639
+      desc: Test fs attributes for functional use case
+      abort-on-fail: false
+  - test:
+      name: test cephfs attributes - negative
+      module: cephfs_case_sensitivity.case_sensitivity_negative.py
+      polarion-id: CEPH-83611927
+      desc: Test fs attributes for negative use case
+      abort-on-fail: false
+  - test:
+      name: test cephfs attributes - disruptive
+      module: cephfs_case_sensitivity.case_sensitivity_disruptive.py
+      polarion-id: CEPH-83611928
+      desc: Test fs attributes for disruptive use case
+      abort-on-fail: false
+  - test:
+      name: test cephfs attributes - subvolume
+      module: cephfs_case_sensitivity.case_sensitivity_subvolume.py
+      polarion-id: CEPH-83617010
+      desc: Test fs attributes for functional use case
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -1,0 +1,228 @@
+---
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_cg_quiesce
+# Conf file : conf/squid/cephfs/tier_1_fs.yaml
+# Test-Case Covered:
+#	CEPH-83581467 Verify CG quiesce functionality tests
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+        node: node10
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+        node: node11
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce release with if-version, repeat with exclude and include prior to release"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_2"
+      polarion-id: CEPH-83581470
+      config:
+       test_name: cg_snap_func_workflow_2
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify restore suceeds from snapshot taken when subvolume was quiesced"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_4"
+      polarion-id: CEPH-83590254
+      config:
+       test_name: cg_snap_func_workflow_4
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce release response when quiesce-timeout and quiesce-expire time is reached"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_5"
+      polarion-id: CEPH-83590255
+      config:
+       test_name: cg_snap_func_workflow_5
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify state transitions suceed during quiescing,quiesced and releasing state"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_6"
+      polarion-id: CEPH-83590256
+      config:
+       test_name: cg_snap_func_workflow_6
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce suceeds with IO from nfs,fuse and kernel mounts"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_interop_workflow_2"
+      polarion-id: CEPH-83591508
+      config:
+       test_name: cg_snap_interop_workflow_2
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify parallel quiesce calls to same quiesce set members"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_neg_workflow_1"
+      polarion-id: CEPH-83591512
+      config:
+       test_name: cg_snap_neg_workflow_1
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify CG quiesce on pre-provisioned quiesce set"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_3"
+      polarion-id: CEPH-83590253
+      config:
+       test_name: cg_snap_func_workflow_3
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+       ENABLE_LOGS : 1
+       daemon_list : ['mds','client']
+       daemon_dbg_level : {'mds':20,'client':20}
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce lifecycle with and without --await"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_1"
+      polarion-id: CEPH-83581467
+      config:
+       test_name: cg_snap_func_workflow_1
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce ops in parallel to multi-MDS failover"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_interop_workflow_1"
+      polarion-id: CEPH-83581472
+      config:
+       test_name: cg_snap_interop_workflow_1
+      comments: product bug bz-2273569
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+       DISABLE_LOGS : 1
+       daemon_list : ['mds','client']

--- a/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml
@@ -1,0 +1,257 @@
+---
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_cg_quiesce_systemic
+# Conf file : conf/reef/cephfs/tier_1_cephfs_cg_quiesce.yaml
+# Test-Case Covered:
+#	CEPH-83581468 CG quiesce Stress and Scalability tests
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.5
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 5"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.6
+        install_packages:
+          - ceph-common
+        node: node10
+      desc: "Configure the Cephfs client system 6"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.7
+        install_packages:
+          - ceph-common
+        node: node11
+      desc: "Configure the Cephfs client system 7"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.8
+        install_packages:
+          - ceph-common
+        node: node12
+      desc: "Configure the Cephfs client system 8"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.9
+        install_packages:
+          - ceph-common
+        node: node13
+      desc: "Configure the Cephfs client system 9"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.10
+        install_packages:
+          - ceph-common
+        node: node14
+      desc: "Configure the Cephfs client system 10"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.11
+        install_packages:
+          - ceph-common
+        node: node15
+      desc: "Configure the Cephfs client system 11"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      desc: "CG snap systemic test"
+      config:
+        qs_cnt: 10
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_system_test.py
+      name: "cg_snap_system_test"
+      polarion-id: CEPH-83581468

--- a/suites/tentacle/cephfs/tier-1_cephfs_fscrypt.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_fscrypt.yaml
@@ -1,0 +1,118 @@
+---
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_fscrypt
+# Conf file : conf/squid/cephfs/tier-1_fs.yaml
+# Test-Case Covered:
+#	CEPH-83607378 Verify fscrypt functionality tests
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup : 1
+        daemon_list : ['mds','osd','mgr','mon']
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify fscrypt basic tests - lifecycle,non_empty_path and metadata_not_encrypted validation"
+      destroy-cluster: false
+      module: cephfs_fscrypt.test_fscrypt_basic.py
+      name: "fscrypt_basic"
+      polarion-id: CEPH-83607378
+  -
+    test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check : 1
+        daemon_list : ['mds','osd','mgr','mon']

--- a/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -1,0 +1,274 @@
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_mirror.yaml
+# Test-Case: Configure CephFS Mirror setup and run IOs
+#
+# Cluster Configuration:
+#    No of Clusters : 2
+#    Cluster 1 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 CEPHFS MIRROR, 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - CephFS Mirror
+#     Node7 - Client
+#    Cluster 2 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - Client
+
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args: # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args: # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:                             # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:                    # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc:  CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph1:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node7
+          ceph2:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node6
+        desc: "Configure the Cephfs client system 1"
+        destroy-cluster: false
+        module: test_client.py
+        name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: "CEPH-83574099"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring modification of source and target cluster"
+      clusters:
+        ceph1:
+          config:
+            name: Configure CephFS Mirroring modification of source and target cluster
+      module: cephfs_mirroring.validate_file_dir_stats_modification_on_mirrored_cluster.py
+      name: validate_file_dir_stats_modification_on_mirrored_cluster
+      polarion-id: "CEPH-83575625"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring on multiple FS"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Mirroring is successful upon enabling fs mirroring on multiple FS from source to same destinatio
+      module: cephfs_mirroring.test_cephfs_mirroring_validate_cephfs-mirroring_on_multifs_setup.py
+      name: Validate the Mirroring is successful upon enabling fs mirroring on multiple FS from source to same destination
+      polarion-id: "CEPH-83574107"
+  - test:
+      abort-on-fail: false
+      desc: "modify User caps and validate the mirroring sync."
+      clusters:
+        ceph1:
+          config:
+            name: "modify User caps and validate the mirroring sync."
+      module: cephfs_mirroring.test_cephfs_mirror_auth_caps.py
+      name: modify User caps and validate the mirroring sync.
+      polarion-id: "CEPH-83574109"
+  - test:
+      abort-on-fail: false
+      desc: "Modify the Remote Snap Directories"
+      clusters:
+        ceph1:
+          config:
+            name: Modify the Remote Snap Directories
+      module: cephfs_mirroring.test_cephfs_mirroring_modify_remote_snapshots.py
+      name: Modify the Remote Snap Directories
+      polarion-id: "CEPH-83574120"
+  - test:
+      abort-on-fail: false
+      desc: "Convert single node to HA configuration"
+      clusters:
+        ceph1:
+          config:
+            name: Convert single node to HA configuration
+      module: cephfs_mirroring.test_cephfs_mirror_ha_conversion.py
+      name: Convert single node to HA configuration
+      polarion-id: "CEPH-83575340"
+  - test:
+      abort-on-fail: false
+      desc: "Validate all failure scenarios to disconnect the mirroring"
+      clusters:
+        ceph1:
+          config:
+            name: Validate all failure scenarios to disconnect the mirroring
+      module: cephfs_mirroring.test_cephfs_mirror_disconnect.py
+      name: Validate all failure scenarios to disconnect the mirroring
+      polarion-id: "CEPH-83574100"
+  - test:
+      abort-on-fail: false
+      desc: "Validate multiple snapshots Synchronization on Mirror setup"
+      clusters:
+        ceph1:
+          config:
+            name: Validate multiple snapshots Synchronization on Mirror setup
+      module: cephfs_mirroring.test_cephfs_mirroring_multiple_snapshots.py
+      name: Validate multiple snapshots Synchronization on Mirror setup
+      polarion-id: "CEPH-83580026"
+  - test:
+      abort-on-fail: false
+      desc: "Validate Snapshot Sync status using asok file"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation Status using asok file
+      module: cephfs_mirroring.test_cephfs_mirroring_snap_status_using_asok.py
+      name: Validate the Synchronisation Status using asok file
+      polarion-id: "CEPH-83593134"
+  - test:
+      abort-on-fail: false
+      desc: "Validate snapshot synchronisation using SnapSchedule"
+      clusters:
+        ceph1:
+          config:
+            name: Validate snapshot synchronisation using SnapSchedul
+      module: cephfs_mirroring.test_cephfs_mirroring_with_snap_schedule.py
+      name: Validate snapshot synchronisation using SnapSchedul
+      polarion-id: "CEPH-83598968"

--- a/suites/tentacle/cephfs/tier-1_fs.yaml
+++ b/suites/tentacle/cephfs/tier-1_fs.yaml
@@ -1,0 +1,217 @@
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Deploy cluster with enforcing mode(default mode).
+      module: test_cephadm.py
+      polarion-id: CEPH-83573740
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            node: node8
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.2
+            node: node9
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 2
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.3
+            node: node10
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 3
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.4
+            node: node11
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 4
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+        name: cephfs_tier1_ops
+        module: cephfs_tier1_ops.py
+        polarion-id: CEPH-83573447
+        desc: cephfs tier1 operations
+        abort-on-fail: false
+  - test:
+        name: cephfs_client_authorize
+        module: client_authorize.py
+        polarion-id: CEPH-83574483
+        desc: client authorize test for cephfs
+        abort-on-fail: false
+  - test:
+      name: cephfs-mdsfailover-pinning-io
+      module: dir_pinning.py
+      config:
+        num_of_dirs: 200
+      polarion-id: CEPH-11227
+      desc: MDSfailover on active-active mdss,performing client IOs with no pinning at the first,later pin 10 dirs with IOs
+      abort-on-fail: false
+  - test:
+      name: cephfs subvolume authorize test
+      desc: Test cephfs subvolume client authorize
+      module: subvolume_authorize.py
+      polarion-id: CEPH-83574596
+      abort-on-fail: false
+  - test:
+      name: no recover session mount
+      module: no_recover_session_mount.py
+      polarion-id: CEPH-11260
+      desc: test no recover session mount by blocking the client node
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Ensure kernel mounts works with all available options and validate the functionality of each option"
+      module: fs_kernel_mount_options.py
+      name: fs_kernel_mount_options
+      polarion-id: "CEPH-83575389"

--- a/suites/tentacle/cephfs/tier-1_fs_kernel.yaml
+++ b/suites/tentacle/cephfs/tier-1_fs_kernel.yaml
@@ -1,0 +1,235 @@
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Deploy cluster with enforcing mode(default mode).
+      module: test_cephadm.py
+      polarion-id: CEPH-83573740
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      desc: "kernel update for CephFS kernel bugs"
+      module: kernel_update.py
+      name: kernel update
+      polarion-id: "CEPH-83575404"
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            node: node8
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.2
+            node: node9
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 2
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.3
+            node: node10
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 3
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.4
+            node: node11
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 4
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      name: Run fsstress on kernel and fuse mounts
+      module: cephfs_bugs.test_fsstress_on_kernel_and_fuse.py
+      polarion-id: CEPH-83575623
+      desc: Run fsstress on kernel and fuse mounts
+      abort-on-fail: false
+  - test:
+      name: Run xfs test on kernel
+      module: xfs_test.py
+      polarion-id: CEPH-83575623
+      desc: Run xfs test on kernel
+      abort-on-fail: false
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573445
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83571366
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+        name: cephfs_tier1_ops
+        module: cephfs_tier1_ops.py
+        polarion-id: CEPH-83573447
+        desc: cephfs tier1 operations
+        abort-on-fail: false
+  - test:
+        name: cephfs_client_authorize
+        module: client_authorize.py
+        polarion-id: CEPH-83574483
+        desc: client authorize test for cephfs
+        abort-on-fail: false
+  - test:
+      name: cephfs-mdsfailover-pinning-io
+      module: dir_pinning.py
+      config:
+        num_of_dirs: 200
+      polarion-id: CEPH-11227
+      desc: MDSfailover on active-active mdss,performing client IOs with no pinning at the first,later pin 10 dirs with IOs
+      abort-on-fail: false
+  - test:
+      name: cephfs subvolume authorize test
+      desc: Test cephfs subvolume client authorize
+      module: subvolume_authorize.py
+      polarion-id: CEPH-83574596
+      abort-on-fail: false
+  - test:
+      name: no recover session mount
+      module: no_recover_session_mount.py
+      polarion-id: CEPH-11260
+      desc: test no recover session mount by blocking the client node
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-1_fs_kernel_pipeline.yaml
+++ b/suites/tentacle/cephfs/tier-1_fs_kernel_pipeline.yaml
@@ -1,0 +1,180 @@
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Deploy cluster with enforcing mode(default mode).
+      module: test_cephadm.py
+      polarion-id: CEPH-83573740
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            node: node8
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.2
+            node: node9
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 2
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.3
+            node: node10
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 3
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.4
+            node: node11
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 4
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      name: Run xfs test on kernel
+      module: xfs_test.py
+      polarion-id: CEPH-83592787
+      desc: Run xfs test on kernel
+      abort-on-fail: false
+  - test:
+      name: Run fsstress on kernel and fuse mounts
+      module: cephfs_bugs.test_fsstress_on_kernel_and_fuse.py
+      polarion-id: CEPH-83575623
+      desc: Run fsstress on kernel and fuse mounts
+      abort-on-fail: false
+

--- a/suites/tentacle/cephfs/tier-2_cephfs_generic.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_generic.yaml
@@ -1,0 +1,167 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_generic.yaml
+# Conf file : conf/reef/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Test-Case Covered:
+#   CEPH-83573462 - Validate the fs command to increase/decrease the max mds daemons
+#   CEPH-83574291 - Configure the standby_replay daemons for active mds, verify add and remove of the feature.
+#   CEPH-83573429 - [Cephfs] Fail mds daemon by it's rank
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: the max mds daemons
+      module: ceph-83573462.py
+      polarion-id: CEPH-83573462
+      desc: Validate the fs command to increase decrease the max mds daemons
+      abort-on-fail: false
+  - test:
+      name: Configure the standby_replay daemons
+      module: ceph_83574291.py
+      polarion-id: CEPH-83574291
+      desc: Configure the standby_replay daemons for active mds verify add and remove of the feature
+      abort-on-fail: false
+  - test:
+      name: Fail mds daemon by it rank
+      module: mds_fail_with_rank.py
+      polarion-id: CEPH-83573429
+      desc: Fail mds daemon by it rank
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_io.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_io.yaml
@@ -1,0 +1,624 @@
+---
+#=======================================================================================================================
+# Tier-level: 0
+# Test-Suite: tier-0_fs.yaml
+# Conf file : conf/quincy/cephfs/tier-0_fs.yaml
+# options : --cloud baremetal if required to run on baremetal
+# Test-Case Covered:
+#	CEPH-83573777: Execute the cluster deployment workflow with label placement.
+#	CEPH-XXXXX: FS_FIO_REPL_MAX_MDS_2
+#	CEPH-XXXXX: FS_FIO_REPL_MAX_MDS_1
+#	CEPH-XXXXX: FS_FIO_EC_MAX_MDS_1
+#	CEPH-XXXXX: FS_FIO_EC_MAX_MDS_2
+#   CEPH-83588102:
+      #FS_SPEC_REPL_MAX_MDS_2_SWBUILD
+      #FS_SPEC_REPL_MAX_MDS_2_VDA
+      #FS_SPEC_REPL_MAX_MDS_2_EDA_BLENDED
+      #FS_SPEC_REPL_MAX_MDS_2_AI_IMAGE
+      #FS_SPEC_REPL_MAX_MDS_2_GENOMICS
+      #FS_SPEC_REPL_MAX_MDS_1_SWBUILD
+      #FS_SPEC_REPL_MAX_MDS_1_VDA
+      #FS_SPEC_REPL_MAX_MDS_1_EDA_BLENDED
+      #FS_SPEC_REPL_MAX_MDS_1_AI_IMAGE
+      #FS_SPEC_REPL_MAX_MDS_1_GENOMICS
+      #FS_SPEC_EC_MAX_MDS_1_SWBUILD
+      #FS_SPEC_EC_MAX_MDS_1_VDA
+      #FS_SPEC_EC_MAX_MDS_1_EDA_BLENDED
+      #FS_SPEC_EC_MAX_MDS_1_AI_IMAGE
+      #FS_SPEC_EC_MAX_MDS_1_GENOMICS
+      #FS_SPEC_EC_MAX_MDS_2SWBUILD
+      #FS_SPEC_EC_MAX_MDS_2_VDA
+      #FS_SPEC_EC_MAX_MDS_2_EDA_BLENDED
+      #FS_SPEC_EC_MAX_MDS_2_AI_IMAGE
+      #FS_SPEC_EC_MAX_MDS_2_GENOMICS
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: FS_FIO_REPL_MAX_MDS_2
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs
+        max_mds: 2
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_REPL_MAX_MDS_2
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+
+  - test:
+      name: FS_FIO_REPL_MAX_MDS_1
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs
+        max_mds: 1
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_REPL_MAX_MDS_1
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+
+  - test:
+      name: FS_FIO_EC_MAX_MDS_1
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs-ec
+        erasure: yes
+        max_mds: 1
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_EC_MAX_MDS_1.
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+  - test:
+      name: FS_FIO_EC_MAX_MDS_2
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs-ec
+        erasure: yes
+        max_mds: 2
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_EC_MAX_MDS_2
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_2_SWBUILD
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: SWBUILD
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 2
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run VDA Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_2_VDA
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: VDA
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 2
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run EDA_BLENDED Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_2_EDA_BLENDED
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: EDA_BLENDED
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 2
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run AI_IMAGE Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_2_AI_IMAGE
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: AI_IMAGE
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 2
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run GENOMICS Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_2_GENOMICS
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: GENOMICS
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 2
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_1_SWBUILD
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: SWBUILD
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 1
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run VDA Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_1_VDA
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: VDA
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 1
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run EDA_BLENDED Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_1_EDA_BLENDED
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: EDA_BLENDED
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 1
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run AI_IMAGE Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_1_AI_IMAGE
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: AI_IMAGE
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 1
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run GENOMICS Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_1_GENOMICS
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: GENOMICS
+        parse_result: True
+        fs_name: cephfs
+        max_mds: 1
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload on EC FS max mds 1"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_1_SWBUILD
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 1
+        benchmark: SWBUILD
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload on EC FS max mds 1"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_1_VDA
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 1
+        benchmark: VDA
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run EDA_BLENDED Workload on EC FS max mds 1"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_1_EDA_BLENDED
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 1
+        benchmark: EDA_BLENDED
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run AI_IMAGE Workload on EC FS max mds 1"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_1_AI_IMAGE
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 1
+        benchmark: AI_IMAGE
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+
+  - test:
+      abort-on-fail: false
+      desc: "Run GENOMICS Workload on EC FS max mds 1"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_1_GENOMICS
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 1
+        benchmark: GENOMICS
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload on EC FS max mds 2"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_2_SWBUILD
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 2
+        benchmark: SWBUILD
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload on EC FS max mds 2"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_2_VDA
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 2
+        benchmark: VDA
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run EDA_BLENDED Workload on EC FS max mds 2"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_2_EDA_BLENDED
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 2
+        benchmark: EDA_BLENDED
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run AI_IMAGE Workload on EC FS max mds 2"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_2_AI_IMAGE
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 2
+        benchmark: AI_IMAGE
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+
+  - test:
+      abort-on-fail: false
+      desc: "Run GENOMICS Workload on EC FS max mds 2"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_2_GENOMICS
+      polarion-id: "CEPH-83588102"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        parse_result: True
+        erasure: yes
+        max_mds: 2
+        benchmark: GENOMICS
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1

--- a/suites/tentacle/cephfs/tier-2_cephfs_mirror_ha.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_mirror_ha.yaml
@@ -1,0 +1,227 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_mirror.yaml
+# Test-Case: Configure CephFS Mirror HA setup and run IOs
+#
+# Cluster Configuration:
+#    No of Clusters : 2
+#    Cluster 1 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 CEPHFS MIRROR, 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - CephFS Mirror
+#     Node7 - CephFS Mirror
+#     Node8 - Client
+#    Cluster 2 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - Client
+
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args: # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args: # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+                        - node7
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:                             # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:                    # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc:  CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph1:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node8
+          ceph2:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node6
+        desc: "Configure the Cephfs client system 1"
+        destroy-cluster: false
+        module: test_client.py
+        name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring HA"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring ha setup
+            cleanup: false
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring_ha.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring ha setup.
+      polarion-id: "CEPH-83575332"
+  - test:
+      abort-on-fail: false
+      desc: "Validate CephFS Mirroring Metrics on a HA Setup"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the CephFS Mirroring Metrics on HA Setup
+      module: cephfs_mirroring.test_cephfs_mirroring_ha_metrics.py
+      name: Validate the CephFS Mirroring Metrics on HA Setup
+      polarion-id: "CEPH-83584059"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring HA using a spec file"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring ha setup using a spec file
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring_ha_using_spec.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring ha setup using a spec file
+      polarion-id: "CEPH-83575333"
+  - test:
+      abort-on-fail: false
+      desc: "Validate all failure scenarios to disconnect the mirroring"
+      clusters:
+        ceph1:
+          config:
+            name: Validate all failure scenarios to disconnect the mirroring
+      module: cephfs_mirroring.test_cephfs_mirror_ha_disconnect.py
+      name: Validate all failure scenarios to disconnect the mirroring
+      polarion-id: "CEPH-83575334"
+  - test:
+      abort-on-fail: false
+      desc: "Validate FS mirroring on ha with 4 nodes"
+      clusters:
+        ceph1:
+          config:
+            name: Validate FS mirroring on ha with 4 nodes
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring_ha_on_4_nodes.py
+      name: Validate FS mirroring on ha with 4 nodes
+      polarion-id: "CEPH-83575338"

--- a/suites/tentacle/cephfs/tier-2_cephfs_mirror_ha_metrics.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_mirror_ha_metrics.yaml
@@ -1,0 +1,198 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_mirror_ha_metrics.yaml
+# Test-Case: Configure CephFS Mirror HA setup and run IOs
+#
+# Cluster Configuration:
+#    No of Clusters : 2
+#    Cluster 1 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 CEPHFS MIRROR, 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - CephFS Mirror
+#     Node7 - CephFS Mirror
+#     Node8 - Client
+#    Cluster 2 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - Client
+
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args: # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args: # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+                        - node7
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:                             # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:                    # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc:  CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph1:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node8
+          ceph2:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node6
+        desc: "Configure the Cephfs client system 1"
+        destroy-cluster: false
+        module: test_client.py
+        name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring HA"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring ha setup
+            cleanup: false
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring_ha.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring ha setup.
+      polarion-id: "CEPH-83575332"
+  - test:
+      abort-on-fail: false
+      desc: "Validate CephFS Mirroring Metrics on a HA Setup"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the CephFS Mirroring Metrics on HA Setup
+      module: cephfs_mirroring.test_cephfs_mirroring_ha_metrics.py
+      name: Validate the CephFS Mirroring Metrics on HA Setup
+      polarion-id: "CEPH-83584059"
+

--- a/suites/tentacle/cephfs/tier-2_cephfs_mirror_metrics.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_mirror_metrics.yaml
@@ -1,0 +1,195 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_mirror_metrics.yaml
+# Test-Case: Configure CephFS Mirror setup and run IOs
+#
+# Cluster Configuration:
+#    No of Clusters : 2
+#    Cluster 1 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 CEPHFS MIRROR, 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - CephFS Mirror
+#     Node7 - Client
+#    Cluster 2 :
+#    3 MONS, 2 MGR, 2 MDS, 3 OSD and 1 Client service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon, OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD, MDS
+#     Node6 - Client
+
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args: # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args: # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:                             # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:                    # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc:  CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph1:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node7
+          ceph2:
+            config:
+              command: add
+              copy_admin_keyring: true
+              id: client.1
+              install_packages:
+                - ceph-common
+                - ceph-fuse
+              node: node6
+        desc: "Configure the Cephfs client system 1"
+        destroy-cluster: false
+        module: test_client.py
+        name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Configure CephFS Mirroring"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+            cleanup: false
+      module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: "CEPH-83574099"
+  - test:
+      abort-on-fail: false
+      desc: "Validate CephFS Mirroring Metrics"
+      clusters:
+        ceph1:
+          config:
+            name: Validate the CephFS Mirroring Metrics
+      module: cephfs_mirroring.test_cephfs_mirroring_metrics.py
+      name: Validate the CephFS Mirroring Metrics
+      polarion-id: "CEPH-83584059"

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-clients.yaml
@@ -1,0 +1,426 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-clients.yaml
+# Conf file : conf/squid/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# options : --cloud baremetal if required to run on baremetal
+# Test-Case Covered:
+#	CEPH-10529: Multiple clients run IO's on the same directory from each client and exercise POSIX locks.
+#   CEPH-10625: Smallfile IO on multiple clients with different operations.
+#   CEPH-11224: Mount a single directory and perform IO ops from multiple clients.
+#   CEPH-11298: Rsync tests between filesystem and other locations and vice versa.
+#   CEPH-11299: SCP between filesystem and remote path and vice versa.
+#   CEPH-11300: Running basic bash commands on Fuse, Kernel, and NFS mounts.
+#   CEPH-11304: Test file locking on mounts.
+#   CEPH-11335: Test filesystem client eviction.
+#   CEPH-11336: Filesystem mount with fstab entry and reboot the client.
+#   CEPH-11337: Mount and unmount CephFS repeatedly in an interval of 30 minutes and check data integrity.
+#   CEPH-11338: Filesystem information restriction for clients.
+#   CEPH-83573529: Multi-client file and directory operations.
+#   CEPH-83573532: Cross-delete operations between Fuse and Kernel clients.
+#   CEPH-83573869: MDS restriction for clients for multiple file systems.
+#   CEPH-83573875: Filesystem information restriction for clients for multiple file systems.
+#   CEPH-83573876: No data sharing between multiple file systems.
+#   CEPH-83573877: Mount multiple file systems with the same client.
+#   CEPH-83574327: Create users with permissions.
+#   CEPH-83574328: Ceph auth caps change permission and check.
+#   CEPH-83575042: Multi-client unlink file.
+#   CEPH-83575574: Verify user read and write permissions.
+#   CEPH-11242: MDS failover while IO is going on each client.
+#   CEPH-11329: Test important MDS Configuration Settings.
+#   CEPH-11340: Multiple clients' permission in mounted directories.
+#   CEPH-11331: MDS journal value conf verification.
+#   CEPH-83573489: MDS scrub only with one MDS after failover.
+#   CEPH-83573868: Verify root_squash cap works in multiFS.
+#   CEPH-83581592: Verify Client eviction is deferred if OSD was laggy.
+#   CEPH-83581613: Verify Client is blocklisted if session metadata is bloated.
+#   CEPH-83591419: Validate Root Sqaush operations on Cephfs
+#
+# Bugs :
+# https://bugzilla.redhat.com/show_bug.cgi?id=2309363
+#.  CEPH-83597462: Validate Client caps update during CG quiesce,MDS failover and Client evict
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+          - config:
+              args:
+                - ceph
+                - config
+                - set
+                - mds
+                - defer_client_eviction_on_laggy_osds
+                - "false"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: multiple clients run IO's on same directory from each clients and exersize POSIX locks
+      module: clients.multiple_clients_posix_calls.py
+      polarion-id: CEPH-10529
+      desc: multiple clients exersizing POSIX locks
+      abort-on-fail: false
+  - test:
+      name: smallfile IO on multiple clients with diff operations
+      module: clients.smallfiles_with_different_operations.py
+      polarion-id: CEPH-10625
+      desc: smallfiles with different operations
+      abort-on-fail: false
+  - test:
+      name: Mount single directory and perform IO ops from multiple clients
+      module: clients.multiclients_io_on_same_directory.py
+      polarion-id: CEPH-11224
+      desc: multiple clients performing IO on same directory
+      abort-on-fail: false
+  - test:
+      name: rsync tests bw fs and other location and vice versa
+      module: clients.rsync_bw_fs_and_other_location.py
+      polarion-id: CEPH-11298
+      desc: rsync bw filesystem and other location and vice versa
+      abort-on-fail: false
+  - test:
+      name: scp bw fs and remote path and vice versa
+      module: clients.mirgate_data_bw_fs_and_remote_using_scp.py
+      polarion-id: CEPH-11299
+      desc: scp bw filesystem and remote directory and vice versa
+      abort-on-fail: false
+  - test:
+       name: Running basic bash commands on fuse,Kernel and NFS mounts
+       module: clients.fs_basic_bash_cmds.py
+       polarion-id: CEPH-11300
+       desc: Running basic bash commands on fuse,Kernel and NFS mounts
+       abort-on-fail: false
+       config:
+         no_of_files: 1000
+         size_of_files: 1
+         num_dir: 100
+  - test:
+      name: Client File locking on mounts
+      module: clients.file_lock_on_mounts.py
+      polarion-id: CEPH-11304
+      desc: Test File locking on mounts
+      abort-on-fail: false
+  - test:
+      name: Client eviction
+      module: clients.client_evict.py
+      polarion-id: CEPH-11335
+      desc: Test Filesystem client eviction
+      abort-on-fail: false
+  - test:
+      name: Filesystem mount with fstab entry and reboot the client
+      module: clients.client_fstab_auto_mount.py
+      polarion-id: CEPH-11336
+      desc: Update fstab and reboot client to check auto mount of FS works
+      abort-on-fail: false
+  - test:
+      name: Mount and unmount CephFS repeatedly in interval of 30 min & check data integrity
+      module: clients.integrity_check_after_remount.py
+      polarion-id: CEPH-11337
+      desc: Mount and unmount CephFS repeatedly in interval of 30 min & check data integrity
+      abort-on-fail: false
+  - test:
+      name: Filesystem information restriction for client
+      module: clients.multiclient_cephx_restrict_fs.py
+      polarion-id: CEPH-11338
+      desc: Test Filesystem information restriction for client for multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: multi client file and dir ops
+      module: clients.multiclient_file_dir_ops.py
+      polarion-id: CEPH-83573529
+      desc: multi client file and dir ops
+      abort-on-fail: false
+  - test:
+      name: cross delete operations
+      module: clients.cross_delete_ops_bw_fuse_and_kernel_clients.py
+      polarion-id: CEPH-83573532
+      desc: Cross Delete Ops b/w Fuse and Kernel mounts
+      abort-on-fail: false
+  - test:
+      name: mds restriction for client for multifs
+      module: clients.client_mds_restriction.py
+      polarion-id: CEPH-83573869
+      desc: Test mds restriction for client for multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: Filesystem information restriction for client
+      module: clients.client_fs_information_restriction.py
+      polarion-id: CEPH-83573875
+      desc: Test Filesystem information restriction for client for multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: No data sharing between multifs
+      module: clients.test_no_data_sharing_multifs.py
+      polarion-id: CEPH-83573876
+      desc: Test no data sharing between multiple cephfs
+      abort-on-fail: false
+  - test:
+      name: Mount multifs with same client
+      module: clients.multifs_mount_same_client.py
+      polarion-id: CEPH-83573877
+      desc: Test mounting multiple cephfs with same client
+      abort-on-fail: false
+  - test:
+      name: Create users with permissions
+      module: clients.create_user_with_permissions.py
+      polarion-id: CEPH-83574327
+      desc: Create users with permissions and verify the permissions
+      abort-on-fail: false
+  - test:
+      name: ceph auth caps change permission and check
+      module: clients.ceph_auth_caps_modifying_permissions.py
+      polarion-id: CEPH-83574328
+      desc: generate all the possible permissions and verify the permissions
+      abort-on-fail: false
+  - test:
+      name: multi client unlink file
+      module: clients.file_unlink_on_clients.py
+      polarion-id: CEPH-83575042
+      desc: multi client unlink file
+      abort-on-fail: false
+  - test:
+      name: verify user read and write permissions
+      module: clients.verify_user_read_write_permissions.py
+      polarion-id: CEPH-83575574
+      desc: verify user read and write permissions
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "MDS failover while IO is going on each client"
+      module: clients.MDS_failover_while_client_IO.py
+      polarion-id: CEPH-11242
+      config:
+        num_of_file_dir: 1000
+      name: "MDS failover whi client IO"
+  - test:
+      name: Test important MDS Configuration Settings
+      module: clients.mds_conf_modifying.py
+      polarion-id: CEPH-11329
+      desc: Test important MDS Configuration Settings
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "multiple clients permission in mounted directory"
+      module: clients.multiple_clients_permission_mounted_directories.py
+      name: multiple clients permission in mounted directory
+      polarion-id: "CEPH-11340"
+  - test:
+      abort-on-fail: false
+      desc: "mds journal value conf verification"
+      module: clients.mds_journal_value_conf_verification.py
+      name: mds journal value conf verification
+      polarion-id: "CEPH-11331"
+  - test:
+      abort-on-fail: false
+      desc: "mds scrub only with one mds after failover"
+      module: clients.mds_scrub_after_failover.py
+      name: mds scrub only with one mds after failover
+      polarion-id: "CEPH-83573489"
+  - test:
+      abort-on-fail: false
+      desc: "Verify root_squash cap works in multiFS"
+      module: clients.verify_root_squash_in_caps.py
+      name: verify root_squash cap works in multiFS
+      polarion-id: "CEPH-83573868"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client eviction is deferred if OSD was laggy"
+      module: cephfs_bugs.test_defer_client_evict_on_laggy_osd.py
+      name: Client eviction deferred if OSD is laggy
+      polarion-id: "CEPH-83581592"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client is blocklisted if session metadata is bloated"
+      module: cephfs_bugs.test_client_blocklist_large_session_metadata.py
+      name: Verify Client is blocklisted if session metadata is bloated
+      polarion-id: "CEPH-83581613"
+  - test:
+      abort-on-fail: false
+      desc: "Client Caps Validation during quiesce,mds failover and evict"
+      module: clients.client_caps_update_validation.py
+      name: client_caps_update_validation
+      polarion-id: "CEPH-83597462"
+  - test:
+      abort-on-fail: false
+      desc: "Validate directory creation with non root user with root_squash"
+      module: clients.client_root_squash_non_root_user.py
+      name: client_root_squash_non_root_user
+      polarion-id: "CEPH-83602912"
+  - test:
+      abort-on-fail: false
+      desc: "Validate Root Sqaush operations on Cephfs"
+      module: clients.validate_root_squash.py
+      name: Validate Root Sqaush operations on Cephfs
+      comments: "BZ-2293943"
+      polarion-id: "CEPH-83591419"

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-metrics.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-metrics.yaml
@@ -1,0 +1,165 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test_metrics.yaml
+# Conf file : conf/reef/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Test-Case Covered:
+#   CEPH-83588303 - Validate the metrics of the clients that mds provides
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: MDS client metrics functional
+      module: cephfs_metrics.cephfs_metrics_functional.py
+      polarion-id: CEPH-83588303
+      desc: Verify MDS client metrics
+      abort-on-fail: false
+  - test:
+      name: MDS client metrics scale
+      module: cephfs_metrics.cephfs_metrics_scale.py
+      polarion-id: CEPH-83588355
+      desc: Verify MDS metrics in multiple clients
+      abort-on-fail: false
+  - test:
+      name: MDS client metrics negative case
+      module: cephfs_metrics.cephfs_client_metrics_negative_case.py
+      polarion-id: CEPH-83588357
+      desc: Reboot MDS node and verify the metrics
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-multi-mds.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-multi-mds.yaml
@@ -1,0 +1,144 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_multi-mds.yaml
+# Conf file : tier-2_cephfs_8mds-cluster.yaml
+# Test-Case Covered:
+#   CEPH-83591709 - Functional Tests for Standby-Replay Feature
+#
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node12
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node13
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node14
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+
+  - test:
+      name: Functional Tests for standby-replay
+      module: cephfs_multi_mds.test_cephfs_multimds_functional.py
+      polarion-id: CEPH-83591709
+      desc: Functional Tests for standby-replay
+      abort-on-fail: false
+      config:
+        num_of_osds: 28
+        num_of_files: 100000
+  - test:
+      name: Repeated MDS restarts
+      module: cephfs_multi_mds.test_cephfs_multimds_repeated_restart_mds.py
+      polarion-id:
+      desc: Repeated MDS restarts
+      abort-on-fail: false
+      config:
+        num_of_osds: 28
+        num_of_files: 100
+        num_of_iterations: 10
+

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-multifs_arch.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-multifs_arch.yaml
@@ -1,0 +1,146 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_multifs.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# Test-Case Covered:
+#   CEPH-83573878 - Verify the option to enable/disable multiFS support
+#   CEPH-83573873 - Try creating 2 Filesystem using same Pool(negative)
+#   CEPH-83573872 - Tests the file system with fstab entries with multiple file systems and reboots with kernel mounts
+#   CEPH-83573871 - Tests the file system with fstab entries with multiple file systems and reboots with fuse mounts
+#   CEPH-83573870 - Create 2 Filesystem with default values on different MDS daemons
+#   CEPH-83573867 - Create 4-5 Filesystem randomly on different MDS daemons
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: multifs flag
+      module: multifs.multifs_flag.py
+      polarion-id: CEPH-83573878
+      desc: Tests the multifs flag functionality
+      abort-on-fail: false
+  - test:
+        name: multifs same pool
+        module: multifs.multifs_same_pool.py
+        polarion-id: CEPH-83573873
+        desc: Tests the file system with same pools
+        abort-on-fail: false
+  - test:
+        name: multifs reboot with fstab
+        module: multifs.multifs_kernelmounts.py
+        polarion-id: CEPH-83573872
+        desc: Tests the file system with fstab entries with multiple file systems and reboots using kernel mount
+        abort-on-fail: false
+  - test:
+      name: multifs reboot with fstab fuse
+      module: multifs.multifs_fusemounts.py
+      polarion-id: CEPH-83573871
+      desc: Tests the file system with fstab entries with multiple file systems and reboots using fuse mount
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems wtih different MDS daemons
+      module: multifs.multifs_default_values.py
+      polarion-id: CEPH-83573870
+      desc: Create 2 Filesystem with default values on different MDS daemons
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems
+      module: multifs.multifs_multiplefs.py
+      polarion-id: CEPH-83573867
+      desc: Create 4-5 Filesystem randomly on different MDS daemons
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-nfs_arch.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-nfs_arch.yaml
@@ -1,0 +1,344 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-nfs.yaml
+# Conf file : conf/pacific/cephfs/tier-2_cephfs_9-node-cluster
+# Test-Case Covered:
+# CEPH-83574028 - Ensure the path of the nfs export is displayed properly.
+# CEPH-83574024 - Ensure Snapshot and cloning works on nfs exports
+# CEPH-83574027 - Ensure creation of Subvolgroups, subvolumes works on NFS exports and run IO from nfs clients
+# CEPH-83574003 - Export the nfs share with cli with RO access
+# CEPH-83574015 - verify if nfs cluster can be deleted. and recreate with the same name works.
+# CEPH-83574022 - Create NFS cluster with 2 Nodes. 1 nfs daemon per node and Ensure the exports are accessible via
+#                 all the NFS nodes in the cluster. and has same data
+# CEPH-83574026 - zip unzip files continuously on a nfs share
+# CEPH-83573993 - Export the nfs share with cli using an existing path created using subvolume
+# CEPH-11309 - Export and import data between NFS and CephFS
+# CEPH-11312 - Test data integrity between cephfs & nfs mounts
+# CEPH-83573995 - Create cephfs nfs export on existing path
+# CEPH-11310 -  Run IOs by mounting same subvolume with all the three mounts
+# CEPH-11314 - Backup and restore data using existing NFS backup tools
+# CEPH-83573992 - Verifying ceph nfs ls export with --detailed option and info with cluster_id
+# CEPH-83574013 - nfs cluster host changes and verification
+# CEPH-83575825 - NFS  File Operations: File/Directory copy b/w local FS and NFS and verify the data integrity
+# CEPH-83575937 - File Operations - File attributes changes and validate whether the same is retained after moving
+#                  b/w nfs mounts and local fs
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+          - config:
+              args:
+                - ceph
+                - config
+                - set
+                - mds
+                - defer_client_eviction_on_laggy_osds
+                - "false"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      desc: "test cephfs nfs export path"
+      module: cephfs_nfs.nfs_export_path.py
+      name: "cephfs nfs export path"
+      polarion-id: "CEPH-83574028"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test cephfs nfs snapshot clone operations"
+      module: cephfs_nfs.nfs_snaphshot_clone.py
+      name: "cephfs nfs snapshot clone operations"
+      polarion-id: "CEPH-83574024"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test cephfs nfs subvolume & subvolumegroup operations"
+      module: cephfs_nfs.nfs_subvolume_subvolumegroup.py
+      name: "cephfs nfs subvolume & subvolumegroup operations"
+      polarion-id: "CEPH-83574027"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test cephfs nfs read only export"
+      module: cephfs_nfs.read_only_nfs_export.py
+      name: "cephfs nfs read only export"
+      polarion-id: "CEPH-83574003"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test recreation of cephfs nfs cluster with same name"
+      module: cephfs_nfs.recreate_same_name_nfs.py
+      name: "recreate same name nfs cluster"
+      polarion-id: "CEPH-83574015"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test creation of 2 node nfs cluster"
+      module: cephfs_nfs.2_node_nfs.py
+      name: "2 node nfs cluster"
+      polarion-id: "CEPH-83574022"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test zipping & unzipping files on nfs export continuously"
+      module: cephfs_nfs.zip_unzip_files_nfs.py
+      name: "zipping & unzipping files on nfs export"
+      polarion-id: "CEPH-83574026"
+  -
+    test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export for cephfs subvolume"
+      module: cephfs_nfs.subvolume_export.py
+      name: "cephfs nfs export for subvolume"
+      polarion-id: "CEPH-83573993"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on non-existing directory"
+      module: cephfs_nfs.nfs_non_exist_export_path.py
+      name: "Create cephfs nfs export on non-existing directory"
+      polarion-id: "CEPH-83573669"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Export and import data between NFS and CephFS"
+      module: cephfs_nfs.move_data_bw_nfs_and_cephfs_mounts.py
+      name: "Move Data bw nfs and cephfs exports"
+      polarion-id: "CEPH-11309"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Test data integrity between cephfs & nfs mounts"
+      module: cephfs_nfs.test_data_integrity_nfs_cephfs_mounts.py
+      name: "data integrity between cephfs & nfs mounts"
+      polarion-id: "CEPH-11312"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on existing path"
+      module: cephfs_nfs.existing_path_nfs_export.py
+      name: "existing path cephfs nfs export"
+      polarion-id: "CEPH-83573995"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Run IOs by mounting same subvolume with all the three mounts"
+      module: cephfs_nfs.nfs_fuse_kernel_same_subvolume.py
+      name: "Mount same volume on fuse,kernel and nfs and runIOs"
+      polarion-id: "CEPH-11310"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Backup and restore data using existing NFS backup tools"
+      module: cephfs_nfs.data_backup_restore_bw_nfs_and_local_mounts.py
+      name: "backup and restore data bw nfs exports and local dir"
+      polarion-id: "CEPH-11314"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
+  - test:
+      abort-on-fail: false
+      desc: "Apply various number of hosts to nfs cluster and verify the changes"
+      module: cephfs_nfs.nfs_update_cluster_node_changes.py
+      name: "nfs cluster host changes and verification"
+      polarion-id: "CEPH-83574013"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs with io and network failures"
+      module: cephfs_nfs.nfs_io_network_failures.py
+      name: "cephfs nfs with io and network failures"
+      polarion-id: "CEPH-83574020"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs mount with fstab entry"
+      module: cephfs_nfs.nfs_mount_with_fstab.py
+      name: "cephfs nfs mount with fstab entry"
+      polarion-id: "CEPH-83574025"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_ro_rw_access.py
+      name: "cephfs nfs RO and RW export"
+      polarion-id: "CEPH-83574001"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_export_config.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83574008"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs config reset"
+      module: cephfs_nfs.nfs_config_reset.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83573999"
+  - test:
+      abort-on-fail: false
+      desc: "modifying_nfs_cluster_invalid_value"
+      module: cephfs_nfs.modifying_nfs_cluster_invalid_value.py
+      name: "modifying_nfs_cluster_invalid_value"
+      polarion-id: "CEPH-83574014"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_transfer_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+      name: "nfs_file_transfer_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575825"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_file_attributes_retention.py
+      name: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575937"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_multiple_export_using_single_conf"
+      module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
+      name: "nfs_multiple_export_using_single_conf"
+      polarion-id: "CEPH-83575082"

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-nfs_ha.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-nfs_ha.yaml
@@ -1,0 +1,188 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-nfs_ha.yaml
+# Conf file :
+# Test-Case Covered:
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      name: nfs-ha-deployment
+      module: cephfs_nfs.test_cephfs_nfs_ha_deployment_cli.py
+      desc: Deploy NFS HA and validate the services are UP.
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-create-using-spec-ingress
+      module: cephfs_nfs.nfs_ha_create_using_spec_ingress.py
+      desc: nfs-ha-create-using-spec-ingress
+      polarion-id: CEPH-83575088
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-failover
+      module: cephfs_nfs.test_cephfs_nfs_ha_failover.py
+      desc: nfs-ha-failover
+      polarion-id: CEPH-83575196
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-deployment_on_non_default_port_and_perform_failover
+      module: cephfs_nfs.test_cephfs_nfs_ha_deployment_with_non_default_port.py
+      desc: Deploy NFS HA on non default port and perform failover.
+      polarion-id: CEPH-83575097
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-power-off
+      module: cephfs_nfs.test_cephfs_nfs_ha_active_power_off.py
+      desc: nfs-ha-power-off
+      polarion-id: CEPH-83575195
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-node-replacement
+      module: cephfs_nfs.test_cephfs_nfs_ha_node_replacement.py
+      desc: nfs-ha-node-replacement
+      polarion-id: CEPH-83575096
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-node-services
+      module: cephfs_nfs.test_cephfs_nfs_ha_keeplive_services.py
+      desc: nfs-ha-node-services
+      polarion-id: CEPH-83575091
+      abort-on-fail: false
+  - test:
+      name: nfs-ha-snapshot-access
+      module: cephfs_nfs.test_cephfs_nfs_ha_snapshot_access.py
+      desc: nfs-ha-snapshot-access
+      polarion-id: CEPH-83574009
+      abort-on-fail: false
+  - test:
+      name: perform-failover-with-mounts-on-all-supported-nfs-versions
+      module: cephfs_nfs.test_all_nfs_vers_mount_and_perform_failover.py
+      desc: Mount nfs with all supported versions and perform failover
+      polarion-id: CEPH-83575085
+      abort-on-fail: false
+  - test:
+      name: modification_of_nfs_ha_configuration
+      module: cephfs_nfs.nfs_ha_spec_file_add_host_while_IOs.py
+      desc: Update the NFS Configuraion by adding an additional host on the fly.
+      polarion-id: CEPH-83575090
+      abort-on-fail: false
+  - test:
+      name: upgrade_standalone_NFS_Cluster_to_NFS_HA_Cluster
+      module: cephfs_nfs.test_cephfs_upgrade_nfs_standalone_to_nfs_ha_cluster.py
+      desc: Upgrade a Standalone NFS Cluster to a NFS HA Configuration
+      polarion-id: CEPH-83575095
+      abort-on-fail: false
+

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-quota_arch.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-quota_arch.yaml
@@ -1,0 +1,219 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-quota.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# Test-Case Covered:
+#	CEPH-83573399	Test to validate the quota.max_files  Create a FS and create 10 directories and
+#                   mount them on kernel client and fuse client(5 mounts each)  Set max files quota to a number(say 50)
+#                   add up to that number of files to that directory and  verify if the set quota limit is working fine.
+#                   Similarly set different limit on different directories and  verify quota.
+#   CEPH-83573400     Test to validate the increase in quota limit once it reaches the max limit. (files)
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client(5 mounts
+#                     each). Set max file quota to a number(say 50) and add up to that number of files to that directory
+#                     and verify if the set quota limit is working fine.
+#                     Increase the set quota limit to more that what was set
+#                     earlier and add more files and verify.
+#                     Similarly set different limit on different directories,increase
+#                     the limit and verify it’s functionality and verify quota
+#   CEPH-83573405     Test to validate the removal of quota_max_files
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client
+#                     Set max files quota to a number(say 50) and add up to that number of files to that directory and
+#                     verify if the set quota limit is working fine. Remove the quota once it reaches the max number of
+#                     files and try adding more files, verify if set quota is removed. Repeat the procedure for few more
+#                     times.
+#   CEPH-83573402     Test to validate the quota.max_bytes
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client
+#                     Set max bytes quota to a number(say 5gb) and add up to that number of files to that directory and
+#                     verify if the set quota limit is working fine.
+#                     Similarly set different limit on different directories and verify quota.
+#   CEPH-83573401     Test to validate the increase in quota limit once it reaches the max limit. (bytes)
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client(5 mounts
+#                     each). Set max bytes quota to a number(say 1Gb) and fill data until it reaches the limit and
+#                     verify if the set quota limit is working fine.
+#                     Increase the set quota limit to more that what was set earlier and
+#                     fill more data and verify. Similarly set different limit on different directories, increase
+#                     the limit and verify it’s functionality and verify quota.
+#   CEPH-83573407     Negative : Test to validate the decrease in quota limit once it reaches the max limit. (bytes)
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client
+#                     Set max bytes quota to a number(say 1Gb) and fill data until it reaches the limit and
+#                     verify if the set quota limit is working fine.
+#                     Try setting the quota limit to lesser than what was set
+#                     earlier, setting quota lesser that the space occupied shouldn’t be allowed. Repeat the same
+#                     procedures for 5-10 times.
+#   CEPH-83573409     Test to validate the removal of quota_max_bytes
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client
+#                     Set max bytes quota to a number and fill data until it reaches the limit,verify if the set
+#                     quota limit is working fine. Remove the quota once it reaches the max bytes and try adding more
+#                     data, verify if set quota is removed. Repeat the procedure for few more times.
+#   CEPH-83573408     Test to validate the quota remains intact even after rebooting the Node.
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client(5 mounts
+#                     each). Set max bytes quota to a number(say 1Gb) and also set max files quota and verify if
+#                     the set quota limit is working fine by filling max number of files and also by filling data to reach
+#                     the max limit. Reboot the node , once the node is up verify if the set quota remains or not.
+#   CEPH-83573406     Test to validate the combination of quota_max_bytes and quota_max_files
+#                     Create a FS and create 10 directories and mount them on kernel client and fuse client
+#                     Set max bytes quota to a number(say 1Gb) and also set max files quota  and verify if the set
+#                     quota limit is working fine by filling max number of files and also by filling data to reach max
+#                     limit. Increase the limit to higher number and add data and files again. Repeat this for few more
+#                     times.
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+        name: Files-quota-increase-test
+        module: quota.quota_files_increase.py
+        polarion-id: CEPH-83573400
+        desc: Tests the increase of file attributes  on the directory
+        abort-on-fail: false
+  - test:
+      name: Files-quota-decrease-test
+      module: quota.quota_files_decrease.py
+      polarion-id: CEPH-83573403
+      desc: Tests the increase of file attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-remove-test
+      module: quota.quota_files_remove.py
+      polarion-id: CEPH-83573405
+      desc: Tests the remove of file attributes on the directory
+      abort-on-fail: false
+  - test:
+        name: Bytes-quota-test
+        module: quota.quota_bytes.py
+        polarion-id: CEPH-83573402
+        desc: Tests the Byte attributes on the directory
+        abort-on-fail: false
+  - test:
+      name: Bytes-quota-increase-test
+      module: quota.quota_bytes_increase.py
+      polarion-id: CEPH-83573401
+      desc: Tests the increase of Byte attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-decrease-test
+      module: quota.quota_bytes_decrease.py
+      polarion-id: CEPH-83573407
+      desc: Tests the decrease of Byte attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-remove-test
+      module: quota.quota_bytes_remove.py
+      polarion-id: CEPH-83573409
+      desc: Tests the remove of Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+        name: Quota-Reboot-test
+        module: quota.quota_reboot.py
+        polarion-id: CEPH-83573408
+        desc: Tests the remove of Byte attributes on the directory
+        abort-on-fail: false
+  - test:
+      name: Quota-file-byte-test
+      module: quota.quota_files_bytes.py
+      polarion-id: CEPH-83573406
+      desc: Tests the file and byte attributes on the directory
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-snapshot-clone_arch.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-snapshot-clone_arch.yaml
@@ -1,0 +1,251 @@
+---
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-snapshot-clone.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# Test-Case Covered:
+#	CEPH-83573499 Remove the original volume after cloning and verify the data is accessible from cloned volume
+#	CEPH-83573501 Create a Cloned Volume using a snapshot
+#	CEPH-83573504 Verify the status of cloning operation
+#	CEPH-83573502 Interrupt the cloning operation in-between and observe the behavior.
+#	CEPH-83573520 Validate the max snapshot that can be created under a root FS sub volume level.
+#	              Increase by 50 at a time until it reaches the max limit.
+#	CEPH-83573521 Remove a subvolume group by retaining the snapshot : ceph fs subvolume rm <vol_n...
+#	CEPH-83573415 Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
+#	CEPH-83573418 Create a Snapshot, reboot the node and rollback the snapshot
+#	CEPH-83573420 Try writing the data to snap directory
+#   CEPH-83573524	Ensure the subvolume attributes are retained post clone operations
+#   CEPH-11319		Create first snap add more data to original then create a second snap.
+#                   Rollback 1st snap do data validation. Rollback 2nd snap and do data validation.
+#                   Perform cross platform rollback i.e. take snap on kernel mount and perform rollback using fuse mount
+#   CEPH-83573255	Try renaming the snapshot directory and rollbackCreate a FS and
+#                   create 10 directories and mount them on kernel client and fuse client(5 mounts each)
+#                   Add data (~ 100 GB). Create a Snapshot and verify the content in snap directory.
+#                   Try modifying the snapshot name.
+#   CEPH-83573522	Verify the retained snapshot details with "ceph fs info" command
+#   CEPH-83574724   Create Clone of subvolume which is completely filled with data till disk quota exceeded
+#   CEPH-83575038   verify CRUD operation on metadata of subvolume's snapshot
+#   CEPH-83574681 Cancel the subvolume snapshot clonning
+#.  CEPH-83579271 Snap schedule and retention testing
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: Concurrent-clone-test
+      module: snapshot_clone.clone_threads.py
+      polarion-id: CEPH-83574592
+      desc: Concurrent-clone-test
+      abort-on-fail: false
+  - test:
+      name: Clone_status
+      module: snapshot_clone.clone_status.py
+      polarion-id: CEPH-83573501
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Clone_cancel_status
+      module: snapshot_clone.clone_cancel_status.py
+      polarion-id: CEPH-83573502
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Retain_Snapshots
+      module: snapshot_clone.retain_snapshots.py
+      polarion-id: CEPH-83573521
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: snapshot_flag
+      module: snapshot_clone.snapshot_flag.py
+      polarion-id: CEPH-83573415
+      desc: Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
+      abort-on-fail: false
+  - test:
+        name: Remove_Subvolume_clone
+        module: snapshot_clone.clone_remove_subvol.py
+        polarion-id: CEPH-83573499
+        desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+        abort-on-fail: false
+  - test:
+      name: Test Max Snapshot limit
+      module: snapshot_clone.max_snapshot_limit.py
+      polarion-id: CEPH-83573520
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: Snapshot reboot
+      module: snapshot_clone.snapshot_reboot.py
+      polarion-id: CEPH-83573418
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: Snapshot write
+      module: snapshot_clone.snapshot_write.py
+      polarion-id: CEPH-83573420
+      desc: Try writing the data to snap directory
+      abort-on-fail: false
+  - test:
+      name: Clone_attributes
+      module: snapshot_clone.clone_attributes.py
+      polarion-id: CEPH-83573524
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: cross_platform_snaps
+      module: snapshot_clone.cross_platform_snaps.py
+      polarion-id: CEPH-11319
+      desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: rename snap directory
+      module: snapshot_clone.rename_snap_dir.py
+      polarion-id: CEPH-83573255
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: subvolume_info_retain
+      module: snapshot_clone.subvolume_info_retain.py
+      polarion-id: CEPH-83573522
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: subvolume_full_vol
+      module: snapshot_clone.clone_subvolume_full_vol.py
+      polarion-id: CEPH-83574724
+      desc: Clone a subvolume with full data in the subvolume
+      abort-on-fail: false
+  - test:
+      name: snapshot_metadata
+      module: snapshot_clone.snapshot_metadata.py
+      polarion-id: CEPH-83575038
+      desc: verify CRUD operation on metadata of subvolume's snapshot
+      abort-on-fail: false
+  - test:
+      name: cancel the subvolume snapshot clonning
+      module: snapshot_clone.clone_cancel_in_progress.py
+      polarion-id: CEPH-83574681
+      desc: Try to cancel the snapshot while clonning is operating
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_test
+      module: snapshot_clone.snap_schedule.py
+      polarion-id: CEPH-83575569
+      desc: snap_schedule_test
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_retention_vol_subvol
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83579271
+      desc: snap schedule and retention functional test on vol and subvol
+      abort-on-fail: false
+      config:
+        test_name : functional
+  - test:
+      name: snapshot_nfs_mount
+      module: snapshot_clone.snapshot_nfs_mount.py
+      polarion-id: CEPH-83592018
+      desc: Validate Snapshot mount through NFS suceeds and snapshot data is accessible
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_with_mds_restart
+      module: snapshot_clone.snap_schedule_with_mds_restart.py
+      polarion-id: CEPH-83600860
+      desc: Validate Verify Kernel and FUSE Mount Behavior with Snapshot Scheduling and MDS Restarts
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_test-volume-management_arch.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test-volume-management_arch.yaml
@@ -1,0 +1,336 @@
+---
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-volume-management.yaml
+# Conf file : conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Test-Case Covered:
+# CEPH-83574164 : Create cephfs subvolumegroup with desired data pool_layout
+# CEPH-83574193 - cephfs subvolume size expansion test
+# CEPH-83574166 - Create cephfs subvolumegroup with specific uid,gid test  //TO DO
+# CEPH-83574182 - Delete subvolume name that does not exist
+# CEPH-83574169 - Remove subvolume group name does not exist with force option
+# CEPH-83574168 - Delete_non_exist_subvol_group
+# CEPH-83573637 - Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+# CEPH-83574158 - arbitary pool removal on volume deletion test
+# CEPH-83573428 - cephfs_vol_mgmt_create_vol_component_exist_name
+# CEPH-83574162 - cephfs_vol_mgmt_non_exist_subvol_group_deletetion
+# CEPH-83573528 - cephfs_vol_mgmt_pool_name_option_test
+# CEPH-83574161 - Checking default subvolume group gid and uid
+# CEPH-83574181 - Checking default subvolume gid and uid
+# CEPH-83574163 - cephfs_vol_mgmt_invalid_pool_layout
+# CEPH-83574190 - Volume default and different permission test
+# CEPH-83574192 - Subvolume creation with invalid pool_layout
+# CEPH-83574187 - Subvolume creation with isolated_namespace option
+# CEPH-83574165	- Create cephfs subvolumegroup with desired permissions test
+# CEPH-83574331 - Adding new data pools to cephfs which has existing data pool.
+# CEPH-83573428 - cephfs_vol_mgmt_volume_with_exist_names
+# CEPH-83574188 - Testing auto-cleanup cephfs subvolume after creation failure
+# CEPH-83603354 - volume related scenarios(delete,rename)
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_test_file_and_dir_layout_arch.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test_file_and_dir_layout_arch.yaml
@@ -1,0 +1,183 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: File and Dir Layout Lifecycle Operations
+      module: cephfs_file_and_dir_layout.file_dir_layout_lifecycle_ops.py
+      polarion-id: CEPH-11334
+      desc: File and Directory Layout Lifecycle Operations
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_cephfs_test_mds_pinning.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_test_mds_pinning.yaml
@@ -1,0 +1,185 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id: null
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:
+                verbose: true
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: cephfs-mdsfailover-pinning-io
+      module: cephfs_mds_pinning.mds_pinning_load_balancing.py
+      config:
+        num_of_dirs: 200
+      polarion-id: CEPH-11227
+      desc: MDSfailover on active-active mdss,performing client IOs with no pinning at
+        the first,later pin 10 dirs with IOs
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDss with max:min number of directories
+      module: cephfs_mds_pinning.mds_pinning_max_min_dir_on_two_mdss.py
+      config:
+          num_of_dirs: 100
+      polarion-id: CEPH-11228
+      desc: MDSfailover on active-active mdss,performing client IOs with max:min directory pinning with 2 active mdss
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDSs with unequal ratio of directories
+      module: cephfs_mds_pinning.mds_pinning_unequal_dir_on_two_mdss.py
+      config:
+          num_of_dirs: 100
+      polarion-id: CEPH-11229
+      desc: MDSfailover on active-active mdss,performing client IOs with 10:2 directory pinning with 2 active mdss
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDS with equal ratio of directories
+      module: cephfs_mds_pinning.mds_pinning_equal_dir_on_two_mdss.py
+      config:
+          num_of_dirs: 100
+      polarion-id: CEPH-11230
+      desc: MDSfailover on active-active mdss,performing client IOs with equal directory pinning with 2 active mdss
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDS with node reboots
+      module: cephfs_mds_pinning.mds_pinning_node_reboots.py
+      polarion-id: CEPH-11231
+      desc: Directory pinning on two MDS with node reboots
+      abort-on-fail: false
+  - test:
+      name: Subtree Split and Subtree merging by pinning Subtrees directories to MDS.
+      module: cephfs_mds_pinning.mds_pinning_split_merge.py
+      polarion-id: CEPH-11233
+      desc: Subtree Split and Subtree merging by pinning Subtrees directories to MDS.
+      abort-on-fail: false
+  - test:
+      name: map and unmap directory trees to a mds rank
+      module: cephfs_mds_pinning.map_and_unmap_directory_trees_to_a_mds_rank.py
+      polarion-id: CEPH-83574329
+      desc: map and unmap directory trees to a mds rank
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Validate selinux relabel on kernel client"
+      module: clients.test_selinux_relabel.py
+      name: Validate selinux relabels
+      polarion-id: "CEPH-83595737"

--- a/suites/tentacle/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/tentacle/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -1,0 +1,491 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: File and Dir Layout Lifecycle Operations
+      module: cephfs_file_and_dir_layout.file_dir_layout_lifecycle_ops.py
+      polarion-id: CEPH-11334
+      desc: File and Directory Layout Lifecycle Operations
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export path"
+      module: cephfs_nfs.nfs_export_path.py
+      name: "cephfs nfs export path"
+      polarion-id: "CEPH-83574028"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs snapshot clone operations"
+      module: cephfs_nfs.nfs_snaphshot_clone.py
+      name: "cephfs nfs snapshot clone operations"
+      polarion-id: "CEPH-83574024"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs subvolume & subvolumegroup operations"
+      module: cephfs_nfs.nfs_subvolume_subvolumegroup.py
+      name: "cephfs nfs subvolume & subvolumegroup operations"
+      polarion-id: "CEPH-83574027"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs read only export"
+      module: cephfs_nfs.read_only_nfs_export.py
+      name: "cephfs nfs read only export"
+      polarion-id: "CEPH-83574003"
+  - test:
+      abort-on-fail: false
+      desc: "test recreation of cephfs nfs cluster with same name"
+      module: cephfs_nfs.recreate_same_name_nfs.py
+      name: "recreate same name nfs cluster"
+      polarion-id: "CEPH-83574015"
+  - test:
+      abort-on-fail: false
+      desc: "test creation of 2 node nfs cluster"
+      module: cephfs_nfs.2_node_nfs.py
+      name: "2 node nfs cluster"
+      polarion-id: "CEPH-83574022"
+  - test:
+      abort-on-fail: false
+      desc: "test zipping & unzipping files on nfs export continuously"
+      module: cephfs_nfs.zip_unzip_files_nfs.py
+      name: "zipping & unzipping files on nfs export"
+      polarion-id: "CEPH-83574026"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export for cephfs subvolume"
+      module: cephfs_nfs.subvolume_export.py
+      name: "cephfs nfs export for subvolume"
+      polarion-id: "CEPH-83573993"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on non-existing directory"
+      module: cephfs_nfs.nfs_non_exist_export_path.py
+      name: "Create cephfs nfs export on non-existing directory"
+      polarion-id: "CEPH-83573669"
+  - test:
+      abort-on-fail: false
+      desc: "Export and import data between NFS and CephFS"
+      module: cephfs_nfs.move_data_bw_nfs_and_cephfs_mounts.py
+      name: "Move Data bw nfs and cephfs exports"
+      polarion-id: "CEPH-11309"
+  - test:
+      abort-on-fail: false
+      desc: "Test data integrity between cephfs & nfs mounts"
+      module: cephfs_nfs.test_data_integrity_nfs_cephfs_mounts.py
+      name: "data integrity between cephfs & nfs mounts"
+      polarion-id: "CEPH-11312"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on existing path"
+      module: cephfs_nfs.existing_path_nfs_export.py
+      name: "existing path cephfs nfs export"
+      polarion-id: "CEPH-83573995"
+  - test:
+      abort-on-fail: false
+      desc: "Run IOs by mounting same subvolume with all the three mounts"
+      module: cephfs_nfs.nfs_fuse_kernel_same_subvolume.py
+      name: "Mount same volume on fuse,kernel and nfs and runIOs"
+      polarion-id: "CEPH-11310"
+  - test:
+      abort-on-fail: false
+      desc: "Backup and restore data using existing NFS backup tools"
+      module: cephfs_nfs.data_backup_restore_bw_nfs_and_local_mounts.py
+      name: "backup and restore data bw nfs exports and local dir"
+      polarion-id: "CEPH-11314"
+  - test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
+  - test:
+      abort-on-fail: false
+      desc: "Apply various number of hosts to nfs cluster and verify the changes"
+      module: cephfs_nfs.nfs_update_cluster_node_changes.py
+      name: "nfs cluster host changes and verification"
+      polarion-id: "CEPH-83574013"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs with io and network failures"
+      module: cephfs_nfs.nfs_io_network_failures.py
+      name: "cephfs nfs with io and network failures"
+      polarion-id: "CEPH-83574020"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs mount with fstab entry"
+      module: cephfs_nfs.nfs_mount_with_fstab.py
+      name: "cephfs nfs mount with fstab entry"
+      polarion-id: "CEPH-83574025"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_ro_rw_access.py
+      name: "cephfs nfs RO and RW export"
+      polarion-id: "CEPH-83574001"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_export_config.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83574008"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs config reset"
+      module: cephfs_nfs.nfs_config_reset.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83573999"
+  - test:
+      abort-on-fail: false
+      desc: "modifying_nfs_cluster_invalid_value"
+      module: cephfs_nfs.modifying_nfs_cluster_invalid_value.py
+      name: "modifying_nfs_cluster_invalid_value"
+      polarion-id: "CEPH-83574014"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_transfer_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+      name: "nfs_file_transfer_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575825"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_file_attributes_retention.py
+      name: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575937"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_multiple_export_using_single_conf"
+      module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
+      name: "nfs_multiple_export_using_single_conf"
+      polarion-id: "CEPH-83575082"
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Create a subvolume in a non-existent subvolume group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: Create a subvolume in a non-existent subvolume group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false
+  - test:
+      name: CephFS Volume Operations
+      module: cephfs_vol_management.cephfs_vol_mgmt_test_volume.py
+      polarion-id: CEPH-83604097
+      desc: Test for validating all CephFS Volume Operations
+      abort-on-fail: false
+  - test:
+      name: volume rename, subvolume earmark, subvolumegroup idempotence scenarios
+      module: cephfs_vol_management.cephfs_vol_mgmt_rename_earmark_subvolume.py
+      polarion-id: CEPH-83604978
+      desc: volume rename, subvolume earmark, subvolumegroup idempotence scenarios
+      abort-on-fail: false
+  - test:
+      name: vol_info
+      module: cephfs_vol_management.cephfs_vol_info.py
+      polarion-id: CEPH-83606764
+      desc: Validate the volume info command and ensure the output is accurate.
+      abort-on-fail: false
+  - test:
+      name: rename scenarios
+      module: cephfs_vol_management.cephfs_vol_mgmt_rename_scenarios.py
+      polarion-id: CEPH-83607848
+      desc: volume rename scenarios
+      abort-on-fail: false
+      comments: bz-2352998

--- a/suites/tentacle/cephfs/tier-2_fs_erasure.yaml
+++ b/suites/tentacle/cephfs/tier-2_fs_erasure.yaml
@@ -1,0 +1,136 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Fill the cluster with specific percentage"
+      module: test_io.py
+      name: Fill_Cluster
+      config:
+        cephfs:
+          "fill_data": 60
+          "io_tool": "smallfile"
+          "mount": "fuse"
+          "filesystem": "cephfs"
+          "mount_dir": ""
+  - test:
+      name: Stanby-replay mds
+      module: stand_by_replay_mds.py
+      polarion-id: CEPH-83573269
+      desc: Stanby-replay mds testt
+      abort-on-fail: false
+  - test:
+      name: mds service add removal test
+      module: mds_rm_add.py
+      polarion-id: CEPH-11259
+      desc: mds service add removal test
+      abort-on-fail: false
+  - test:
+      name: mon service add removal test
+      module: mon_rm_add.py
+      polarion-id: CEPH-11345
+      desc: mon service add removal test
+      abort-on-fail: false
+  - test:
+      name: mds service stop & start test
+      module: mon_rm_add.py
+      polarion-id: CEPH-83574339
+      desc: mds service stop & start test
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_fs_mutlifs_quota_snaphost.yaml
+++ b/suites/tentacle/cephfs/tier-2_fs_mutlifs_quota_snaphost.yaml
@@ -1,0 +1,362 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Fill the cluster with specific percentage"
+      module: test_io.py
+      name: Fill_Cluster
+      config:
+        cephfs:
+          "fill_data": 60
+          "io_tool": "smallfile"
+          "mount": "fuse"
+          "filesystem": "cephfs"
+          "mount_dir": ""
+  - test:
+      name: Stanby-replay mds
+      module: stand_by_replay_mds.py
+      polarion-id: CEPH-83573269
+      desc: Stanby-replay mds testt
+      abort-on-fail: false
+  - test:
+      name: mds service add removal test
+      module: mds_rm_add.py
+      polarion-id: CEPH-11259
+      desc: mds service add removal test
+      abort-on-fail: false
+  - test:
+      name: mon service add removal test
+      module: mon_rm_add.py
+      polarion-id: CEPH-11345
+      desc: mon service add removal test
+      abort-on-fail: false
+  - test:
+      name: mds service stop & start test
+      module: mon_rm_add.py
+      polarion-id: CEPH-83574339
+      desc: mds service stop & start test
+      abort-on-fail: false
+  - test:
+      name: multifs flag
+      module: multifs.multifs_flag.py
+      polarion-id: CEPH-83573878
+      desc: Tests the multifs flag functionality
+      abort-on-fail: false
+  - test:
+      name: multifs same pool
+      module: multifs.multifs_same_pool.py
+      polarion-id: CEPH-83573873
+      desc: Tests the file system with same pools
+      abort-on-fail: false
+  - test:
+      name: multifs reboot with fstab
+      module: multifs.multifs_kernelmounts.py
+      polarion-id: CEPH-83573872
+      desc: Tests the file system with fstab entries with multiple file systems and reboots using kernel mount
+      abort-on-fail: false
+  - test:
+      name: multifs reboot with fstab fuse
+      module: multifs.multifs_fusemounts.py
+      polarion-id: CEPH-83573871
+      desc: Tests the file system with fstab entries with multiple file systems and reboots using fuse mount
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems wtih different MDS daemons
+      module: multifs.multifs_default_values.py
+      polarion-id: CEPH-83573870
+      desc: Create 2 Filesystem with default values on different MDS daemons
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems
+      module: multifs.multifs_multiplefs.py
+      polarion-id: CEPH-83573867
+      desc: Create 4-5 Filesystem randomly on different MDS daemons
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-increase-test
+      module: quota.quota_files_increase.py
+      polarion-id: CEPH-83573400
+      desc: Tests the increase of file attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-decrease-test
+      module: quota.quota_files_decrease.py
+      polarion-id: CEPH-83573403
+      desc: Tests the increase of file attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Files-quota-remove-test
+      module: quota.quota_files_remove.py
+      polarion-id: CEPH-83573405
+      desc: Tests the remove of file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573402
+      desc: Tests the Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-increase-test
+      module: quota.quota_bytes_increase.py
+      polarion-id: CEPH-83573401
+      desc: Tests the increase of Byte attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-decrease-test
+      module: quota.quota_bytes_decrease.py
+      polarion-id: CEPH-83573407
+      desc: Tests the decrease of Byte attributes  on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-remove-test
+      module: quota.quota_bytes_remove.py
+      polarion-id: CEPH-83573409
+      desc: Tests the remove of Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Quota-Reboot-test
+      module: quota.quota_reboot.py
+      polarion-id: CEPH-83573408
+      desc: Tests the remove of Byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Quota-file-byte-test
+      module: quota.quota_files_bytes.py
+      polarion-id: CEPH-83573406
+      desc: Tests the file and byte attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Concurrent-clone-test
+      module: snapshot_clone.clone_threads.py
+      polarion-id: CEPH-83574592
+      desc: Concurrent-clone-test
+      abort-on-fail: false
+  - test:
+      name: Clone_status
+      module: snapshot_clone.clone_status.py
+      polarion-id: CEPH-83573501
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Clone_cancel_status
+      module: snapshot_clone.clone_cancel_status.py
+      polarion-id: CEPH-83573502
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Retain_Snapshots
+      module: snapshot_clone.retain_snapshots.py
+      polarion-id: CEPH-83573521
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: snapshot_flag
+      module: snapshot_clone.snapshot_flag.py
+      polarion-id: CEPH-83573415
+      desc: Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
+      abort-on-fail: false
+  - test:
+      name: Remove_Subvolume_clone
+      module: snapshot_clone.clone_remove_subvol.py
+      polarion-id: CEPH-83573499
+      desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: Test Max Snapshot limit
+      module: snapshot_clone.max_snapshot_limit.py
+      polarion-id: CEPH-83573520
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: Snapshot reboot
+      module: snapshot_clone.snapshot_reboot.py
+      polarion-id: CEPH-83573418
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: Snapshot write
+      module: snapshot_clone.snapshot_write.py
+      polarion-id: CEPH-83573420
+      desc: Try writing the data to snap directory
+      abort-on-fail: false
+  - test:
+      name: Clone_attributes
+      module: snapshot_clone.clone_attributes.py
+      polarion-id: CEPH-83573524
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: cross_platform_snaps
+      module: snapshot_clone.cross_platform_snaps.py
+      polarion-id: CEPH-11319
+      desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: rename snap directory
+      module: snapshot_clone.rename_snap_dir.py
+      polarion-id: CEPH-83573255
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: subvolume_info_retain
+      module: snapshot_clone.subvolume_info_retain.py
+      polarion-id: CEPH-83573522
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: subvolume_full_vol
+      module: snapshot_clone.clone_subvolume_full_vol.py
+      polarion-id: CEPH-83574724
+      desc: Clone a subvolume with full data in the subvolume
+      abort-on-fail: false
+  - test:
+      name: snapshot_metadata
+      module: snapshot_clone.snapshot_metadata.py
+      polarion-id: CEPH-83575038
+      desc: verify CRUD operation on metadata of subvolume's snapshot
+      abort-on-fail: false
+  - test:
+      name: cancel the subvolume snapshot clonning
+      module: snapshot_clone.clone_cancel_in_progress.py
+      polarion-id: CEPH-83574681
+      desc: Try to cancel the snapshot while clonning is operating
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_test
+      module: snapshot_clone.snap_schedule.py
+      polarion-id: CEPH-83575569
+      desc: snap_schedule_test
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_retention_vol_subvol
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83579271
+      desc: snap schedule and retention functional test on vol and subvol
+      abort-on-fail: false
+      config:
+        test_name: functional
+  - test:
+      name: snap_sched_multi_fs
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83581235
+      desc: snap schedule and retention functional test on multi-fs setup
+      abort-on-fail: false
+      config:
+        test_name: systemic
+  - test:
+      name: snapshot_nfs_mount
+      module: snapshot_clone.snapshot_nfs_mount.py
+      polarion-id: CEPH-83592018
+      desc: Validate Snapshot mount through NFS suceeds and snapshot data is accessible
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_with_mds_restart
+      module: snapshot_clone.snap_schedule_with_mds_restart.py
+      polarion-id: CEPH-83600860
+      desc: Validate Verify Kernel and FUSE Mount Behavior with Snapshot Scheduling and MDS Restarts
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-3_cephfs.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs.yaml
@@ -1,0 +1,205 @@
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-3_cephfs.yaml
+# Conf file : conf/reef/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Test-Case Covered:
+#   CEPH-11238: Converting standy MDS to active MDS
+#   CEPH-11258: Add & remove osd while doing CephFS IOs & check cluster health
+#   CEPH-11330: set config option and verify the value
+#=======================================================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node12
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: Converting standy MDS to active MDS
+      module: CEPH-11238.py
+      config:
+        num_of_file_dir: 5000
+      polarion-id: CEPH-11238
+      desc: Converting standy MDS to active MDS while IO is going on each directories
+      abort-on-fail: false
+  - test:
+      name: Add & remove osd while doing CephFS IOs
+      module: osd_add_rm_FS_IO.py
+      polarion-id: CEPH-11258
+      desc: Add & remove osd while doing CephFS IOs & check cluster health
+  - test:
+      name: client config option and value verification
+      module: clients.client_option_value_verification.py
+      polarion-id: CEPH-11330
+      desc: set config option and verify the value
+

--- a/suites/tentacle/cephfs/tier-3_cephfs_bugs.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_bugs.yaml
@@ -1,0 +1,295 @@
+#=======================================================================================================================
+# Tier-level: 3
+# Test-Suite: cephfs_bugs
+# Conf file : conf/pacific/cephfs/tier-3_cephfs_4clients_4osd.yaml
+# Description - This test suite contains tests which were automated during bug verification
+# Test-Case Covered:
+  # CEPH-11260 - Change replication size of Cephfs pools increase and decrease, with client IO
+  # CEPH-83574833 - Performace test for file write_sync() on cephfs kernel mount
+  # CEPH-83574632 - Allow recreating file system with specific fscid
+  # CEPH-83572726 - Active-Active MDS with multiclients to verify the race condition
+  # CEPH-83575622 - create a file(fileA) , create a hard link (fileB),
+  #          remove the fileA first and then fileB and run this in a loop for some time and check for deadlock
+  # CEPH-83575623 - Run fsstress.sh repeatedly on fuse and kernel clients for a while and validate no crash is seen.
+  # CEPH-83575781: Remove contents of lost+found directory.
+  # CEPH-83575762: Run create and unlink operations concurrently.
+  # CEPH-83575630: Check for large omaps with files and snapshots.
+  # CEPH-83575624: Check for Standby-reply nodes changes if there is a network glitch for more than 60 seconds.
+  # CEPH-83583762: Check to prevent usage of Pools which has Pool level snaps for Filesystem creation.
+  # CEPH-83584084: Validate if no repeated mclientscaps(revoke) entries found in MDS.
+  # CEPH-83586730: validate standby replay node not removed after setting mds_inject_health_dummy
+  # CEPH-83583721 - Validate the details of all MDS servers are displayed with command `ceph mds metadata`.
+  # CEPH-83583723 - Ensure deletion of clones are allowed when the clones are stuck and in pending state
+  # CEPH-83589266 - Validate Ceph commands when ceph file system is in failed state
+  # CEPH-83592512 - Prevent scrub running using standby MDS
+  # CEPH-83592513 - Verify Client evict -h,--help works without running the function
+  # CEPH-83609202 - Verify data scan works on missing non-immediate dir frags and FS recovery suceeds
+#=======================================================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            nodes:
+              - node9
+              - node10
+              - node11
+              - node12
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      name: Change pg size of cephfs pools
+      module: cephfs_bugs.test_cephfs_pool_size_change.py
+      polarion-id: CEPH-11260
+      desc: test decrease & increase in pg size of cephfs pools
+      abort-on-fail: false
+  - test:
+      name: Performace test for file write_fsync() on cephfs kernel mount
+      module: cephfs_bugs.test_write_fsync_on_file_kernel_mount.py
+      polarion-id: CEPH-83574833
+      desc: Performace test for file write_fsync() on cephfs kernel mount
+      abort-on-fail: false
+  - test:
+      name: Allow recreating file system with specific fscid
+      module: cephfs_bugs.test_custom_fscid_cephfs.py
+      polarion-id: CEPH-83574632
+      desc: Allow recreating file system with specific fscid
+      abort-on-fail: false
+  - test:
+      name: Active-Active MDS with multiclients to verify the race condition
+      module: cephfs_bugs.verify_race_condition_between_MDS.py
+      polarion-id: CEPH-83572726
+      desc: Active-Active MDS with multiclients to verify the race condition
+      abort-on-fail: false
+  - test:
+      name: Validate deadlock between unlink and rename
+      module: cephfs_bugs.test_validate_deadlock_bw_unlink_and_rename.py
+      polarion-id: CEPH-83575622
+      desc: Validate deadlock between unlink and rename
+      abort-on-fail: false
+  - test:
+      name: Run fsstress on kernel and fuse mounts
+      module: cephfs_bugs.test_fsstress_on_kernel_and_fuse.py
+      polarion-id: CEPH-83575623
+      desc: Run fsstress on kernel and fuse mounts
+      abort-on-fail: false
+  - test:
+      name: Remove Contents of lost+found dir
+      module: cephfs_bugs.test_rm_on_lost_found_dir.py
+      polarion-id: CEPH-83575781
+      desc: Remove Contents of lost+found dir
+      abort-on-fail: false
+  - test:
+      name: Run create and unlink operations concurrently.
+      module: cephfs_bugs.test_create_unlink_ops_concorrently.py
+      polarion-id: CEPH-83575762
+      desc: Run create and unlink operations concurrently
+      abort-on-fail: false
+  - test:
+      name: Check for large omaps with files and snapshots
+      module: cephfs_bugs.test_large_omap.py
+      polarion-id: CEPH-83575630
+      desc: Check for large omaps with files and snapshots
+      abort-on-fail: false
+  - test:
+      name: Check for Standby-reply nodes changes if there is network glitch for more than 60 sec
+      module: cephfs_bugs.test_mds_laggy_thrown_out.py
+      polarion-id: CEPH-83575624
+      desc: Check for Standby-reply nodes changes if there is network glitch for more than 60 sec
+      abort-on-fail: false
+  - test:
+      name: Check to prevent usage of Pools which has Pool level snaps for Filesystem creation.
+      module: cephfs_bugs.test_disallow_fs_creation_with_pool_level_snaps.py
+      polarion-id: CEPH-83583762
+      desc: Creation of pool-level snaps for pools actively associated with a filesystem is disallowed
+      abort-on-fail: false
+  - test:
+      name: validate standby reply node not removed after setting mds_inject_health_dummy
+      module: cephfs_bugs.test_mds_inject_health_dummy.py
+      polarion-id: CEPH-83586730
+      desc: validate standby reply node not removed after setting mds_inject_health_dummy
+      abort-on-fail: false
+  - test:
+      name:  Validate the details of all MDS servers are displayed with command ceph mds metadata
+      module: cephfs_bugs.validate_mds_metadata.py
+      polarion-id: CEPH-83583721
+      desc: Validate the details of all MDS servers are displayed with command ceph mds metadata
+      abort-on-fail: false
+  - test:
+      name: Ensure deletion of clones are allowed when the clones are stuck and in pending state
+      module: cephfs_bugs.test_clone_delete_with_FS_fail.py
+      polarion-id: CEPH-83583723
+      desc: Ensure deletion of clones are allowed when the clones are stuck and in pending state
+      abort-on-fail: false
+  - test:
+      name: Validate Ceph commands when ceph file system is in failed state
+      module: cephfs_bugs.validate_ceph_ops_wtih_fs_fail.py
+      polarion-id: CEPH-83589266
+      desc: Validate Ceph commands when ceph file system is in failed state
+      abort-on-fail: false
+  - test:
+      name: Verify Ceph Health Warning for Slow MDS Requests After Cluster Installation
+      module: cephfs_bugs.validate_mds_health_with_client_evict.py
+      polarion-id: CEPH-83591136
+      desc: Verify Ceph Health Warning for Slow MDS Requests After Cluster Installation
+      abort-on-fail: false
+  - test:
+      name: Prevent scrub running using standby MDS
+      module: cephfs_bugs.prevent_scrub_with_standby_mds.py
+      comments: BZ 2294478
+      polarion-id: CEPH-83592512
+      desc: Prevent scrub running using standby MDS
+      abort-on-fail: false
+  - test:
+      name: Verify Client evict -h,--help works without running the function
+      module: cephfs_bugs.evict_all_clients_add_to_blocklist.py
+      comments: BZ 2160855
+      polarion-id: CEPH-83592513
+      desc: Verify Client evict -h,--help works without running the function
+      abort-on-fail: false
+  - test:
+      name: clone_no_wait_if_max_concurrent
+      module: cephfs_bugs.clone_no_wait_if_max_concurrent.py
+      polarion-id: CEPH-83593402
+      desc: Additional clone create not started if max concurrent clone creating and snapshot_clone_no_wait is True
+      abort-on-fail: false
+  - test:
+      name: mds_cache_oversized_warning_counter
+      module: cephfs_bugs.test_mds_cache_oversized_warning_counter.py
+      polarion-id: CEPH-83594160
+      desc: mds_cache_oversized_warning_counter
+      abort-on-fail: false
+  - test:
+      name: mds_dir_max_commit_size
+      module: cephfs_bugs.test_mds_dir_max_commit_size.py
+      polarion-id: CEPH-83600107
+      desc: mds_dir_max_commit_size
+      abort-on-fail: false
+  - test:
+      name: fs_recovery_dir_rm
+      module: cephfs_bugs.test_fs_recovery_dir_rm.py
+      polarion-id: CEPH-83609202
+      desc: fs_recovery_dir_rm
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-3_cephfs_bugs_baremetal.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_bugs_baremetal.yaml
@@ -1,0 +1,153 @@
+#=======================================================================================================================
+# Tier-level: 3
+# Test-Suite: cephfs_bugs
+# Conf file : mero1_1admin_4node_4client.yaml or mero2_1admin_4node_4client.yaml
+# Description - This test suite contains tests which were automated during bug verification
+#=======================================================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            nodes:
+              - node9
+              - node10
+              - node11
+              - node12
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      name: Validate if MDS Cache Oversized Warning seen when standby-allow is added
+      module: cephfs_bugs.test_mds_oversized_cache.py
+      polarion-id: CEPH-83586294
+      desc: Validate if MDS Cache Oversized Warning seen when standby-allow is added
+      abort-on-fail: false
+  - test:
+      name: Validate if no repeated mclientscaps(revoke) entries found in MDS.
+      module: cephfs_bugs.test_validate_mclientcaps_revoke_ack.py
+      polarion-id: CEPH-83584084
+      desc: Validate if no repeated mclientscaps(revoke) entries found in MDS.
+      abort-on-fail: false
+

--- a/suites/tentacle/cephfs/tier-3_cephfs_scale.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_scale.yaml
@@ -1,0 +1,166 @@
+---
+#=======================================================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_cephfs_scale.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# options : --cloud baremetal if required to run on baremetal
+# Test-Case Covered:
+#  CEPH-83573517 - Validate the max subvolumes that can be created under a FS volume.
+#  CEPH-83573518 - Validate the max subvolume groups that can be created under a FS volume.
+#  CEPH-83574957 - Validate the max snapshot that can be created under a root FS sub volume group.
+#  CEPH-83575405 - Include large number of smallfiles in a single subvolume and take
+#                  snapshots and capture the time taken
+#  CEPH-83575584 - Validate the max snapshot that can be created under a root FS sub volume.
+#  CEPH-83575629 - Validate the max clones can be created from single snapshot of subvolume.
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      config:
+        fill_data: 80
+        clean_up: true
+      desc: "Max subvolumess"
+      module: cephfs_scale.max_subvolumes.py
+      name: cephfs Scale test for max subvolumes
+      polarion-id: "CEPH-83573517"
+  - test:
+      abort-on-fail: false
+      config:
+        fill_data: 80
+        clean_up: true
+      desc: "Max sub volume groups"
+      module: cephfs_scale.max_svg_sv.py
+      name: cephfs Scale test for max subvolume groups
+      polarion-id: "CEPH-83573518"
+  - test:
+      abort-on-fail: false
+      desc: "Max snaps per volume"
+      module: cephfs_scale.max_smallfile_snap.py
+      name: cephfs Scale test for max Snapshots per volume
+      polarion-id: "CEPH-83574957"
+  - test:
+      abort-on-fail: false
+      config:
+        fill_data: 80
+        clean_up: true
+      desc: "Cephfs Scale test for max Snapshots under single subvolume until it reaches the default limit"
+      module: cephfs_scale.max_snapshots_single_volume.py
+      name: cephfs Scale test for max Snapshots under single subvolume to it's default limit
+      polarion-id: "CEPH-83575405"
+  - test:
+      abort-on-fail: false
+      config:
+        fill_data: 80
+        clean_up: true
+      desc: "Cephfs Scale test for max Snapshots under single subvolume"
+      module: cephfs_scale.max_snapshots.py
+      name: cephfs Scale test for max Snapshots under single subvolume
+      polarion-id: "CEPH-83575584"
+  - test:
+      abort-on-fail: false
+      config:
+        subvol_size: 5368706371
+        test_timeout: 7200
+        subvol_data_fill: 2
+      desc: "Validate max clones from single snapshot of subvolume"
+      module: cephfs_scale.max_clones_from_snap.py
+      name: "Clone scale testing"
+      polarion-id: "CEPH-83575629"

--- a/suites/tentacle/cephfs/tier-3_cephfs_scale_baremetal.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_scale_baremetal.yaml
@@ -1,0 +1,2535 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+        - ceph-common
+        node: node201
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+        - ceph-common
+        node: node202
+      desc: Configure the Cephfs client system 2
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+        - ceph-common
+        node: node203
+      desc: Configure the Cephfs client system 3
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+        - ceph-common
+        node: node204
+      desc: Configure the Cephfs client system 4
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.5
+        install_packages:
+        - ceph-common
+        node: node205
+      desc: Configure the Cephfs client system 5
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.6
+        install_packages:
+        - ceph-common
+        node: node206
+      desc: Configure the Cephfs client system 6
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.7
+        install_packages:
+        - ceph-common
+        node: node207
+      desc: Configure the Cephfs client system 7
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.8
+        install_packages:
+        - ceph-common
+        node: node208
+      desc: Configure the Cephfs client system 8
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.9
+        install_packages:
+        - ceph-common
+        node: node209
+      desc: Configure the Cephfs client system 9
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.10
+        install_packages:
+        - ceph-common
+        node: node210
+      desc: Configure the Cephfs client system 10
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.11
+        install_packages:
+        - ceph-common
+        node: node211
+      desc: Configure the Cephfs client system 11
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.12
+        install_packages:
+        - ceph-common
+        node: node212
+      desc: Configure the Cephfs client system 12
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.13
+        install_packages:
+        - ceph-common
+        node: node213
+      desc: Configure the Cephfs client system 13
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.14
+        install_packages:
+        - ceph-common
+        node: node214
+      desc: Configure the Cephfs client system 14
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.15
+        install_packages:
+        - ceph-common
+        node: node215
+      desc: Configure the Cephfs client system 15
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.16
+        install_packages:
+        - ceph-common
+        node: node216
+      desc: Configure the Cephfs client system 16
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.17
+        install_packages:
+        - ceph-common
+        node: node217
+      desc: Configure the Cephfs client system 17
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.18
+        install_packages:
+        - ceph-common
+        node: node218
+      desc: Configure the Cephfs client system 18
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.19
+        install_packages:
+        - ceph-common
+        node: node219
+      desc: Configure the Cephfs client system 19
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.20
+        install_packages:
+        - ceph-common
+        node: node220
+      desc: Configure the Cephfs client system 20
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.21
+        install_packages:
+        - ceph-common
+        node: node221
+      desc: Configure the Cephfs client system 21
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.22
+        install_packages:
+        - ceph-common
+        node: node222
+      desc: Configure the Cephfs client system 22
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.23
+        install_packages:
+        - ceph-common
+        node: node223
+      desc: Configure the Cephfs client system 23
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.24
+        install_packages:
+        - ceph-common
+        node: node224
+      desc: Configure the Cephfs client system 24
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.25
+        install_packages:
+        - ceph-common
+        node: node225
+      desc: Configure the Cephfs client system 25
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.26
+        install_packages:
+        - ceph-common
+        node: node226
+      desc: Configure the Cephfs client system 26
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.27
+        install_packages:
+        - ceph-common
+        node: node227
+      desc: Configure the Cephfs client system 27
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.28
+        install_packages:
+        - ceph-common
+        node: node228
+      desc: Configure the Cephfs client system 28
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.29
+        install_packages:
+        - ceph-common
+        node: node229
+      desc: Configure the Cephfs client system 29
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.30
+        install_packages:
+        - ceph-common
+        node: node230
+      desc: Configure the Cephfs client system 30
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.31
+        install_packages:
+        - ceph-common
+        node: node231
+      desc: Configure the Cephfs client system 31
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.32
+        install_packages:
+        - ceph-common
+        node: node232
+      desc: Configure the Cephfs client system 32
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.33
+        install_packages:
+        - ceph-common
+        node: node233
+      desc: Configure the Cephfs client system 33
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.34
+        install_packages:
+        - ceph-common
+        node: node234
+      desc: Configure the Cephfs client system 34
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.35
+        install_packages:
+        - ceph-common
+        node: node235
+      desc: Configure the Cephfs client system 35
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.36
+        install_packages:
+        - ceph-common
+        node: node236
+      desc: Configure the Cephfs client system 36
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.37
+        install_packages:
+        - ceph-common
+        node: node237
+      desc: Configure the Cephfs client system 37
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.38
+        install_packages:
+        - ceph-common
+        node: node238
+      desc: Configure the Cephfs client system 38
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.39
+        install_packages:
+        - ceph-common
+        node: node239
+      desc: Configure the Cephfs client system 39
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.40
+        install_packages:
+        - ceph-common
+        node: node240
+      desc: Configure the Cephfs client system 40
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.41
+        install_packages:
+        - ceph-common
+        node: node241
+      desc: Configure the Cephfs client system 41
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.42
+        install_packages:
+        - ceph-common
+        node: node242
+      desc: Configure the Cephfs client system 42
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.43
+        install_packages:
+        - ceph-common
+        node: node243
+      desc: Configure the Cephfs client system 43
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.44
+        install_packages:
+        - ceph-common
+        node: node244
+      desc: Configure the Cephfs client system 44
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.45
+        install_packages:
+        - ceph-common
+        node: node245
+      desc: Configure the Cephfs client system 45
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.46
+        install_packages:
+        - ceph-common
+        node: node246
+      desc: Configure the Cephfs client system 46
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.47
+        install_packages:
+        - ceph-common
+        node: node247
+      desc: Configure the Cephfs client system 47
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.48
+        install_packages:
+        - ceph-common
+        node: node248
+      desc: Configure the Cephfs client system 48
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.49
+        install_packages:
+        - ceph-common
+        node: node249
+      desc: Configure the Cephfs client system 49
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.50
+        install_packages:
+        - ceph-common
+        node: node250
+      desc: Configure the Cephfs client system 50
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      name: Fill Cluster
+      module: test_parallel.py
+      parallel:
+      - test:
+          abort-on-fail: false
+          desc: "Fill the cluster with specific percentage"
+          name: "Fill Cluster"
+          module: test_io.py
+          config:
+            wait_for_io: True
+            cephfs:
+              "fill_data": 3
+              "num_of_clients": 10
+              "io_tool": "smallfile"
+              "mount": "fuse"
+              "batch_size": 4
+              "filesystem": "cephfs"
+              "mount_dir": ""
+      - test:
+          abort-on-fail: false
+          desc: "Fill the cluster with specific percentage"
+          name: "Fill Cluster"
+          module: test_io.py
+          config:
+            wait_for_io: True
+            cephfs:
+              "fill_data": 3
+              "num_of_clients": 10
+              "io_tool": "smallfile"
+              "mount": "kernel"
+              "batch_size": 4
+              "filesystem": "cephfs"
+              "mount_dir": ""
+      desc: "Fill the cluster with specific percentage"
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup: 1
+        daemon_list: [ 'mds','osd','mgr','mon' ]
+
+#LargeFile Configs Starts here :
+  - test:
+      name: Write 100GB of large file on 10 Subvol with 10 Client
+      module: cephfs_scale.run_scale_io.py
+      config:
+        num_of_subvolumes: 10
+        num_of_clients: 10
+        io_type: largefile
+        mount_type: fuse
+        cleanup: true
+      desc: Write 100GB of large file on 10 Subvol with 10 Client
+      abort-on-fail: false
+
+  - test:
+      name: Write 100GB of large file on 50 Subvol with 50 Client
+      module: cephfs_scale.run_scale_io.py
+      config:
+        num_of_subvolumes: 50
+        num_of_clients: 50
+        io_type: largefile
+        mount_type: fuse
+        cleanup: true
+      desc: Write 100GB of large file on 50 Subvol with 50 Client
+      abort-on-fail: false
+
+  - test:
+      name: Write 100GB of large file on 100 Subvol with 50 Client
+      module: cephfs_scale.run_scale_io.py
+      config:
+        num_of_subvolumes: 100
+        num_of_clients: 50
+        io_type: largefile
+        mount_type: fuse
+        cleanup: true
+      desc: Write 100GB of large file on 100 Subvol with 50 Client
+      abort-on-fail: false
+
+  - test:
+        name: Write 100GB of large file on 200 Subvol with 100 Client
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 200
+          num_of_clients: 100
+          io_type: largefile
+          mount_type : fuse
+          cleanup: true
+        desc: Write 100GB of large file on 200 Subvol with 100 Client
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of large file on 500 Subvol with 100 Client
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 500
+          num_of_clients: 100
+          io_type: largefile
+          mount_type : fuse
+          cleanup: true
+        desc: Write 100GB of large file on 500 Subvol with 100 Client
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of large file on 1000 Subvol with 100 Client
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 1000
+          num_of_clients: 100
+          io_type: largefile
+          mount_type : fuse
+          cleanup: true
+        desc: Write 100GB of large file on 1000 Subvol with 100 Client
+        abort-on-fail: false
+
+  - test:
+      name: Write 100GB of large file on 10 Subvol with 10 Client
+      module: cephfs_scale.run_scale_io.py
+      config:
+        num_of_subvolumes: 10
+        num_of_clients: 10
+        io_type: largefile
+        mount_type: kernel
+        cleanup: true
+      desc: Write 100GB of large file on 10 Subvol with 10 Client (Kernel)
+      abort-on-fail: false
+
+  - test:
+      name: Write 100GB of large file on 50 Subvol with 50 Client
+      module: cephfs_scale.run_scale_io.py
+      config:
+        num_of_subvolumes: 50
+        num_of_clients: 50
+        io_type: largefile
+        mount_type: kernel
+        cleanup: true
+      desc: Write 100GB of large file on 50 Subvol with 50 Client (Kernel)
+      abort-on-fail: false
+
+  - test:
+      name: Write 100GB of large file on 100 Subvol with 50 Client
+      module: cephfs_scale.run_scale_io.py
+      config:
+        num_of_subvolumes: 100
+        num_of_clients: 50
+        io_type: largefile
+        mount_type: kernel
+        cleanup: true
+      desc: Write 100GB of large file on 100 Subvol with 50 Client (Kernel)
+      abort-on-fail: false
+
+  - test:
+        name: Write 100GB of large file on 200 Subvol with 100 Client
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 200
+          num_of_clients: 100
+          io_type: largefile
+          mount_type : kernel
+          cleanup: true
+        desc: Write 100GB of large file on 200 Subvol with 100 Client
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of large file on 500 Subvol with 100 Client
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 500
+          num_of_clients: 100
+          io_type: largefile
+          mount_type : kernel
+          cleanup: true
+        desc: Write 100GB of large file on 500 Subvol with 100 Client
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of large file on 1000 Subvol with 100 Client
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 1000
+          num_of_clients: 100
+          io_type: largefile
+          mount_type : kernel
+          cleanup: true
+        desc: Write 100GB of large file on 1000 Subvol with 100 Client
+        abort-on-fail: false
+
+# End of Large File IOs
+
+#SmallFile Configs:
+  - test:
+        name: Write 100GB of small files on 50 Subvol with 50 Fuse Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 50
+          num_of_clients: 50
+          io_type: smallfile
+          mount_type : fuse
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 50 Subvol with 50 Fuse Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 100 Subvol with 100 Fuse Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 100
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : fuse
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 100 Subvol with 100 Fuse Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 200 Subvol with 100 Fuse Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 200
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : fuse
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 200 Subvol with 100 Fuse Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 500 Subvol with 100 Fuse Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 500
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : fuse
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 500 Subvol with 100 Fuse Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 1000 Subvol with 100 Fuse Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 1000
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : fuse
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 1000 Subvol with 100 Fuse Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 50 Subvol with 50 kernel Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 50
+          num_of_clients: 50
+          io_type: smallfile
+          mount_type : kernel
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 50 Subvol with 50 kernel Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 100 Subvol with 100 kernel Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 100
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : kernel
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 100 Subvol with 100 kernel Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 200 Subvol with 100 kernel Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 200
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : kernel
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 200 Subvol with 100 kernel Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 500 Subvol with 100 kernel Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 500
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : kernel
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 500 Subvol with 100 kernel Clients and 1 thread
+        abort-on-fail: false
+
+  - test:
+        name: Write 100GB of small files on 1000 Subvol with 100 kernel Clients and 1 thread
+        module: cephfs_scale.run_scale_io.py
+        config:
+          num_of_subvolumes: 1000
+          num_of_clients: 100
+          io_type: smallfile
+          mount_type : kernel
+          smallfile_operation : create
+          smallfile_threads : 1
+          smallfile_file_size : 1024
+          smallfile_files : 100000
+          cleanup: true
+        desc: Write 100GB of small files on 1000 Subvol with 100 kernel Clients and 1 thread
+        abort-on-fail: false
+
+
+# FIO Configs:
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 kernel clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 kernel clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 kernel clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 kernel clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 kernel clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 kernel clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 kernel clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 kernel clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: kernel
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 kernel clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 50
+        num_of_subvolumes: 50
+        cleanup: true
+      desc: Write 100GB with fio on 50 Subvols with 50 fuse clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 50 Subvols with 50 fuse clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 100
+        cleanup: true
+      desc: Write 100GB with fio on 100 Subvols with 100 fuse clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 100 Subvols with 100 fuse clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 200
+        cleanup: true
+      desc: Write 100GB with fio on 200 Subvols with 100 fuse clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 200 Subvols with 100 fuse clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 500
+        cleanup: true
+      desc: Write 100GB with fio on 500 Subvols with 100 fuse clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 500 Subvols with 100 fuse clients with 32k bs 16 iodepth
+
+#####
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 4k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 4k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 4K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 4k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 4k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 8k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 8k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 8K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 8k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 8k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 16k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 16k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 16K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 16k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 16k bs 16 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 8
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 32k bs 8 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 32k bs 8 iodepth
+
+  - test:
+      abort-on-fail: false
+      config:
+        fio_block_size: 32K
+        fio_depth: 16
+        fio_direct: 1
+        fio_engine: libaio
+        fio_file_size: 100G
+        fio_operation: randwrite
+        io_type: fio
+        mount_type: fuse
+        num_of_clients: 100
+        num_of_subvolumes: 1000
+        cleanup: true
+      desc: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 32k bs 16 iodepth
+      module: cephfs_scale.run_scale_io.py
+      name: Write 100GB with fio on 1000 Subvols with 100 fuse clients with 32k bs 16 iodepth
+
+#####

--- a/suites/tentacle/cephfs/tier-3_cephfs_system_test.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_system_test.yaml
@@ -1,0 +1,341 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/squid/cephfs/tier-3_cephfs_system_test.yaml
+#===============================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      name: Configure OSD
+      module: misc_env.homogenous_osd_cluster.py
+      desc: Deploy OSDs on node to setup homogenous cluster.
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: rhel94client1
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: rhel94client2
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+        node: rhel94client3
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+        node: rhel94client4
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.5
+        install_packages:
+          - ceph-common
+        node: rhel94client5
+      desc: "Configure the Cephfs client system 5"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.6
+        install_packages:
+          - ceph-common
+        node: rhel94client6
+      desc: "Configure the Cephfs client system 6"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.7
+        install_packages:
+          - ceph-common
+        node: rhel94client7
+      desc: "Configure the Cephfs client system 7"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.8
+        install_packages:
+          - ceph-common
+        node: rhel94client8
+      desc: "Configure the Cephfs client system 8"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.9
+        install_packages:
+          - ceph-common
+        node: rhel94client9
+      desc: "Configure the Cephfs client system 9"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.10
+        install_packages:
+          - ceph-common
+        node: rhel94client10
+      desc: "Configure the Cephfs client system 10"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: cephfs_system.cephfs_systest_setup.py
+      name: "setup system test configuration"
+  -
+    test:
+      abort-on-fail: false
+      desc: Remove OSD
+      module: cephfs_system.cephfs_systest_disruptive_tests.py
+      name: "Remove OSD"
+      config:
+        test_name: "remove_osd_during_systest"
+        osd_rm_limit: 0
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+        ENABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+        daemon_dbg_level : {'mds':10,'client':10,'osd':5,'mgr':5,'mon':5}
+  - test:
+      abort-on-fail: false
+      desc: "Set size limit for log rotation"
+      name: size limit for log rotation
+      module: cephfs_logs_util.py
+      config:
+        LOG_ROTATE_SIZE : 1
+        log_size : '200M'
+  -
+    test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup : 1
+        daemon_list : ['mds','osd','mgr','mon']
+
+  - test:
+      name: CephFS_System_test_1
+      module: test_parallel.py
+      parallel:
+        -
+          test:
+            abort-on-fail: false
+            desc: Run Client IO workflows
+            module: cephfs_system.cephfs_systest_client_io.py
+            name: "CephFS System Test Client IO"
+        -
+          test:
+            abort-on-fail: false
+            desc: Run MDS config updates
+            module: cephfs_system.cephfs_config_update.py
+            name: "CephFS MDS config update"
+        -
+          test:
+            abort-on-fail: false
+            desc: Run SV and Clone ops
+            module: cephfs_system.cephfs_systest_sv_clone_ops.py
+            name: "CephFS System Test SV Clone ops"
+        -
+          test:
+            abort-on-fail: false
+            desc: Run MDS ops
+            module: cephfs_system.cephfs_systest_mds_ops.py
+            name: "CephFS System Test MDS ops"
+        -
+          test:
+            abort-on-fail: false
+            desc: Run Disruptive tests during IO - Add and Remove OSD
+            module: cephfs_system.cephfs_systest_disruptive_tests.py
+            name: "Add and Remove OSD with snapshot create"
+        -
+          test:
+            abort-on-fail: true
+            desc: System monitor
+            module: cephfs_system.cephfs_systest_monitor.py
+            name: "CephFS System monitor"
+      desc: Running all System test workflows in parallel
+      abort-on-fail: false
+  - test:
+      name: CephFS_System_test_2
+      module: test_parallel.py
+      parallel:
+        -
+          test:
+            abort-on-fail: false
+            desc: Run Client IO workflow 7
+            module: cephfs_system.cephfs_systest_client_io.py
+            name: "CephFS System Test Client IO 7"
+            config:
+              test_name : io_test_workflow_7
+        -
+          test:
+            abort-on-fail: true
+            desc: System monitor
+            module: cephfs_system.cephfs_systest_monitor.py
+            name: "CephFS System monitor"
+        -
+          test:
+            name: Test fs volume creation, run IO & deletion in loop for 5 times
+            module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
+            polarion-id: CEPH-83604070
+            desc: Test fs volume creation, run IO & deletion in loop for 5 times
+            abort-on-fail: false
+            config:
+              iteration_cnt : 5
+      desc: Running all System test workflows in parallel
+      abort-on-fail: false
+  -
+    test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check : 1
+        daemon_list : ['mds','osd','mgr','mon']
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+        DISABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+  -
+    test:
+      name: Parse dbg logs for specific strings
+      module: cephfs_logs_util.py
+      config:
+        LOG_PARSER : 1
+        daemon : 'mds'
+        expect_list : ['issue_new_caps','get_allowed_caps','"sending MClientCaps"','client_caps\(revoke']
+        unexpect_list: ['Exception','assert']

--- a/suites/tentacle/cephfs/tier-3_cephfs_test_cephfs-top.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_test_cephfs-top.yaml
@@ -1,0 +1,216 @@
+---
+#=======================================================================================================================
+# Tier-level: 3
+# Test-Suite: cephfs_test_cephfs-top
+# Conf file : conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Description - This test suite contains tests which covers cephfs-top feature
+# Test-Case Covered:
+  # CEPH-83573836 - Verify enable and disble mgr module for stats works - $ ceph mgr module enable stats
+#=======================================================================================================================
+
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: Verify enable and disble mgr module for stats works
+      module: cephfs_top.cephfs_cephfs-top_verify_mgr_module_for_stats.py
+      polarion-id: CEPH-83573836
+      desc: Verify enable and disble mgr module for stats works
+      abort-on-fail: false
+  - test:
+      name: cephfs-top initiate testing
+      module: cephfs_top.cephfs_top_initiate.py
+      polarion-id: CEPH-83573829
+      desc: Testing basic cephfs-top initiate conditions
+  - test:
+      name: cephfs-top negative testing
+      module: cephfs_top.cephfs_top_negative_tests.py
+      polarion-id: CEPH-83575020
+      desc: cephfs-top negative testing
+      abort-on-fail: false
+  - test:
+      name: cephfs-top metrcis testing
+      module: cephfs_top.cephfs_top_dump.py
+      polarion-id: CEPH-83573848
+      desc: cephfs-top metrcis verification using --dump
+      abort-on-fail: false
+  - test:
+      name: cephfs-top validate top stats
+      module: cephfs_top.validate_fs_top_stats.py
+      polarion-id: CEPH-83573838
+      desc: cephfs-top validate top stats
+      abort-on-fail: false
+

--- a/suites/tentacle/cephfs/tier-3_cephfs_test_performance.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_test_performance.yaml
@@ -1,0 +1,215 @@
+---
+#=======================================================================================================================
+# Tier-level: 3
+# Test-Suite: cephfs_test_performance
+# Conf file : conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Description - This test suite contains tests which covers cephfs performance scenarios
+# Test-Case Covered:
+  # CEPH-10560 - CephFS performance between Fuse and kernel client.
+  # CEPH-11220 - Mount CephFS on multiple clients, perform write from one client and read the
+  #               same data from other clients
+  # CEPH-11221 - Mount CephFS on multiple clients and run Stress IO from all clients on same directory
+  # CEPH-11222 - Mount CephFS on multiple clients and run Stress IO from all clients on different directories
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: CephFS performance between Fuse and kernel client.
+      module: cephfs_perf.fuse_kernel_performance.py
+      polarion-id: CEPH-10560
+      desc: CephFS performance between Fuse and kernel client.
+      abort-on-fail: false
+  - test:
+      name: CephFS-IO Read and Write from 2 different Clients
+      module: cephfs_perf.cephfs_io_read_write_from_diff_clients.py
+      polarion-id: CEPH-11220
+      desc: Mount CephFS on multiple clients, read and write same file from 2 different clients.
+      abort-on-fail: false
+  - test:
+      name: CephFS-IO Read and Write from multiple different clients
+      module: cephfs_perf.cephfs_io_read_write_from_multiple_clients.py
+      polarion-id: CEPH-11221
+      desc: Mount CephFS on multiple clients, perform IO ,fill cluster upto 30%, read and write from multiple clients
+      abort-on-fail: false
+  - test:
+      name: cephfs-stressIO
+      module: cephfs_perf.cephfs_stress_io_from_multiple_clients.py
+      polarion-id: CEPH-11222
+      config:
+        num_of_osds: 12
+      desc: Mount CephFS on multiple clients,
+      abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-4_cephfs_recovery.yaml
+++ b/suites/tentacle/cephfs/tier-4_cephfs_recovery.yaml
@@ -1,0 +1,242 @@
+---
+#=======================================================================================================================
+# Tier-level: 4
+# Test-Suite: tier-4_cephfs_recovery.yaml
+# Conf file : conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# options : --cloud baremetal if required to run on baremetal
+# Test-Case Covered:
+#	CEPH-83573264 - [Cephfs]Taking the cephfs down with down flag.
+#   CEPH-11267 - Execute FS Scrub Commands on cephfs
+#   CEPH-83575627 : Verify Snapshot retention works even after service restarts
+#   CEPH-11264 - Move data and meta_data pool to different root level bucket in OSD tree.
+
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Taking the cephfs down with down flag"
+      module: cephfs_recovery.fs_down_flag.py
+      polarion-id: CEPH-83573264
+      name: "Taking the cephfs down with down flag"
+      comments: "Product bug - BZ-2225891"
+  - test:
+      abort-on-fail: false
+      desc: "Execute FS Scrub Commands on cephfs"
+      module: cephfs_recovery.fs_scrub.py
+      polarion-id: CEPH-11267
+      name: "Cephfs Scrubing"
+  - test:
+      name: snap_retention_service_restart
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83575627
+      desc: Verify Snapshot retention works even after service restarts
+      abort-on-fail: false
+      config:
+        test_name : snap_retention_service_restart
+  - test:
+      name: Move data and meta_data pool to different root level bucket in OSD tree.
+      module: cephfs_generic.test_data_migrate_bw_buckets.py
+      polarion-id: CEPH-11264
+      desc: Move data and meta_data pool to different root level bucket in OSD tree.
+      abort-on-fail: false
+      comments: "Unable to install ceph-base"
+  - test:
+      abort-on-fail: false
+      desc: "cephfs_journal_tool_journal_mode_functional"
+      module: cephfs_journal_tool.cephfs_journal_tool_journal_mode.py
+      name: journal_tool_journal_mode
+      polarion-id: "CEPH-83594249"
+  - test:
+      abort-on-fail: false
+      desc: "cephfs_journal_tool_header_mode_functional"
+      module: cephfs_journal_tool.cephfs_journal_tool_header_mode.py
+      name: journal_tool_header_mode
+      polarion-id: "CEPH-83594266"
+  - test:
+      abort-on-fail: false
+      desc: "cephfs_journal_tool_event_mode_functional"
+      module: cephfs_journal_tool.cephfs_journal_tool_event_mode.py
+      name: journal_tool_event_mode
+      polarion-id: "CEPH-83595482"
+      comments: "BZ 2335321"
+  - test:
+      abort-on-fail: false
+      desc: "mds_last_seen_functional"
+      module: cephfs_recovery.mds_last_seen.py
+      name: mds_last_seen
+      polarion-id: "CEPH-83614244"

--- a/suites/tentacle/cephfs/tier-4_cephfs_system.yaml
+++ b/suites/tentacle/cephfs/tier-4_cephfs_system.yaml
@@ -1,0 +1,274 @@
+---
+#=======================================================================================================================
+# Tier-level: 4
+# Test-Suite: tier-4_cephfs_system.yaml
+# Conf file : conf/reef/cephfs/tier-2_cephfs_upgrade.yaml
+# Test-Case Covered:
+#   CEPH-11261: MON node power failure, with client IO
+#   CEPH-11263: MDS node power failure, with client IO
+#   CEPH-11262: OSD node power failure, with client IO
+#   CEPH-11254: MON node failures ops with client IO
+#   CEPH-11256: MDS node failures ops with client IO
+#   CEPH-11255: OSD node failures ops with client IO
+#   CEPH-11266: mds_node_remove_with_IO
+#   CEPH-11311: mds_nfs_node_failure_ops
+#   CEPH-11320: snap_rollback_with_node_reboots.py
+#   CEPH-11241: shutdown_mds_bring_one_by_one
+#   CEPH-11240: mds_shutdown_together_io_continue
+#   CEPH-83572891: MDS admin socket dump testing
+#   CEPH-83572890: MDS admin socket perf flush log testing
+#.  CEPH-83595235: MDS standby replay node failures ops with client IO
+#.  CEPH-83591709: MDS Standy-Replay system testing
+#   CEPH-83594640: MDS Cache Trimming and Client Caps Recall test
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Fill the cluster with specific percentage"
+      module: test_io.py
+      name: "Fill the cluster with specific percentage"
+      config:
+        wait_for_io: True
+        cephfs:
+          "fill_data": 20
+          "io_tool": "smallfile"
+          "mount": "fuse"
+          "filesystem": "cephfs_1"
+          "mount_dir": ""
+  - test:
+        abort-on-fail: false
+        desc: "MDS admin socket dump testing"
+        module: cephfs_system.mds_admin_daemon_socket_dump.py
+        polarion-id: CEPH-83572891
+        name: "MDS admin socket dump testing"
+  - test:
+        abort-on-fail: false
+        desc: "MDS admin socket perf flush log testing"
+        module: cephfs_system.mds_admin_daemon_socket_perf_flush_log.py
+        polarion-id: CEPH-83572890
+        name: "MDS admin socket perf flush log testing"
+  - test:
+      abort-on-fail: false
+      desc: "MON node power failure, with client IO"
+      module: cephfs_system.mon_failure_with_client_IO.py
+      polarion-id: CEPH-11261
+      name: "MON node power failure, with client IO"
+      config:
+          num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "MDS node power failure, with client IO"
+      module: cephfs_system.mds_failure_with_client_IO.py
+      polarion-id: CEPH-11263
+      name: "MDS node power failure, with client IO"
+      config:
+        num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "OSD node power failure, with client IO"
+      module: cephfs_system.osd_failure_with_client_IO.py
+      polarion-id: CEPH-11262
+      name: "OSD node power failure, with client IO"
+      config:
+          num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "MON node failures ops with client IO"
+      module: cephfs_system.mon_node_failure_ops.py
+      polarion-id: CEPH-11254
+      name: "MON node power failure with client IO"
+      config:
+        num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "MDS node failures ops with client IO"
+      module: cephfs_system.mds_node_failure_ops.py
+      polarion-id: CEPH-11256
+      name: "MDS node power failure with client IO ops"
+      config:
+        num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "OSD node failures ops with client IO"
+      module: cephfs_system.osd_node_failure_ops.py
+      polarion-id: CEPH-11255
+      name: "OSD node power failure with client IO ops"
+      config:
+        num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "mds_node_remove_with_IO"
+      module: cephfs_system.mds_node_remove_with_IO.py
+      polarion-id: CEPH-11266
+      name: "mds_node_remove_with_IO"
+  - test:
+      abort-on-fail: false
+      desc: "mds_nfs_node_failure_ops"
+      module: cephfs_system.mds_nfs_node_failure_ops.py
+      polarion-id: CEPH-11311
+      name: "mds_nfs_node_failure_ops.py"
+  - test:
+      abort-on-fail: false
+      desc: "snap_rollback_with_node_reboots.py"
+      module: cephfs_system.snap_rollback_with_node_reboots.py
+      polarion-id: CEPH-11320
+      name: "snap_rollback_with_node_reboots.py"
+  - test:
+      abort-on-fail: false
+      desc: "shutdown_mds_bring_one_by_one"
+      module: cephfs_system.shutdown_mds_bring_one_by_one.py
+      polarion-id: CEPH-11241
+      name: "shutdown_mds_bring_one_by_one.py"
+  - test:
+      abort-on-fail: false
+      desc: "mds_shutdown_together_io_continue"
+      module: cephfs_system.mds_shutdown_together_io_continue.py
+      polarion-id: CEPH-11240
+      name: "mds_shutdown_together_io_continue.py"
+  - test:
+      abort-on-fail: false
+      desc: "StandbyReplay MDS node failures ops with client IO"
+      module: cephfs_system.mds_standby_replay_node_failure_ops.py
+      polarion-id: CEPH-83595235
+      name: "mds_standby_replay_node_failure_ops"
+      config:
+        num_of_osds: 12
+  - test:
+      abort-on-fail: false
+      desc: "MDS Standy-Replay system testing"
+      module: cephfs_system.mds_failover_standby_replay_systemic_test.py
+      polarion-id: CEPH-83591710
+      name: "mds_failover_standby_replay_systemic_test"
+  - test:
+      abort-on-fail: false
+      desc: "MDS Cache Trimming and Client Caps Recall test"
+      module: cephfs_system.mds_cache_trimming_caps_recall.py
+      polarion-id: CEPH-83594640
+      name: "mds_cache_trimming_caps_recall"
+  - test:
+      abort-on-fail: false
+      desc: "Fill the cluster with 95 percentage and delete the contents"
+      module: cephfs_system.fill_cluster_full_del.py
+      polarion-id: CEPH-11328
+      name: "Fill the cluster with 95 percentage and delete the contents"
+      config:
+        wait_for_io: True
+        cephfs:
+          "fill_data": 65
+          "io_tool": "smallfile"
+          "mount": "fuse"
+          "filesystem": "cephfs_io"
+          "mount_dir": ""

--- a/suites/tentacle/cephfs/tier_fs_top_recover_metric_perf_pin_generic_kernel.yaml
+++ b/suites/tentacle/cephfs/tier_fs_top_recover_metric_perf_pin_generic_kernel.yaml
@@ -1,0 +1,393 @@
+---
+#=======================================================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_fs_top_recovery_metrics_perf_pin_generic_kernel
+# Conf file : conf/squid/cephfs/tier-2_cephfs_9-node-cluster.yaml
+# Description - This test suite contains tests which covers cephfs-top feature
+# Test-Case Covered:
+#  1.tier-3_cephfs_test_cephfs-top.yaml
+#  2.tier-4_cephfs_recovery.yaml#
+#  3.tier-2_cephfs_test-metrics.yaml
+#  4.tier-3_cephfs_test_performance.yaml
+#  5.tier-2_cephfs_test_mds_pinning.yaml
+#  6.tier-2_cephfs_generic.yaml
+#  7.tier-1_fs_kernel_pipeline.yaml
+#=======================================================================================================================
+
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: Run xfs test on kernel
+      module: xfs_test.py
+      polarion-id: CEPH-83592787
+      desc: Run xfs test on kernel
+      abort-on-fail: false
+  - test:
+      name: Run fsstress on kernel and fuse mounts
+      module: cephfs_bugs.test_fsstress_on_kernel_and_fuse.py
+      polarion-id: CEPH-83575623
+      desc: Run fsstress on kernel and fuse mounts
+      abort-on-fail: false
+  - test:
+      name: Verify enable and disble mgr module for stats works
+      module: cephfs_top.cephfs_cephfs-top_verify_mgr_module_for_stats.py
+      polarion-id: CEPH-83573836
+      desc: Verify enable and disble mgr module for stats works
+      abort-on-fail: false
+  - test:
+      name: cephfs-top initiate testing
+      module: cephfs_top.cephfs_top_initiate.py
+      polarion-id: CEPH-83573829
+      desc: Testing basic cephfs-top initiate conditions
+  - test:
+      name: cephfs-top negative testing
+      module: cephfs_top.cephfs_top_negative_tests.py
+      polarion-id: CEPH-83575020
+      desc: cephfs-top negative testing
+      abort-on-fail: false
+  - test:
+      name: cephfs-top metrcis testing
+      module: cephfs_top.cephfs_top_dump.py
+      polarion-id: CEPH-83573848
+      desc: cephfs-top metrcis verification using --dump
+      abort-on-fail: false
+  - test:
+      name: cephfs-top validate top stats
+      module: cephfs_top.validate_fs_top_stats.py
+      polarion-id: CEPH-83573838
+      desc: cephfs-top validate top stats
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Taking the cephfs down with down flag"
+      module: cephfs_recovery.fs_down_flag.py
+      polarion-id: CEPH-83573264
+      name: "Taking the cephfs down with down flag"
+      comments: "Product bug - BZ-2225891"
+  - test:
+      abort-on-fail: false
+      desc: "Execute FS Scrub Commands on cephfs"
+      module: cephfs_recovery.fs_scrub.py
+      polarion-id: CEPH-11267
+      name: "Cephfs Scrubing"
+  - test:
+      name: snap_retention_service_restart
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83575627
+      desc: Verify Snapshot retention works even after service restarts
+      abort-on-fail: false
+      config:
+        test_name: snap_retention_service_restart
+      comments: "Product bug - BZ-2314146"
+  - test:
+      name: Move data and meta_data pool to different root level bucket in OSD tree.
+      module: cephfs_generic.test_data_migrate_bw_buckets.py
+      polarion-id: CEPH-11264
+      desc: Move data and meta_data pool to different root level bucket in OSD tree.
+      abort-on-fail: false
+      comments: "Unable to install ceph-base"
+  - test:
+      abort-on-fail: false
+      desc: "cephfs_journal_tool_journal_mode_functional"
+      module: cephfs_journal_tool.cephfs_journal_tool_journal_mode.py
+      name: journal_tool_journal_mode
+      polarion-id: "CEPH-83594249"
+  - test:
+      abort-on-fail: false
+      desc: "cephfs_journal_tool_header_mode_functional"
+      module: cephfs_journal_tool.cephfs_journal_tool_header_mode.py
+      name: journal_tool_header_mode
+      polarion-id: "CEPH-83594266"
+  - test:
+      abort-on-fail: false
+      desc: "cephfs_journal_tool_event_mode_functional"
+      module: cephfs_journal_tool.cephfs_journal_tool_event_mode.py
+      name: journal_tool_event_mode
+      polarion-id: "CEPH-83595482"
+  - test:
+      name: MDS client metrics scale
+      module: cephfs_metrics.cephfs_metrics_scale.py
+      polarion-id: CEPH-83588355
+      desc: Verify MDS metrics in multiple clients
+      abort-on-fail: false
+  - test:
+      name: MDS client metrics functional
+      module: cephfs_metrics.cephfs_metrics_functional.py
+      polarion-id: CEPH-83588303
+      desc: Verify MDS client metrics
+      abort-on-fail: false
+  - test:
+      name: MDS client metrics negative case
+      module: cephfs_metrics.cephfs_client_metrics_negative_case.py
+      polarion-id: CEPH-83588357
+      desc: Reboot MDS node and verify the metrics
+      abort-on-fail: false
+  - test:
+      name: CephFS performance between Fuse and kernel client.
+      module: cephfs_perf.fuse_kernel_performance.py
+      polarion-id: CEPH-10560
+      desc: CephFS performance between Fuse and kernel client.
+      abort-on-fail: false
+  - test:
+      name: CephFS-IO Read and Write from 2 different Clients
+      module: cephfs_perf.cephfs_io_read_write_from_diff_clients.py
+      polarion-id: CEPH-11220
+      desc: Mount CephFS on multiple clients, read and write same file from 2 different clients.
+      abort-on-fail: false
+  - test:
+      name: CephFS-IO Read and Write from multiple different clients
+      module: cephfs_perf.cephfs_io_read_write_from_multiple_clients.py
+      polarion-id: CEPH-11221
+      desc: Mount CephFS on multiple clients, perform IO ,fill cluster upto 30%, read and write from multiple clients
+      abort-on-fail: false
+  - test:
+      name: cephfs-stressIO
+      module: cephfs_perf.cephfs_stress_io_from_multiple_clients.py
+      polarion-id: CEPH-11222
+      config:
+        num_of_osds: 12
+      desc: Mount CephFS on multiple clients,
+      abort-on-fail: false
+  - test:
+      name: cephfs-mdsfailover-pinning-io
+      module: cephfs_mds_pinning.mds_pinning_load_balancing.py
+      config:
+        num_of_dirs: 200
+      polarion-id: CEPH-11227
+      desc: MDSfailover on active-active mdss,performing client IOs with no pinning at
+        the first,later pin 10 dirs with IOs
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDss with max:min number of directories
+      module: cephfs_mds_pinning.mds_pinning_max_min_dir_on_two_mdss.py
+      config:
+        num_of_dirs: 100
+      polarion-id: CEPH-11228
+      desc: MDSfailover on active-active mdss,performing client IOs with max:min directory pinning with 2 active mdss
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDSs with unequal ratio of directories
+      module: cephfs_mds_pinning.mds_pinning_unequal_dir_on_two_mdss.py
+      config:
+        num_of_dirs: 100
+      polarion-id: CEPH-11229
+      desc: MDSfailover on active-active mdss,performing client IOs with 10:2 directory pinning with 2 active mdss
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDS with equal ratio of directories
+      module: cephfs_mds_pinning.mds_pinning_equal_dir_on_two_mdss.py
+      config:
+        num_of_dirs: 100
+      polarion-id: CEPH-11230
+      desc: MDSfailover on active-active mdss,performing client IOs with equal directory pinning with 2 active mdss
+      abort-on-fail: false
+  - test:
+      name: Directory pinning on two MDS with node reboots
+      module: cephfs_mds_pinning.mds_pinning_node_reboots.py
+      polarion-id: CEPH-11231
+      desc: Directory pinning on two MDS with node reboots
+      abort-on-fail: false
+  - test:
+      name: Subtree Split and Subtree merging by pinning Subtrees directories to MDS.
+      module: cephfs_mds_pinning.mds_pinning_split_merge.py
+      polarion-id: CEPH-11233
+      desc: Subtree Split and Subtree merging by pinning Subtrees directories to MDS.
+      abort-on-fail: false
+  - test:
+      name: map and unmap directory trees to a mds rank
+      module: cephfs_mds_pinning.map_and_unmap_directory_trees_to_a_mds_rank.py
+      polarion-id: CEPH-83574329
+      desc: map and unmap directory trees to a mds rank
+      abort-on-fail: false
+  - test:
+      name: the max mds daemons
+      module: ceph-83573462.py
+      polarion-id: CEPH-83573462
+      desc: Validate the fs command to increase decrease the max mds daemons
+      abort-on-fail: false
+  - test:
+      name: Configure the standby_replay daemons
+      module: ceph_83574291.py
+      polarion-id: CEPH-83574291
+      desc: Configure the standby_replay daemons for active mds verify add and remove of the feature
+      abort-on-fail: false
+  - test:
+      name: Fail mds daemon by it rank
+      module: mds_fail_with_rank.py
+      polarion-id: CEPH-83573429
+      desc: Fail mds daemon by it rank
+      abort-on-fail: false


### PR DESCRIPTION
# Description

Included conf and suite files for tentacle similar to squid

## Changes
Modified below upgrade file names and its image path according to the tentacle

- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_8x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_8x_latest_to_81x_latest.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_81x_latest_to_9x_latest.yaml
- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_8x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_8GA_to_81x_latest.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_81x_latest_to_9x_latest.yaml
- suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_seq_6x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_seq_7x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_upgrade_8x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_6x_to_8x.yaml -> suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_7x_to_9x.yaml
- tier-0_cephfs_upgrade_ibm_7x_to_8x.yaml -> tier-0_cephfs_upgrade_ibm_8x_to_9x.yaml
- suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_8x_latest_to_81x_latest.yaml -> suites/tentacle/cephfs/tier-0_cephfs_upgrade_ibm_81x_latest_to_9x_latest.yaml

Additional Suite file placeholder added
- suites/tentacle/cephfs/9_0_features_suite.yaml -> New file added

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
