### PR TITLE
[TFA][DMFG] Remove obsolete test case from OSD scenarios suite

### DIFF
--- a/suites/reef/cephadm/tier2-osd-scenarios.yaml
+++ b/suites/reef/cephadm/tier2-osd-scenarios.yaml
@@ -146,13 +146,6 @@ tests:
       polarion-id: CEPH-83575349
       abort-on-fail: true
 
-  - test:  # The test is expected fail till BZ:2259884 is fixed
-      name: Test OSD memory usage
-      desc: Verify ceph orch ps output does show an incorrect amount of used memory for OSDs
-      module: test_verify_incorrect_mem_usage.py
-      polarion-id: CEPH-83584007
-      abort-on-fail: false
-
   - test:
       name: Test OSD blocklisted clients
       desc: Verify ceph OSD blocklist client list

--- a/suites/squid/cephadm/tier2-osd-scenarios.yaml
+++ b/suites/squid/cephadm/tier2-osd-scenarios.yaml
@@ -146,13 +146,6 @@ tests:
       polarion-id: CEPH-83575349
       abort-on-fail: true
 
-  - test:  # The test is expected fail till BZ:2259884 is fixed
-      name: Test OSD memory usage
-      desc: Verify ceph orch ps output does show an incorrect amount of used memory for OSDs
-      module: test_verify_incorrect_mem_usage.py
-      polarion-id: CEPH-83584007
-      abort-on-fail: false
-
   - test:
       name: Test OSD blocklisted clients
       desc: Verify ceph OSD blocklist client list

--- a/suites/tentacle/cephadm/tier2-osd-scenarios.yaml
+++ b/suites/tentacle/cephadm/tier2-osd-scenarios.yaml
@@ -146,13 +146,6 @@ tests:
       polarion-id: CEPH-83575349
       abort-on-fail: true
 
-  - test:  # The test is expected fail till BZ:2259884 is fixed
-      name: Test OSD memory usage
-      desc: Verify ceph orch ps output does show an incorrect amount of used memory for OSDs
-      module: test_verify_incorrect_mem_usage.py
-      polarion-id: CEPH-83584007
-      abort-on-fail: false
-
   - test:
       name: Test OSD blocklisted clients
       desc: Verify ceph OSD blocklist client list


### PR DESCRIPTION
# Description

The BZ #2259884 has been closed as NOTABUG, making the specific test scenario obsolete.
Hence , removing the obsolete test scenario which is causing failure.