### PR TITLE
Changing number of ns per subsystem to suit available OSD space

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -90,7 +90,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 20
+            - count: 10
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -99,7 +99,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 20
+            - count: 10
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -141,7 +141,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -149,7 +149,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -157,7 +157,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode3
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -165,7 +165,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode4
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -207,7 +207,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 20
+            - count: 10
               size: 5G
             listener_port: 4420
             listeners: [node6, node7]
@@ -216,7 +216,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 20
+            - count: 10
               size: 5G
             listener_port: 4420
             listeners: [node6, node7]
@@ -266,7 +266,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -274,7 +274,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -282,7 +282,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode3
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -290,7 +290,7 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode4
             serial: 1
             bdevs:
-            - count: 10
+            - count: 5
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -333,7 +333,7 @@ tests:
             serial: 1
             max_ns: 2048
             bdevs:
-            - count: 20
+            - count: 10
               size: 5G                              # auto NS load balancing for namespace addition would be verified here
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
@@ -342,7 +342,7 @@ tests:
             serial: 1
             max_ns: 2048
             bdevs:
-            - count: 20
+            - count: 10
               size: 5G
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
@@ -353,7 +353,7 @@ tests:
             node: node8
         load_balancing:
           - ns_del:
-              count: 10
+              count: 5
               subsystems:
                 - nqn.2016-06.io.spdk:cnode1
                 - nqn.2016-06.io.spdk:cnode2


### PR DESCRIPTION
As discussed, added 20 namespaces of 5gb each for each test.