### PR TITLE
Moves rbd and rgw io before enabling stretch mode and uncomments code commented due to BZ-2376109

### DIFF
--- a/ceph/rados/serviceability_workflows.py
+++ b/ceph/rados/serviceability_workflows.py
@@ -518,8 +518,6 @@ class ServiceabilityMethods:
                 time.sleep(20)
             except json.JSONDecodeError:
                 log.info("Drain operations completed on host : " + host_obj.hostname)
-                # Add checks for 8.1 OSD process not removed.
-                # https://bugzilla.redhat.com/show_bug.cgi?id=2376109
                 if self.rados_obj.check_daemon_exists_on_host(host_obj.hostname):
                     log.info(
                         "Drain operations not completed on host : " + host_obj.hostname

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -155,18 +155,9 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
-  - test:
-      name: Deploy stretch Cluster
-      polarion-id: CEPH-83574982
-      module: test_stretch_deployment_with_placement.py
-      config:
-        no_affinity: false
-        stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: tiebreaker
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
-      abort-on-fail: true
-
-
+  # Moving IO modules before enabling stretch mode inorder to test
+  # `ceph mon enable_stretch_mode` along with data in pools
+  #  tracker for reference : https://tracker.ceph.com/issues/72069
   - test:
       name: rbd-io
       module: rbd_faster_exports.py
@@ -189,6 +180,20 @@ tests:
         timeout: 300
       desc: Perform rgw tests
 
+  - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  # "cephfs basic operations" and "nfs-ganesha_with_cephfs"
+  # does not support retaining data. Data cleans up after test executes.
+  # Hence the test modules are not moved before enabling stretch mode
   - test:
       abort-on-fail: false
       desc: "cephfs basic operations"

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -172,17 +172,9 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
-  - test:
-      name: Deploy stretch Cluster
-      polarion-id: CEPH-83574982
-      module: test_stretch_deployment_with_placement.py
-      config:
-        no_affinity: false
-        stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: tiebreaker
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
-      abort-on-fail: true
-
+  # Moving IO modules before enabling stretch mode inorder to test
+  # `ceph mon enable_stretch_mode` along with data in pools
+  #  tracker for reference : https://tracker.ceph.com/issues/72069
   - test:
       name: rbd-io
       module: rbd_faster_exports.py
@@ -205,6 +197,20 @@ tests:
         timeout: 300
       desc: Perform rgw tests
 
+  - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  # "cephfs basic operations" and "nfs-ganesha_with_cephfs"
+  # does not support retaining data. Data cleans up after test executes.
+  # Hence the test modules are not moved before enabling stretch mode
   - test:
       abort-on-fail: false
       desc: "cephfs basic operations"

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -171,17 +171,9 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
-  - test:
-      name: Deploy stretch Cluster
-      polarion-id: CEPH-83574982
-      module: test_stretch_deployment_with_placement.py
-      config:
-        no_affinity: false
-        stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: tiebreaker
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
-      abort-on-fail: true
-
+  # Moving IO modules before enabling stretch mode inorder to test
+  # `ceph mon enable_stretch_mode` along with data in pools
+  #  tracker for reference : https://tracker.ceph.com/issues/72069
   - test:
       name: rbd-io
       module: rbd_faster_exports.py
@@ -205,6 +197,20 @@ tests:
       desc: Perform rgw tests
 
   - test:
+      name: Deploy stretch Cluster
+      polarion-id: CEPH-83574982
+      module: test_stretch_deployment_with_placement.py
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  # "cephfs basic operations" and "nfs-ganesha_with_cephfs"
+  # does not support retaining data. Data cleans up after test executes.
+  # Hence the test modules are not moved before enabling stretch mode
+  - test:
       abort-on-fail: false
       desc: "cephfs basic operations"
       module: cephfs_basic_tests.py
@@ -217,7 +223,6 @@ tests:
       desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
       polarion-id: CEPH-83574439
       abort-on-fail: false
-
 
   - test:
       name: Verify stretch Cluster

--- a/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -171,6 +171,31 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+  # Moving IO modules before enabling stretch mode inorder to test
+  # `ceph mon enable_stretch_mode` along with data in pools
+  #  tracker for reference : https://tracker.ceph.com/issues/72069
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
   - test:
       name: Deploy stretch Cluster
       polarion-id: CEPH-83574982
@@ -197,28 +222,9 @@ tests:
           release: rc
       abort-on-fail: false
 
-  - test:
-      name: rbd-io
-      module: rbd_faster_exports.py
-      polarion-id: CEPH-83574972
-      config:
-        rep-pool-only: True
-        rep_pool_config:
-          pool: rbd_rep_pool
-          image: rbd_rep_image
-          size: 10G
-        io-total: 100M
-      desc: Perform export during read/write,resizing,flattening,lock operations
-
-  - test:
-      name: rgw sanity tests
-      module: sanity_rgw.py
-      config:
-        script-name: test_multitenant_user_access.py
-        config-file-name: test_multitenant_access.yaml
-        timeout: 300
-      desc: Perform rgw tests
-
+  # "cephfs basic operations" and "nfs-ganesha_with_cephfs"
+  # does not support retaining data. Data cleans up after test executes.
+  # Hence the test modules are not moved before enabling stretch mode
   - test:
       abort-on-fail: false
       desc: "cephfs basic operations"

--- a/tests/rados/test_mon_connection_scores.py
+++ b/tests/rados/test_mon_connection_scores.py
@@ -197,37 +197,35 @@ def run(ceph_cluster, **kw):
 
             # Remove added mon service
             # and perform connection score validation
-            # Skipping scenario #3 in 8.1 due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=2376109
-            if config.get("rhbuild")[0] <= "7":
-                log.debug(
-                    "STARTING::Scenario 3:: Removing the added Monitor daemon & "
-                    "perform validations for mon connection scores"
-                )
-                previous_mon_map_epoch = get_mon_map_epoch(rados_obj=rados_obj)
+            log.debug(
+                "STARTING::Scenario 3:: Removing the added Monitor daemon & "
+                "perform validations for mon connection scores"
+            )
+            previous_mon_map_epoch = get_mon_map_epoch(rados_obj=rados_obj)
 
-                if not mon_workflow_obj.remove_mon_service(host=new_mon_host.hostname):
-                    log.error(f"Could not remove mon on host {new_mon_host.hostname}")
-                    raise Exception("mon service not removed error")
+            if not mon_workflow_obj.remove_mon_service(host=new_mon_host.hostname):
+                log.error(f"Could not remove mon on host {new_mon_host.hostname}")
+                raise Exception("mon service not removed error")
 
-                log.debug(f"Successfully removed mon.{new_mon_host.hostname} service")
-                log.debug(
-                    "Proceeding to check mon connection scores after removing newly added mon"
-                )
+            log.debug(f"Successfully removed mon.{new_mon_host.hostname} service")
+            log.debug(
+                "Proceeding to check mon connection scores after removing newly added mon"
+            )
 
-                wait_until_mon_map_epoch_changes(
-                    rados_obj=rados_obj, previous_epoch=previous_mon_map_epoch
-                )
+            wait_until_mon_map_epoch_changes(
+                rados_obj=rados_obj, previous_epoch=previous_mon_map_epoch
+            )
 
-                if not mon_workflow_obj.connection_score_checks():
-                    raise Exception("Connection score checks failed")
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Connection score checks failed")
 
-                log.debug(
-                    f"Mon connection scores verified after removing mon host {new_mon_host.hostname}"
-                )
-                log.debug(
-                    "COMPLETED::Scenario 3:: Removing the added Monitor daemon & "
-                    "perform validations for mon connection scores"
-                )
+            log.debug(
+                f"Mon connection scores verified after removing mon host {new_mon_host.hostname}"
+            )
+            log.debug(
+                "COMPLETED::Scenario 3:: Removing the added Monitor daemon & "
+                "perform validations for mon connection scores"
+            )
 
             # Restart monitor service and perform connection
             # score validation

--- a/tests/rados/test_pg_split.py
+++ b/tests/rados/test_pg_split.py
@@ -333,7 +333,7 @@ def run(ceph_cluster, **kw):
                     wait_for_daemon_status,
                     rados_obj=rados_obj,
                     daemon_type="osd",
-                    daemon_id=osd_id,
+                    daemon_id=target_osd,
                     status="running",
                     timeout=60,
                 )


### PR DESCRIPTION
PR address the below:- 
```
-> Moves IO prior to deploy stretch mode. Tracker :- https://tracker.ceph.com/issues/72069 
-> Uncomments code commented due to BZ 2376109
-> Failure in Verify_add_remove_osd_during_PG_split_0 -> http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-222/rados/15/tier-2_rados_test-pg-split-merge/Verify_add_remove_osd_during_PG_split_0.log 
```

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
