### PR TITLE
Merging CephFS Scale and System Suites with new barenetal conf file

### DIFF
--- a/conf/squid/cephfs/extensa_cephfs_scale_system.yaml
+++ b/conf/squid/cephfs/extensa_cephfs_scale_system.yaml
@@ -1,0 +1,448 @@
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.0.0.0/8']
+      nodes:
+        -
+          hostname: extensa010
+          id: node1
+          ip: 10.8.130.210
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+        -
+          hostname: extensa011
+          id: node2
+          ip: 10.8.130.211
+          root_password: passwd
+          role:
+            - mgr
+            - mon
+            - mds
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: extensa015
+          id: node3
+          ip: 10.8.130.215
+          root_password: passwd
+          role:
+            - mon
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: extensa016
+          id: node4
+          ip: 10.8.130.216
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: extensa017
+          id: node5
+          ip: 10.8.130.217
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: extensa018
+          id: node6
+          ip: 10.8.130.218
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: extensa019
+          id: node7
+          ip: 10.8.130.219
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+
+        -
+          hostname: rhel94client1
+          id: node201
+          ip: 10.8.131.201
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client2
+          id: node202
+          ip: 10.8.131.202
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client3
+          id: node203
+          ip: 10.8.131.203
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client4
+          id: node204
+          ip: 10.8.131.204
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client5
+          id: node205
+          ip: 10.8.131.205
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client6
+          id: node206
+          ip: 10.8.131.206
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client7
+          id: node207
+          ip: 10.8.131.207
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client8
+          id: node208
+          ip: 10.8.131.208
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client9
+          id: node209
+          ip: 10.8.131.209
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client10
+          id: node210
+          ip: 10.8.131.210
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client11
+          id: node211
+          ip: 10.8.131.211
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client12
+          id: node212
+          ip: 10.8.131.212
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client13
+          id: node213
+          ip: 10.8.131.213
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client14
+          id: node214
+          ip: 10.8.131.214
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client15
+          id: node215
+          ip: 10.8.131.215
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client16
+          id: node216
+          ip: 10.8.131.216
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client17
+          id: node217
+          ip: 10.8.131.217
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client18
+          id: node218
+          ip: 10.8.131.218
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client19
+          id: node219
+          ip: 10.8.131.219
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client20
+          id: node220
+          ip: 10.8.131.220
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client21
+          id: node221
+          ip: 10.8.131.221
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client22
+          id: node222
+          ip: 10.8.131.222
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client23
+          id: node223
+          ip: 10.8.131.223
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client24
+          id: node224
+          ip: 10.8.131.224
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client25
+          id: node225
+          ip: 10.8.131.225
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client26
+          id: node226
+          ip: 10.8.131.226
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client27
+          id: node227
+          ip: 10.8.131.227
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client28
+          id: node228
+          ip: 10.8.131.228
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client29
+          id: node229
+          ip: 10.8.131.229
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client30
+          id: node230
+          ip: 10.8.131.230
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client31
+          id: node231
+          ip: 10.8.131.231
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client32
+          id: node232
+          ip: 10.8.131.232
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client33
+          id: node233
+          ip: 10.8.131.233
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client34
+          id: node234
+          ip: 10.8.131.234
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client35
+          id: node235
+          ip: 10.8.131.235
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client36
+          id: node236
+          ip: 10.8.131.236
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client37
+          id: node237
+          ip: 10.8.131.237
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client38
+          id: node238
+          ip: 10.8.131.238
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client39
+          id: node239
+          ip: 10.8.131.239
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client40
+          id: node240
+          ip: 10.8.131.240
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client41
+          id: node241
+          ip: 10.8.131.241
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client42
+          id: node242
+          ip: 10.8.131.242
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client43
+          id: node243
+          ip: 10.8.131.243
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client44
+          id: node244
+          ip: 10.8.131.244
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client45
+          id: node245
+          ip: 10.8.131.245
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client46
+          id: node246
+          ip: 10.8.131.246
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client47
+          id: node247
+          ip: 10.8.131.247
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client48
+          id: node248
+          ip: 10.8.131.248
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client49
+          id: node249
+          ip: 10.8.131.249
+          root_password: passwd
+          role:
+            - client
+        -
+          hostname: rhel94client50
+          id: node250
+          ip: 10.8.131.250
+          root_password: passwd
+          role:
+            - client

--- a/suites/squid/cephfs/tier-4_cephfs_system_scale_baremetal.yaml
+++ b/suites/squid/cephfs/tier-4_cephfs_system_scale_baremetal.yaml
@@ -1,0 +1,745 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: false
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+
+### Configure Clients
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+        - ceph-common
+        node: node201
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+        - ceph-common
+        node: node202
+      desc: Configure the Cephfs client system 2
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+        - ceph-common
+        node: node203
+      desc: Configure the Cephfs client system 3
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+        - ceph-common
+        node: node204
+      desc: Configure the Cephfs client system 4
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.5
+        install_packages:
+        - ceph-common
+        node: node205
+      desc: Configure the Cephfs client system 5
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.6
+        install_packages:
+        - ceph-common
+        node: node206
+      desc: Configure the Cephfs client system 6
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.7
+        install_packages:
+        - ceph-common
+        node: node207
+      desc: Configure the Cephfs client system 7
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.8
+        install_packages:
+        - ceph-common
+        node: node208
+      desc: Configure the Cephfs client system 8
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.9
+        install_packages:
+        - ceph-common
+        node: node209
+      desc: Configure the Cephfs client system 9
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.10
+        install_packages:
+        - ceph-common
+        node: node210
+      desc: Configure the Cephfs client system 10
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.11
+        install_packages:
+        - ceph-common
+        node: node211
+      desc: Configure the Cephfs client system 11
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.12
+        install_packages:
+        - ceph-common
+        node: node212
+      desc: Configure the Cephfs client system 12
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.13
+        install_packages:
+        - ceph-common
+        node: node213
+      desc: Configure the Cephfs client system 13
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.14
+        install_packages:
+        - ceph-common
+        node: node214
+      desc: Configure the Cephfs client system 14
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.15
+        install_packages:
+        - ceph-common
+        node: node215
+      desc: Configure the Cephfs client system 15
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.16
+        install_packages:
+        - ceph-common
+        node: node216
+      desc: Configure the Cephfs client system 16
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.17
+        install_packages:
+        - ceph-common
+        node: node217
+      desc: Configure the Cephfs client system 17
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.18
+        install_packages:
+        - ceph-common
+        node: node218
+      desc: Configure the Cephfs client system 18
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.19
+        install_packages:
+        - ceph-common
+        node: node219
+      desc: Configure the Cephfs client system 19
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.20
+        install_packages:
+        - ceph-common
+        node: node220
+      desc: Configure the Cephfs client system 20
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.21
+        install_packages:
+        - ceph-common
+        node: node221
+      desc: Configure the Cephfs client system 21
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.22
+        install_packages:
+        - ceph-common
+        node: node222
+      desc: Configure the Cephfs client system 22
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.23
+        install_packages:
+        - ceph-common
+        node: node223
+      desc: Configure the Cephfs client system 23
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.24
+        install_packages:
+        - ceph-common
+        node: node224
+      desc: Configure the Cephfs client system 24
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.25
+        install_packages:
+        - ceph-common
+        node: node225
+      desc: Configure the Cephfs client system 25
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.26
+        install_packages:
+        - ceph-common
+        node: node226
+      desc: Configure the Cephfs client system 26
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.27
+        install_packages:
+        - ceph-common
+        node: node227
+      desc: Configure the Cephfs client system 27
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.28
+        install_packages:
+        - ceph-common
+        node: node228
+      desc: Configure the Cephfs client system 28
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.29
+        install_packages:
+        - ceph-common
+        node: node229
+      desc: Configure the Cephfs client system 29
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.30
+        install_packages:
+        - ceph-common
+        node: node230
+      desc: Configure the Cephfs client system 30
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.31
+        install_packages:
+        - ceph-common
+        node: node231
+      desc: Configure the Cephfs client system 31
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.32
+        install_packages:
+        - ceph-common
+        node: node232
+      desc: Configure the Cephfs client system 32
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.33
+        install_packages:
+        - ceph-common
+        node: node233
+      desc: Configure the Cephfs client system 33
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.34
+        install_packages:
+        - ceph-common
+        node: node234
+      desc: Configure the Cephfs client system 34
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.35
+        install_packages:
+        - ceph-common
+        node: node235
+      desc: Configure the Cephfs client system 35
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.36
+        install_packages:
+        - ceph-common
+        node: node236
+      desc: Configure the Cephfs client system 36
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.37
+        install_packages:
+        - ceph-common
+        node: node237
+      desc: Configure the Cephfs client system 37
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.38
+        install_packages:
+        - ceph-common
+        node: node238
+      desc: Configure the Cephfs client system 38
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.39
+        install_packages:
+        - ceph-common
+        node: node239
+      desc: Configure the Cephfs client system 39
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.40
+        install_packages:
+        - ceph-common
+        node: node240
+      desc: Configure the Cephfs client system 40
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.41
+        install_packages:
+        - ceph-common
+        node: node241
+      desc: Configure the Cephfs client system 41
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.42
+        install_packages:
+        - ceph-common
+        node: node242
+      desc: Configure the Cephfs client system 42
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.43
+        install_packages:
+        - ceph-common
+        node: node243
+      desc: Configure the Cephfs client system 43
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.44
+        install_packages:
+        - ceph-common
+        node: node244
+      desc: Configure the Cephfs client system 44
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.45
+        install_packages:
+        - ceph-common
+        node: node245
+      desc: Configure the Cephfs client system 45
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.46
+        install_packages:
+        - ceph-common
+        node: node246
+      desc: Configure the Cephfs client system 46
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.47
+        install_packages:
+        - ceph-common
+        node: node247
+      desc: Configure the Cephfs client system 47
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.48
+        install_packages:
+        - ceph-common
+        node: node248
+      desc: Configure the Cephfs client system 48
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.49
+        install_packages:
+        - ceph-common
+        node: node249
+      desc: Configure the Cephfs client system 49
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.50
+        install_packages:
+        - ceph-common
+        node: node250
+      desc: Configure the Cephfs client system 50
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+### Configure Debugging and Crash
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+        ENABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+        daemon_dbg_level : {'mds':10,'client':10,'osd':5,'mgr':5,'mon':5}
+  -
+    test:
+      abort-on-fail: false
+      desc: "Set size limit for log rotation"
+      name: size limit for log rotation
+      module: cephfs_logs_util.py
+      config:
+        LOG_ROTATE_SIZE : 1
+        log_size : '200M'
+  -
+    test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup : 1
+        daemon_list : ['mds','osd','mgr','mon']
+
+### System Tests
+
+
+
+### Scale Tests


### PR DESCRIPTION
# Description

* Created a common conf file with 7 identical extensa nodes to run system and scale tests on a single baremetal cluster.
* Included the 50 clients as of now. Will be including 50 more once the VMs are made available.
* Common suite file is also included with basic cluster deployment and debug and crash module tests. 

@sumabai - please include System Tests once this is merged.. 

* Created a common conf file with 7 identical extensa nodes to run system and scale tests on a single baremetal cluster.
* Included the 50 clients as of now. Will be including 50 more once the VMs are made available.
* Common suite file is also included with basic cluster deployment and debug and crash module tests. 

Please use the suite file to include the System and Scale Tests..


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
