### PR TITLE
[RADOS] TFA RHCEPHQE-20447: Fetch OSD information from metadata instead of ceph-volume

### DIFF
--- a/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
@@ -191,7 +191,6 @@ tests:
       config:
         non-collocated: true
       desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
-      comments: regression Bug in 8.1 - 2309610
 
   - test:
       name: cbt utility bluefs spillover

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -106,10 +106,10 @@ def run(ceph_cluster, **kw):
         )
 
         log.info(
-            "Write OMAP entries to the pool using rados bench, 100 objects with 50 omap entries each"
+            "Write OMAP entries to the pool using rados bench, 100 objects with 5 omap entries each"
         )
         assert pool_obj.fill_omap_entries(
-            pool_name="cot-pool", obj_start=0, obj_end=100, num_keys_obj=50
+            pool_name="cot-pool", obj_start=0, obj_end=100, num_keys_obj=5
         )
 
         for operation in operations:


### PR DESCRIPTION
At places, the output of ceph-volume lvm list was being used to determine the OSD data path and device names, this method fails if the OSDs have not been deployed with lvm method.

Switching to ceph-volume raw list poses another challenge as the output and structure of ceph-volume raw list and ceph-volume lvm list do not coincide.

Instead of aligning the code for each ODS deployment type, it was decided to use osd metadata output to fetch the required information.
This PR replaces ceph-volume lvm list calls with osd metadata calls.

Test cases modified:
- `tests/rados/test_bluestoretool_workflows.py`

For a while now, it has been observed that command execution times out if the output being captured is considerably large, to reduce the length of output, the amount of OMAPs being reduced by 10 times.

Test cases modified:
- `tests/rados/test_objectstoretool_workflows.py`

Logs:
Reef - 
Squid - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Y31U8B/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
