### PR TITLE
[TFA][staggered-upgrade] Fix ceph health output dict handling

### DIFF
--- a/cli/ceph/ceph.py
+++ b/cli/ceph/ceph.py
@@ -83,7 +83,13 @@ class Ceph(Cli):
         if detail:
             cmd += " detail"
         out = self.execute(sudo=True, check_ec=False, long_running=False, cmd=cmd)
-        if isinstance(out, tuple):
+        if isinstance(out, dict):
+            for key, value in out.items():
+                if isinstance(value, tuple):
+                    return value[0].strip()
+                else:
+                    return value[0]
+        elif isinstance(out, tuple):
             return out[0].strip()
         return out
 

--- a/cli/utilities/operations.py
+++ b/cli/utilities/operations.py
@@ -21,6 +21,7 @@ def wait_for_cluster_health(node, status, timeout=300, interval=20):
     """
     for w in WaitUntil(timeout=timeout, interval=interval):
         _status = Ceph(node).health()
+        log.info(f"Cluster status is {_status}")
         if status in _status:
             log.info(f"Cluster status is in expected state {status}")
             return True


### PR DESCRIPTION
# Description

### Problem
The staggered upgrade tests are failing during health check even though the cluster is in expected state.

### Reason
The output of the `ceph health` command is in a dictionary format and it is not being handled properly.
`output = {'ceph-vpap-tfa-43zse4-node4': ('HEALTH_OK\n', '')}`

### Solution
Add logic to handle the dictionary output

### Test run logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-13QSGB