### PR TITLE
Changes to incorporate IBMC keystone and LDAP URLs

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -50,6 +50,7 @@ import yaml
 from utility import utils
 from utility.log import Log
 from utility.utils import (
+    config_keystone_ldap,
     configure_kafka_security,
     install_start_kafka,
     setup_cluster_access,
@@ -87,6 +88,7 @@ def run(ceph_cluster, **kw):
     install_start_kafka_broker = config.get("install_start_kafka")
     configure_kafka_broker_security = config.get("configure_kafka_security")
     cloud_type = config.get("cloud-type")
+    log.info(f"Cloud Type is {cloud_type}")
     test_config = {"config": config.get("test-config", {})}
     rgw_node = rgw_ceph_object.node
     client_node = client_ceph_object.node
@@ -158,6 +160,9 @@ def run(ceph_cluster, **kw):
         install_start_kafka(rgw_node, cloud_type)
     if configure_kafka_broker_security:
         configure_kafka_security(rgw_node, cloud_type)
+
+    if cloud_type:
+        config_keystone_ldap(rgw_node, cloud_type)
 
     out, err = exec_from.exec_command(cmd="ls -l venv", check_ec=False)
     if not out:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1842,6 +1842,28 @@ def configure_kafka_security(rgw_node, cloud_type):
     rgw_node.exec_command(sudo=True, cmd=f"ceph orch restart {rgw_name}")
 
 
+def config_keystone_ldap(rgw_node, cloud_type):
+    """Set the keystone config option on the cluster at startup"""
+    if cloud_type == "openstack":
+        keystone_server = get_cephci_config()["rhosd"].get("keystone_url")
+        ldap_url = get_cephci_config()["rhosd"].get("ldap_url")
+    elif cloud_type == "ibmc":
+        keystone_server = get_cephci_config()["ibmcos"].get("keystone_url")
+        ldap_url = get_cephci_config()["ibmcos"].get("ldap_url")
+
+    out = rgw_node.exec_command(sudo=True, cmd="ceph orch ls | grep rgw")
+    rgw_name = out[0].split()[0]
+    rgw_node.exec_command(
+        sudo=True,
+        cmd=f"ceph config set client.{rgw_name} rgw_keystone_url {keystone_server}",
+    )
+    rgw_node.exec_command(
+        sudo=True,
+        cmd=f"ceph config set client.{rgw_name} rgw_ldap_uri {ldap_url}",
+    )
+    rgw_node.exec_command(sudo=True, cmd=f"ceph orch restart {rgw_name}")
+
+
 def method_should_succeed(function, *args, **kwargs):
     """
     Wrapper function to verify the return value of executed method.


### PR DESCRIPTION
With execution moving to IBMC , these changes are necessary to capture the URLs for keystone, LDAP for RHOSd or IBMC.

Pass log:
http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-6CA9IZ/
