### PR TITLE
[rgw] adding testcases for server-access-logging sanity

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -419,6 +419,42 @@ tests:
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
         run-on-haproxy: true
 
+
+  # server-access-logging tests
+
+  - test:
+      name: test bucket logging with Journal mode, SimplePrefix, rgw_admin_flush
+      desc: test bucket logging with Journal mode, SimplePrefix, rgw_admin_flush
+      polarion-id: CEPH-83623532
+      module: sanity_rgw.py
+      config:
+        script-name: test_server_access_logging.py
+        config-file-name: test_bucket_logging_journal_mode.yaml
+  - test:
+      name: test bucket logging with Journal mode, multipart_objects, PartitionedPrefix, rest_api_flush
+      desc: test bucket logging with Journal mode, multipart_objects, PartitionedPrefix, rest_api_flush
+      polarion-id: CEPH-83623532
+      module: sanity_rgw.py
+      config:
+        script-name: test_server_access_logging.py
+        config-file-name: test_bucket_logging_journal_mode_multipart.yaml
+  - test:
+      name: test bucket logging with Standard mode, PartitionedPrefix, rgw_admin_flush
+      desc: test bucket logging with Standard mode, PartitionedPrefix, rgw_admin_flush
+      polarion-id: CEPH-83623532
+      module: sanity_rgw.py
+      config:
+        script-name: test_server_access_logging.py
+        config-file-name: test_bucket_logging_standard_mode.yaml
+  - test:
+      name: test bucket logging with Standard mode, multipart_objects, SimplePrefix, rest_api_flush
+      desc: test bucket logging with Standard mode, multipart_objects, SimplePrefix, rest_api_flush
+      polarion-id: CEPH-83623532
+      module: sanity_rgw.py
+      config:
+        script-name: test_server_access_logging.py
+        config-file-name: test_bucket_logging_standard_mode_multipart.yaml
+
   - test:
       name: Test large omap creation and clearance
       desc: Test large omap creation and clearance


### PR DESCRIPTION
this PR is to add support for testing rgw feature server-access-logging
tested the feature for:

1. Journal mode and standard mode
2. simple prefix and partitioned prefix
3. rgw_admin flush and rest_api flush


also added support for testing below bz's:

[2308169](https://bugzilla.redhat.com/show_bug.cgi?id=2308169) [RFE] add partial bucket logging support to the RGW
[2344993](https://bugzilla.redhat.com/show_bug.cgi?id=2344993) [rgw][server-access-logging]: radosgw-admin bucket logging flush command is returning next log object name instead of current log object name
[2365697](https://bugzilla.redhat.com/show_bug.cgi?id=2365697) [rgw][server-access-logging]: REST.POST.UPLOAD (complete multipart) log record is not populated with object size even in the Standard mode
[2345305](https://bugzilla.redhat.com/show_bug.cgi?id=2345305) [rgw][server-access-logging][RFE]: add support for configuring permission for a bucket to be used as a target bucket for log object delivery
[2365931](https://bugzilla.redhat.com/show_bug.cgi?id=2365931) [rgw][server-access-logging]: please modify the operation name for multipart upload_part to REST.PUT.PART in the Standard mode
[2364399](https://bugzilla.redhat.com/show_bug.cgi?id=2364399) [RFE][rgw][server-access-logging] send flushed object name in API reply
[2370241](https://bugzilla.redhat.com/show_bug.cgi?id=2370241) [rgw][server-access-logging]: partitioned key format does not follow the spec
[2370245](https://bugzilla.redhat.com/show_bug.cgi?id=2370245) [rgw][server-access-logging][RFE]: make the unique portion of the log object name ordered

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_bucket_logging/cephci-run-I75XT1/



# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
