### PR TITLE
Adding fix for IO progression issue in NVMe load balancing test suites

### DIFF
--- a/ceph/parallel.py
+++ b/ceph/parallel.py
@@ -36,6 +36,11 @@ In version 2, you can choose whether to use threads or processes by
     with parallel(thread_pool=False, timeout=10) as p:
         _r = [p.spawn(quux, x) for name in names]
 
+You can also specify the maximum number of worker threads/processes:
+    with parallel(max_workers=20) as p:
+        for foo in bar:
+            p.spawn(quux, foo, baz=True)
+
 If one of the spawned functions throws an exception, it will be thrown
 when iterating over the results, or when the with block ends.
 
@@ -59,6 +64,7 @@ class parallel:
         thread_pool=True,
         timeout=None,
         shutdown_cancel_pending=False,
+        max_workers=None,
     ):
         """Object initialization method.
 
@@ -67,7 +73,10 @@ class parallel:
             timeout (int | float)       Maximum allowed time.
             shutdown_cancel_pending (bool) If enabled, it would cancel pending tasks.
         """
-        self._executor = ThreadPoolExecutor() if thread_pool else ProcessPoolExecutor()
+        if thread_pool:
+            self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        else:
+            self._executor = ProcessPoolExecutor(max_workers=max_workers)
         self._timeout = timeout
         self._cancel_pending = shutdown_cancel_pending
         self._futures = list()

--- a/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -90,8 +90,8 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
-              size: 8G
+            - count: 20
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -99,8 +99,8 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
-              size: 8G
+            - count: 20
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -141,32 +141,32 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode3
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode4
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -207,8 +207,8 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
-              size: 8G
+            - count: 20
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7]
             allow_host: "*"
@@ -216,8 +216,8 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
-              size: 8G
+            - count: 20
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7]
             allow_host: "*"
@@ -266,32 +266,32 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode3
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode4
             serial: 1
             bdevs:
-            - count: 2
-              size: 8G
+            - count: 10
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -333,8 +333,8 @@ tests:
             serial: 1
             max_ns: 2048
             bdevs:
-            - count: 10
-              size: 8G                              # auto NS load balancing for namespace addition would be verified here
+            - count: 20
+              size: 5G                              # auto NS load balancing for namespace addition would be verified here
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
             allow_host: "*"
@@ -342,8 +342,8 @@ tests:
             serial: 1
             max_ns: 2048
             bdevs:
-            - count: 10
-              size: 8G
+            - count: 20
+              size: 5G
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
             allow_host: "*"
@@ -362,11 +362,11 @@ tests:
                 - nqn: nqn.2016-06.io.spdk:cnode1
                   bdevs:
                     - count: 5
-                      size: 8G
+                      size: 5G
                 - nqn: nqn.2016-06.io.spdk:cnode2
                   bdevs:
                     - count: 5
-                      size: 8G
+                      size: 5G
           - ns_del:
               count: 3
               subsystems:

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -158,7 +158,8 @@ class NVMeInitiator(Initiator):
 
         results = []
         io_args = {"size": "100%"}
-        with parallel() as p:
+        # Use max_workers to ensure all FIO processes can start simultaneously
+        with parallel(max_workers=len(paths) + 4) as p:
             for path in paths:
                 _io_args = {}
                 if io_args.get("test_name"):


### PR DESCRIPTION
IO was getting initiated for only 16 out of the 20 namespaces across 2 subsystems in the load balancing test suite.
So, I added a new parameter max_workers to the Parallel class, which will then be used to instantiate ThreadPoolExecutor class, so that it doesn't take the default max_workers value and instead takes the value specified during initialisation.

I then set the max_workers value to max_workers=len(paths) + 4 where paths are the devices. So that we can instantiate enough number of threads to initiate IOs for all devices at once.

With this change IO progression is working as expected (refer logs below). However I uncovered another issue that after adding listeners to the scaled up node, few of the devices are missing in the initiator. Need to analyse this issue further as a separate new issue. So I will not be combining the analysis and fix of this issue as part of this PR.

Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-98TQ97/

Logs for 4 subsystems - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U4OIU6/