### PR TITLE
Changes needed to get cloud type parameter for execution

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -50,6 +50,7 @@ import yaml
 from utility import utils
 from utility.log import Log
 from utility.utils import (
+    config_keystone_ldap,
     configure_kafka_security,
     install_start_kafka,
     setup_cluster_access,
@@ -87,6 +88,7 @@ def run(ceph_cluster, **kw):
     install_start_kafka_broker = config.get("install_start_kafka")
     configure_kafka_broker_security = config.get("configure_kafka_security")
     cloud_type = config.get("cloud-type")
+    log.info(f"Cloud Type is {cloud_type}")
     test_config = {"config": config.get("test-config", {})}
     rgw_node = rgw_ceph_object.node
     client_node = client_ceph_object.node
@@ -158,6 +160,9 @@ def run(ceph_cluster, **kw):
         install_start_kafka(rgw_node, cloud_type)
     if configure_kafka_broker_security:
         configure_kafka_security(rgw_node, cloud_type)
+
+    if cloud_type:
+        config_keystone_ldap(rgw_node, cloud_type)
 
     out, err = exec_from.exec_command(cmd="ls -l venv", check_ec=False)
     if not out:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1842,6 +1842,28 @@ def configure_kafka_security(rgw_node, cloud_type):
     rgw_node.exec_command(sudo=True, cmd=f"ceph orch restart {rgw_name}")
 
 
+def config_keystone_ldap(rgw_node, cloud_type):
+    """Set the keystone config option on the cluster at startup"""
+    if cloud_type == "openstack":
+        keystone_server = get_cephci_config()["rhosd"].get("keystone_url")
+        ldap_url = get_cephci_config()["rhosd"].get("ldap_url")
+    elif cloud_type == "ibmc":
+        keystone_server = get_cephci_config()["ibmcos"].get("keystone_url")
+        ldap_url = get_cephci_config()["ibmcos"].get("ldap_url")
+
+    out = rgw_node.exec_command(sudo=True, cmd="ceph orch ls | grep rgw")
+    rgw_name = out[0].split()[0]
+    rgw_node.exec_command(
+        sudo=True,
+        cmd=f"ceph config set client.{rgw_name} rgw_keystone_url {keystone_server}",
+    )
+    rgw_node.exec_command(
+        sudo=True,
+        cmd=f"ceph config set client.{rgw_name} rgw_ldap_uri {ldap_url}",
+    )
+    rgw_node.exec_command(sudo=True, cmd=f"ceph orch restart {rgw_name}")
+
+
 def method_should_succeed(function, *args, **kwargs):
     """
     Wrapper function to verify the return value of executed method.


### PR DESCRIPTION
Since the new instance configuration in IBMC , we have all the required server configurations present. This change is to get the appropriate cloud type for execution, and set the server configurations accordingly.

CephCI run has failed because required changes are not in "ceph-qe-scripts" yet 
Log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-2RZ4DR/Verify_unified_namespace_for_S3_and_swift_0.log

We see the "--cloud-type openstack" option passed
"sudo venv/bin/python ~/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/../aws/test_unified_namespace.py -c rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/configs/../../aws/configs/test_unified_namespace.yaml --rgw-node <> --cloud-type openstack"

Pass log with ceph-qe-script changes added:
http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/IBMC_unified_namespace.txt

Adding the DNM flag because this change affects all ceph-qe-scripts suite execution.


