### PR TITLE
TFA fix for fscrypt functional test script

### DIFF
--- a/tests/cephfs/lib/fscrypt_utils.py
+++ b/tests/cephfs/lib/fscrypt_utils.py
@@ -673,22 +673,18 @@ class FscryptUtils(object):
         def rename():
             test_files_list = self.get_file_list(client, encrypt_path)
             file_to_rename, file_to_rename_1 = random.sample(test_files_list, 2)
-            retry_cnt = 5
-            while retry_cnt:
-                if ("renamed_file" in file_to_rename) or (
-                    "renamed_file" in file_to_rename_1
-                ):
-                    file_to_rename, file_to_rename_1 = random.sample(test_files_list, 2)
-                    retry_cnt -= 1
-                else:
-                    retry_cnt = 0
+            rand_str = "".join(
+                random.choice(string.ascii_lowercase + string.digits)
+                for _ in list(range(4))
+            )
             try:
                 client.exec_command(
-                    sudo=True, cmd=f"mv {file_to_rename} {encrypt_path}/renamed_file"
+                    sudo=True,
+                    cmd=f"mv {file_to_rename} {encrypt_path}/renamed_file_{rand_str}",
                 )
                 client.exec_command(
                     sudo=True,
-                    cmd=f"mv {file_to_rename_1} {encrypt_path}/../renamed_file",
+                    cmd=f"mv {file_to_rename_1} {encrypt_path}/../renamed_file_{rand_str}",
                 )
             except BaseException as ex:
                 log.info(ex)


### PR DESCRIPTION
# Description

JIRA: https://issues.redhat.com/browse/RHCEPHQE-20977
TFA fix for: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/8.1/rhel-9/Regression/19.2.1-234/cephfs/114/8_1_features_suite/fscrypt_functional_0.log

Failure details:

2025-07-16 12:29:01,717 - cephci - fscrypt_utils:694 - INFO - mv /mnt/cephfs_fuse_8sy//testdir_6f5i/renamed_file /mnt/cephfs_fuse_8sy//testdir_6f5i/renamed_file returned mv: '/mnt/cephfs_fuse_8sy//testdir_6f5i/renamed_file' and '/mnt/cephfs_fuse_8sy//testdir_6f5i/renamed_file' are the same file and code 1 on 10.0.195.144

Reason: Picking the file which is already renamed

Fix: Create unique file name during rename
Passed logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W45B9K

2025-07-21 03:14:00,956 - cephci - ceph:1613 - INFO - Execute mv /mnt/cephfs_fuse_dvr//testdir_2hpy/renamed_file_kzrs /mnt/cephfs_fuse_dvr//testdir_2hpy/renamed_file_xo7z on 10.0.66.204
2025-07-21 03:14:01,959 - cephci - ceph:1643 - INFO - Execution of mv /mnt/cephfs_fuse_dvr//testdir_2hpy/renamed_file_kzrs /mnt/cephfs_fuse_dvr//testdir_2hpy/renamed_file_xo7z on 10.0.66.204 took 1.003103 seconds

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
