### PR TITLE
Fixing MDS Pinning issues

### DIFF
--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_equal_dir_on_two_mdss.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_equal_dir_on_two_mdss.py
@@ -264,4 +264,6 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(e)
         log.error(traceback.format_exc())
+        log.info(fs_util_v1.get_fs_status_dump(client1[0]))
+        fs_util_v1.get_ceph_health_status(client1[0])
         return 1

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_load_balancing.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_load_balancing.py
@@ -407,6 +407,8 @@ def run(ceph_cluster, **kw):
             log.info("Cleaning up successfull")
         return 1
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
+        log.info(fs_util_v1.get_fs_status_dump(client1[0]))
+        fs_util_v1.get_ceph_health_status(client1[0])
         return 1

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_max_min_dir_on_two_mdss.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_max_min_dir_on_two_mdss.py
@@ -326,4 +326,6 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(e)
         log.error(traceback.format_exc())
+        log.info(fs_util_v1.get_fs_status_dump(client1[0]))
+        fs_util_v1.get_ceph_health_status(client1[0])
         return 1

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_node_reboots.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_node_reboots.py
@@ -484,4 +484,6 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(e)
         log.error(traceback.format_exc())
+        log.info(fs_util_v1.get_fs_status_dump(client1[0]))
+        fs_util_v1.get_ceph_health_status(client1[0])
         return 1

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_unequal_dir_on_two_mdss.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_unequal_dir_on_two_mdss.py
@@ -130,7 +130,7 @@ def run(ceph_cluster, **kw):
             log.info("Data validation success")
             for client in client1:
                 client.exec_command(
-                    cmd="sudo mkdir %s%s" % (client_info["mounting_dir"], test_dir)
+                    cmd="sudo mkdir -p %s%s" % (client_info["mounting_dir"], test_dir)
                 )
             log.info("Execution of Test case CEPH-%s started:" % (tc))
             num_of_dirs = int(num_of_dirs / 5)
@@ -317,4 +317,5 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(e)
         log.error(traceback.format_exc())
+        fs_util_v1.get_ceph_health_status(client1[0])
         return 1


### PR DESCRIPTION
# Description

This PR includes fixes for two failures. 
The remaining three failures are due to I/O getting stuck. 
We observed that MDS Rank 0 remained in the `up:replay` state for an extended period before recovering, which appears to be the root cause. 
We will be raising a BZ for this, as the issue is consistently reproducible

Failed Log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-222/cephfs/28/tier-2_cephfs_test_mds_pinning/

Partial Pass Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XCSZ22/



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
