### PR TITLE
[TFA][mix-os] Remove unsupported IO

### DIFF
--- a/suites/reef/cephadm/tier1-mix-os-deployment.yaml
+++ b/suites/reef/cephadm/tier1-mix-os-deployment.yaml
@@ -96,60 +96,37 @@ tests:
 
   # Testing stage
   - test:
-      name: Executes RGW, RBD and FS operations
-      desc: Run object, block and filesystem basic operations parallelly.
-      polarion-id: CEPH-83575549
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Test M buckets with N objects
-            desc: test to create "M" no of buckets and "N" no of objects
-            polarion-id: CEPH-9789
-            module: sanity_rgw.py
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
-
-        - test:
-            name: Run RBD tier-0 operations
-            desc: Run RBD tier-0 operations
-            polarion-id: CEPH-83575401
-            module: rbd_tier0.py
-            config:
-              ec-pool-k-m: 2,1
-              ec-pool-only: False
-              ec_pool_config:
-                pool: rbd_pool
-                data_pool: rbd_ec_pool
-                ec_profile: rbd_ec_profile
-                image: rbd_image
-                image_thick_provision: rbd_thick_image
-                snap_thick_provision: rbd_thick_snap
-                clone_thick_provision: rbd_thick_clone
-                thick_size: 2G
-                size: 10G
-                snap: rbd_ec_pool_snap
-                clone: rbd_ec_pool_clone
-              rep_pool_config:
-                pool: rbd_rep_pool
-                image: rbd_rep_image
-                image_thick_provision: rbd_rep_thick_image
-                snap_thick_provision: rbd_rep_thick_snap
-                clone_thick_provision: rbd_rep_thick_clone
-                thick_size: 2G
-                size: 10G
-                snap: rbd_rep_pool_snap
-                clone: rbd_rep_pool_clone
-              operations:
-                map: true
-                io: true
-                nounmap: false
-            destroy-cluster: false
-
-        - test:
-            name: cephfs-basics
-            desc: "cephfs basic operations"
-            polarion-id: "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295"
-            module: cephfs_basic_tests.py
-            abort-on-fail: false
+      name: Run RBD tier-0 operations
+      desc: Run RBD tier-0 operations
+      polarion-id: CEPH-83575401
+      module: rbd_tier0.py
+      config:
+        ec-pool-k-m: 2,1
+        ec-pool-only: False
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          ec_profile: rbd_ec_profile
+          image: rbd_image
+          image_thick_provision: rbd_thick_image
+          snap_thick_provision: rbd_thick_snap
+          clone_thick_provision: rbd_thick_clone
+          thick_size: 2G
+          size: 10G
+          snap: rbd_ec_pool_snap
+          clone: rbd_ec_pool_clone
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          image_thick_provision: rbd_rep_thick_image
+          snap_thick_provision: rbd_rep_thick_snap
+          clone_thick_provision: rbd_rep_thick_clone
+          thick_size: 2G
+          size: 10G
+          snap: rbd_rep_pool_snap
+          clone: rbd_rep_pool_clone
+        operations:
+          map: true
+          io: true
+          nounmap: false
+      destroy-cluster: false

--- a/suites/squid/cephadm/tier1-mix-os-deployment.yaml
+++ b/suites/squid/cephadm/tier1-mix-os-deployment.yaml
@@ -96,60 +96,37 @@ tests:
 
   # Testing stage
   - test:
-      name: Executes RGW, RBD and FS operations
-      desc: Run object, block and filesystem basic operations parallelly.
-      polarion-id: CEPH-83575549
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Test M buckets with N objects
-            desc: test to create "M" no of buckets and "N" no of objects
-            polarion-id: CEPH-9789
-            module: sanity_rgw.py
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
-
-        - test:
-            name: Run RBD tier-0 operations
-            desc: Run RBD tier-0 operations
-            polarion-id: CEPH-83575401
-            module: rbd_tier0.py
-            config:
-              ec-pool-k-m: 2,1
-              ec-pool-only: False
-              ec_pool_config:
-                pool: rbd_pool
-                data_pool: rbd_ec_pool
-                ec_profile: rbd_ec_profile
-                image: rbd_image
-                image_thick_provision: rbd_thick_image
-                snap_thick_provision: rbd_thick_snap
-                clone_thick_provision: rbd_thick_clone
-                thick_size: 2G
-                size: 10G
-                snap: rbd_ec_pool_snap
-                clone: rbd_ec_pool_clone
-              rep_pool_config:
-                pool: rbd_rep_pool
-                image: rbd_rep_image
-                image_thick_provision: rbd_rep_thick_image
-                snap_thick_provision: rbd_rep_thick_snap
-                clone_thick_provision: rbd_rep_thick_clone
-                thick_size: 2G
-                size: 10G
-                snap: rbd_rep_pool_snap
-                clone: rbd_rep_pool_clone
-              operations:
-                map: true
-                io: true
-                nounmap: false
-            destroy-cluster: false
-
-        - test:
-            name: cephfs-basics
-            desc: "cephfs basic operations"
-            polarion-id: "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295"
-            module: cephfs_basic_tests.py
-            abort-on-fail: false
+      name: Run RBD tier-0 operations
+      desc: Run RBD tier-0 operations
+      polarion-id: CEPH-83575401
+      module: rbd_tier0.py
+      config:
+        ec-pool-k-m: 2,1
+        ec-pool-only: False
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          ec_profile: rbd_ec_profile
+          image: rbd_image
+          image_thick_provision: rbd_thick_image
+          snap_thick_provision: rbd_thick_snap
+          clone_thick_provision: rbd_thick_clone
+          thick_size: 2G
+          size: 10G
+          snap: rbd_ec_pool_snap
+          clone: rbd_ec_pool_clone
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          image_thick_provision: rbd_rep_thick_image
+          snap_thick_provision: rbd_rep_thick_snap
+          clone_thick_provision: rbd_rep_thick_clone
+          thick_size: 2G
+          size: 10G
+          snap: rbd_rep_pool_snap
+          clone: rbd_rep_pool_clone
+        operations:
+          map: true
+          io: true
+          nounmap: false
+      destroy-cluster: false


### PR DESCRIPTION
# Description

With mix-OS deployment, the IO fails due to older python version (3.6) in RHEL 8.x which is not supported.
These IOs are running and passing in other suites and are not necessary here, hence removing them from these suites.