### PR TITLE
Revert stretch mode scenarios 1,2

### DIFF
--- a/suites/tentacle/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -404,3 +404,16 @@ tests:
         scenarios_to_run:
           - scenario-7
       desc: Test stretch Cluster Host replacement
+
+  - test:
+      name: Revert stretch mode scenarios 1,2
+      module: test_stretch_revert.py
+      polarion-id: CEPH-83620057
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario1
+          - scenario2
+      desc: Performs tests related to reverting from stretch mode

--- a/tests/rados/test_bluestore_data_compression.py
+++ b/tests/rados/test_bluestore_data_compression.py
@@ -1362,7 +1362,7 @@ def run(ceph_cluster, **kw):
             daemon_type="osd",
             daemon_id=target_osd,
             status="running",
-            timout=60,
+            timeout=60,
         )
         assert service_obj.add_osds_to_managed_service(
             osds=[target_osd], spec=target_osd_spec_name

--- a/tests/rados/test_stretch_revert.py
+++ b/tests/rados/test_stretch_revert.py
@@ -1,0 +1,260 @@
+"""
+This test module is used to test revert stretch mode
+includes:
+1. revert from health stretch mode to default/non-default crush rule
+2. revert from health stretch mode to custom crush rule
+3. revert from site down stretch mode to default crush rule
+4. revert from site down stretch mode to custome crush rule
+5. revert from netsplit scenario to default/non-default crush rule
+6. revert from netsplit scenario to custom crush rule
+"""
+
+from collections import namedtuple
+
+from ceph.ceph import CephNode
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from ceph.rados.serviceability_workflows import ServiceabilityMethods
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from tests.rados.test_stretch_revert_class import RevertStretchModeFunctionalities
+from tests.rados.test_stretch_site_down import stretch_enabled_checks
+from utility.log import Log
+
+log = Log(__name__)
+
+Hosts = namedtuple("Hosts", ["dc_1_hosts", "dc_2_hosts", "tiebreaker_hosts"])
+
+
+def run(ceph_cluster, **kw):
+    """
+    performs replacement scenarios in stretch mode
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): ceph cluster
+    Scenarios:
+        1. Scenario 1:- revert from health stretch mode to default/non-default crush rule
+        1. Scenario 2:- revert from health stretch mode to custom crush rule
+        2. Scenario 3:- revert from site down stretch mode to default crush rule
+        2. Scenario 4:- revert from site down stretch mode to custome crush rule
+        3. Scenario 5:- revert from netsplit scenario to default/non-default crush rule
+        3. Scenario 6:- revert from netsplit scenario to custom crush rule
+    """
+
+    log.info(run.__doc__)
+    config = kw.get("config")
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    pool_obj = PoolFunctions(node=cephadm)
+    service_obj = ServiceabilityMethods(cluster=ceph_cluster, **config)
+    rhbuild = config.get("rhbuild")
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_name = config.get("pool_name", "test_stretch_io")
+    stretch_bucket = config.get("stretch_bucket", "datacenter")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
+    add_network_delay = config.get("add_network_delay", False)
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+    scenarios_to_run = config.get(
+        "scenarios_to_run",
+        [
+            "scenario1",
+            "scenario2",
+        ],
+    )
+    config = {
+        "rados_obj": rados_obj,
+        "pool_obj": pool_obj,
+        "tiebreaker_mon_site_name": tiebreaker_mon_site_name,
+        "stretch_bucket": stretch_bucket,
+    }
+    try:
+
+        revert_stretch_mode_scenarios = RevertStretchModeScenarios(**config)
+
+        if "scenario1" in scenarios_to_run:
+            revert_stretch_mode_scenarios.scenario1(client_node=client_node)
+
+        if "scenario2" in scenarios_to_run:
+            revert_stretch_mode_scenarios.scenario2(client_node=client_node)
+
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
+        return 1
+
+    finally:
+        log.info(
+            "\n \n ************** Execution of finally block begins here *************** \n \n"
+        )
+
+        if (
+            "revert_stretch_mode_scenarios" in locals()
+            and "revert_stretch_mode_scenarios" in globals()
+        ):
+            revert_stretch_mode_scenarios.enable_stretch_mode(
+                revert_stretch_mode_scenarios.tiebreaker_mon
+            )
+            wait_for_clean_pg_sets(rados_obj=rados_obj)
+
+        if config.get("delete_pool"):
+            rados_obj.delete_pool(pool=pool_name)
+
+        # log cluster health
+        rados_obj.log_cluster_health()
+
+        # check for crashes after test execution
+        if rados_obj.check_crash_status():
+            log.error("Test failed due to crash at the end of test")
+            return 1
+
+    log.info("All the tests completed on the cluster, Pass!!!")
+    return 0
+
+
+class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
+    """
+    Class includes test scenarios of RADOS feature exiting from 2 site + tiebreaker stretch mode.
+    Usage:-
+        config = {
+            "rados_obj": rados_obj,
+            "pool_obj": pool_obj,
+            "tiebreaker_mon_site_name": tiebreaker_mon_site_name,
+            "stretch_bucket": stretch_bucket,
+        }
+        revert_stretch_mode_scenarios = RevertStretchModeScenarios(**config)
+        revert_stretch_mode_scenarios.scenario1(client_node=client_node)
+
+    """
+
+    def scenario1(self, client_node: CephNode):
+        """
+        Scenario 1:- Revert stretch mode from health stretch cluster to default crush rules
+        Steps:-
+        1) Check stretch mode is enabled
+        2) Create a pool and write IO
+        3) Revert from healthy stretch mode
+        4) Validate all pools are reverted to default rules
+        5) Validate stretch mode related configs are reset in OSD map
+        6) Validate stretch mode related configs are reset in MON map
+        7) Validate PGs reach active+clean
+        8) Re-enter stretch mode for next scenario
+        """
+        log.info(self.scenario1.__doc__)
+        log.info("Step 1 -> Check if stretch mode is enabled")
+        if not stretch_enabled_checks(self.rados_obj):
+            log.error(
+                "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
+            )
+            raise Exception("Test pre-execution checks failed")
+
+        log.info("Step 2 -> Create a pool and write IO")
+        pool_name = "revert_scenario_1_pool"
+        self.create_pool_and_write_io(pool_name, client_node=client_node)
+
+        log.info("Step 3 ->  Revert from healthy stretch mode")
+        self.revert_stretch_mode()
+
+        log.info("Step 4 -> Validate all pools are reverted to default rules")
+        expected_pool_properties = {
+            "size": "3",
+            "min_size": "2",
+            "crush_rule": "0",  # default crush rule has a crush rule id of 1
+        }
+        self.validate_pool_configurations_post_revert(expected_pool_properties)
+
+        log.info("Step 5 -> Validate stretch mode related configs are reset in OSD map")
+        expected_osd_map_values = {
+            "stretch_mode_enabled": False,
+            "stretch_bucket_count": 0,
+            "degraded_stretch_mode": 0,
+            "recovering_stretch_mode": 0,
+            "stretch_mode_bucket": 0,
+        }
+        self.validate_osd_configurations_post_revert(expected_osd_map_values)
+
+        log.info("Step 6 -> Validate stretch mode related configs are reset in MON map")
+        expected_mon_map_values = {
+            "tiebreaker_mon": "",
+            "stretch_mode": False,
+            "tiebreaker_mon": "",
+        }
+        self.validate_mon_configurations_post_revert(expected_mon_map_values)
+
+        log.info("Step 7 -> Validate PGs reach active+clean")
+        wait_for_clean_pg_sets(rados_obj=self.rados_obj)
+
+        log.info(
+            "Step 8 ->  Re-enter stretch mode for next scenario and wait till PGs are active+clean"
+        )
+        self.enable_stretch_mode(self.tiebreaker_mon)
+        wait_for_clean_pg_sets(rados_obj=self.rados_obj)
+
+    def scenario2(self, client_node: CephNode):
+        """
+        Scenario 2:- Revert stretch mode from health stretch cluster to non-default crush rules
+        Steps:-
+        1) Check stretch mode is enabled
+        2) Create a pool and write IO
+        3) Create a custom crush rule
+        4) Revert from healthy stretch mode
+        5) Validate all pools are reverted to default rules
+        6) Validate stretch mode related configs are reset in OSD map
+        7) Validate stretch mode related configs are reset in MON map
+        8) Validate PGs reach active+clean
+        9) Re-enter stretch mode for next scenario
+        """
+        log.info(self.scenario2.__doc__)
+        log.info("Step 1 -> Check stretch mode is enabled")
+        if not stretch_enabled_checks(self.rados_obj):
+            log.error(
+                "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
+            )
+            raise Exception("Test pre-execution checks failed")
+
+        log.info("Step 2 ->  Create a pool and write IO")
+        pool_name = "revert_scenario_2_pool"
+        self.create_pool_and_write_io(pool_name, client_node=client_node)
+
+        log.info("Step 3 ->  Create a custom crush rule")
+        custom_crush_rule_name = "test_rule"
+        custom_crush_rule_id = self.create_or_retrieve_crush_rule(
+            crush_rule_name=custom_crush_rule_name
+        )
+
+        log.info("Step 4 -> Revert from healthy stretch mode to non-default crush rule")
+        self.revert_stretch_mode(crush_rule_name=custom_crush_rule_name)
+
+        log.info("Step 5 -> validate pool configurations are reset")
+        expected_pool_properties = {
+            "size": "3",
+            "min_size": "2",
+            "crush_rule": custom_crush_rule_id,
+        }
+        self.validate_pool_configurations_post_revert(expected_pool_properties)
+
+        log.info("Step 6 -> validate osd configurations are reset")
+        expected_osd_map_values = {
+            "stretch_mode_enabled": False,
+            "stretch_bucket_count": 0,
+            "degraded_stretch_mode": 0,
+            "recovering_stretch_mode": 0,
+            "stretch_mode_bucket": 0,
+        }
+        self.validate_osd_configurations_post_revert(expected_osd_map_values)
+
+        log.info("Step 7 -> validate mon configurations are reset")
+        expected_mon_map_values = {
+            "tiebreaker_mon": "",
+            "stretch_mode": False,
+            "tiebreaker_mon": "",
+        }
+        self.validate_mon_configurations_post_revert(expected_mon_map_values)
+
+        log.info("Step 8 -> validate PG's reached active+clean")
+        wait_for_clean_pg_sets(rados_obj=self.rados_obj)
+
+        log.info(
+            "Step 9 ->  Re-enter stretch mode for next scenario and wait till PGs are active+clean"
+        )
+        self.enable_stretch_mode(self.tiebreaker_mon)
+        wait_for_clean_pg_sets(rados_obj=self.rados_obj)

--- a/tests/rados/test_stretch_revert_class.py
+++ b/tests/rados/test_stretch_revert_class.py
@@ -1,0 +1,267 @@
+from collections import namedtuple
+
+from ceph.ceph import CephNode
+from utility.log import Log
+
+log = Log(__name__)
+
+Hosts = namedtuple("Hosts", ["dc_1_hosts", "dc_2_hosts", "tiebreaker_hosts"])
+
+
+class StretchMode:
+    def __init__(self, **kwargs):
+        self.rados_obj = kwargs.get("rados_obj")
+        self.tiebreaker_mon_site_name = kwargs.get(
+            "tiebreaker_mon_site_name", "tiebreaker"
+        )
+        self.tiebreaker_mon = self.get_tiebreaker_mon()
+        self.pool_obj = kwargs.get("pool_obj")
+        self.custom_crush_rule = {}
+
+    def get_tiebreaker_mon(self):
+        """
+        Identifies and returns the name of the tiebreaker monitor in a Ceph cluster.
+
+        This method runs the `ceph mon dump` command to retrieve monitor information,
+        then searches for a monitor whose CRUSH location matches the specified
+        tiebreaker site name. If found, it returns the name of that monitor.
+
+        Returns:
+            str or None: The name of the tiebreaker monitor if found, otherwise None.
+        """
+        mon_dump_cmd = "ceph mon dump"
+        mons = self.rados_obj.run_ceph_command(mon_dump_cmd)
+        tiebreaker_mon = None
+        for mon in mons["mons"]:
+            if (
+                mon["crush_location"]
+                == "{datacenter=" + f"{self.tiebreaker_mon_site_name}" + "}"
+            ):
+                tiebreaker_mon = mon["name"]
+        return tiebreaker_mon
+
+    def enable_stretch_mode(self, tiebreaker_mon):
+        """
+        Enables stretch mode in the Ceph cluster using the specified tiebreaker monitor.
+
+        Args:
+            tiebreaker_mon (str): The name of the monitor to be used as the tiebreaker.
+
+        Returns:
+            None
+
+        Raises Exception:-
+            When command `ceph mon enable_stretch_mode {tiebreaker_mon} stretch_rule datacenter` fails
+        """
+        stretch_enable_cmd = (
+            f"ceph mon enable_stretch_mode {tiebreaker_mon} stretch_rule datacenter"
+        )
+        self.rados_obj.run_ceph_command(cmd=stretch_enable_cmd, print_output=True)
+
+    def create_pool_and_write_io(self, pool_name: str, client_node: CephNode):
+        """
+        method to create pool with passed <pool_name> and writes IO to the pool
+        using rados put command.
+        """
+        if not self.rados_obj.create_pool(pool_name=pool_name):
+            err_msg = f"Failed to create pool : {pool_name}"
+            log.error(err_msg)
+            raise Exception(err_msg)
+        if (
+            self.pool_obj.do_rados_put(
+                client=client_node, pool=pool_name, nobj=200, timeout=100
+            )
+            == 1
+        ):
+            err_msg = f"Failed to write IO using rados put command to pool {pool_name}"
+            log.error(err_msg)
+            raise Exception(err_msg)
+
+    def create_or_retrieve_crush_rule(self, crush_rule_name: str):
+        """
+        method to create CRUSH rule if it does not exist and if CRUSH rule exists
+        It will return the CRUSH rule ID.
+        Args:
+                crush_rule_name: (type: str) Name of the crush rule to create or retrieve
+        Returns:
+                CRUSH rule ID
+        Raise Exception:
+            If `ceph osd crush rule create-simple` or `ceph osd crush rule dump <rule name> fails`
+        """
+        if self.custom_crush_rule.get(crush_rule_name, None) is not None:
+            return self.custom_crush_rule["crush_rule_name"]
+
+        command = f"ceph osd crush rule create-simple {crush_rule_name} default osd"
+        self.rados_obj.run_ceph_command(
+            cmd=command, client_exec=True, print_output=True
+        )
+
+        command = f"ceph osd crush rule dump {crush_rule_name}"
+        out = self.rados_obj.run_ceph_command(
+            cmd=command, client_exec=True, print_output=True
+        )
+        self.custom_crush_rule[crush_rule_name] = out["rule_id"]
+        return self.custom_crush_rule[crush_rule_name]
+
+
+class RevertStretchModeFunctionalities(StretchMode):
+    """
+    Class contains revert stretch mode related methods.
+    validate_pool_configurations_post_revert()
+    validate_osd_configurations_post_revert()
+    validate_mon_configurations_post_revert()
+    revert_stretch_mode()
+    """
+
+    def revert_stretch_mode(self, crush_rule_name=None):
+        """
+        method to exit stretch mode. Executes command -
+        ceph mon disable_stretch_mode [{crush_rule}] --yes-i-really-mean-it
+
+        args:
+            crush_rule: (Optional , type: string) Name of the crush rule to revert
+        returns:
+            None
+        raises Exception:
+            When command execution fails
+        """
+        command = "ceph mon disable_stretch_mode"
+        if crush_rule_name is not None:
+            command += f" {crush_rule_name}"
+        command += " --yes-i-really-mean-it"
+        _ = self.rados_obj.run_ceph_command(
+            command, print_output=True, client_exec=True
+        )
+
+    def validate_pool_configurations_post_revert(self, pool_properties):
+        """
+        method takes pool_properties as input in dict and validates each property on all pools
+        in `ceph osd pool ls detail`.
+        Example:-
+            pool_properties = {
+                "size": "3",
+                "min_size": "2",
+                "crush_rule": "0",
+            }
+            revert_stretch_mode_obj = RevertStretchModeFunctionalities(**config)
+            revert_stretch_mode_obj.validate_pool_configurations_post_revert(pool_properties)
+        Args:-
+            pool_properties: (type : dict) properties of each pool to validate.
+        Returns:-
+            None
+        Raises Exception:-
+            When the one of the pool properties are not matching the passed properties.
+        """
+        log.info("Validating pool properties for each pool : ")
+        log.info(pool_properties)
+        cmd = "ceph osd pool ls detail"
+        pool_detail = self.rados_obj.run_ceph_command(cmd=cmd)
+        for pool_detail in pool_detail:
+            pool_name = pool_detail["pool_name"]
+            for property_name, property_value in pool_properties.items():
+                current_pool_property = pool_detail[property_name]
+                log_msg = (
+                    f"\nPool name: {pool_name}"
+                    f"\nExpected {property_name} -> {property_value}"
+                    f"\nCurrent {property_name} -> {current_pool_property}"
+                )
+                log.info(log_msg)
+                if str(current_pool_property) != str(property_value):
+                    err_msg = f"Failed to reset pool configuration {property_name} for pool {pool_name}"
+                    log.error(err_msg)
+                    raise Exception(err_msg + log_msg)
+        log.info("Successfully validated pool properties for all pool : ")
+
+    def validate_osd_configurations_post_revert(self, expected_osd_map_values):
+        """
+        method takes expected_osd_map_values as input in dict format and validates properties of OSD
+        MAP in "ceph osd dump" output.
+        Example:-
+            expected_osd_map_values = {
+                "stretch_mode_enabled": False,
+                "stretch_bucket_count": 0,
+                "degraded_stretch_mode": 0,
+                "recovering_stretch_mode": 0,
+                "stretch_mode_bucket": 0
+            }
+            revert_stretch_mode_obj = RevertStretchModeFunctionalities(**config)
+            revert_stretch_mode_obj.validate_osd_configurations_post_revert(expected_osd_map_values)
+        Args:-
+            expected_osd_map_values: (type : dict) OSD MAP property to validate
+        Returns:-
+            None
+        Raises Exception:-
+            When the current OSD MAP property does not match the expected property.
+        """
+        cmd = "ceph osd dump"
+        ceph_osd_dump_output = self.rados_obj.run_ceph_command(
+            cmd=cmd, print_output=True
+        )
+        osd_map_configs_to_validate = (
+            expected_osd_map_values.keys()
+        )  # ["stretch_mode_enabled", "stretch_bucket_count".....]
+        log.info("Validating OSD map configs of stretch mode")
+        for config_name in osd_map_configs_to_validate:
+            expected_config_value = expected_osd_map_values[config_name]
+            current_config_value = ceph_osd_dump_output["stretch_mode"][config_name]
+
+            log_msg = (
+                f" Expected {config_name} -> {expected_config_value}"
+                f" Current {config_name} -> {current_config_value}"
+            )
+            log.info(log_msg)
+            if str(current_config_value) != str(expected_config_value):
+                log.error(
+                    "Failed to reset Stretch mode related OSD map configurations."
+                    + log_msg
+                )
+                raise Exception(log_msg)
+        log.info("Successfully validated OSD map configs of stretch mode")
+
+    def validate_mon_configurations_post_revert(self, expected_mon_map_values):
+        """
+        method takes expected_mon_map_values as input in dict and validates each property
+        in `ceph mon dump` command.
+        Example:-
+            expected_mon_map_values = {
+                "tiebreaker_mon": "",
+                "stretch_mode": False,
+                "tiebreaker_mon": "",
+            }
+            revert_stretch_mode_obj = RevertStretchModeFunctionalities(**config)
+            revert_stretch_mode_obj.validate_mon_configurations_post_revert(expected_mon_map_values)
+        Args:-
+            expected_mon_map_values: (type : dict) properties of MON map to validate.
+        Returns:-
+            None
+        Raises Exception:-
+            When the expected MON map property does not match the current MON map values.
+        """
+        cmd = "ceph mon dump"
+        ceph_mon_dump_output = self.rados_obj.run_ceph_command(
+            cmd=cmd, print_output=True
+        )
+
+        mon_map_configs_to_validate = (
+            expected_mon_map_values.keys()
+        )  # ["tiebreaker_mon", "stretch_mode", ..... ]
+
+        log.info("Validating MON map configs of stretch mode")
+        for config_name in mon_map_configs_to_validate:
+            expected_config_value = expected_mon_map_values[config_name]
+            current_config_value = ceph_mon_dump_output[config_name]
+
+            log_msg = (
+                f" Expected {config_name} -> {expected_config_value}"
+                f" Current {config_name} -> {current_config_value}"
+            )
+            log.info(log_msg)
+
+            if str(current_config_value) != str(expected_config_value):
+                log.error(
+                    "Failed to reset Stretch mode related MON map configurations."
+                    + log_msg
+                )
+                raise Exception(log_msg)
+
+        log.info("Successfully validated MON map configs of stretch mode")


### PR DESCRIPTION
PR includes below 2 scenarios for RADOS 9.0 feature revert stretch mode.

```
        Scenario 1:- Revert stretch mode from health stretch cluster to default crush rules
        Steps:-
        1) Check stretch mode is enabled
        2) Create a pool and write IO
        3) Revert from healthy stretch mode
        4) Validate all pools are reverted to default rules
        5) Validate stretch mode related configs are reset in OSD map
        6) Validate stretch mode related configs are reset in MON map
        7) Validate PGs reach active+clean
        8) Re-enter stretch mode for next scenario
```

```
        Scenario 2:- Revert stretch mode from health stretch cluster to non-default crush rules
        Steps:-
        1) Check stretch mode is enabled
        2) Create a pool and write IO
        3) Create a custom crush rule
        4) Revert from healthy stretch mode
        5) Validate all pools are reverted to default rules
        6) Validate stretch mode related configs are reset in OSD map
        7) Validate stretch mode related configs are reset in MON map
        8) Validate PGs reach active+clean
        9) Re-enter stretch mode for next scenario
```

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
