### PR TITLE
[TFA] Fix edge case during site shutdown

### DIFF
--- a/tests/rados/test_osd_ecpool_inconsistency_scenario.py
+++ b/tests/rados/test_osd_ecpool_inconsistency_scenario.py
@@ -458,8 +458,15 @@ def get_inconsistent_count(scrub_object, pg_id, rados_obj, operation):
         log.debug(
             f"The inconsistent object details in the pg-{pg_id} is - {inconsistent_details}"
         )
+        ceph_health_detail = rados_obj.run_ceph_command("ceph health detail")
+        log.debug(f"Health detail: {ceph_health_detail}")
         obj_count = len(inconsistent_details["inconsistents"])
         log.info(f" The inconsistent object count after {operation} is {obj_count}")
+        # BZ https://bugzilla.redhat.com/show_bug.cgi?id=2299659
+        # rados  list-inconsistent-obj  14.0 -f json
+        # {'epoch': 1836, 'inconsistents': []}
+        if obj_count > 0:
+            return obj_count
         chk_count = chk_count + 1
         time.sleep(30)
     return obj_count

--- a/tests/rados/test_pg_autoscale_flag.py
+++ b/tests/rados/test_pg_autoscale_flag.py
@@ -95,16 +95,19 @@ def run(ceph_cluster, **kw):
         )
         cmd = "ceph osd pool autoscale-status"
         pool_status = rados_obj.run_ceph_command(cmd=cmd, timeout=600)
-
+        out, _ = rados_obj.client.exec_command(cmd=cmd, sudo=True, pretty_print=True)
         for entry in pool_status:
             if entry["pg_autoscale_mode"] == "on":
                 log.error(
                     f"Pg autoscaler mode still on for pool : {entry['pool_name']}"
+                    f"ceph osd pool autoscale-status:- {out}"
+                    f"ceph osd pool autoscale-status -fjson:- {pool_status}"
                 )
-                # tbd: Uncomment the below exception upon bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2252788
+                # tbd: Uncomment the below exception upon bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2361441
                 raise Exception(
-                    "PG autoscaler mode still on error. fixed only in squid"
-                    "Open bug : https://bugzilla.redhat.com/show_bug.cgi?id=2252788. "
+                    "PG autoscaler mode still on error."
+                    "Squid Open bug : https://bugzilla.redhat.com/show_bug.cgi?id=2361441"
+                    "Reef closed bug : https://bugzilla.redhat.com/show_bug.cgi?id=2252788"
                 )
         log.debug(
             "All the pools have the autoscaler mode changed from default on. pass"

--- a/tests/rados/test_stretch_n_az_site_down_scenarios.py
+++ b/tests/rados/test_stretch_n_az_site_down_scenarios.py
@@ -408,10 +408,10 @@ def run(ceph_cluster, **kw):
         if "scenario-5" in scenarios_to_run:
             # Scenario 5 : Shutdown & Start 1 Host on all DC
             shutdown_hosts = []
+            osd_hosts = set(rados_obj.get_osd_hosts())
             for target_dc in dc_names:
                 target_hosts = getattr(all_hosts, target_dc)
                 # Ensure target_host has OSD daemons in it
-                osd_hosts = set(rados_obj.get_osd_hosts())
                 target_host = random.choice(target_hosts)
                 while target_host not in osd_hosts:
                     target_host = random.choice(target_hosts)


### PR DESCRIPTION
PR addresses below

**(1)** In tier-2_rados_test-bugfixes / Inconsistent objects in EC pool functionality check due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=2299659 the `rados list-inconsistent-obj` returns empty intermittently. Hence we return the obj_count when it is > 0. 

        rados  list-inconsistent-obj  14.0 -f json 
        {'epoch': 1836, 'inconsistents': []} 

**(2)** Edge case in site down scenario in Scenario-5 when 1 Host from all DC is selected for shutdown, If installer node was used for shutdown the suite execution would stop. 

Move the method `get_osd_hosts` before stopping Host.

Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_rados_tests_25_06_25_22_35_18/ 

**(3)** Adds more information for test case:- tier-3_rados_test-3-AZ-Cluster | autoscaler flags

Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_test_scrubbing_25_06_23_02_40_33/ 
**Note:-** Test case fails due to be BZ https://bugzilla.redhat.com/show_bug.cgi?id=2361441 

Prints the ceph pg autoscale-status

`POOL                   SIZE  TARGET SIZE  RATE  RAW CAPACITY   RATIO  TARGET RATIO  EFFECTIVE RATIO  BIAS  PG_NUM  NEW PG_NUM  AUTOSCALE  BULK   
.mgr                 904.0k                3.0        374.9G  0.0000                                  1.0       1              off        False  
cephfs.cephfs.meta   33607                 3.0        374.9G  0.0000                                  4.0      16              off        False  
.rgw.root            24576                 3.0        374.9G  0.0000                                  1.0      32              off        False  
default.rgw.log      264.0k                3.0        374.9G  0.0000                                  1.0      32              off        False  
default.rgw.control      0                 3.0        374.9G  0.0000                                  1.0      32              off        False  
default.rgw.meta      8192                 3.0        374.9G  0.0000                                  4.0      32              off        False  
re_pool_10               0                 3.0        374.9G  0.0000                                  1.0      32              off        False  
ec_pool_10               0                1.75        374.9G  0.0000                                  1.0      32              off        False  
cephfs.cephfs.data       0                 3.0        374.9G  0.0000                                  1.0     512              off        True   `

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
