### PR TITLE
TFA issues fixes - adds set_debug and check_ec as false

### DIFF
--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -672,11 +672,11 @@ class PoolFunctions:
                 out = self.rados_obj.run_ceph_command(cmd=cmd)
                 log.debug(out)
                 pool_id = self.get_pool_id(pool_name=pool)
-                for pool in out["pool_stats"]:
-                    if pool["poolid"] == pool_id:
+                for pool_stats in out["pool_stats"]:
+                    if pool_stats["poolid"] == pool_id:
                         if (
-                            pool["stat_sum"]["num_omap_bytes"] <= 0
-                            or pool["stat_sum"]["num_omap_keys"] <= 0
+                            pool_stats["stat_sum"]["num_omap_bytes"] <= 0
+                            or pool_stats["stat_sum"]["num_omap_keys"] <= 0
                         ):
                             log.error(
                                 f"omap entries are not part of ceph pg pool stats for pool {pool}"
@@ -690,11 +690,11 @@ class PoolFunctions:
                 cmd = "ceph df detail"
                 out = self.rados_obj.run_ceph_command(cmd=cmd)
                 log.debug(out)
-                for pool in out["pools"]:
-                    if pool["name"] == pool:
+                for pool_detail in out["pools"]:
+                    if pool_detail["name"] == pool:
                         if (
-                            pool["stats"]["omap_bytes_used"] <= 0
-                            or pool["stats"]["stored_omap"] <= 0
+                            pool_detail["stats"]["omap_bytes_used"] <= 0
+                            or pool_detail["stats"]["stored_omap"] <= 0
                         ):
                             log.error(
                                 f"omap entries are not part of ceph df detail for pool {pool}, but expected."
@@ -704,11 +704,17 @@ class PoolFunctions:
                             self.rados_obj.restart_daemon_services(daemon="osd")
                             out = self.rados_obj.run_ceph_command(cmd="ceph df detail")
                             log.debug(out)
-                            for pool in out["pools"]:
-                                if pool["name"] == pool:
+                            for pool_detail_post_osd_restart in out["pools"]:
+                                if pool_detail_post_osd_restart["name"] == pool:
                                     if (
-                                        pool["stats"]["omap_bytes_used"] <= 0
-                                        or pool["stats"]["stored_omap"] <= 0
+                                        pool_detail_post_osd_restart["stats"][
+                                            "omap_bytes_used"
+                                        ]
+                                        <= 0
+                                        or pool_detail_post_osd_restart["stats"][
+                                            "stored_omap"
+                                        ]
+                                        <= 0
                                     ):
                                         log.error(
                                             f"omap entries are not part of ceph df detail for pool {pool},"

--- a/suites/tentacle/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-scrubbing.yaml
@@ -97,6 +97,7 @@ tests:
       desc: Verify CPU and Memory check during scheduled scrub
       polarion-id: CEPH-9369
       config:
+        set_debug: true
         create_pools:
           - create_pool:
               pool_name: scheduled_scrub

--- a/tests/rados/test_osd_full.py
+++ b/tests/rados/test_osd_full.py
@@ -266,6 +266,7 @@ def run(ceph_cluster, **kw):
                     "byte_size": f"{bench_obj_size_kb}KB",
                     "nocleanup": True,
                     "max_objs": subseq_obj_full,
+                    "check_ec": False,
                 }
                 if (
                     rados_obj.bench_write(


### PR DESCRIPTION
PR addresses below:- 
Credits:- Team

1) adds debug for tier-2_rados_test-scrubbing/ CPU and Memory check during scheduled scrub due to the product issue observed

```
2025-07-13 19:07:47,292 - cephci - core_workflows:182 - ERROR - Exception hit while command execution. cephadm shell -- ceph pg dump  -f json returned Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/sbin/cephadm/__main__.py", line 6254, in <module>
  File "/usr/sbin/cephadm/__main__.py", line 6240, in main
  File "/usr/sbin/cephadm/cephadmlib/container_engines.py", line 138, in check_container_engine
  File "/usr/sbin/cephadm/cephadmlib/container_engines.py", line 34, in get_version
  File "/usr/sbin/cephadm/cephadmlib/call_wrappers.py", line 307, in call_throws
RuntimeError: Failed command: /usr/bin/podman version --format {{.Client.Version}}: Error: beginning transaction: database is locked

 and code 1 on 10.0.195.155
```

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-234/rados/30/tier-2_rados_test-scrubbing/CPU_and_Memory_check_during_scheduled_scrub_0.log  

2) Disables checking exit code for rados bench due to issue in http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-234/rados/16/tier-2_rados_test-osd-rebalance/Cluster_behaviour_when_OSDs_are_full_0.log 
```
2025-07-17 04:46:25,659 - cephci - ceph:1667 - ERROR - sudo rados --no-log-to-stderr -b 16384KB -p re_pool_3 bench 200 write --no-cleanup --max-objects 48 failed to execute within 300 seconds.
```

3) Added saftey check for pool deletion in tests/rados/test_scrub_cpu_memory_usage.py 
```
"pool_name" in globals() or "pool_name" in locals()
```

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
