### PR TITLE
[Proposal]: Enhancement to support vm node objects across platforms

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1376,8 +1376,10 @@ class SSHConnectionManager(object):
 
     def __getstate__(self):
         pickle_dict = self.__dict__.copy()
-        del pickle_dict["_SSHConnectionManager__transport"]
-        del pickle_dict["_SSHConnectionManager__client"]
+        if pickle_dict.get("_SSHConnectionManager__transport"):
+            del pickle_dict["_SSHConnectionManager__transport"]
+        if pickle_dict.get("_SSHConnectionManager__client"):
+            del pickle_dict["_SSHConnectionManager__client"]
         return pickle_dict
 
 
@@ -1763,8 +1765,6 @@ class CephNode(object):
 
     def __getstate__(self):
         d = dict(self.__dict__)
-        if d.get("vm_node"):
-            del d["vm_node"]
 
         if d.get("rssh"):
             del d["rssh"]

--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -99,6 +99,22 @@ class CephBaremetalNode:
         self.rssh().exec_command(command=f"chown {name}:{name} /home/{name}")
         self.rssh().exec_command(command=bash_script)
 
+    def shutdown(self, wait: bool = False) -> None:
+        """
+        Shutdown the baremetal node.
+        Args:
+            wait (bool): If True, wait until the node is completely shut down.
+        """
+        raise NotImplementedError(
+            "Implementation not available for baremetal node shutdown."
+        )
+
+    def power_on(self) -> None:
+        """Power on the baremetal node."""
+        raise NotImplementedError(
+            "Implementation not available for baremetal node power on."
+        )
+
     @property
     def ip_address(self) -> str:
         """Return the private IP address of the node."""

--- a/compute/ibm_vpc.py
+++ b/compute/ibm_vpc.py
@@ -20,7 +20,13 @@ from requests.exceptions import ReadTimeout
 from utility.log import Log
 from utility.retry import retry
 
-from .exceptions import NodeDeleteFailure, NodeError, ResourceNotFound
+from .exceptions import (
+    NetworkOpFailure,
+    NodeDeleteFailure,
+    NodeError,
+    ResourceNotFound,
+    VolumeOpFailure,
+)
 
 LOG = Log(__name__)
 
@@ -145,8 +151,7 @@ class CephVMNodeIBM:
 
     def __init__(
         self,
-        access_key: str,
-        service_url: str,
+        os_cred_ibm: dict,
         vsi_id: Optional[str] = None,
         node: Optional[Dict] = None,
     ) -> None:
@@ -154,18 +159,20 @@ class CephVMNodeIBM:
         Initializes the instance using the provided information.
 
         Args:
-            access_key (str):   Service credential secret token
-            service_url (str):  Endpoint of the service provider
+            os_cred_ibm (dict): Dictionary containing 'accesskey' and 'service_url'.
             vsi_id (str):       The VSI node ID to be retrieved
             node (dict):
         """
         # CephVM attributes
+        self._os_cred_ibm = os_cred_ibm
         self._subnet: str = ""
         self._roles: list = list()
         self.node = None
 
-        self.service = get_ibm_service(access_key=access_key, service_url=service_url)
-        self.dns_service = get_dns_service(access_key=access_key)
+        self.service = get_ibm_service(
+            access_key=os_cred_ibm["accesskey"], service_url=os_cred_ibm["service_url"]
+        )
+        self.dns_service = get_dns_service(access_key=os_cred_ibm["accesskey"])
 
         if vsi_id:
             self.node = self.service.get_instance(id=vsi_id).get_result()
@@ -407,7 +414,7 @@ class CephVMNodeIBM:
             response = self.service.create_instance(instance_prototype)
 
             instance_id = response.get_result()["id"]
-            self.wait_until_vm_state_running(instance_id)
+            self._wait_until_vm_state(instance_id, target_state="running")
 
             response = self.service.get_instance(instance_id)
             self.node = response.get_result()
@@ -515,7 +522,60 @@ class CephVMNodeIBM:
         LOG.debug(resp.get_result())
         raise NodeDeleteFailure(f"Failed to remove {node_name}")
 
-    def wait_until_vm_state_running(self, instance_id: str) -> None:
+    def shutdown(self, wait: bool = False) -> None:
+        """
+        Gracefully power off the IBM Cloud VM.
+        Args:
+            wait (bool): Wait until the VM is fully powered off.
+        """
+        try:
+            if not self.node:
+                return
+            node_id = self.node["id"]
+            LOG.info(
+                "Initiating shutdown of IBM node: {} (ID: {})".format(
+                    self.node["name"], node_id
+                )
+            )
+            self.service.create_instance_action(node_id, type="stop")
+            if wait:
+                try:
+                    self._wait_until_vm_state(node_id, target_state="stopped")
+                except NodeError as e:
+                    LOG.error(
+                        "Error while waiting for IBM Cloud VM to stop with error: {}".format(
+                            e
+                        )
+                    )
+                    raise
+        except (ResourceNotFound, NetworkOpFailure, NodeError, VolumeOpFailure):
+            LOG.error(
+                "Error while initiating shutdown on node {}".format(self.node["id"])
+            )
+            raise
+
+    def power_on(self) -> None:
+        """
+        Start the IBM Cloud VM.
+        """
+        try:
+            if not self.node:
+                return
+            node_id = self.node["id"]
+            LOG.info(
+                "Powering on IBM node: {} (ID: {})".format(self.node["name"], node_id)
+            )
+            self.service.create_instance_action(node_id, type="start")
+            self._wait_until_vm_state(node_id, target_state="running")
+        except (ResourceNotFound, NetworkOpFailure, NodeError, VolumeOpFailure):
+            LOG.error(
+                "Error while initiating powering on node {}".format(self.node["id"])
+            )
+            raise
+
+    def _wait_until_vm_state(
+        self, instance_id: str, target_state: str, timeout: int = 1200
+    ) -> None:
         """
         Waits until the VSI moves to a running state within the specified time.
 
@@ -529,7 +589,7 @@ class CephVMNodeIBM:
             NodeError
         """
         start_time = datetime.now()
-        end_time = start_time + timedelta(seconds=1200)
+        end_time = start_time + timedelta(seconds=timeout)
 
         node_details = None
         while end_time > datetime.now():
@@ -541,12 +601,13 @@ class CephVMNodeIBM:
                 continue
 
             node_details = resp.get_result()
-            if node_details["status"] == "running":
+            if node_details["status"] == target_state:
                 end_time = datetime.now()
                 duration = (end_time - start_time).total_seconds()
                 LOG.info(
-                    "%s moved to running state in %d seconds.",
+                    "%s moved to %s state in %d seconds.",
                     node_details["name"],
+                    target_state,
                     int(duration),
                 )
                 return
@@ -603,3 +664,25 @@ class CephVMNodeIBM:
         # This code path can happen if there are no matching/associated DNS records
         # Or we have a problem
         LOG.debug(f"No matching DNS records found for {self.node['name']}")
+
+    def __getstate__(self) -> dict:
+        """
+        Prepare the object state for pickling.
+        Removes unserializable fields like service clients.
+        """
+        state = dict(self.__dict__)
+        state["service"] = None
+        state["dns_service"] = None
+        return state
+
+    def __setstate__(self, state) -> None:
+        """
+        Rehydrate the object after unpickling.
+        Rebuilds the IBM Cloud services using stored credentials.
+        """
+        self.__dict__.update(state)
+
+        access_key = self._os_cred_ibm["accesskey"]
+        service_url = self._os_cred_ibm["service_url"]
+        self.service = get_ibm_service(access_key=access_key, service_url=service_url)
+        self.dns_service = get_dns_service(access_key=access_key)


### PR DESCRIPTION
# Description

Proposal doc: https://docs.google.com/document/d/1_sAd5V7wpR2xaLlEx2xCY9Xml8-LCBT2CLjpxCO8kZU/edit?usp=sharing

## Log:

### Openstack
1. Using store(with parallel run on openstack) - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343-1/store/
2. Using reuse(with parallel run on openstack) - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343-1/resuse/
3. Using reuse(serial on openstack) - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343/

### Baremetal
1. Using store - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343-1/bm_store/
2. Using reuse - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343-1/bm_reuse/

Note: Implementation for shutdown and power_on will be covered in the next PR. Currently added a warning so that the other TCs will not fail when run on Baremetal

### IBM Cloud 
1. Using store - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343-1/ibmc-store/
2. Using reuse - http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-20343-1/ibmc-reuse/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
