### PR TITLE
Fixing xunit file creation issue

### DIFF
--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -128,6 +128,7 @@ def create_xunit_results(suite_name, test_cases, test_run_metadata):
     props.append(Property(name="polarion-group-id", value=test_group_id))
     xml.append(props)
     xml.add_testsuite(suite)
-    xml.write(xml_file, pretty=True)
+    with open(xml_file, "w", encoding="utf-8") as f:
+        xml.write(f, pretty=True)
 
     log.info(f"xUnit result file created: {xml_file}")


### PR DESCRIPTION
# Description

Fixing xunit file creation issue

Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/BVT/18.2.1-340/2/cephci/run.py", line 1098, in <module>
    rc = run(args)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/BVT/18.2.1-340/2/cephci/run.py", line 997, in run
    create_xunit_results(suite_name, tcs, test_run_metadata)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/BVT/18.2.1-340/2/cephci/utility/xunit.py", line 131, in create_xunit_results
    xml.write(xml_file, pretty=True)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/BVT/18.2.1-340/2/cephci/.venv/lib64/python3.9/site-packages/junitparser/junitparser.py", line 791, in write
    write_xml(self, file_or_filename=file_or_filename, pretty=pretty)
  File "/home/jenkins/ceph-builds/openstack/RH/7.1/rhel-9/BVT/18.2.1-340/2/cephci/.venv/lib64/python3.9/site-packages/junitparser/junitparser.py", line 36, in write_xml
    with open(file_or_filename, encoding="utf-8", mode="wb") as xmlfile:
ValueError: binary mode doesn't take an encoding argument

logs
https://jenkins-csb-rhgsocs3x-ocs3xstage.dno.corp.redhat.com/job/qe-reef-stage-bvt-openstack/3/console

