### PR TITLE
Fixing junitparser version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "ibm-cloud-networking-services==0.25.0",
         "jinja_markdown==1.210911",
         "jinja2==3.1.6",
-        "junitparser==3.2.0",
+        "junitparser==4.0.2",
         "paramiko==3.5.1",
         "plotly==6.1.2",
         "pyyaml==6.0.2",


### PR DESCRIPTION
# Description

Fixing junitparser version

Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/nfs/21/cephci/run.py", line 1098, in <module>
    rc = run(args)
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/nfs/21/cephci/run.py", line 997, in run
    create_xunit_results(suite_name, tcs, test_run_metadata)
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/nfs/21/cephci/utility/xunit.py", line 132, in create_xunit_results
    xml.write(f, pretty=True)
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/nfs/21/cephci/.venv/lib64/python3.9/site-packages/junitparser/junitparser.py", line 766, in write
    write_xml(self, filepath=filepath, pretty=pretty, to_console=to_console)
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/nfs/21/cephci/.venv/lib64/python3.9/site-packages/junitparser/junitparser.py", line 37, in write_xml
    with open(filepath, "wb") as xmlfile:
TypeError: expected str, bytes or os.PathLike object, not TextIOWrapper

logs:
http://10.70.46.85:8080/view/Sanity/job/qe-squid-sanity-openstack/41/consoleFull
