### PR TITLE
[Squid][SMB][Automation]SMB service deployment with firewall enable

### DIFF
--- a/suites/squid/smb/tier-1-smb-firewall.yaml
+++ b/suites/squid/smb/tier-1-smb-firewall.yaml
@@ -1,0 +1,124 @@
+tests:
+  - test:
+      name: setup pre-requisites
+      desc: Install software pre-requisites for cluster deployment
+      module: install_prereq.py
+      config:
+        enable_firewall: True
+      abort-on-fail: true
+
+  - test:
+      name: Deploy cluster using cephadm with firewall enabled
+      desc: Bootstrap and deploy services
+      module: test_cephadm.py
+      polarion-id: CEPH-83573713
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: configure client
+      desc: Configure client system
+      module: test_client.py
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - samba-client
+      copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Deploy Samba services with the firewall enabled.
+      desc: Deploy Samba services with the firewall enabled.
+      module: smb_deployment_imperative_method
+      polarion-id: CEPH-83622480
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [sv1, sv2]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1, share2]
+        path: "/"
+
+  - test:
+      name: Deploy Samba services with the firewall enabled and perform load testing.
+      desc: Deploy Samba services with the firewall enabled and perform load testing.
+      module: smb_multi_connection.py
+      polarion-id: CEPH-83622481
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [sv1]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1]
+        path: "/"
+        load_test:
+          total_load_process: 1
+          thread_per_load_process: 3
+          load_runtime: 300 # In sec
+          load_file_size: 3 # In mb
+          load_dir: loadtest
+          port: 445
+          actions:
+            - write
+            - read
+            - delete


### PR DESCRIPTION
Scenarios:
1. Deploy Samba services with the firewall enabled.
2. Deploy Samba services with the firewall enabled and perform load testing. 
