### PR TITLE
adding support for GKLM testcases to run on both openstack and ibmc with corressponding certs and gklm endpoints

### DIFF
--- a/suites/reef/rgw/sanity_rgw_multisite.yaml
+++ b/suites/reef/rgw/sanity_rgw_multisite.yaml
@@ -458,64 +458,6 @@ tests:
       name: test_sse_s3_per_object_with_sts
       polarion-id: CEPH-83586489
 
-  # GKLM prerequisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "rm -rf /usr/local/gklm; mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.pri} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.sec} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-      desc: Setting up certs, mount the certs path and redeploy rgw
-      module: exec.py
-      name: Setting up certs, mount the certs path and redeploy rgw
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.pri}"
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.sec}"
-      desc: Setting sse_kms configs with kmip backend for gklm
-      module: exec.py
-      name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
 
@@ -523,6 +465,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -392,70 +392,13 @@ tests:
       name: test_sse_s3_per_object_with_sts
       polarion-id: CEPH-83586489
 
-  # GKLM prerequisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "rm -rf /usr/local/gklm; mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.pri} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.sec} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-      desc: Setting up certs, mount the certs path and redeploy rgw
-      module: exec.py
-      name: Setting up certs, mount the certs path and redeploy rgw
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.pri}"
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.sec}"
-      desc: Setting sse_kms configs with kmip backend for gklm
-      module: exec.py
-      name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
   - test:
       clusters:
         ceph-pri:
           config:
+            setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload

--- a/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -445,64 +445,6 @@ tests:
       name: test_sse_kms_per_bucket_with_bucket_policy
       polarion-id: CEPH-83586489
 
-  # GKLM prerequisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: true
-            commands:
-              - "rm -rf /usr/local/gklm; mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.pri} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: true
-            commands:
-              - "mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.sec} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-      desc: Setting up certs, mount the certs path and redeploy rgw
-      module: exec.py
-      name: Setting up certs, mount the certs path and redeploy rgw
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.pri}"
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.sec}"
-      desc: Setting sse_kms configs with kmip backend for gklm
-      module: exec.py
-      name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
 
@@ -510,6 +452,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload

--- a/suites/squid/upstream/sanity_rgw_multisite.yaml
+++ b/suites/squid/upstream/sanity_rgw_multisite.yaml
@@ -392,70 +392,13 @@ tests:
       name: test_sse_s3_per_object_with_sts
       polarion-id: CEPH-83586489
 
-  # GKLM prerequisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "rm -rf /usr/local/gklm; mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.pri} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.sec} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-      desc: Setting up certs, mount the certs path and redeploy rgw
-      module: exec.py
-      name: Setting up certs, mount the certs path and redeploy rgw
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.pri}"
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.sec}"
-      desc: Setting sse_kms configs with kmip backend for gklm
-      module: exec.py
-      name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
   - test:
       clusters:
         ceph-pri:
           config:
+            setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload

--- a/suites/tentacle/rgw/sanity_rgw_multisite.yaml
+++ b/suites/tentacle/rgw/sanity_rgw_multisite.yaml
@@ -392,70 +392,13 @@ tests:
       name: test_sse_s3_per_object_with_sts
       polarion-id: CEPH-83586489
 
-  # GKLM prerequisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "rm -rf /usr/local/gklm; mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.pri} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.sec} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-      desc: Setting up certs, mount the certs path and redeploy rgw
-      module: exec.py
-      name: Setting up certs, mount the certs path and redeploy rgw
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.pri}"
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.sec}"
-      desc: Setting sse_kms configs with kmip backend for gklm
-      module: exec.py
-      name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
   - test:
       clusters:
         ceph-pri:
           config:
+            setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload

--- a/suites/tentacle/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -435,64 +435,6 @@ tests:
       name: test_sse_kms_per_bucket_with_bucket_policy
       polarion-id: CEPH-83586489
 
-  # GKLM prerequisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: true
-            commands:
-              - "rm -rf /usr/local/gklm; mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.pri} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: true
-            commands:
-              - "mkdir /usr/local/gklm"
-              - "curl -o /usr/local/gklm/rgwselfsigned.cert http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.cert"
-              - "curl -o /usr/local/gklm/rgwselfsigned.key http://magna002.ceph.redhat.com/cephci-jenkins/gklm/rgwselfsigned.key"
-              - "ceph orch ls --service-name {service_name:shared.sec} --export > /root/rgw_spec.yaml"
-              - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
-              - "ceph orch apply -i /root/rgw_spec.yaml"
-              - "sleep 20"
-      desc: Setting up certs, mount the certs path and redeploy rgw
-      module: exec.py
-      name: Setting up certs, mount the certs path and redeploy rgw
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.pri}"
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_s3_kms_backend kmip"
-              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_kmip_addr 10.0.64.87:5696"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
-              - "ceph orch restart {service_name:shared.sec}"
-      desc: Setting sse_kms configs with kmip backend for gklm
-      module: exec.py
-      name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
 
@@ -500,6 +442,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload


### PR DESCRIPTION
this PR is to add support for GKLM testcases to run on both openstack and ibmc environments as well.
removed dependency of magna links for GKLM certs, we can pass the path of gklm certs with --custom-config so that the code will copy the files from localhost to remote node
Note: for this to work, the node from where the cephci run.py is running (either local or jenkins) should contain the gklm certs present in the path mentioned in custom-config.

run.py sample command:
```
python run.py ....
  --custom-config gklm-auth-cert-path=<cert-path>
  --custom-config gklm-auth-key-path=<cert-key-path>
```

for pipeline runs we pass custom-config from jenkins metadata.
PR raised for it here: https://gitlab.cee.redhat.com/rhcs-qe/cephqe-jenkins/-/merge_requests/988


pass logs on openstack env: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_gklm_ibmc_changes/cephci-run-F568DN/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
