### PR TITLE
TFA [RADOS]: Fetch UP OSDs | Reuse rados orch object

### DIFF
--- a/tests/rados/rados_test_util.py
+++ b/tests/rados/rados_test_util.py
@@ -223,36 +223,41 @@ def wait_for_device_rados(host, osd_id, action: str, timeout: int = 900) -> bool
 
 
 def wait_for_daemon_status(
-    host, daemon_type: str, daemon_id: str, status: str, timeout: int = 900
+    rados_obj, daemon_type: str, daemon_id: str, status: str, timeout: int = 900
 ) -> bool:
     """
     Waiting for the device to be removed/added based on the action
     Args:
-        host: CephNode object
+        rados_obj: RadosOrchestrator object
         status: status of daemon. "running" "stopped" "unknown"
         timeout: wait timeout in seconds
-        daemon_id: (str) id of the daemo. --daemon-id 1 passed in 'ceph orch ps --daemon-type osd --daemon-id 1'
-        daaemon_type: (str) type of daemon. --daemon-type osd as passed in
+        daemon_id: (str) id of the daemon --daemon-id 1 passed in 'ceph orch ps --daemon-type osd --daemon-id 1'
+        daemon_type: (str) type of daemon --daemon-type osd as passed in
             'ceph orch ps --daemon-type osd --daemon-id 1'
     Returns:  True -> pass, False -> fail
     """
-    base_cmd = f"cephadm shell -- ceph orch ps --daemon-type {daemon_type} --daemon-id {daemon_id} -f json"
     end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
     while end_time > datetime.datetime.now():
-        out, _ = host.exec_command(cmd=f"{base_cmd}", sudo=True, pretty_print=True)
-        ceph_orch_ps = json.loads(out)
+        _, curr_status = rados_obj.get_daemon_status(
+            daemon_type=daemon_type, daemon_id=daemon_id
+        )
 
-        if ceph_orch_ps and ceph_orch_ps[0]["status_desc"] == status:
-            log_info_msg = f"Status of {daemon_type}.{daemon_id} is {status}"
+        if not curr_status:
+            curr_status = ""
+
+        if status.lower() in curr_status.lower():
+            log_info_msg = f"Status of {daemon_type}.{daemon_id} is {curr_status}"
             log.info(log_info_msg)
-            break
-        else:
-            sleep_duration_in_seconds = 10
-            log_info_msg = f"\n Current status of {daemon_type}.{daemon_id} is {ceph_orch_ps[0]['status_desc']}"
-            f"\n Expected status of {daemon_type}.{daemon_id} is {status}"
-            f"\n Retrying after {sleep_duration_in_seconds} seconds."
-            log.info(log_info_msg)
-            time.sleep(sleep_duration_in_seconds)
+            return True
+
+        sleep_duration_in_seconds = 10
+        log_info_msg = (
+            f"\n Current status of {daemon_type}.{daemon_id} is {curr_status}"
+        )
+        f"\n Expected status of {daemon_type}.{daemon_id} is {status}"
+        f"\n Retrying after {sleep_duration_in_seconds} seconds."
+        log.info(log_info_msg)
+        time.sleep(sleep_duration_in_seconds)
     else:
         log_error_msg = (
             f"\n Status of {daemon_type}.{daemon_id} is not changed to {status}"
@@ -260,4 +265,3 @@ def wait_for_daemon_status(
         f"\n after {timeout} seconds."
         log.error(log_error_msg)
         return False
-    return True

--- a/tests/rados/test_bluestore_data_compression.py
+++ b/tests/rados/test_bluestore_data_compression.py
@@ -1358,7 +1358,7 @@ def run(ceph_cluster, **kw):
         )
         method_should_succeed(
             wait_for_daemon_status,
-            host=test_host,
+            rados_obj=rados_obj,
             daemon_type="osd",
             daemon_id=target_osd,
             status="running",

--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -248,7 +248,7 @@ def run(ceph_cluster, **kw):
                 )
                 method_should_succeed(
                     wait_for_daemon_status,
-                    host=test_host,
+                    rados_obj=rados_obj,
                     daemon_type="osd",
                     daemon_id=target_osd,
                     status="running",

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -751,7 +751,7 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=target_osd,
                 status="running",

--- a/tests/rados/test_config_parameter_chk.py
+++ b/tests/rados/test_config_parameter_chk.py
@@ -24,7 +24,6 @@ def run(ceph_cluster, **kw):
     log.info(run.__doc__)
     config = kw["config"]
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
-    osd_list = []
     mclock_profile = ["balanced", "high_recovery_ops", "high_client_ops"]
     rados_object = RadosOrchestrator(node=cephadm)
     mon_object = MonConfigMethods(rados_obj=rados_object)
@@ -36,14 +35,8 @@ def run(ceph_cluster, **kw):
     log.info(f"The rhcs build version is-{build}")
 
     # To get the OSD list
-    ceph_nodes = kw.get("ceph_nodes")
-    for node in ceph_nodes:
-        if node.role == "osd":
-            node_osds = rados_object.collect_osd_daemon_ids(node)
-            # Pick a single OSD from the host OSDs list
-            node_osds = random.sample(node_osds, 1)
-            osd_list = osd_list + node_osds
-    log.info(f"The number of OSDs in the cluster are-{len(osd_list)}")
+    osd_list = rados_object.get_osd_list(status="up")
+    log.info(f"The number of OSDs in the cluster are: {len(osd_list)}")
     # If OSD list is more than 10 then randomly picking the 10 OSDs to check the parameters.
     if len(osd_list) > 10:
         osd_list = random.sample(osd_list, 10)

--- a/tests/rados/test_election_strategies.py
+++ b/tests/rados/test_election_strategies.py
@@ -253,7 +253,7 @@ def run(ceph_cluster, **kw):
             for mon in mon_obj.get_mon_quorum().keys():
                 method_should_succeed(
                     wait_for_daemon_status,
-                    host=installer_node,
+                    rados_obj=rados_obj,
                     daemon_type="mon",
                     daemon_id=mon,
                     status="running",

--- a/tests/rados/test_four_node_ecpool.py
+++ b/tests/rados/test_four_node_ecpool.py
@@ -435,7 +435,7 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=target_osd,
                 status="running",

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -84,7 +84,7 @@ def run(ceph_cluster, **kw):
         method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
         method_should_succeed(
             wait_for_daemon_status,
-            host=host,
+            rados_obj=rados_obj,
             daemon_type="osd",
             daemon_id=osd_id,
             status="running",
@@ -119,7 +119,7 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=osd_id,
                 status="running",
@@ -135,7 +135,7 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device_rados, host1, osd_id1, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=osd_id,
                 status="running",

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -130,7 +130,7 @@ def run(ceph_cluster, **kw):
         method_should_succeed(wait_for_device, host, osd_id, action="add")
         method_should_succeed(
             wait_for_daemon_status,
-            host=host,
+            rados_obj=rados_obj,
             daemon_type="osd",
             daemon_id=osd_id,
             status="running",
@@ -167,7 +167,7 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device, host, osd_id, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=osd_id,
                 status="running",

--- a/tests/rados/test_osd_rebalance_snap.py
+++ b/tests/rados/test_osd_rebalance_snap.py
@@ -89,7 +89,7 @@ def run(ceph_cluster, **kw):
         method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
         method_should_succeed(
             wait_for_daemon_status,
-            host=host,
+            rados_obj=rados_obj,
             daemon_type="osd",
             daemon_id=osd_id,
             status="running",
@@ -146,7 +146,7 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=osd_id,
                 status="running",

--- a/tests/rados/test_pg_split.py
+++ b/tests/rados/test_pg_split.py
@@ -151,9 +151,9 @@ def run(ceph_cluster, **kw):
             method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
-                daemon_id=osd_id,
+                daemon_id=target_osd,
                 status="running",
                 timeout=60,
             )
@@ -331,7 +331,7 @@ def run(ceph_cluster, **kw):
                 time.sleep(10)
                 method_should_succeed(
                     wait_for_daemon_status,
-                    host=host,
+                    rados_obj=rados_obj,
                     daemon_type="osd",
                     daemon_id=osd_id,
                     status="running",

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -270,7 +270,7 @@ def run(ceph_cluster, **kw) -> int:
                 )
                 method_should_succeed(
                     wait_for_daemon_status,
-                    host=host,
+                    rados_obj=rados_obj,
                     daemon_type="osd",
                     daemon_id=target_osd,
                     status="running",

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -728,7 +728,7 @@ def run(ceph_cluster, **kw):
             )
             method_should_succeed(
                 wait_for_daemon_status,
-                host=host,
+                rados_obj=rados_obj,
                 daemon_type="osd",
                 daemon_id=target_osd,
                 status="running",


### PR DESCRIPTION
### Reuse RADOS Orch object
`wait_for_daemon_status` method now accepts Orch object of class `RadosOrchestrator` from `core_worflows.py`. This removes the requirement of passing the host object in order to execute the `ceph orch ps command`

### Fetch UP OSDs
At times it was observed that OSD config parameters could not be set on few OSDs, a simple enhancement made to the test case to fetch list of UP OSDs instead of all OSDs on the cluster

Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/rados/15/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
