### PR TITLE
Install ceph packages from IBM CDN repo when staging repo is unavailable

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -244,12 +244,15 @@ class CephAdmin(BootstrapMixin, ShellMixin, RegistryLoginMixin):
               upgrade: boolean # to upgrade cephadm RPM package
               nogpgcheck: boolean
               upgrade_client: boolean # to upgrade ceph client RPM packages (default: true)
+              rpm_version: specific rpm version to be installed
 
 
         :Note: At present, they are prefixed with -- hence use long options
 
         """
-        cmd = "yum install cephadm -y"
+        cmd = "yum -y install cephadm"
+        if kwargs.get("rpm_version", None):
+            cmd = f"{cmd}-{kwargs['rpm_version']}"
 
         if kwargs.get("nogpgcheck", True):
             cmd += " --nogpgcheck"
@@ -262,7 +265,10 @@ class CephAdmin(BootstrapMixin, ShellMixin, RegistryLoginMixin):
                 if self.config.get("ibm_build"):
                     setup_ibm_licence(node, build_type=None)
                 node.exec_command(sudo=True, cmd="yum update metadata", check_ec=False)
-                node.exec_command(sudo=True, cmd="yum update --nogpgcheck -y ceph*")
+                upd_cmd = "yum update --nogpgcheck -y ceph*"
+                if kwargs.get("rpm_version", None):
+                    upd_cmd = f"{upd_cmd}-{kwargs['rpm_version']}"
+                node.exec_command(sudo=True, cmd=upd_cmd)
 
                 node.exec_command(cmd="rpm -qa | grep ceph")
 


### PR DESCRIPTION
#### Description

Verification of a few RADOS customer bugs in ceph-ci pipeline runs required deployment of older GAed build in order to first reproduce the issue and then upgrade to a newer version to verify the fix.
Recently it was observed that few staging repos for IBM Ceph 7.1 were not longer available, these were releases that had probably passed the retention policy duration for IBM staging repo directory.

Jira: [RHCEPHQE-20509](https://issues.redhat.com/browse/RHCEPHQE-20509)

#### Problem at hand:
-------------------------------
Build team is against retaining IBM Ceph packages in staging for older GAed version

#### Impact on testing:
-------------------------------
Any test workflow that requires deployment of a specific version of IBM Ceph build fails if the required staging repo has been cleared off.

#### Proposed solution:
-------------------------------
- When deploying custom older staging IBM builds, fall back to using IBM CDN package repo if staging repos and unavailable and install the correct ceph packages - negligible chance of version mismatch b/w package and build

#### Logs:
-------------------------------
- Deploying IBM Ceph 7.1 z1(_staging repo unavailable_) **--->** Upgrading to IBM Ceph 7.1z2(_staging repo unavailable_) **--->** Upgrading to IBM Ceph 8.1 latest | http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OVTZL8/
- Deploying IBM Ceph 7.1 z4 **--->** Upgrading to IBM Ceph 7.1z5 **--->** Upgrading to IBM Ceph 8.1 latest | http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NBV3NB/

Sanity pipeline run: http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Sanity/19.2.1-234/70

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

