### PR TITLE
NVMeoFMultipleNamespacesOfRBDImage alert timeout issue

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -288,7 +288,7 @@ def test_ceph_83610950(ceph_cluster, config):
     _rbd_pool = config["rbd_pool"]
     _rbd_obj = config["rbd_obj"]
     time_to_fire = 60
-    interval = 10
+    interval = 30
     alert = "NVMeoFMultipleNamespacesOfRBDImage"
     msg = "RBD image {image} cannot be reused for multiple NVMeoF namespace"
     svcs = []


### PR DESCRIPTION
# Description

NVMeoFMultipleNamespacesOfRBDImage alert is not firing and its on pending state in pipeline runs.

Analyzed and found that in pipeline runs alert is coming to firing state around 65 to 90 seconds so increased interval

TFA of http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/nvmeotcp/14/tier-2_nvmeof-alerts_health-checks-events/

Fixed same by increasing timing.
