### PR TITLE
[TFA] Adds option to remove the services after OSDs are moved from service

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -154,11 +154,18 @@ class RadosOrchestrator:
         log.info("Email alerts configured on the cluster")
         return True
 
-    def run_ceph_command(self, cmd: str, timeout: int = 300, client_exec: bool = False):
+    def run_ceph_command(
+        self,
+        cmd: str,
+        timeout: int = 300,
+        client_exec: bool = False,
+        print_output: bool = False,
+    ):
         """
         Runs ceph commands with json tag for the action specified otherwise treats action as command
         and returns formatted output
         Args:
+            print_output: bool to print output and error
             cmd: Command that needs to be run
             timeout: Maximum time allowed for execution.
             client_exec: Selection if true, runs the command on the client node
@@ -177,6 +184,9 @@ class RadosOrchestrator:
         if out.isspace():
             return {}
         status = json.loads(out)
+        if print_output:
+            log.info("out: " + out + "\n")
+            log.info("err: " + err + "\n")
         return status
 
     def pool_inline_compression(self, pool_name: str, **kwargs) -> bool:
@@ -5187,3 +5197,123 @@ EOF"""
                 )
                 return False
         return True if rule_name not in self.get_crush_rule_names() else False
+
+    def remove_empty_service_spec(self, service_type: str = None):
+        """
+        Method to remove empty service specs.
+        Args:
+            [ optional ] service_type: ( type: string ) type of the service such as osd, mon, mgr
+        Usage:
+             remove_empty_service_spec(service_type="osd") => Removes empty service spec of type "osd"
+             remove_empty_service_spec() => Removes empty service spec of any type
+        Returns:
+            True -> If removal of service was successful
+            False -> If removal of service failed
+        Output:
+            Service will be deleted if the status.size is 0
+            $ ceph orch ls -f json
+            [{
+                "events": [
+                    "2025-06-18T02:52:32.577657Z service:prometheus [INFO] \"service was created\""
+                ],
+                "placement": {
+                    "count": 1
+                },
+                "service_name": "prometheus",
+                "service_type": "prometheus",
+                "status": {
+                    "created": "2025-06-18T02:49:28.122168Z",
+                    "last_refresh": "2025-06-24T07:30:04.509405Z",
+                    "ports": [
+                        9095
+                    ],
+                    "running": 1,
+                    "size": 1
+                }
+            }]
+        """
+        log_info_msg = "Removing empty service spec of type "
+        if service_type:
+            log_info_msg += service_type
+        else:
+            log_info_msg += "Any"
+        log.info(log_info_msg)
+
+        removed_services = list()
+        failed_removal_services = list()
+        ceph_orch_ls = self.run_ceph_command("ceph orch ls")
+        for service in ceph_orch_ls:
+            current_service_type = service["service_type"]
+            current_service_size = service["status"]["size"]
+            current_service_name = service["service_name"]
+            if (service_type is None and current_service_size == 0) or (
+                current_service_type == service_type and current_service_size == 0
+            ):
+                if self.remove_orch_service(service_name=current_service_name):
+                    removed_services.append(current_service_name)
+                else:
+                    failed_removal_services.append(current_service_name)
+            else:
+                log_info_msg = (
+                    f"Service {current_service_name} service_type did not match"
+                    f" or Service is not empty"
+                )
+                log.info(log_info_msg)
+
+        if len(failed_removal_services) != 0:
+            log_error_msg = f"{failed_removal_services} removal failed."
+            log.error(log_error_msg)
+            return False
+
+        if len(removed_services) == 0:
+            log_error_msg = "Empty service spec not found"
+            log.error(log_error_msg)
+            return True
+
+        log_info_msg = f"Successfully removed empty service specs : {removed_services}"
+        log.info(log_info_msg)
+        return True
+
+    def remove_orch_service(self, service_name: str, force: bool = None):
+        """
+        Method to remove orchestrator service using command 'ceph orch rm <service-name>' for service
+        removal and uses command 'ceph orch ls' to validate service was removed.
+        Use force=True to forcefully remove a service. 'ceph orch rm <service-name> --force'
+        will be used.
+
+        Args:
+            service_name: Name of the service. Example:- osd.default
+            force: Boolean flag to control force removal of service. Adds --force flag during removal.
+
+        Returns:
+            True :- If service removal using 'ceph orch rm <service-name>' succeeded
+            False :- If service removal using 'ceph orch rm <service-name>' failed
+        """
+        log_info_msg = f"Removing service {service_name}"
+        log.info(log_info_msg)
+
+        cmd = f"ceph orch rm {service_name}"
+        if force:
+            cmd += " --force"
+        out, _ = self.client.exec_command(cmd=cmd)
+
+        if "Removed service" not in out:
+            log_err_msg = (
+                f"ceph orch rm {service_name} command execution did"
+                f" not yield expected message. \n"
+                f"Expected message: Removed service {service_name}\n"
+                f"Current message: {out}"
+            )
+            log.error(log_err_msg)
+        time.sleep(5)
+        if service_name in self.run_ceph_command("ceph orch ls", client_exec=True):
+            log_err_msg = (
+                f"Service {service_name} removal failed."
+                f" Service is listed in `ceph orch ls` output"
+            )
+            log.error(log_err_msg)
+            return False
+
+        log_info_msg = f"Removed service {service_name} successfully"
+        log.info(log_info_msg)
+        return True

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -553,6 +553,8 @@ def run(ceph_cluster, **kw):
                 log.error("Cluster cloud not reach active+clean state")
                 return 1
             rados_obj.change_recovery_threads(config=config, action="rm")
+            # remove empty service specs after host removal
+            rados_obj.remove_empty_service_spec()
             # set osd service to managed
             rados_obj.set_service_managed_type(service_type="osd", unmanaged=False)
 

--- a/tests/rados/test_four_node_ecpool.py
+++ b/tests/rados/test_four_node_ecpool.py
@@ -506,6 +506,8 @@ def run(ceph_cluster, **kw):
 
         # removing the recovery threads on the cluster
         rados_obj.change_recovery_threads(config={}, action="rm")
+        # remove empty service specs after host removal
+        rados_obj.remove_empty_service_spec()
 
         if set_debug:
             log.debug("Removing debug configs on the cluster for mon, osd & Mgr")

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -328,6 +328,8 @@ def run(ceph_cluster, **kw) -> int:
             service_obj.remove_custom_host(
                 host_node_name=config.get("remove_host", "node13")
             )
+            # remove empty service specs after host removal
+            rados_obj.remove_empty_service_spec()
             # Waiting for recovery to post OSD host remove
             method_should_succeed(wait_for_clean_pg_sets, rados_obj)
             log.debug("PG's are active + clean post OSD removal")

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -1036,6 +1036,8 @@ def run(ceph_cluster, **kw):
             )
         # restoring the recovery threads on the cluster
         rados_obj.change_recovery_threads(config={}, action="rm")
+        # remove empty service specs after host removal
+        rados_obj.remove_empty_service_spec()
 
         if config.get("delete_pool"):
             rados_obj.delete_pool(pool=pool_name)


### PR DESCRIPTION
PR addresses below:- 

(1) Adds a method to remove service which does not manage any daemons. i.e `ceph orch ls <service-name> -fjson` size is 0. 

(2) tier-4_rados_tests | Verify MAX_AVAIL variance with OSD size change
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-222/rados/29/tier-4_rados_tests/Verify_MAX_AVAIL_variance_with_OSD_size_change_0.log 

Issue when setting OSD services to managed. Since there were no hosts in osd.default service `ceph orch apply` command failed.

After adding OSDs using `ceph orch daemon add` we move the OSDs to manageable services and remove osd.default service.  

Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_test_verify_max_avail_25_06_26_06_43_50/ 






# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
