### PR TITLE
[TFA]inventory for ibmc rgw

### DIFF
--- a/conf/inventory/ibm-rhel-9-server-bx2-4x16-rgw.yaml
+++ b/conf/inventory/ibm-rhel-9-server-bx2-4x16-rgw.yaml
@@ -1,0 +1,50 @@
+---
+version_id: 9.6
+id: rhel
+instance:
+  create:
+    image-name: rhel-96-server-amd64-kvm
+    network_name: ci-sn-01
+    private_key: ceph-qe-sa-svc
+    group_access: sec-grp-ci-vpc-01
+    profile: bx2-4x16
+
+  setup: |
+    #cloud-config
+    no_ssh_fingerprints: true
+    disable_root: false
+    ssh_pwauth: true
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(root) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwmsOkNX16LikH7spbmVVOLhGOSsNSlAYSk0ifhLpaO
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPoKGCTzMmNvHFY4THKNpZYFLeEgB7Do8y2JAEy+ZvIZ ceph-qe-sa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
+
+    chpasswd:
+      expire: false
+      users:
+        - name: cephuser
+          password: $y$j9T$PxJ09a3yVNnPj0Veb8QDT.$bdWoyLq1IdGwlimyJC98P5OsSFE2w7.9ac68z4eoa01
+        - name: root
+          password: $y$j9T$L0/xJyxgqCPIezC0dp/0/0$KawKfTR2FhliH9YrG4/30wot90M3xtF03K1XwGnYz2A
+
+    runcmd:
+      - timedatectl set-timezone Etc/UTC
+      - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
+      - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/50-ceph-qe.conf
+      - systemctl restart sshd
+      - touch /ceph-qa-ready
+      - mkdir -p /root/rgw_rpms
+      - curl -k -o /root/rgw_rpms/jdk.rpm https://download.oracle.com/java/24/latest/jdk-24_linux-x64_bin.rpm
+      - curl -k -o /root/rgw_rpms/oathtool.rpm https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+
+
+    final_message: "Ready for ceph qa testing"


### PR DESCRIPTION
# Description
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/rgw/14/tier-2_rgw_regression_test/multipart_versioned_object_deletion_with_mfa_token_0.log

http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/rgw/14/tier-2_rgw_regression_test/incorrect_syntax_for_mfa_resync_commnad_appropriate_usage_message_is_displayed_0.log 

here issue seen since the inventory file of ibm does not support extra packages, adding support

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
