### PR TITLE
TFA fix for fscrypt_basic, add correct param value for testlib call

### DIFF
--- a/tests/cephfs/cephfs_fscrypt/test_fscrypt_basic.py
+++ b/tests/cephfs/cephfs_fscrypt/test_fscrypt_basic.py
@@ -81,7 +81,7 @@ def run(ceph_cluster, **kw):
                 "/mnt/nfs_",
             ]:
                 if cephfs_common_utils.client_mount_cleanup(
-                    client_tmp, mnt_prefix=mnt_prefix
+                    client_tmp, mount_path_prefix=mnt_prefix
                 ):
                     log.error("Client old mountpoints cleanup didn't suceed")
                     fs_util.reboot_node(client_tmp)


### PR DESCRIPTION
# Description

Jira: https://issues.redhat.com/browse/RHCEPHQE-20282

Failure log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/cephfs/106/8_1_features_suite/fscrypt_basic_0.log
Failure reason : While invoking test method client_mount_cleanup, extra param 'mount_path_prefix' was passed with value in fscrypt_basic script, but the param name was called by 'mnt_prefix' instead of 'mount_path_prefix'. 

testlib code snippet:
client_mount_cleanup(client, mount_path_prefix="/mnt/cephfs_"):

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
