### PR TITLE
Adding missed coverage in reef for 4 node pools.

### DIFF
--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -407,17 +407,19 @@ tests:
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-#  - test:
-#      name: ceph-bluestore-tool utility
-#      module: test_bluestoretool_workflows.py
-#      polarion-id: CEPH-83571692
-#      desc: Verify ceph-bluestore-tool functionalities
-#
-#  - test:
-#      name: ceph-objectstore-tool utility
-#      module: test_objectstoretool_workflows.py
-#      polarion-id: CEPH-83581811
-#      desc: Verify ceph-objectstore-tool functionalities
+# below Commented in squid as it's covered in 8+6 suite
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+# below Commented in squid as it's covered in 8+6 suite
+  - test:
+      name: ceph-objectstore-tool utility
+      module: test_objectstoretool_workflows.py
+      polarion-id: CEPH-83581811
+      desc: Verify ceph-objectstore-tool functionalities
 
   - test:
       name: Verify premerge PGS during PG split
@@ -477,28 +479,9 @@ tests:
         pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
-#  - test:
-#      name: Autoscaler test - pool target size ratio
-#      module: pool_tests.py
-#      polarion-id: CEPH-83573424
-#      config:
-#        verify_pool_target_ratio:
-#          configurations:
-#            pool-1:
-#              profile_name: ec86_10
-#              pool_name: ec86_pool10
-#              pool_type: erasure
-#              pg_num: 32
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#              plugin: jerasure
-#              target_size_ratio: 0.8
-#              rados_write_duration: 50
-#              rados_read_duration: 10
-#              delete_pool: true
-#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
-
+# below Commented in squid as it's covered in 8+6 suite
+# However, even in reef, This test can remain commented,
+# as this scenario for EC pools is covered in tier-2_rados_test-pool-functionalities.yaml
 #  - test:
 #      name: Autoscaler test - pool pg_num_min
 #      module: pool_tests.py
@@ -520,6 +503,9 @@ tests:
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
+# below Commented in squid as it's covered in 8+6 suite
+# However, even in reef, This test can remain commented,
+# as this scenario for EC pools is covered in tier-2_rados_test-pool-functionalities.yaml
 #  - test:
 #      name: client pg access
 #      module: test_client_pg_access.py
@@ -576,59 +562,62 @@ tests:
         pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
       desc: Migrating data between different pools. Scenario-4. Ec -> EC
 
+# below Commented in squid as it's covered in 8+6 suite
 # Blocked due to BZ 2172795. Bugzilla fixed.
-#  - test:
-#      name: Verify cluster behaviour during PG autoscaler warn
-#      module: pool_tests.py
-#      polarion-id:  CEPH-83573413
-#      config:
-#        verify_pool_warnings:
-#          pool_configs:
-#            - type: erasure
-#              conf: sample-pool-5
-#          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
-#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: erasure
+              conf: sample-pool-5
+          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
-#  - test:
-#      name: Scrub enhancement
-#      module: test_scrub_enhancement.py
-#      desc: Verify scrub enhancement feature
-#      polarion-id: CEPH-83575885
-#      config:
-#        create_pools:
-#          - create_pool:
-#              pg_num: 1
-#              pg_num_max: 1
-#              profile_name: ec86_13
-#              pool_name: ec86_pool13
-#              pool_type: erasure
-#              k: 2
-#              m: 2
-#              plugin: jerasure
-#              crush-failure-domain: host
-#        delete_pools:
-#          - ec86_pool13
+# below Commented in squid as it's covered in 8+6 suite
+  - test:
+      name: Scrub enhancement
+      module: test_scrub_enhancement.py
+      desc: Verify scrub enhancement feature
+      polarion-id: CEPH-83575885
+      config:
+        create_pools:
+          - create_pool:
+              pg_num: 1
+              pg_num_max: 1
+              profile_name: ec86_13
+              pool_name: ec86_pool13
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool13
 
-#  - test:
-#      name: Limit slow request details to cluster log
-#      module: test_slow_op_requests.py
-#      desc: Limit slow request details to cluster log
-#      polarion-id: CEPH-83574884
-#      config:
-#        profile_name: ec86_14
-#        pool_name: ec86_pool14
-#        pool_type: erasure
-#        k: 2
-#        m: 2
-#        plugin: jerasure
-#        crush-failure-domain: host
-#        pg_num: 64
-#        rados_write_duration: 1000
-#        byte_size: 1024
-#        osd_max_backfills: 16
-#        osd_recovery_max_active: 16
-#        delete_pools:
-#          - ec86_pool14
+# below Commented in squid as it's covered in 8+6 suite
+  - test:
+      name: Limit slow request details to cluster log
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        profile_name: ec86_14
+        pool_name: ec86_pool14
+        pool_type: erasure
+        k: 2
+        m: 2
+        plugin: jerasure
+        crush-failure-domain: host
+        pg_num: 64
+        rados_write_duration: 1000
+        byte_size: 1024
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        delete_pools:
+          - ec86_pool14
 
   - test:
       name: Robust rebalancing - in progress osd replacement

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -226,6 +226,7 @@ tests:
       polarion-id: CEPH-83574439
       abort-on-fail: false
 
+# TBD : Enhancement might be needed for this test
   - test:
       name: Verify stretch Cluster
       module: stretch_cluster.py

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -476,27 +476,6 @@ tests:
         pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
-#  - test:
-#      name: Autoscaler test - pool target size ratio
-#      module: pool_tests.py
-#      polarion-id: CEPH-83573424
-#      config:
-#        verify_pool_target_ratio:
-#          configurations:
-#            pool-1:
-#              profile_name: ec86_10
-#              pool_name: ec86_pool10
-#              pool_type: erasure
-#              pg_num: 32
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#              plugin: jerasure
-#              target_size_ratio: 0.8
-#              rados_write_duration: 50
-#              rados_read_duration: 10
-#              delete_pool: true
-#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
 #  - test:
 #      name: Autoscaler test - pool pg_num_min

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -225,6 +225,7 @@ tests:
       polarion-id: CEPH-83574439
       abort-on-fail: false
 
+# TBD : Enhancement might be needed for this test
   - test:
       name: Verify stretch Cluster
       module: stretch_cluster.py


### PR DESCRIPTION
We have balanced tests between 2+2 & 8+6 MSR pools, as both are configured on 4 nodes. However, since there is no 8+6 MSR pool in reef, same test suite cannot be maintained as squid.

- Updated the missing coverage in reef

