### PR TITLE
Automation of CEPH-83609769 test case

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -429,3 +429,61 @@ tests:
       module: test_ceph_nvmeof_loadbalancing.py
       name: Test load balancing for namespace addition and deletion with same LB group.
       polarion-id: CEPH-83608838
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: apply_spec
+        gw_nodes:
+          - node3
+          - node4
+          - node5
+          - node6
+        rbd_pool: rbd
+        gw_group: gw_group1
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            max_ns: 1024
+            listener_port: 4420
+            listeners:
+              - node3
+              - node4
+              - node5
+              - node6
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            max_ns: 1024
+            listener_port: 4420
+            listeners:
+              - node3
+              - node4
+              - node5
+              - node6
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            max_ns: 1024
+            listener_port: 4420
+            listeners:
+              - node3
+              - node4
+              - node5
+              - node6
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            max_ns: 1024
+            listener_port: 4420
+            listeners:
+              - node3
+              - node4
+              - node5
+              - node6
+            allow_host: "*"
+        test_case: CEPH-83609769
+        cleanup:
+          - pool
+          - gateway
+      desc: Test disabling auto namespace load balancing in a GW group
+      destroy-cluster: false
+      module: test_ceph_nvmeof_loadbalancing.py
+      name: Test disabling auto namespace load balancing in a GW group
+      polarion-id: CEPH-83609769

--- a/tests/nvmeof/workflows/nvme_utils.py
+++ b/tests/nvmeof/workflows/nvme_utils.py
@@ -114,6 +114,11 @@ def apply_nvme_sdk_cli_support(ceph_cluster, config):
             cfg["config"]["specs"][0]["spec"]["group"] = gw_group
         else:
             cfg["config"]["pos_args"].append(gw_group)
+
+        if config.get("rebalance_period", False):
+            cfg["config"]["specs"][0]["spec"]["rebalance_period_sec"] = config.get(
+                "rebalance_period_sec"
+            )
         return cfg
 
 


### PR DESCRIPTION
### Automation of CEPH-83609769 test case
Polarian link:- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83609769
```
2025-06-25 14:43:50,771 - cephci - run:918 - INFO - Test <module 'test_ceph_nvmeof_loadbalancing' from '/Users/pjayaprakash/Library/CloudStorage/OneDrive-IBM/automation/cephci_ssh/cephci/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py'> passed
2025-06-25 14:43:50,772 - cephci - run:973 - INFO - 
All test logs located here: /Users/pjayaprakash/logs/test_ceph_83609769
```
Logs attached in text file because xunit is getting failed
[Test_disabling_auto_namespace_load_balancing_in_a_GW_group_0.log](https://github.com/user-attachments/files/20900654/Test_disabling_auto_namespace_load_balancing_in_a_GW_group_0.log)
