### PR TITLE
[cephci][integration]:CEPH-83622656:Getting ERROR: failed to decode o…

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -140,6 +140,15 @@ tests:
         config-file-name: test_object_lock_no_overwrite.yaml
 
   - test:
+      name: Test olh get on versioned objects
+      desc: Test olh get on versioned objects
+      polarion-id: CEPH-83622656
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_olh_get.yaml
+
+  - test:
       name: Swift user with read access
       desc: Swift user with read access
       polarion-id: CEPH-9220


### PR DESCRIPTION
…lh info while performing radosgw-admin olh get

[cephci][integration]:CEPH-83622656:Getting ERROR: failed to decode olh info while performing radosgw-admin olh get
Polarion: CEPH-83622656
BZ: BZ2338402
since issue only targeted to squid adding testcase only to squid suite.
Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-8VPRWM/

dependent on ceph-qe-script PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/755



# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
