### PR TITLE
[TFA] Inconsistent object error fix by tuning the scrub parameters

### DIFF
--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -144,43 +144,6 @@ tests:
       desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
 
   - test:
-      name: Inconsistent objects in  EC pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in EC pool
-      module: test_osd_ecpool_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        ec_pool:
-          create: true
-          pool_name: ecpool
-          pg_num: 1
-          k: 2
-          m: 2
-          plugin: jerasure
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - ecpool
-      comments:  Intermittent active bug 2277111
-
-  - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
-      module: test_osd_replicated_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - replicated_pool
-      comments: Active bug 2362650
-
-  - test:
       name: Verification of ceph config show & get
       module: test_bug_fixes.py
       config:

--- a/suites/reef/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -1,0 +1,209 @@
+# Suite is to be used to verify the scrub tests  on 4 nodes
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:  CEPH-83573758
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                     # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+  - test:
+      name: Inconsistent objects in  EC pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          pool_name: ecpool
+          pg_num: 1
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - ecpool
+      comments: Intermittent active bug 2277111
+
+  - test:
+      name: Inconsistent objects in replicated pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        replicated_pool:
+          create: true
+          pool_name: replicated_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - replicated_pool
+

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -159,43 +159,6 @@ tests:
         - recovery_pool
 
   - test:
-      name: Inconsistent objects in  EC pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in EC pool
-      module: test_osd_ecpool_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        ec_pool:
-          create: true
-          pool_name: ecpool
-          pg_num: 1
-          k: 2
-          m: 2
-          plugin: jerasure
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - ecpool
-      comments:  Intermittent active bug 2277111
-
-  - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
-      module: test_osd_replicated_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - replicated_pool
-      comments: Active bug 2316244
-
-  - test:
       name: Verification of ceph config show & get
       module: test_bug_fixes.py
       config:

--- a/suites/squid/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -1,0 +1,209 @@
+# Suite is to be used to verify the scrub tests  on 4 nodes
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:  CEPH-83573758
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                     # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+  - test:
+      name: Inconsistent objects in  EC pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          pool_name: ecpool
+          pg_num: 1
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - ecpool
+      comments: Intermittent active bug 2277111
+
+  - test:
+      name: Inconsistent objects in replicated pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        replicated_pool:
+          create: true
+          pool_name: replicated_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - replicated_pool
+

--- a/suites/tentacle/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-bugfixes.yaml
@@ -159,42 +159,6 @@ tests:
         - recovery_pool
 
   - test:
-      name: Inconsistent objects in  EC pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in EC pool
-      module: test_osd_ecpool_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        ec_pool:
-          create: true
-          pool_name: ecpool
-          pg_num: 1
-          k: 2
-          m: 2
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - ecpool
-      comments:  Intermittent active bug 2277111
-
-  - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
-      module: test_osd_replicated_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - replicated_pool
-      comments: Active bug 2316244
-
-  - test:
       name: Verification of ceph config show & get
       module: test_bug_fixes.py
       config:
@@ -249,6 +213,7 @@ tests:
               pg_num_max: 1
               k: 3
               m: 2
+              plugin: jerasure
               crush-failure-domain: osd
 
   - test:

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -1,0 +1,209 @@
+# Suite is to be used to verify the scrub tests  on 4 nodes
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:  CEPH-83573758
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                     # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+  - test:
+      name: Inconsistent objects in  EC pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          pool_name: ecpool
+          pg_num: 1
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - ecpool
+      comments: Intermittent active bug 2277111
+
+  - test:
+      name: Inconsistent objects in replicated pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        replicated_pool:
+          create: true
+          pool_name: replicated_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - replicated_pool
+

--- a/tests/rados/test_osd_replicated_inconsistency_scenario.py
+++ b/tests/rados/test_osd_replicated_inconsistency_scenario.py
@@ -24,7 +24,10 @@ import time
 import traceback
 
 from test_osd_ecpool_inconsistency_scenario import (
+    check_for_pg_scrub_state,
     get_inconsistent_count,
+    get_pg_inconsistent_object_count,
+    print_parameter_messages,
     set_ecpool_inconsistent_default_param_value,
     verify_pg_state,
 )
@@ -56,23 +59,44 @@ def run(ceph_cluster, **kw):
     pool_obj = PoolFunctions(node=cephadm)
     scrub_obj = RadosScrubber(node=cephadm)
     global replicated_pool_name
+    wait_time = 30
 
     try:
+
         replicated_config = config.get("replicated_pool")
         replicated_pool_name = replicated_config["pool_name"]
         no_of_objects = config.get("inconsistent_obj_count")
-        pg_info = create_pool_inconsistent_object(
-            rados_obj, no_of_objects, pool_obj, **replicated_config
+
+        # Set the default values
+        log.info(
+            "Reset the scrub minimum and maximum interval settings to their default values before initiating "
+            "the tests. This ensures that any custom values set by previous tests in the suite are cleared, "
+            "preventing the scrub operation from starting immediately."
         )
-        if pg_info is None:
+        log.info("Before starting the tests ")
+        mon_obj.remove_config(section="osd", name="osd_scrub_min_interval")
+        mon_obj.remove_config(section="osd", name="osd_scrub_max_interval")
+        mon_obj.remove_config(section="osd", name="osd_deep_scrub_interval")
+
+        scrub_obj.set_osd_flags("set", "nodeep-scrub")
+        scrub_obj.set_osd_flags("set", "noscrub")
+
+        try:
+            pg_info = create_pool_inconsistent_object(
+                rados_obj, no_of_objects, pool_obj, **replicated_config
+            )
+        except Exception as e:
+            log.error(e)
             log.error(
                 "The inconsistent_obj_count is 0.To proceed further tests the auto_repair_param_value "
                 "should be less than Inconsistent objects count which is -1.The -1 is not acceptable to "
                 "run the tests"
             )
             return 1
-        scrub_obj.set_osd_flags("set", "nodeep-scrub")
-        scrub_obj.set_osd_flags("set", "noscrub")
+
+        # getting the acting set for the created pool
+        acting_pg_set = rados_obj.get_pg_acting_set(pool_name=replicated_pool_name)
+
         if config.get("debug_enable"):
             mon_obj.set_config(section="osd", name="debug_osd", value="20/20")
             mon_obj.set_config(section="mgr", name="debug_mgr", value="20/20")
@@ -114,9 +138,13 @@ def run(ceph_cluster, **kw):
             + "operation : scrub\n"
             + "Expectation : No repairs to be made"
         )
-        scrub_error_count = get_scrub_error_count(rados_obj)
+        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+            log.error(
+                "Test_scenario1: The scrub operations are still in progress.Not executing the further tests"
+            )
+            return 1
+        scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         auto_repair_param_value = scrub_error_count - 1
-        scrub_obj.set_osd_flags("unset", "noscrub")
 
         log.info(
             "Test scenario1: scrub error count greater than the osd_scrub_auto_repair_num_errors count"
@@ -128,14 +156,24 @@ def run(ceph_cluster, **kw):
         )
         msg_auto_repair = f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
         log.info(msg_auto_repair)
-
         mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
         log.info("The osd_scrub_auto_repair value is set to true")
+        scrub_obj.set_osd_flags("unset", "noscrub")
+        print_parameter_messages(
+            1,
+            scrub_error_count,
+            auto_repair_param_value,
+            auto_repair_value="True",
+            operation="scrub",
+        )
+
         try:
-            get_inconsistent_count(scrub_object, pg_id, rados_obj, "scrub")
+            get_inconsistent_count(
+                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            )
         except Exception as e:
             log.info(e)
-        new_scrub_error_count = get_scrub_error_count(rados_obj)
+        new_scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         if scrub_error_count != new_scrub_error_count:
             msg_err_inconsistent = (
                 f"Scrub repaired the {scrub_error_count - new_scrub_error_count} "
@@ -151,15 +189,21 @@ def run(ceph_cluster, **kw):
             + f"Inconsistent count before test:{scrub_error_count}\n"
             + f"Inconsistent count after test:{new_scrub_error_count}"
         )
+
         log.info(
             "Test scenario2:Inconsistent objects less than the osd_scrub_auto_repair_num_errors count and "
             "osd_scrub_auto_repair is false\n"
             + "operation : scrub\n"
             + "Expectation : No repairs to be made"
         )
-        mon_obj.remove_config(section="osd", name="osd_scrub_auto_repair")
+        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+            log.error(
+                "Test_scenario2: The scrub operations are still in progress.Not executing the further tests"
+            )
+            return 1
+        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="false")
         log.info("The osd_scrub_auto_repair value is set to false")
-        scrub_error_count = get_scrub_error_count(rados_obj)
+        scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         auto_repair_param_value = scrub_error_count + 1
         mon_obj.set_config(
             section="osd",
@@ -169,11 +213,20 @@ def run(ceph_cluster, **kw):
         log.info(
             f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
         )
+        print_parameter_messages(
+            2,
+            scrub_error_count,
+            auto_repair_param_value,
+            auto_repair_value="False",
+            operation="scrub",
+        )
         try:
-            get_inconsistent_count(scrub_object, pg_id, rados_obj, "scrub")
+            get_inconsistent_count(
+                scrub_object, mon_obj, pg_id, rados_obj, "scrub", acting_pg_set
+            )
         except Exception as e:
             log.info(e)
-        new_scrub_error_count = get_scrub_error_count(rados_obj)
+        new_scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         if scrub_error_count != new_scrub_error_count:
             log.error(
                 f"Scrub repaired the {scrub_error_count - new_scrub_error_count} inconsistent objects"
@@ -196,19 +249,34 @@ def run(ceph_cluster, **kw):
             + "operation : scrub\n"
             + "Expectation : No repairs to be made"
         )
-        scrub_error_count = get_scrub_error_count(rados_obj)
-        auto_repair_param_value = scrub_error_count - 1
+        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+            log.error(
+                "Test_scenario3: The scrub operations are still in progress.Not executing the further tests"
+            )
+            return 1
+        scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
+        auto_repair_param_value = scrub_error_count + 1
         mon_obj.set_config(
             section="osd",
             name="osd_scrub_auto_repair_num_errors",
             value=auto_repair_param_value,
         )
         mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
+
+        print_parameter_messages(
+            3,
+            scrub_error_count,
+            auto_repair_param_value,
+            auto_repair_value="True",
+            operation="scrub",
+        )
         try:
-            get_inconsistent_count(scrub_object, pg_id, rados_obj, "scrub")
+            get_inconsistent_count(
+                scrub_object, mon_obj, pg_id, rados_obj, "scrub", acting_pg_set
+            )
         except Exception as e:
             log.info(e)
-        new_scrub_error_count = get_scrub_error_count(rados_obj)
+        new_scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         if scrub_error_count != new_scrub_error_count:
             msg_err = f"Scrub repaired the {scrub_error_count - new_scrub_error_count} inconsistent objects"
             log.error(msg_err)
@@ -239,7 +307,12 @@ def run(ceph_cluster, **kw):
             + "operation : Deep-Scrub\n"
             + "Expectation : No repairs to be made"
         )
-        scrub_error_count = get_scrub_error_count(rados_obj)
+        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+            log.error(
+                "Test_scenario4: The scrub operations are still in progress.Not executing the further tests"
+            )
+            return 1
+        scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         auto_repair_param_value = scrub_error_count - 1
 
         mon_obj.set_config(
@@ -248,24 +321,46 @@ def run(ceph_cluster, **kw):
             value=auto_repair_param_value,
         )
         msg_repair_info = f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
+        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
         log.info(msg_repair_info)
-
         scrub_obj.set_osd_flags("unset", "nodeep-scrub")
         time.sleep(5)
+        print_parameter_messages(
+            4,
+            scrub_error_count,
+            auto_repair_param_value,
+            auto_repair_value="True",
+            operation="deep-scrub",
+        )
+        log.info(
+            "===================Test scenario4 - Parameter details before starting test  =========="
+        )
+        msg_tmp = f"The scrub error count is - {scrub_error_count}"
+        log.info(msg_tmp)
+        msg_tmp = (
+            f"The osd_scrub_auto_repair_num_errors value is - {auto_repair_param_value}"
+        )
+        log.info(msg_tmp)
+        log.info("The osd_scrub_auto_repair value is - True")
+        log.info(" Operation : Deep-Scrub")
+        log.info(
+            "===================Test scenario4 - Parameter details before starting test =========="
+        )
 
         log.info("Comment the scenario-4 code due to the BZ#2316244")
-        # try:
-        #     # At the moment, this scenario fails.This is  due to the BZ#2316244
-        #     get_inconsistent_count(scrub_object, pg_id, rados_obj, "deep-scrub")
-        # except Exception as e:
-        #     log.info(e)
-        # new_scrub_error_count = get_scrub_error_count(rados_obj)
-        # if scrub_error_count != new_scrub_error_count:
-        #     log.error(
-        #         f"Deep-Scrub repaired the {scrub_error_count - new_scrub_error_count} inconsistent objects"
-        #     )
-        #     rados_obj.log_cluster_health()
-        #     return 1
+        try:
+            get_inconsistent_count(
+                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            )
+        except Exception as e:
+            log.info(e)
+        new_scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
+        if scrub_error_count != new_scrub_error_count:
+            log.error(
+                f"Deep-Scrub repaired the {scrub_error_count - new_scrub_error_count} inconsistent objects"
+            )
+            rados_obj.log_cluster_health()
+            return 1
         msg_scenario = (
             "Test scenario4 completed:Inconsistent objects greater than the "
             "osd_scrub_auto_repair_num_errors count operation : Deep-scrub\n"
@@ -280,9 +375,14 @@ def run(ceph_cluster, **kw):
             + "operation : Deep-scrub\n"
             + "Expectation : No repairs to be made"
         )
-        mon_obj.remove_config(section="osd", name="osd_scrub_auto_repair")
+        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+            log.error(
+                "Test_scenario5: The scrub operations are still in progress.Not executing the further tests"
+            )
+            return 1
+        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="false")
         log.info("The osd_scrub_auto_repair value is set to false")
-        scrub_error_count = get_scrub_error_count(rados_obj)
+        scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         auto_repair_param_value = scrub_error_count + 1
         mon_obj.set_config(
             section="osd",
@@ -291,11 +391,20 @@ def run(ceph_cluster, **kw):
         )
         msg_auto_repair = f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
         log.info(msg_auto_repair)
+        print_parameter_messages(
+            5,
+            scrub_error_count,
+            auto_repair_param_value,
+            auto_repair_value="False",
+            operation="deep-scrub",
+        )
         try:
-            get_inconsistent_count(scrub_object, pg_id, rados_obj, "deep-scrub")
+            get_inconsistent_count(
+                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            )
         except Exception as e:
             log.info(e)
-        new_scrub_error_count = get_scrub_error_count(rados_obj)
+        new_scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
         if scrub_error_count != new_scrub_error_count:
             msg_repair_info = (
                 f"Deep-Scrub repaired the "
@@ -319,19 +428,35 @@ def run(ceph_cluster, **kw):
             + "operation : Deep-scrub\n"
             + "Expectation : Repairs to be made"
         )
-        scrub_error_count = get_scrub_error_count(rados_obj)
-        auto_repair_param_value = scrub_error_count - 1
+        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+            log.error(
+                "Test_scenario6: The scrub operations are still in progress.Not executing the further tests"
+            )
+            return 1
+        scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
+
+        auto_repair_param_value = scrub_error_count + 1
         mon_obj.set_config(
             section="osd",
             name="osd_scrub_auto_repair_num_errors",
             value=auto_repair_param_value,
         )
         mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
+        print_parameter_messages(
+            6,
+            scrub_error_count,
+            auto_repair_param_value,
+            auto_repair_value="True",
+            operation="deep-scrub",
+        )
         try:
-            get_inconsistent_count(scrub_object, pg_id, rados_obj, "deep-scrub")
+            get_inconsistent_count(
+                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            )
         except Exception as e:
             log.info(e)
-        new_scrub_error_count = get_scrub_error_count(rados_obj)
+        new_scrub_error_count = get_pg_inconsistent_object_count(rados_obj, pg_id)
+        # new_scrub_error_count = get_inconsistent_object_count(rados_obj, pg_id)
         if new_scrub_error_count != 0:
             msg_repair_info = (
                 f"Deep-Scrub repaired the {scrub_error_count - new_scrub_error_count} "
@@ -449,19 +574,3 @@ def create_pool_inconsistent_object(
         return 1
     pg_id = pg_id_set.pop()
     return pg_id, rep_count
-
-
-def get_scrub_error_count(rados_object):
-    """
-    Method is used to get the scrub error count in the cluster
-    Args:
-        rados_object: Rados object
-    Return:
-        Retuns the scrub error count.If not present returns 0
-
-    """
-    status_out_put = rados_object.run_ceph_command(cmd="ceph -s")
-    if "OSD_SCRUB_ERRORS" not in status_out_put["health"]["checks"]:
-        log.error("The inconsistent objects not created")
-        return 0
-    return status_out_put["health"]["checks"]["OSD_SCRUB_ERRORS"]["summary"]["count"]


### PR DESCRIPTION
# Description

The fix is provided for the following issues-

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/109/tier-2_rados_test-bugfixes/Inconsistent_objects_in_replicated_pool_functionality_check_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-335/rados/39/tier-2_rados_test-bugfixes/Inconsistent_objects_in_replicated_pool_functionality_check_0.log


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
