### PR TITLE
[CephFS]: TFA and Kernel fix

### DIFF
--- a/suites/pacific/cephfs/tier-1_fs_kernel_pipeline.yaml
+++ b/suites/pacific/cephfs/tier-1_fs_kernel_pipeline.yaml
@@ -47,7 +47,7 @@ tests:
                 all-available-devices: true
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args: # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
@@ -95,10 +95,10 @@ tests:
           - config:
               command: apply
               service: mds
-              base_cmd_args:          # arguments to ceph orch
+              base_cmd_args: # arguments to ceph orch
                 verbose: true
               pos_args:
-                - cephfs              # name of the filesystem
+                - cephfs # name of the filesystem
               args:
                 placement:
                   label: mds
@@ -114,57 +114,63 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
   - test:
-        abort-on-fail: true
-        config:
-            command: add
-            id: client.1
-            node: node8
-            install_packages:
-                - ceph-common
-            copy_admin_keyring: true
-        desc: Configure the Cephfs client system 1
-        destroy-cluster: false
-        module: test_client.py
-        name: configure client
+      abort-on-fail: true
+      desc: "kernel update for CephFS kernel bugs"
+      module: kernel_update.py
+      name: kernel update
+      polarion-id: "CEPH-83575404"
   - test:
-        abort-on-fail: true
-        config:
-            command: add
-            id: client.2
-            node: node9
-            install_packages:
-                - ceph-common
-            copy_admin_keyring: true
-        desc: Configure the Cephfs client system 2
-        destroy-cluster: false
-        module: test_client.py
-        name: configure client
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node8
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
   - test:
-        abort-on-fail: true
-        config:
-            command: add
-            id: client.3
-            node: node10
-            install_packages:
-                - ceph-common
-            copy_admin_keyring: true
-        desc: Configure the Cephfs client system 3
-        destroy-cluster: false
-        module: test_client.py
-        name: configure client
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2
+        node: node9
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 2
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
   - test:
-        abort-on-fail: true
-        config:
-            command: add
-            id: client.4
-            node: node11
-            install_packages:
-                - ceph-common
-            copy_admin_keyring: true
-        desc: Configure the Cephfs client system 4
-        destroy-cluster: false
-        module: test_client.py
-        name: configure client
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3
+        node: node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 3
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.4
+        node: node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 4
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
   - test:
       name: Run xfs test on kernel
       module: xfs_test.py
@@ -177,4 +183,3 @@ tests:
       polarion-id: CEPH-83575623
       desc: Run fsstress on kernel and fuse mounts
       abort-on-fail: false
-

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -948,6 +948,7 @@ class FsUtils(object):
                 check_ec=False,
             )
             mds_hosts = json.loads(out)
+            log.debug("MDS Hosts Output: %s", mds_hosts)
             if ispresent:
                 for mds in mds_hosts:
                     if process_name in mds["daemon_id"]:


### PR DESCRIPTION
# Description

Fixing the automation code based on recent kernel runs

## Changes:

- Include kernel update logic on tier-1-kernel-pipeline
- Added "wait_for_healthy_ceph" in few places to avoid unintended failure
- Included the fs_name in kernel mounts
- Added additional debug logs

## Logs
Tier-0: http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHEL-20905/post/tier-0/
Tier-1: http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHEL-20905/post/tier-1/

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
