### PR TITLE
Removing SOS report TC

### DIFF
--- a/suites/squid/cephfs/regression_suite_1.yaml
+++ b/suites/squid/cephfs/regression_suite_1.yaml
@@ -277,7 +277,7 @@ tests:
       abort-on-fail: false
   - test:
       name: mds service stop & start test
-      module: mon_rm_add.py
+      module: mds_stop_start.py
       polarion-id: CEPH-83574339
       desc: mds service stop & start test
       abort-on-fail: false

--- a/suites/squid/cephfs/tier-0_fs.yaml
+++ b/suites/squid/cephfs/tier-0_fs.yaml
@@ -125,8 +125,3 @@ tests:
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false
-  -
-    test:
-      desc: "generate sosreport"
-      module: sosreport.py
-      name: "generate sosreport"


### PR DESCRIPTION
# Description
Removing SOS report TC

As part of this update, we have removed sosreport from the sanity suite and corrected the test case that was incorrectly referencing it


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
