### PR TITLE
TFA fix for upgrade test infra slowness

### DIFF
--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -247,13 +247,21 @@ def snap_sched_test(snap_req_params):
             out, _ = mnt_client.exec_command(sudo=True, cmd=cmd)
         except CommandFailed as ex:
             log.info(ex)
-            if "No such file or directory" in str(ex):
-                cmd = f"cd {mnt_pt}/.snap/;ls -l ./*"
-                out1, _ = mnt_client.exec_command(sudo=True, cmd=cmd)
-                log.info(out1)
-                cmd = f"ls {mnt_pt}/.snap/_{sv_snap[sv]['snap_list'][0]}*/dd_test_file"
-                out, _ = mnt_client.exec_command(sudo=True, cmd=cmd)
-                log.info(out)
+            retry_exec = retry(CommandFailed, tries=3, delay=20)(
+                mnt_client.exec_command
+            )
+            cmd = f"cd {mnt_pt}/.snap/;ls -l ./*"
+            out1, _ = retry_exec(
+                sudo=True,
+                cmd=cmd,
+            )
+            log.info(out1)
+            cmd = f"ls {mnt_pt}/.snap/_{sv_snap[sv]['snap_list'][0]}*/dd_test_file"
+            out, _ = retry_exec(
+                sudo=True,
+                cmd=cmd,
+            )
+            log.info(out)
         file_path = out.strip()
         cmd = f"dd if={file_path} count=10 bs=1M > read_dd"
         out, rc = mnt_client.exec_command(sudo=True, cmd=cmd)


### PR DESCRIPTION
# Description

Failed log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Upgrade/19.2.1-233/118/tier-0_cephfs_upgrade_8x_latest_to_81x_latest/Validates_NFS_after_upgrade_0.log

Failure Reason: ls command on .snap dir of existing fuse mount after upgrade fails with permission denied error.
Fix: We had handled no such file error that comes when .snap is accessed immediately after upgrade, but permissiond enied is a new error. So added retries with delay of 10secs to see if eventually .snap can be accessed.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
