### PR TITLE
Fix setting pg_num_min on pools for EC 4 node pools

### DIFF
--- a/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
+++ b/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
@@ -512,6 +512,7 @@ tests:
               pool_type: erasure
               k: 8
               m: 6
+              pg_num: 32
               create_rule: false
               crush-osds-per-failure-domain: 4
               crush-num-failure-domains: 4

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -504,6 +504,7 @@ tests:
               pool_type: erasure
               k: 8
               m: 6
+              pg_num: 32
               create_rule: false
               crush-osds-per-failure-domain: 4
               crush-num-failure-domains: 4

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -504,6 +504,7 @@ tests:
               pool_type: erasure
               k: 8
               m: 6
+              pg_num: 32
               create_rule: false
               crush-osds-per-failure-domain: 4
               crush-num-failure-domains: 4


### PR DESCRIPTION
issue with pg_num_min being set before PG count increases. Fixing the issue, and also dynamically chooing value for pg_num_min for pools
