### PR TITLE
[TFA] Add method to wait until daemon reaches running/stopped state

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3122,9 +3122,12 @@ EOF"""
             daemon_status_ls = self.run_ceph_command(
                 cmd=f"ceph orch ps --service_name {service} --refresh"
             )
+            # TODO: current system time to be used when
+            # daemon is stopped/unknown since 'started' key will
+            # not exist in ceph orch ps --service_name {service} output
             for entry in daemon_status_ls:
                 start_time, _ = self.client.exec_command(
-                    cmd=f"date -d {entry['started']} +'%Y%m%d%H%M%S'"
+                    cmd=f"date -d {entry.get('started')} +'%Y%m%d%H%M%S'"
                 )
                 daemon_map[entry["daemon_name"]] = start_time
 
@@ -3148,16 +3151,16 @@ EOF"""
                         assert entry["status_desc"] != "stopped"
                         log.info(f"{entry['daemon_name']} has started")
                         success = True
-                    except AssertionError:
+                    except Exception:
                         log.info(
                             f"{daemon} daemon {entry['daemon_name']} is yet to restart. "
-                            f"Sleeping for 30 secs"
+                            f"Sleeping for 120 secs"
                         )
                         self.client.exec_command(
                             cmd=f"ceph orch daemon restart {entry['daemon_name']}",
                             sudo=True,
                         )
-                        time.sleep(30)
+                        time.sleep(120)
                         success = False
                         break
                 if success:

--- a/tests/rados/test_bluestore_data_compression.py
+++ b/tests/rados/test_bluestore_data_compression.py
@@ -21,7 +21,11 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from tests.rados.monitor_configurations import MonConfigMethods
-from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.rados_test_util import (
+    get_device_path,
+    wait_for_daemon_status,
+    wait_for_device_rados,
+)
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import generate_unique_id, method_should_succeed, should_not_be_empty
@@ -1351,6 +1355,14 @@ def run(ceph_cluster, **kw):
         utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
         method_should_succeed(
             wait_for_device_rados, test_host, target_osd, action="add"
+        )
+        method_should_succeed(
+            wait_for_daemon_status,
+            host=test_host,
+            daemon_type="osd",
+            daemon_id=target_osd,
+            status="running",
+            timout=60,
         )
         assert service_obj.add_osds_to_managed_service(
             osds=[target_osd], spec=target_osd_spec_name

--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -11,7 +11,11 @@ from ceph.rados import utils
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from tests.rados.monitor_configurations import MonConfigMethods
-from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.rados_test_util import (
+    get_device_path,
+    wait_for_daemon_status,
+    wait_for_device_rados,
+)
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed, should_not_be_empty
@@ -241,6 +245,14 @@ def run(ceph_cluster, **kw):
                 utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
                 method_should_succeed(
                     wait_for_device_rados, test_host, target_osd, action="add"
+                )
+                method_should_succeed(
+                    wait_for_daemon_status,
+                    host=test_host,
+                    daemon_type="osd",
+                    daemon_id=target_osd,
+                    status="running",
+                    timeout=60,
                 )
                 assert service_obj.add_osds_to_managed_service(
                     osds=[target_osd], spec=target_osd_spec_name

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -14,7 +14,11 @@ from ceph.rados.rados_bench import RadosBench
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from cli.utilities.utils import reboot_node
 from tests.rados.monitor_configurations import MonConfigMethods
-from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.rados_test_util import (
+    get_device_path,
+    wait_for_daemon_status,
+    wait_for_device_rados,
+)
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed
@@ -745,6 +749,14 @@ def run(ceph_cluster, **kw):
             # Adding the removed OSD back and checking the cluster status
             utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
             method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=target_osd,
+                status="running",
+                timeout=60,
+            )
             log.debug("Completed addition of the OSD back to cluster.")
 
             # Checking if the newly added OSD is without placement

--- a/tests/rados/test_config_parameter_chk.py
+++ b/tests/rados/test_config_parameter_chk.py
@@ -49,22 +49,57 @@ def run(ceph_cluster, **kw):
         osd_list = random.sample(osd_list, 10)
     log.info(f"The parameters are checking on {osd_list} osds")
     if config.get("scenario") == "msgrv2_5x":
-        ini_file = config.get("ini-file")
-        config_info.read(ini_file)
-        msgr_parameter = config_info.items("MSGRV2")
-        result = config_param_checker(mon_object, osd_list, msgr_parameter)
-        if result:
-            log.error("The MSGRV2 parameters are exist in the 5.x build")
+        try:
+            ini_file = config.get("ini-file")
+            config_info.read(ini_file)
+            msgr_parameter = config_info.items("MSGRV2")
+            result = config_param_checker(mon_object, osd_list, msgr_parameter)
+            if result:
+                log.error("The MSGRV2 parameters are exist in the 5.x build")
+                raise Exception("parameter value is not correct in the 5.x build")
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            # log cluster health
+            rados_object.log_cluster_health()
             return 1
+        finally:
+            log.info(
+                "\n \n ************** Execution of finally block begins here *************** \n \n"
+            )
+            # log cluster health
+            rados_object.log_cluster_health()
+            # check for crashes after test execution
+            if rados_object.check_crash_status():
+                log.error("Test failed due to crash at the end of test")
+                return 1
         return 0
+
     if config.get("scenario") == "msgrv2_6x":
-        ini_file = config.get("ini-file")
-        config_info.read(ini_file)
-        msgr_parameter = config_info.items("MSGRV2")
-        result = config_param_checker(mon_object, osd_list, msgr_parameter)
-        if not result:
-            log.error("The MSGRV2 parameter value is not correct in the 6.x build")
+        try:
+            ini_file = config.get("ini-file")
+            config_info.read(ini_file)
+            msgr_parameter = config_info.items("MSGRV2")
+            result = config_param_checker(mon_object, osd_list, msgr_parameter)
+            if not result:
+                log.error("The MSGRV2 parameter value is not correct in the 6.x build")
+                raise Exception("parameter value is not correct in the 6.x build")
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            # log cluster health
+            rados_object.log_cluster_health()
             return 1
+        finally:
+            log.info(
+                "\n \n ************** Execution of finally block begins here *************** \n \n"
+            )
+            # log cluster health
+            rados_object.log_cluster_health()
+            # check for crashes after test execution
+            if rados_object.check_crash_status():
+                log.error("Test failed due to crash at the end of test")
+                return 1
         return 0
 
     # Checking all sleep parameters in mclock profiles

--- a/tests/rados/test_election_strategies.py
+++ b/tests/rados/test_election_strategies.py
@@ -5,7 +5,9 @@ from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.monitor_workflows import MonitorWorkflows
 from tests.rados.monitor_configurations import MonElectionStrategies
+from tests.rados.rados_test_util import wait_for_daemon_status
 from utility.log import Log
+from utility.utils import method_should_succeed
 
 log = Log(__name__)
 
@@ -248,9 +250,15 @@ def run(ceph_cluster, **kw):
 
             # todo: add other tests to ascertain the health of mon daemons in quorum
             # [12-Feb-2024] added ^
-            if not check_mon_status(rados_obj, mon_obj):
-                log.error("All Mon daemons are not in running state")
-                return 1
+            for mon in mon_obj.get_mon_quorum().keys():
+                method_should_succeed(
+                    wait_for_daemon_status,
+                    host=installer_node,
+                    daemon_type="mon",
+                    daemon_id=mon,
+                    status="running",
+                    timeout=60,
+                )
 
             # Collecting the number of mons in the quorum after the test
             mon_final_count = len(mon_obj.get_mon_quorum().keys())

--- a/tests/rados/test_four_node_ecpool.py
+++ b/tests/rados/test_four_node_ecpool.py
@@ -17,7 +17,11 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from tests.rados.monitor_configurations import MonConfigMethods
-from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.rados_test_util import (
+    get_device_path,
+    wait_for_daemon_status,
+    wait_for_device_rados,
+)
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed, should_not_be_empty
@@ -373,6 +377,14 @@ def run(ceph_cluster, **kw):
             log.debug("Adding the removed OSD back and checking the cluster status")
             utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
             method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=target_osd,
+                status="running",
+                timeout=60,
+            )
             assert service_obj.add_osds_to_managed_service(
                 osds=[target_osd], spec=target_osd_spec_name
             )

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -10,7 +10,7 @@ from tests.rados.rados_test_util import (
     wait_for_device_rados,
     write_to_pools,
 )
-from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets, wait_for_daemon_status
 from tests.rados.test_9281 import do_rados_get
 from utility.log import Log
 from utility.utils import method_should_succeed, should_not_be_empty
@@ -81,6 +81,14 @@ def run(ceph_cluster, **kw):
         method_should_succeed(utils.set_osd_out, ceph_cluster, osd_id1)
         utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
         method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
+        method_should_succeed(
+            wait_for_daemon_status,
+            host=host,
+            daemon_type="osd",
+            daemon_id=osd_id,
+            status="running",
+            timeout=60,
+        )
         assert service_obj.add_osds_to_managed_service()
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, test_pool=pool_name)
 
@@ -108,6 +116,14 @@ def run(ceph_cluster, **kw):
             rados_obj.set_service_managed_type(service_type="osd", unmanaged=True)
             utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
             method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=osd_id,
+                status="running",
+                timeout=60,
+            )
             assert service_obj.add_osds_to_managed_service(
                 osds=[osd_id], spec=target_osd1_spec_name
             )
@@ -116,6 +132,14 @@ def run(ceph_cluster, **kw):
             rados_obj.set_service_managed_type(service_type="osd", unmanaged=True)
             utils.add_osd(ceph_cluster, host1.hostname, dev_path1, osd_id1)
             method_should_succeed(wait_for_device_rados, host1, osd_id1, action="add")
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=osd_id,
+                status="running",
+                timeout=60,
+            )
             assert service_obj.add_osds_to_managed_service(
                 osds=[osd_id1], spec=target_osd2_spec_name
             )

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -7,6 +7,7 @@ from ceph.ceph_admin import CephAdmin
 from ceph.rados import utils
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
+from tests.rados.rados_test_util import wait_for_daemon_status
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_9281 import do_rados_get, do_rados_put
 from utility.log import Log
@@ -127,6 +128,14 @@ def run(ceph_cluster, **kw):
         method_should_succeed(wait_for_device, host, osd_id, action="remove")
         utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
         method_should_succeed(wait_for_device, host, osd_id, action="add")
+        method_should_succeed(
+            wait_for_daemon_status,
+            host=host,
+            daemon_type="osd",
+            daemon_id=osd_id,
+            status="running",
+            timeout=60,
+        )
         assert service_obj.add_osds_to_managed_service(
             osds=[osd_id], spec=target_osd_spec_name
         )
@@ -156,6 +165,14 @@ def run(ceph_cluster, **kw):
             rados_obj.set_service_managed_type(service_type="osd", unmanaged=True)
             utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
             method_should_succeed(wait_for_device, host, osd_id, action="add")
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=osd_id,
+                status="running",
+                timeout=60,
+            )
         assert service_obj.add_osds_to_managed_service()
         rados_obj.set_service_managed_type(service_type="osd", unmanaged=False)
         if config.get("delete_pools"):

--- a/tests/rados/test_osd_rebalance_snap.py
+++ b/tests/rados/test_osd_rebalance_snap.py
@@ -8,6 +8,7 @@ from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from tests.rados.rados_test_util import (
     create_pools,
     get_device_path,
+    wait_for_daemon_status,
     wait_for_device_rados,
     write_to_pools,
 )
@@ -86,6 +87,14 @@ def run(ceph_cluster, **kw):
 
         utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
         method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
+        method_should_succeed(
+            wait_for_daemon_status,
+            host=host,
+            daemon_type="osd",
+            daemon_id=osd_id,
+            status="running",
+            timeout=60,
+        )
         assert service_obj.add_osds_to_managed_service(
             osds=[osd_id], spec=target_osd_spec_name
         )
@@ -135,6 +144,14 @@ def run(ceph_cluster, **kw):
             rados_obj.set_service_managed_type(service_type="osd", unmanaged=True)
             utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
             method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=osd_id,
+                status="running",
+                timeout=60,
+            )
         assert service_obj.add_osds_to_managed_service()
         rados_obj.set_service_managed_type(service_type="osd", unmanaged=False)
         rados_obj.change_recovery_threads(config=pool, action="rm")

--- a/tests/rados/test_pg_split.py
+++ b/tests/rados/test_pg_split.py
@@ -10,6 +10,7 @@ from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from tests.rados.rados_test_util import (
     create_pools,
     get_device_path,
+    wait_for_daemon_status,
     wait_for_device_rados,
     write_to_pools,
 )
@@ -148,7 +149,14 @@ def run(ceph_cluster, **kw):
             # Adding the removed OSD back and checking the cluster status
             utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
             method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
-            time.sleep(20)
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=osd_id,
+                status="running",
+                timeout=60,
+            )
             assert service_obj.add_osds_to_managed_service(
                 osds=[target_osd], spec=target_osd_spec_name
             )
@@ -321,6 +329,14 @@ def run(ceph_cluster, **kw):
                     wait_for_device_rados, host, target_osd, action="add"
                 )
                 time.sleep(10)
+                method_should_succeed(
+                    wait_for_daemon_status,
+                    host=host,
+                    daemon_type="osd",
+                    daemon_id=osd_id,
+                    status="running",
+                    timeout=60,
+                )
             assert service_obj.add_osds_to_managed_service()
             rados_obj.set_service_managed_type(service_type="osd", unmanaged=False)
 

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -23,7 +23,11 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.monitor_workflows import MonitorWorkflows
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from ceph.utils import get_node_by_id
-from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.rados_test_util import (
+    get_device_path,
+    wait_for_daemon_status,
+    wait_for_device_rados,
+)
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_data_migration_bw_pools import create_given_pool
 from utility.log import Log
@@ -263,6 +267,14 @@ def run(ceph_cluster, **kw) -> int:
                 utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
                 method_should_succeed(
                     wait_for_device_rados, host, target_osd, action="add"
+                )
+                method_should_succeed(
+                    wait_for_daemon_status,
+                    host=host,
+                    daemon_type="osd",
+                    daemon_id=target_osd,
+                    status="running",
+                    timeout=60,
                 )
                 assert service_obj.add_osds_to_managed_service(
                     osds=[target_osd], spec=target_osd_spec_name

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -32,7 +32,11 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from cli.utilities.operations import wait_for_osd_daemon_state
-from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.rados_test_util import (
+    get_device_path,
+    wait_for_daemon_status,
+    wait_for_device_rados,
+)
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_stretch_site_down import (
     get_stretch_site_hosts,
@@ -721,6 +725,14 @@ def run(ceph_cluster, **kw):
             utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
             method_should_succeed(
                 wait_for_device_rados, test_host, target_osd, action="add"
+            )
+            method_should_succeed(
+                wait_for_daemon_status,
+                host=host,
+                daemon_type="osd",
+                daemon_id=target_osd,
+                status="running",
+                timeout=60,
             )
             assert service_obj.add_osds_to_managed_service(
                 osds=[target_osd], spec=target_osd_spec_name

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -48,7 +48,7 @@ def run(ceph_cluster, **kw):
     log.info(run.__doc__)
     config = kw["config"]
     args = config.get("args", {})
-    timeout = config.get("timeout", 1800)
+    timeout = config.get("timeout", 3600)
     rhbuild = config.get("rhbuild")
     cephadm_obj = CephAdmin(cluster=ceph_cluster, **config)
     cluster_obj = Orch(cluster=ceph_cluster, **config)
@@ -264,6 +264,10 @@ def run(ceph_cluster, **kw):
                 "Upgrade in progress, sleeping for 5 seconds and checking cluster state again"
             )
             time.sleep(5)
+        else:
+            log_err_msg = f"Upgrade was not completed on the cluster within {timeout}"
+            log.error(log_err_msg)
+            raise Exception("Upgrade not complete")
 
         if not upgrade_complete:
             log.error("Upgrade was not completed on the cluster. Fail")
@@ -369,6 +373,11 @@ def run(ceph_cluster, **kw):
         msg = f"time when upgrade test was ended : {end_time}"
         log.info(msg)
         time.sleep(10)
+
+        log_dump = (
+            f"ceph versions: {rados_obj.run_ceph_command(cmd='ceph versions')} \n"
+        )
+        log.info(log_dump)
 
         # log cluster health
         rados_obj.log_cluster_health()


### PR DESCRIPTION
REEF Pass logs for monitor elections and wait until daemon method :- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_test_pr_25_06_16_23_36_38/ 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
