### PR TITLE
[TFA] Increases timeout for upgrade and sleep duration for daemon restart

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3122,9 +3122,12 @@ EOF"""
             daemon_status_ls = self.run_ceph_command(
                 cmd=f"ceph orch ps --service_name {service} --refresh"
             )
+            # TODO: current system time to be used when
+            # daemon is stopped/unknown since 'started' key will
+            # not exist in ceph orch ps --service_name {service} output
             for entry in daemon_status_ls:
                 start_time, _ = self.client.exec_command(
-                    cmd=f"date -d {entry['started']} +'%Y%m%d%H%M%S'"
+                    cmd=f"date -d {entry.get('started')} +'%Y%m%d%H%M%S'"
                 )
                 daemon_map[entry["daemon_name"]] = start_time
 
@@ -3148,7 +3151,7 @@ EOF"""
                         assert entry["status_desc"] != "stopped"
                         log.info(f"{entry['daemon_name']} has started")
                         success = True
-                    except AssertionError:
+                    except Exception:
                         log.info(
                             f"{daemon} daemon {entry['daemon_name']} is yet to restart. "
                             f"Sleeping for 30 secs"

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -48,7 +48,7 @@ def run(ceph_cluster, **kw):
     log.info(run.__doc__)
     config = kw["config"]
     args = config.get("args", {})
-    timeout = config.get("timeout", 1800)
+    timeout = config.get("timeout", 3600)
     rhbuild = config.get("rhbuild")
     cephadm_obj = CephAdmin(cluster=ceph_cluster, **config)
     cluster_obj = Orch(cluster=ceph_cluster, **config)
@@ -264,6 +264,10 @@ def run(ceph_cluster, **kw):
                 "Upgrade in progress, sleeping for 5 seconds and checking cluster state again"
             )
             time.sleep(5)
+        else:
+            log_err_msg = f"Upgrade was not completed on the cluster within {timeout}"
+            log.error(log_err_msg)
+            raise Exception("Upgrade not complete")
 
         if not upgrade_complete:
             log.error("Upgrade was not completed on the cluster. Fail")
@@ -369,6 +373,11 @@ def run(ceph_cluster, **kw):
         msg = f"time when upgrade test was ended : {end_time}"
         log.info(msg)
         time.sleep(10)
+
+        log_dump = (
+            f"ceph versions: {rados_obj.run_ceph_command(cmd='ceph versions')} \n"
+        )
+        log.info(log_dump)
 
         # log cluster health
         rados_obj.log_cluster_health()


### PR DESCRIPTION
TFA fixes :- 

Increase timeout for upgrade to 1 hour since we observed upgrade taking more than 30 minutes
Catch all Exceptions when started key is not present in JSON
Note:- Fixed by team on TFA discussion call 


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
