### PR TITLE
[tfa][stabilization] wait for OSD_DOWN label when OSD is down

### DIFF
--- a/tests/rados/test_stretch_n_az_site_down_scenarios.py
+++ b/tests/rados/test_stretch_n_az_site_down_scenarios.py
@@ -110,9 +110,22 @@ def run(ceph_cluster, **kw):
             )
 
             for warning in health_warns:
-                if not rados_obj.check_health_warning(warning=warning):
-                    log.error(
-                        "Expected health warning : %s not found on the cluster", warning
+                for _ in range(3):
+                    if rados_obj.check_health_warning(warning=warning):
+                        log.info(
+                            "Expected health warning : %s found on the cluster", warning
+                        )
+                        break
+                    log.info(
+                        "Expected health warning : %s not found on the cluster\n"
+                        "Retrying after 20 seconds",
+                        warning,
+                    )
+                    time.sleep(20)
+                else:
+                    log.info(
+                        "Expected health warning : %s not found on the cluster after retries",
+                        warning,
                     )
                     return False
                 log.debug("Warning : %s present on the cluster", warning)


### PR DESCRIPTION
Issue :- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/111/tier-3_rados_test-3-AZ-Cluster/Site-down_Scenarios_0.log 

`2025-06-16 07:45:10,181 - cephci - ceph:1613 - INFO - Execute ceph report -f json on 10.0.195.148
2025-06-16 07:45:11,185 - cephci - ceph:1643 - INFO - Execution of ceph report -f json on 10.0.195.148 took 1.003839 seconds
2025-06-16 07:45:11,189 - cephci - core_workflows:641 - INFO - Warning: OSD_DOWN not present on the cluster. all Generated warnings : ['BLUESTORE_SLOW_OP_ALERT', 'CEPHADM_CHECK_NETWORK_MISSING']
2025-06-16 07:45:11,190 - cephci - test_stretch_n_az_site_down_scenarios:114 - ERROR - **Expected health warning : OSD_DOWN not found on the cluster**`

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
