### PR TITLE
[DNM][LibFix] Add fallback mechanism for subscription manager release set command

### DIFF
--- a/cli/utilities/packages.py
+++ b/cli/utilities/packages.py
@@ -1,6 +1,7 @@
 import re
 
 from cli import Cli
+from cli.exceptions import OperationFailedError
 from cli.utilities.utils import verify_execution_status
 
 RPM_QUERY_ERROR_MSG = "package {} is not installed"
@@ -217,6 +218,32 @@ class SubscriptionManager(Cli):
         if isinstance(out, tuple):
             return out[0].strip()
         return out
+
+    def clean(self):
+        """Cleans all local subscription data: entitlements, certs, identity.
+
+        Raises:
+            SubscriptionManagerError: if clean fails.
+        """
+        cmd = f"{self.base_cmd} clean"
+
+        if self.execute(sudo=True, long_running=True, cmd=cmd):
+            raise OperationFailedError("Failed to clean repositories.")
+
+    def set(self, version):
+        """Set the subscription-manager release version.
+
+        Args:
+            version (str): The RHEL release version to set (e.g., "8.6", "9.2").
+
+        Raises:
+            SubscriptionManagerError: If setting the release fails.
+        """
+        cmd = f"{self.base_cmd} release --set={version}"
+        if self.execute(sudo=True, long_running=True, cmd=cmd):
+            raise OperationFailedError(
+                f"Failed to set subscription release to {version}."
+            )
 
 
 class Repos(Cli):

--- a/cli/utilities/repos.py
+++ b/cli/utilities/repos.py
@@ -1,0 +1,71 @@
+from cli.exceptions import NotSupportedError, OperationFailedError
+from cli.utilities.packages import Package, SubscriptionManager
+from cli.utilities.subscription_manager import re_register_subscription_manager
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def enable_rhel_rpms(node, distro_ver, server="rhsm"):
+    """Enable required RHEL repositories based on the distro version.
+
+    Args:
+        node: The node or context to run commands on.
+        distro_ver (str): The major RHEL version (e.g., '7', '8', '9')
+    """
+    # Define the repositories for each RHEL version
+    repos = {
+        "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
+        "8": ["rhel-8-for-x86_64-appstream-rpms", "rhel-8-for-x86_64-baseos-rpms"],
+        "9": ["rhel-9-for-x86_64-appstream-rpms", "rhel-9-for-x86_64-baseos-rpms"],
+    }
+
+    # Set the subscription-manager release version
+    try:
+        SubscriptionManager(node).set(distro_ver)
+    except OperationFailedError as e:
+        # Reregister the subscription manager
+        log.info(
+            f"Failed to set subscription-manager release for {distro_ver}: "
+            f"{e},\nre-registering ..."
+        )
+        re_register_subscription_manager(node, server)
+
+        # Reattempt to set the subscription-manager release version
+        log.info(f"Retrying to set subscription-manager release for {distro_ver}")
+        SubscriptionManager(node).set(distro_ver)
+
+    # Enable the repositories based on the distro version
+    for repo in repos.get(distro_ver[0]):
+        SubscriptionManager(node).repos.enable(repos=repo)
+
+
+def enable_rhel_eus_rpms(node, distro_ver):
+    """Enable Extended Update Support (EUS) repositories for RHEL 7.
+
+    Args:
+        node: The node or object to run commands on.
+        distro_ver (str): The major RHEL version (e.g., '7').
+
+    Raises:
+        NotSupportedError: If the version is not supported for EUS.
+    """
+    # Define the EUS repositories for RHEL 7
+    repos = {"7": ["rhel-7-server-eus-rpms", "rhel-7-server-extras-rpms"]}
+
+    # Enable the EUS repositories based on the distro version
+    for repo in repos.get(distro_ver[0]):
+        SubscriptionManager(node).repos.enable(repos=repo)
+
+    # Check if the distro version is supported for EUS
+    if distro_ver[0] != "7":
+        raise NotSupportedError(f"Cannot set EUS repos for {distro_ver[0]}")
+
+    # Set the release version for EUS repositories
+    release = "7.7"
+
+    # Set the subscription-manager release version for EUS
+    SubscriptionManager(node).set(release)
+
+    # Clean up the yum cache to ensure the new repositories are recognized
+    Package(node).clean()

--- a/cli/utilities/subscription_manager.py
+++ b/cli/utilities/subscription_manager.py
@@ -1,0 +1,142 @@
+import re
+
+from cli.exceptions import OperationFailedError, ResourceNotFoundError
+from cli.utilities.packages import SubscriptionManager
+from cli.utilities.waiter import WaitUntil
+from utility.log import Log
+from utility.utils import get_cephci_config
+
+log = Log(__name__)
+
+
+def setup_subscription_manager(node, server, timeout=300, interval=60):
+    """Setup the subscription manager on a Ceph node.
+
+    Args:
+        ceph: Ceph node object.
+        server: Name of the subscription server (e.g., "rhsm", "satellite").
+        timeout: Maximum time to wait for subscription (default: 300 seconds).
+        interval: Time interval between retries (default: 60 seconds).
+
+    Returns:
+        bool: True if subscription is successful, False otherwise.
+    """
+    # Get configuration details from `~/.cephci.yaml`
+    configs = get_cephci_config()
+
+    # Get credentials and validate
+    creds = configs.get(f"{server}_credentials")
+    if not creds:
+        raise ResourceNotFoundError(f"{server} credentials are not provided.")
+
+    # Subscribe to server
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        try:
+            SubscriptionManager(node).register(
+                username=creds.get("username"),
+                password=creds.get("password"),
+                serverurl=creds.get("serverurl"),
+                baseurl=creds.get("baseurl"),
+                force=True,
+            )
+            log.info(f"Subscribed to {server} server successfully.")
+            return True
+        except OperationFailedError:
+            log.info(f"Failed to subscribe to {server} server. Retrying ...")
+
+    if w.expired:
+        log.info(f"Failed to subscribe to {server} server.")
+
+    return False
+
+
+def re_register_subscription_manager(node, server):
+    """Setup the subscription manager on a Ceph node.
+
+    Args:
+        node: Ceph node object.
+        server: Name of the subscription server.
+
+    Returns:
+        bool: True if subscription is successful, False otherwise.
+
+    Raises:
+        ConfigError: if credentials for the given server are not found.
+    """
+    # Create subscription manager instance
+    sm = SubscriptionManager(node)
+
+    # Unregister the subscription manager
+    try:
+        sm.unregister()
+    except OperationFailedError as e:
+        log.info(f"Failed to unregister subscription manager:\n{str(e)}")
+
+    # Clean all subscription-related configs
+    try:
+        sm.clean()
+    except OperationFailedError as e:
+        log.info(f"Failed to clean subscription manager:\n{str(e)}")
+
+    # Clean up any residual subscription files
+    try:
+        cleanup_subscription_files(node)
+    except OperationFailedError as e:
+        log.info(f"Failed to clean up residual subscription files:\n{str(e)}")
+
+    # Re-register the subscription manager
+    if not setup_subscription_manager(node, "cdn"):
+        log.info("Trying to subscribe to stage server")
+        return setup_subscription_manager(node, "stage")
+
+    return True
+
+
+def subscription_manager_status(node):
+    """Returns the current status of subscription-manager on the Ceph node.
+
+    Args:
+        node: Ceph node object
+
+    Returns:
+        str: Status string (e.g., "Subscribed", "Unknown", etc.)
+
+    Raises:
+        OperationFailedError: if parsing the status fails.
+    """
+    # Regular expression to match the overall status in subscription-manager output
+    expr = ".*Overall Status:(.*).*"
+
+    # Get the status of subscription manager
+    status = SubscriptionManager(node).status()
+
+    # Check if the status is empty
+    match = re.search(expr, status)
+    if not match:
+        raise OperationFailedError("Unexpected subscription manager status")
+
+    # Return the matched status
+    return match.group(0)
+
+
+def cleanup_subscription_files(node):
+    """Remove residual subscription-related certificate and identity files.
+
+    Args:
+        node: Ceph node object.
+
+    Raises:
+        OperationFailedError: if the file cleanup command fails.
+    """
+    # List of subscription manager certificate directories to clean up
+    log.info("Cleaning up subscription manager files...")
+    subscription_manager_certs = [
+        "/etc/pki/consumer",
+        "/etc/pki/product",
+        "/etc/pki/entitlement",
+    ]
+
+    # Remove subscription manager certificate files
+    for cert in subscription_manager_certs:
+        log.info(f"Removing subscription manager certificate: {cert}")
+        node.remove_file(cert)


### PR DESCRIPTION
Subscription manager `release --set` command is intermittently failing with below error - 
```
2025-06-10 00:00:15,666 - cephci - run:860 - ERROR - subscription-manager release --set 9.6 returned System certificates corrupted. Please reregister.
 and code 70 on 10.0.195.100
Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/38/cephci/run.py", line 845, in run
    rc = test_mod.run(
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/38/cephci/tests/misc_env/install_prereq.py", line 95, in run
    time.sleep(20)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/38/cephci/ceph/parallel.py", line 131, in __exit__
    self._results.append(_f.result())
  File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/lib64/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/38/cephci/tests/misc_env/install_prereq.py", line 175, in install_prereq
    enable_rhel_rpms(ceph, distro_ver)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/38/cephci/tests/misc_env/install_prereq.py", line 341, in enable_rhel_rpms
    ceph.exec_command(sudo=True, cmd=f"subscription-manager release --set {distro_ver}")
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/38/cephci/ceph/ceph.py", line 1737, in exec_command
    raise CommandFailed(
ceph.ceph.CommandFailed: subscription-manager release --set 9.6 returned System certificates corrupted. Please reregister.
 and code 70 on 10.0.195.100
```
To fix issue add fallback mechanism to re-register subscription manager with clean command.