### PR TITLE
RHCEPHQE-20368 | CEPH-83620743: RADOS ceph-objectstore-tool data-export functionalities in read-only mode

### DIFF
--- a/ceph/rados/objectstoretool_workflows.py
+++ b/ceph/rados/objectstoretool_workflows.py
@@ -16,6 +16,11 @@ Possible obj operations:
     set-size
     clear-data-digest
     remove-clone-metadata
+    export
+    meta-list
+    get-osdmap
+    get-superblock
+    get-inc-osdmap
 
 ceph-objectstore-tool --data-path path to osd [ --op list $obj_ID]
 
@@ -105,7 +110,7 @@ class objectstoreToolWorkflows:
             Returns the output of
             ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op list
         """
-        # Extracting the crush map from the cluster
+        # Extracting the list of objects for an OSD
         _cmd = "--op list"
         if pgid:
             _cmd = f"{_cmd} --pgid {pgid}"
@@ -170,7 +175,7 @@ class objectstoreToolWorkflows:
             in_file: output file for redirection
             start: flag to control osd restart
         Returns:
-            Returns the output of cbt repair cmd
+            Returns the output of cbt set-bytes cmd
         """
         if not start:
             self.nostart = True
@@ -343,4 +348,88 @@ class objectstoreToolWorkflows:
             ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT dump
         """
         _cmd = f"'{obj}' dump"
+        return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_superblock(self, osd_id: int):
+        """Module to retrieve objectstore superblock for an OSD
+        Args:
+            osd_id: OSD ID for which cot will be executed
+        Returns:
+            Returns the output of
+            ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op get-superblock
+        """
+        # Extracting the superblock from the osd
+        _cmd = "--op get-superblock"
+        return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_osdmap(self, osd_id: int, pgid: str = None, obj_name: str = None):
+        """Module to retrieve osdmap for an object in input OSD
+        Args:
+            osd_id: OSD ID for which cot will be executed
+            pgid: pg ID for which objs will be listed
+            obj_name: name of a specific object to be listed
+        Returns:
+            Returns the output of
+            ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op get-osdmap
+        """
+        # Extracting the osdmap from the osd
+        _cmd = "--op get-osdmap"
+        if pgid:
+            _cmd = f"{_cmd} --pgid {pgid}"
+        if obj_name:
+            _cmd = f"{_cmd} {obj_name}"
+        return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_inc_osdmap(self, osd_id: int, pgid: str = None, obj_name: str = None):
+        """Module to retrieve inc-osdmap for an object in input OSD
+        Args:
+            osd_id: OSD ID for which cot will be executed
+            pgid: pg ID for which objs will be listed
+            obj_name: name of a specific object to be listed
+        Returns:
+            Returns the output of
+            ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op get-inc-osdmap
+        """
+        # Extracting the incremental osdmap from the osd
+        _cmd = "--op get-inc-osdmap"
+        if pgid:
+            _cmd = f"{_cmd} --pgid {pgid}"
+        if obj_name:
+            _cmd = f"{_cmd} {obj_name}"
+        return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_meta_list(self, osd_id: int, pgid: str = None, obj_name: str = None):
+        """Module to retrieve meta-list for the input OSD
+        Args:
+            osd_id: OSD ID for which cot will be executed
+            pgid: pg ID for which objs will be listed
+            obj_name: name of a specific object to be listed
+        Returns:
+            Returns the output of
+            ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op meta-list
+        """
+        # Extracting the incremental osdmap from the osd
+        _cmd = "--op meta-list"
+        if pgid:
+            _cmd = f"{_cmd} --pgid {pgid}"
+        if obj_name:
+            _cmd = f"{_cmd} {obj_name}"
+        return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
+
+    def export(self, osd_id: int, pgid: str = None, obj_name: str = None):
+        """Module to export content of input OSD
+        Args:
+            osd_id: OSD ID for which cot will be executed
+            pgid: pg ID for which objs will be listed
+            obj_name: name of a specific object to be listed
+        Returns:
+            Returns the output of
+            ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op export
+        """
+        # Extracting the incremental osdmap from the osd
+        _cmd = "--op export"
+        if pgid:
+            _cmd = f"{_cmd} --pgid {pgid}"
+        if obj_name:
+            _cmd = f"{_cmd} {obj_name}"
         return self.run_cot_command(cmd=_cmd, osd_id=osd_id)

--- a/ceph/rados/rados_bench.py
+++ b/ceph/rados/rados_bench.py
@@ -154,11 +154,13 @@ class RadosBench:
                 concurrent-ios (Str) : integer (String value)
                 reuse-bench (Str) : bench name (String value)
                 max-objects(Str) : max number of objects to be written
+                check_ec(bool): flag to control Exit code checks
 
         """
         base_cmd = ["rados", "bench"]
         seconds = str(config.pop("seconds"))
         _timeout = config.get("timeout", int(seconds) + 100)
+        check_ec = config.get("check_ec", True)
         base_cmd.extend(["-p", pool_name, seconds, "write"])
 
         run_name = config.pop("run-name", False)
@@ -169,7 +171,9 @@ class RadosBench:
         base_cmd.append(config_dict_to_string(config))
         base_cmd = " ".join(base_cmd)
 
-        client.exec_command(cmd=base_cmd, sudo=True, timeout=_timeout)
+        client.exec_command(
+            cmd=base_cmd, sudo=True, timeout=_timeout, check_ec=check_ec
+        )
         return run_name if run_name else None
 
     @staticmethod

--- a/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
@@ -205,3 +205,11 @@ tests:
       module: test_objectstoretool_workflows.py
       polarion-id: CEPH-83581811
       desc: Verify ceph-objectstore-tool functionalities
+
+  - test:
+      name: ceph-objectstore-tool functionalities during enospc
+      module: test_objectstoretool_workflows.py
+      polarion-id: CEPH-83581811
+      config:
+        bluestore-enospc: true
+      desc: Verify ceph-objectstore-tool functionalities during ENOSPC

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -17,8 +17,10 @@ Possible obj operations:
 ceph-objectstore-tool --data-path path to osd [ --op list $obj_ID]
 """
 
+import datetime
 import json
 import random
+import time
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
@@ -43,6 +45,7 @@ def run(ceph_cluster, **kw):
     rados_obj = RadosOrchestrator(node=cephadm)
     pool_obj = PoolFunctions(node=cephadm)
     objectstore_obj = objectstoreToolWorkflows(node=cephadm)
+    bench_obj_size_kb = 4096
 
     def get_bench_obj(_osd_id):
         out = objectstore_obj.list_objects(osd_id=_osd_id)
@@ -75,486 +78,870 @@ def run(ceph_cluster, **kw):
                 f"No obj with OMAP data found in the list of objs for OSD: {osd_id}"
             )
 
-    all_ops = [
-        "print_usage",
-        "list_objects",
-        "remove_object",
-        "fixing_lost_objects",
-        "manipulate_object_content",
-        "list_omap",
-        "manipulate_omap_header",
-        "manipulate_omap_key",
-        "remove_omap_key",
-        "list_attributes",
-        "manipulate_object_attribute",
-        "remove_obj_attribute",
-    ]
-    operations = config.get("operations", all_ops)
     try:
-        osd_list = rados_obj.get_osd_list(status="up")
-        log.info(f"List of OSDs: \n{osd_list}")
+        all_ops = [
+            "print_usage",
+            "list_objects",
+            "remove_object",
+            "fixing_lost_objects",
+            "manipulate_object_content",
+            "list_omap",
+            "manipulate_omap_header",
+            "manipulate_omap_key",
+            "remove_omap_key",
+            "list_attributes",
+            "manipulate_object_attribute",
+            "remove_obj_attribute",
+        ]
+        readonly_ops = [
+            "list_objects",
+            "list_omap",
+            "list_attributes",
+            "get_omap",
+            "get_omap_header" "get_attributes",
+            "get_bytes",
+            "dump",
+            "export",
+            "meta-list",
+            "get-osdmap",
+            "get-superblock",
+            "get-inc-osdmap",
+        ]
+        if config.get("bluestore-enospc"):
+            operations = config.get("operations", readonly_ops)
 
-        log.info("Create a data pool with default config")
-        assert rados_obj.create_pool(pool_name="cot-pool")
+            log.info(
+                "\n\n Execution begins for COT Bluestore ENOSPC scenarios ************ \n\n"
+            )
 
-        log.info("Write data to the pool using rados bench, 100 objects")
-        assert rados_obj.bench_write(
-            pool_name="cot-pool",
-            rados_write_duration=200,
-            max_objs=200,
-            verify_stats=False,
-        )
+            # create a data pool with single pg
+            _pool_name = "cot-enospc"
+            assert rados_obj.create_pool(pool_name=_pool_name)
+            log.info("Pool %s with single PG created successfully" % _pool_name)
 
-        log.info(
-            "Write OMAP entries to the pool using rados bench, 100 objects with 5 omap entries each"
-        )
-        assert pool_obj.fill_omap_entries(
-            pool_name="cot-pool", obj_start=0, obj_end=100, num_keys_obj=5
-        )
-
-        for operation in operations:
-            if operation == "print_usage":
-                # Execute ceph-objectstore-tool --help
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n ----------------------------------"
-                    f"\n Printing COT Usage/help for OSD {osd_id}"
-                    f"\n ----------------------------------"
+            # retrieving the size of each osd part of acting set for the pool
+            acting_set = rados_obj.get_pg_acting_set(pool_name=_pool_name)
+            osd_sizes = {}
+            for osd_id in acting_set:
+                osd_df_stats = rados_obj.get_osd_df_stats(
+                    tree=False, filter_by="name", filter=f"osd.{osd_id}"
                 )
-                try:
-                    out = objectstore_obj.help(osd_id=osd_id)
-                except Exception as e:
-                    log.info(e)
+                osd_sizes[osd_id] = osd_df_stats["nodes"][0]["kb"]
+            primary_osd_size = osd_sizes[acting_set[0]]
 
-            if operation == "list_objects":
-                # Execute ceph-objectstore-tool --data-path <osd_path> --op list
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n ------------------------------------------"
-                    f"\n Identify all objects within an OSD: {osd_id}"
-                    f"\n ------------------------------------------"
-                )
-                out = objectstore_obj.list_objects(osd_id=osd_id)
-                obj_list = [json.loads(x) for x in out.split()]
-                log.info(f"List of objects in OSD {osd_id}: \n\n {obj_list}")
-                assert 'oid":"benchmark_data_' in out
+            log.info(
+                "Write OMAP entries to the pool using librados, 100 objects with 5 omap entries each"
+            )
+            assert pool_obj.fill_omap_entries(
+                pool_name=_pool_name, obj_start=0, obj_end=100, num_keys_obj=5
+            )
+            time.sleep(30)
 
-                # Execute ceph-objectstore-tool --data-path <osd_path> --op list $OBJECT_ID
-                log.info(
-                    f"\n -------------------------------------------"
-                    f"\n Identify the placement group (PG) that an object belongs to for OSD {osd_id}"
-                    f"\n -------------------------------------------"
-                )
-                # sample object -
-                # ["5.1f",{"oid":"lc.0","key":"","snapid":-2,"hash":641746943,"max":0,"pool":5,"namespace":"lc","max":0}]
-                pg_id, obj = get_bench_obj(_osd_id=osd_id)
-                object_id = json.loads(obj)["oid"]
-                out = objectstore_obj.get_pg_from_object(
-                    osd_id=osd_id, obj_id=object_id
-                )
-                fetched_obj = json.loads(out)
-                log.info(fetched_obj)
-                _pg = fetched_obj[0]
-                log.info(f"PG for ObjectID {object_id}: {_pg} | Expected value {pg_id}")
-                assert _pg == pg_id
+            # determine how much % cluster is already filled
+            current_fill_ratio = rados_obj.get_cephdf_stats()["stats"][
+                "total_used_raw_ratio"
+            ]
 
-                # Execute ceph-objectstore-tool --data-path <osd_path> --pgid $PG_ID --op list
-                log.info(
-                    f"\n ----------------------------------"
-                    f"\n Identify all objects within a placement group {pg_id} for OSD.{osd_id}"
-                    f"\n ----------------------------------"
-                )
-                out = objectstore_obj.list_objects(osd_id=osd_id, pgid=pg_id)
-                log.info(f"List of objects in OSD.{osd_id} and PG {pg_id}: \n {out}")
-                assert f'["{pg_id}",{{"oid":' in out
+            # determine the number of objects to be written to the pool
+            # to achieve ENOPSC state
+            objs_enospc = (
+                int(primary_osd_size * (1 - current_fill_ratio) / bench_obj_size_kb) + 1
+            )
 
-            """ Removal of an object as documented here
-            https://docs.ceph.com/en/latest/man/8/ceph-objectstore-tool/#removing-an-object does not work
-            for Pacific builds.
-            BZ - 2262909 | RHCS 5.3
-            """
-            if operation == "remove_object" and (not rhbuild.startswith("5")):
-                # Execute ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT remove
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n ------------------------------------"
-                    f"\n Remove an object within an OSD: {osd_id}"
-                    f"\n ------------------------------------"
-                )
-                pg_id, obj = get_bench_obj(_osd_id=osd_id)
-                obj_list = objectstore_obj.list_objects(
-                    osd_id=osd_id, pgid=pg_id
-                ).strip()
-                log.info(f"List of objects before removal: {obj_list}")
-                out = objectstore_obj.remove_object(osd_id=osd_id, obj=obj, pgid=pg_id)
-                assert "remove" in out
-                _obj_list = objectstore_obj.list_objects(
-                    osd_id=osd_id, pgid=pg_id
-                ).strip()
-                log.info(f"List of objects post removal: \n {_obj_list}")
-                assert str(obj) not in _obj_list
+            # set nearfull, backfill-full and full-ratio to 100%
+            cmds = [
+                "ceph osd set-full-ratio 1",
+                "ceph osd set-backfillfull-ratio 1",
+                "ceph osd set-nearfull-ratio 1",
+            ]
 
-            if operation == "fixing_lost_objects":
-                # Execute ceph-objectstore-tool --data-path <osd_path> --op fix-lost
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n -----------------------------------"
-                    f"\n Fix all lost objects for OSD: {osd_id}"
-                    f"\n -----------------------------------"
-                )
-                out = objectstore_obj.fix_lost_object(osd_id=osd_id)
-                log.info(out)
+            [cephadm.shell(args=[cmd]) for cmd in cmds]
 
-                # Execute ceph-objectstore-tool --data-path <osd_path> --pgid $PG_ID --op fix-lost
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n ---------------------------------"
-                    f"\n Fix all the lost objects within a specified placement group: for OSD.{osd_id}"
-                    f"\n ---------------------------------"
-                )
-                pg_id = rados_obj.get_pgid(osd_primary=osd_id)[0]
-                out = objectstore_obj.fix_lost_object(osd_id=osd_id, pgid=pg_id)
-                log.info(out)
+            # perform rados bench to trigger ENOSPC warning
+            assert rados_obj.bench_write(
+                pool_name=_pool_name,
+                rados_write_duration=500,
+                max_objs=objs_enospc,
+                byte_size=f"{bench_obj_size_kb}KB",
+                verify_stats=False,
+                check_ec=False,
+            )
+            time.sleep(30)
 
-                """
-                Error: Can't specify both --op and object command syntax
-                BZ-2263374 | Pacific and Quincy
-                """
-                if rhbuild.startswith("7"):
-                    # Execute ceph-objectstore-tool --data-path <osd_path> --op fix-lost $OBJECT_ID
+            # log the cluster and pool fill %
+            cluster_fill = (
+                int(rados_obj.get_cephdf_stats()["stats"]["total_used_raw_ratio"]) * 100
+            )
+            pool_fill = (
+                int(
+                    rados_obj.get_cephdf_stats(pool_name=_pool_name)["stats"][
+                        "percent_used"
+                    ]
+                )
+                * 100
+            )
+
+            log.info("Cluster fill percentage: %d" % cluster_fill)
+            log.info("Pool %s fill percentage: %d" % (_pool_name, pool_fill))
+
+            timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=600)
+            # wait for 600 secs to see ENOSPC warning in health detail
+            while datetime.datetime.now() < timeout_time:
+                health_detail = rados_obj.log_cluster_health()
+                if "ENOSPC" in health_detail:
+                    log.info("ENOSPC warning found on the cluster")
+                    break
+                log.info("ENOSPC warning yet to populate, sleeping for 30 secs")
+                time.sleep(30)
+            else:
+                log.error("Could not generate ENOSPC warning on the cluster")
+                raise Exception("Could not generate ENOSPC warning on the cluster")
+
+            # execute COT commands that are now feasible in read-only mode
+            for operation in operations:
+                osd_list = rados_obj.get_osd_list(status="up")
+                if operation == "list_objects":
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --op list
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------"
+                        f"\n Identify all objects within an OSD: {osd_id}"
+                        f"\n ------------------------------------------"
+                    )
+                    out = objectstore_obj.list_objects(osd_id=osd_id)
+                    obj_list = [json.loads(x) for x in out.split()]
+                    log.info(f"List of objects in OSD {osd_id}: \n\n {obj_list}")
+                    assert 'oid":"benchmark_data_' in out
+
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --op list $OBJECT_ID
+                    log.info(
+                        f"\n -------------------------------------------"
+                        f"\n Identify the placement group (PG) that an object belongs to for OSD {osd_id}"
+                        f"\n -------------------------------------------"
+                    )
+                    # sample object -
+                    # ["5.1f",{"oid":"lc.0","key":"","snapid":-2,"hash":641746943,"max":0,"pool":5,"namespace":"lc","max":0}]
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    object_id = json.loads(obj)["oid"]
+                    out = objectstore_obj.get_pg_from_object(
+                        osd_id=osd_id, obj_id=object_id
+                    )
+                    fetched_obj = json.loads(out)
+                    log.info(fetched_obj)
+                    _pg = fetched_obj[0]
+                    log.info(
+                        f"PG for ObjectID {object_id}: {_pg} | Expected value {pg_id}"
+                    )
+                    assert _pg == pg_id
+
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --pgid $PG_ID --op list
+                    log.info(
+                        f"\n ----------------------------------"
+                        f"\n Identify all objects within a placement group {pg_id} for OSD.{osd_id}"
+                        f"\n ----------------------------------"
+                    )
+                    out = objectstore_obj.list_objects(osd_id=osd_id, pgid=pg_id)
+                    log.info(
+                        f"List of objects in OSD.{osd_id} and PG {pg_id}: \n {out}"
+                    )
+                    assert f'["{pg_id}",{{"oid":' in out
+
+                if operation == "list_get_omap":
+                    # Use the ceph-objectstore-tool to list the contents of the object map (OMAP).
+                    # The output is a list of keys.
                     osd_id = random.choice(osd_list)
                     log.info(
                         f"\n --------------------"
-                        f"\n Fix a lost object by its identifier for OSD: {osd_id}"
+                        f"\n List the object map for OSD: {osd_id}"
                         f"\n --------------------"
                     )
-                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
-                    obj_id = json.loads(obj)["oid"]
-                    out = objectstore_obj.fix_lost_object(osd_id=osd_id, obj_id=obj_id)
+                    pg_id, obj = get_omap_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-omap
+                    log.info(f"Fetch object map for obj {obj}")
+                    out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
+                    log.info(f"List of omap entries for obj {obj}: \n {out}")
+                    assert "key_" in out
+
+                    # Use the ceph-objectstore-tool utility to retrieve the object map (OMAP) key.
+                    # You need to provide the data path, the placement group identifier (PG ID),
+                    # the object, and the key in the OMAP.
+                    log.info(
+                        f"\n --------------------"
+                        f"\n Fetching the object map key for OSD: {osd_id}"
+                        f"\n --------------------"
+                    )
+                    omap_key = out.split()[-1]
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+                    log.info(f"Chosen OMAP key: {omap_key}")
+
+                    # fetch the omap key value
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omap $KEY > out_file
+                    value = objectstore_obj.get_omap(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, key=omap_key
+                    )
+                    log.info(f"Value for OMAP key {omap_key} in object {obj}: {value}")
+
+                if operation == "get_omap_header":
+                    # The ceph-objectstore-tool utility will output the object map (OMAP) header
+                    # with the values associated with the object’s keys.
+                    osd_id = random.choice(osd_list)
+                    osd_host = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    pg_id, obj = get_omap_obj(_osd_id=osd_id)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch OMAP header for object {obj} in OSD {osd_id} and PG: {pg_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+
+                    # Get the object map header
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr > out_file
+                    log.info(f"Fetch OMAP header for obj {obj}")
+                    objectstore_obj.get_omap_header(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/omaphdr_org"
+                    )
+
+                    # log the object's OMAP header
+                    log.info("OMAP header fetched for the object %s" % obj)
+                    out, _ = osd_host.exec_command(
+                        sudo=True, cmd="cat /tmp/omaphdr_org"
+                    )
                     log.info(out)
 
-            if operation == "manipulate_object_content":
-                # Find the object by listing the objects of the OSD or placement group.
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n ------------------------------------------------------"
-                    f"\n Manipulate object content in OSD {osd_id}"
-                    f"\n ------------------------------------------------------"
-                )
-                osd_host = rados_obj.fetch_host_node(
-                    daemon_type="osd", daemon_id=osd_id
-                )
-                pg_id, obj = get_bench_obj(_osd_id=osd_id)
-
-                # Before setting the bytes on the object, make a backup and a working copy of the object.
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-bytes > out_file
-                log.info(f"Fetch object bytes for obj: {obj} in PG: {pg_id}")
-                objectstore_obj.get_bytes(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/obj_work"
-                )
-
-                # Edit the working copy object's data
-                log.info("Modify bytes fetched for the object")
-                edit_cmd = "echo 'random data' >> /tmp/obj_work"
-                out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
-
-                # Set the bytes of the object
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-bytes < modified_file
-                log.info(f"Inject modified object bytes for obj {obj}")
-                out = objectstore_obj.set_bytes(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, in_file="/tmp/obj_work"
-                )
-                log.info(out)
-
-                # verify manipulation of object data
-                log.info(f"Fetch object bytes for obj {obj} post injection")
-                objectstore_obj.get_bytes(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/mod_obj"
-                )
-
-                try:
-                    mod_obj_data, _ = osd_host.exec_command(
-                        sudo=True, cmd="cat /tmp/mod_obj"
-                    )
-                    log.info(mod_obj_data)
-                    assert "random data" in mod_obj_data
+                if operation == "list_get_attributes":
+                    # Use the ceph-objectstore-tool utility to list an object’s attributes.
+                    # The output provides you with the object’s keys and values.
+                    osd_id = random.choice(osd_list)
                     log.info(
-                        f"Additional text found in modified bytes fetched for object {obj}"
+                        f"\n --------------------------------"
+                        f"\n List attributes of an object within OSD: {osd_id}"
+                        f"\n --------------------------------"
                     )
-                except UnicodeDecodeError:
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-attrs
+                    log.info(f"List attributes for obj {obj}")
+                    out = objectstore_obj.list_attributes(
+                        osd_id=osd_id, pgid=pg_id, obj=obj
+                    )
+                    attr_list = out.split()
+                    obj_attr = attr_list[-1]
+                    log.info(f"List of attributes for obj {obj}: \n {out}")
+
+                    log.info(f"Chosen attribute for object {obj}: {obj_attr}")
+
+                    # Use the ceph-objectstore-tool utility to fetch an object’s attribute.
+                    # To fetch the object’s attributes you need the data and journal paths,
+                    # the placement group identifier (PG ID), the object,
+                    # and the key in the object’s attribute.
+                    # fetch the value of object's attribute
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-attr $KEY > out_file
                     log.info(
-                        "Object content was not in utf-8 encoding, attempting to fix"
+                        f"\n -----------------------------------"
+                        f"\n Fetch object attribute for OSD: {osd_id}"
+                        f"\n ------------------------------------"
                     )
-                    mod_obj_data = mod_obj_data.decode("utf-8", "ignore")
+                    value = objectstore_obj.get_attribute(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, attr=obj_attr
+                    )
+                    log.info(
+                        f"Value for object attribute {obj_attr} in object {obj}: {value}"
+                    )
 
-            if operation == "list_omap":
-                # Use the ceph-objectstore-tool to list the contents of the object map (OMAP).
-                # The output is a list of keys.
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n --------------------"
-                    f"\n List the object map for OSD: {osd_id}"
-                    f"\n --------------------"
-                )
-                pg_id, obj = get_omap_obj(_osd_id=osd_id)
-                log.info(f"PG: {pg_id}")
-                log.info(f"Chosen object: {obj}")
+                if operation == "get_bytes":
+                    # Find the object by listing the objects of the OSD or placement group.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch object content in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    osd_host = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
 
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-omap
-                log.info(f"Fetch object map for obj {obj}")
-                out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
-                log.info(f"List of omap entries for obj {obj}: \n {out}")
-                assert "key_" in out
+                    # Before setting the bytes on the object, make a backup and a working copy of the object.
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-bytes > out_file
+                    log.info(f"Fetch object bytes for obj: {obj} in PG: {pg_id}")
+                    objectstore_obj.get_bytes(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/obj_work"
+                    )
 
-            if operation == "manipulate_omap_header":
-                # The ceph-objectstore-tool utility will output the object map (OMAP) header
-                # with the values associated with the object’s keys.
-                osd_id = random.choice(osd_list)
-                osd_host = rados_obj.fetch_host_node(
-                    daemon_type="osd", daemon_id=osd_id
-                )
-                pg_id, obj = get_omap_obj(_osd_id=osd_id)
-                log.info(
-                    f"\n ------------------------------------------------------"
-                    f"\n Manipulate OMAP header for object {obj} in OSD {osd_id} and PG: {pg_id}"
-                    f"\n ------------------------------------------------------"
-                )
+                    # log the working copy object's data
+                    log.info("Logging bytes fetched for the object")
+                    out, _ = osd_host.exec_command(sudo=True, cmd="cat /tmp/obj_work")
+                    log.info(out)
 
-                # Get the object map header
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr > out_file
-                log.info(f"Fetch OMAP header for obj {obj}")
-                objectstore_obj.get_omap_header(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/omaphdr_org"
-                )
+                    # verify manipulation of object data
+                    log.info(f"Fetch object bytes for obj {obj} post injection")
+                    objectstore_obj.get_bytes(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/mod_obj"
+                    )
 
-                # Edit the working copy of object's OMAP header
-                log.info(f"Modify OMAP header fetched for the object {obj}")
-                edit_cmd = "echo 'random omap header data' >> /tmp/omaphdr_org"
-                out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
+                if operation == "dump":
+                    # Obtain the object dump for objects of the OSD or placement group.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch object dump for an object in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    out = objectstore_obj.fetch_object_dump(osd_id=osd_id, obj=obj)
+                    log.info(out)
+                    obj_dump = json.loads(out)
+                    obj_dump_stats = obj_dump["stat"]
+                    obj_dump_extents = obj_dump["onode"]["extents"]
+                    log.info("Object dump stats: \n %s" % obj_dump_stats)
+                    log.info("Object dump extents: \n %s" % obj_dump_extents)
 
-                # Set the modified object map header
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omaphdr < in_file
-                out = objectstore_obj.set_omap_header(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, in_file="/tmp/omaphdr_org"
-                )
-                log.info(out)
+                if operation == "export":
+                    # export the content of an object from an OSD
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Export the content of an object in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    out = objectstore_obj.export(
+                        osd_id=osd_id, pgid=pg_id, obj_name=obj
+                    )
+                    log.info(out)
+                if operation == "meta-list":
+                    # get the meta-list of an object from an OSD
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch the meta-list for an object in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    out = objectstore_obj.get_meta_list(
+                        osd_id=osd_id, pgid=pg_id, obj_name=obj
+                    )
+                    log.info(out)
+                if operation == "get-osdmap":
+                    # get the osd-map of an object from an OSD
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch the osd-map for an object in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    out = objectstore_obj.get_osdmap(
+                        osd_id=osd_id, pgid=pg_id, obj_name=obj
+                    )
+                    log.info(out)
+                if operation == "inc-get-osdmap":
+                    # get the inc-osd-map of an object from an OSD
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch the inc-osd-map for an object in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    out = objectstore_obj.get_inc_osdmap(
+                        osd_id=osd_id, pgid=pg_id, obj_name=obj
+                    )
+                    log.info(out)
+                if operation == "get-superblock":
+                    # get the objectstore superblock of an object from an OSD
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Fetch the objectstore superblock for an object in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    out = objectstore_obj.get_superblock(osd_id=osd_id)
+                    log.info(out)
+        else:
+            operations = config.get("operations", all_ops)
 
-                # verify manipulation of OMAP header data
-                log.info(f"Fetch OMAP header for obj {obj} post modification")
-                objectstore_obj.get_omap_header(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/omaphdr_mod"
-                )
+            osd_list = rados_obj.get_osd_list(status="up")
+            log.info(f"List of OSDs: \n{osd_list}")
 
-                mod_omap_header, _ = osd_host.exec_command(
-                    sudo=True, cmd="cat /tmp/omaphdr_mod"
-                )
-                assert "random omap header" in mod_omap_header
-                log.info(
-                    f"Additional text found in modified OMAP header fetched for object {obj}"
-                )
+            log.info("Create a data pool with default config")
+            assert rados_obj.create_pool(pool_name="cot-pool")
 
-            if operation == "manipulate_omap_key":
-                # Use the ceph-objectstore-tool utility to change the object map (OMAP) key.
-                # You need to provide the data path, the placement group identifier (PG ID),
-                # the object, and the key in the OMAP.
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n --------------------"
-                    f"\n Manipulation of object map key for OSD: {osd_id}"
-                    f"\n --------------------"
-                )
-                osd_host = rados_obj.fetch_host_node(
-                    daemon_type="osd", daemon_id=osd_id
-                )
-                pg_id, obj = get_omap_obj(_osd_id=osd_id)
+            log.info("Write data to the pool using rados bench, 100 objects")
+            assert rados_obj.bench_write(
+                pool_name="cot-pool",
+                rados_write_duration=200,
+                max_objs=200,
+                verify_stats=False,
+            )
 
-                # Get the object map key list
-                out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
-                omap_key = out.split()[-1]
+            log.info(
+                "Write OMAP entries to the pool using librados, 100 objects with 5 omap entries each"
+            )
+            assert pool_obj.fill_omap_entries(
+                pool_name="cot-pool", obj_start=0, obj_end=100, num_keys_obj=5
+            )
 
-                log.info(f"PG: {pg_id}")
-                log.info(f"Chosen object: {obj}")
-                log.info(f"Chosen OMAP key: {omap_key}")
+            for operation in operations:
+                if operation == "print_usage":
+                    # Execute ceph-objectstore-tool --help
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ----------------------------------"
+                        f"\n Printing COT Usage/help for OSD {osd_id}"
+                        f"\n ----------------------------------"
+                    )
+                    try:
+                        out = objectstore_obj.help(osd_id=osd_id)
+                    except Exception as e:
+                        log.info(e)
 
-                # fetch the omap key value
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omap $KEY > out_file
-                value = objectstore_obj.get_omap(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, key=omap_key
-                )
-                log.info(f"Value for OMAP key {omap_key} in object {obj}: {value}")
+                if operation == "list_objects":
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --op list
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------"
+                        f"\n Identify all objects within an OSD: {osd_id}"
+                        f"\n ------------------------------------------"
+                    )
+                    out = objectstore_obj.list_objects(osd_id=osd_id)
+                    obj_list = [json.loads(x) for x in out.split()]
+                    log.info(f"List of objects in OSD {osd_id}: \n\n {obj_list}")
+                    assert 'oid":"benchmark_data_' in out
 
-                # Modify OMAP key's value
-                log.info(f"Modify OMAP key for the object {obj}")
-                mod_value = "value_1111"
-                edit_cmd = f"echo '{mod_value}' > /tmp/omap_value"
-                out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --op list $OBJECT_ID
+                    log.info(
+                        f"\n -------------------------------------------"
+                        f"\n Identify the placement group (PG) that an object belongs to for OSD {osd_id}"
+                        f"\n -------------------------------------------"
+                    )
+                    # sample object -
+                    # ["5.1f",{"oid":"lc.0","key":"","snapid":-2,"hash":641746943,"max":0,"pool":5,"namespace":"lc","max":0}]
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    object_id = json.loads(obj)["oid"]
+                    out = objectstore_obj.get_pg_from_object(
+                        osd_id=osd_id, obj_id=object_id
+                    )
+                    fetched_obj = json.loads(out)
+                    log.info(fetched_obj)
+                    _pg = fetched_obj[0]
+                    log.info(
+                        f"PG for ObjectID {object_id}: {_pg} | Expected value {pg_id}"
+                    )
+                    assert _pg == pg_id
 
-                # Set the object map value for an omap key
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omap $KEY < in_file
-                out = objectstore_obj.set_omap(
-                    osd_id=osd_id,
-                    obj=obj,
-                    pgid=pg_id,
-                    key=omap_key,
-                    in_file="/tmp/omap_value",
-                )
-                log.info(out)
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --pgid $PG_ID --op list
+                    log.info(
+                        f"\n ----------------------------------"
+                        f"\n Identify all objects within a placement group {pg_id} for OSD.{osd_id}"
+                        f"\n ----------------------------------"
+                    )
+                    out = objectstore_obj.list_objects(osd_id=osd_id, pgid=pg_id)
+                    log.info(
+                        f"List of objects in OSD.{osd_id} and PG {pg_id}: \n {out}"
+                    )
+                    assert f'["{pg_id}",{{"oid":' in out
 
-                # verify manipulation of OMAP key value
-                log.info(f"Fetch OMAP key's value for obj {obj} post modification")
-                value = objectstore_obj.get_omap(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, key=omap_key
-                )
-                assert mod_value in value
-                log.info(
-                    f"Modified value({value}) for OMAP key({omap_key}) verified for object {obj}"
-                )
+                """ Removal of an object as documented here
+                https://docs.ceph.com/en/latest/man/8/ceph-objectstore-tool/#removing-an-object does not work
+                for Pacific builds.
+                BZ - 2262909 | RHCS 5.3
+                """
+                if operation == "remove_object" and (not rhbuild.startswith("5")):
+                    # Execute ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT remove
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------"
+                        f"\n Remove an object within an OSD: {osd_id}"
+                        f"\n ------------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    obj_list = objectstore_obj.list_objects(
+                        osd_id=osd_id, pgid=pg_id
+                    ).strip()
+                    log.info(f"List of objects before removal: {obj_list}")
+                    out = objectstore_obj.remove_object(
+                        osd_id=osd_id, obj=obj, pgid=pg_id
+                    )
+                    assert "remove" in out
+                    _obj_list = objectstore_obj.list_objects(
+                        osd_id=osd_id, pgid=pg_id
+                    ).strip()
+                    log.info(f"List of objects post removal: \n {_obj_list}")
+                    assert str(obj) not in _obj_list
 
-            if operation == "remove_omap_key":
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n --------------------"
-                    f"\n Remove an Object map key for OSD: {osd_id}"
-                    f"\n --------------------"
-                )
-                pg_id, obj = get_omap_obj(_osd_id=osd_id)
-                log.info(f"PG: {pg_id}")
-                log.info(f"Chosen object: {obj}")
+                if operation == "fixing_lost_objects":
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --op fix-lost
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n -----------------------------------"
+                        f"\n Fix all lost objects for OSD: {osd_id}"
+                        f"\n -----------------------------------"
+                    )
+                    out = objectstore_obj.fix_lost_object(osd_id=osd_id)
+                    log.info(out)
 
-                # Get the object map key list
-                out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
-                omap_key = out.split()[-1]
-                log.info(f"Chosen omap key: {omap_key}")
+                    # Execute ceph-objectstore-tool --data-path <osd_path> --pgid $PG_ID --op fix-lost
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ---------------------------------"
+                        f"\n Fix all the lost objects within a specified placement group: for OSD.{osd_id}"
+                        f"\n ---------------------------------"
+                    )
+                    pg_id = rados_obj.get_pgid(osd_primary=osd_id)[0]
+                    out = objectstore_obj.fix_lost_object(osd_id=osd_id, pgid=pg_id)
+                    log.info(out)
 
-                # remove the object map key
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-omap $KEY
-                out = objectstore_obj.remove_omap(
-                    osd_id=osd_id, pgid=pg_id, obj=obj, key=omap_key
-                )
-                log.info(out)
+                    """
+                    Error: Can't specify both --op and object command syntax
+                    BZ-2263374 | Pacific and Quincy
+                    """
+                    if rhbuild.startswith("7"):
+                        # Execute ceph-objectstore-tool --data-path <osd_path> --op fix-lost $OBJECT_ID
+                        osd_id = random.choice(osd_list)
+                        log.info(
+                            f"\n --------------------"
+                            f"\n Fix a lost object by its identifier for OSD: {osd_id}"
+                            f"\n --------------------"
+                        )
+                        pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                        obj_id = json.loads(obj)["oid"]
+                        out = objectstore_obj.fix_lost_object(
+                            osd_id=osd_id, obj_id=obj_id
+                        )
+                        log.info(out)
 
-                # verify removal of omap key
-                out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
-                log.info(f"List of omap entries post deletion: {out}")
-                assert omap_key not in out
+                if operation == "manipulate_object_content":
+                    # Find the object by listing the objects of the OSD or placement group.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Manipulate object content in OSD {osd_id}"
+                        f"\n ------------------------------------------------------"
+                    )
+                    osd_host = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
 
-            if operation == "list_attributes":
-                # Use the ceph-objectstore-tool utility to list an object’s attributes.
-                # The output provides you with the object’s keys and values.
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n --------------------------------"
-                    f"\n List attributes of an object within OSD: {osd_id}"
-                    f"\n --------------------------------"
-                )
-                pg_id, obj = get_bench_obj(_osd_id=osd_id)
-                log.info(f"PG: {pg_id}")
-                log.info(f"Chosen object: {obj}")
+                    # Before setting the bytes on the object, make a backup and a working copy of the object.
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-bytes > out_file
+                    log.info(f"Fetch object bytes for obj: {obj} in PG: {pg_id}")
+                    objectstore_obj.get_bytes(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/obj_work"
+                    )
 
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-attrs
-                log.info(f"List attributes for obj {obj}")
-                out = objectstore_obj.list_attributes(
-                    osd_id=osd_id, pgid=pg_id, obj=obj
-                )
-                log.info(f"List of attributes for obj {obj}: \n {out}")
+                    # Edit the working copy object's data
+                    log.info("Modify bytes fetched for the object")
+                    edit_cmd = "echo 'random data' >> /tmp/obj_work"
+                    out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
 
-            if operation == "manipulate_object_attribute":
-                # Use the ceph-objectstore-tool utility to change an object’s attribute.
-                # To manipulate the object’s attributes you need the data and journal paths,
-                # the placement group identifier (PG ID), the object,
-                # and the key in the object’s attribute.
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n -----------------------------------"
-                    f"\n Manipulate object attribute for OSD: {osd_id}"
-                    f"\n ------------------------------------"
-                )
-                osd_host = rados_obj.fetch_host_node(
-                    daemon_type="osd", daemon_id=osd_id
-                )
-                pg_id, obj = get_bench_obj(_osd_id=osd_id)
-                log.info(f"PG: {pg_id}")
-                log.info(f"Chosen object: {obj}")
-                log.info(f"List attributes for obj {obj}")
-                out = objectstore_obj.list_attributes(
-                    osd_id=osd_id, pgid=pg_id, obj=obj
-                )
-                attr_list = out.split()
-                obj_attr = attr_list[-1]
-                log.info(f"List of attributes for obj {obj}: \n {attr_list}")
+                    # Set the bytes of the object
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-bytes < modified_file
+                    log.info(f"Inject modified object bytes for obj {obj}")
+                    out = objectstore_obj.set_bytes(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, in_file="/tmp/obj_work"
+                    )
+                    log.info(out)
 
-                log.info(f"Chosen attribute for object {obj}: {obj_attr}")
+                    # verify manipulation of object data
+                    log.info(f"Fetch object bytes for obj {obj} post injection")
+                    objectstore_obj.get_bytes(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/mod_obj"
+                    )
 
-                # fetch the value of object's attribute
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-attr $KEY > out_file
-                value = objectstore_obj.get_attribute(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, attr=obj_attr
-                )
-                log.info(
-                    f"Value for object attribute {obj_attr} in object {obj}: {value}"
-                )
+                    try:
+                        mod_obj_data, _ = osd_host.exec_command(
+                            sudo=True, cmd="cat /tmp/mod_obj"
+                        )
+                        log.info(mod_obj_data)
+                        assert "random data" in mod_obj_data
+                        log.info(
+                            f"Additional text found in modified bytes fetched for object {obj}"
+                        )
+                    except UnicodeDecodeError:
+                        log.info(
+                            "Object content was not in utf-8 encoding, attempting to fix"
+                        )
+                        mod_obj_data = mod_obj_data.decode("utf-8", "ignore")
 
-                # Modify object attribute's value
-                log.info(f"Modify {obj_attr} object attribute's value for {obj}")
-                mod_value = "Base64:AwIdAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-                edit_cmd = f"echo '{mod_value}' > /tmp/attr_value"
-                out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
+                if operation == "list_omap":
+                    # Use the ceph-objectstore-tool to list the contents of the object map (OMAP).
+                    # The output is a list of keys.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n --------------------"
+                        f"\n List the object map for OSD: {osd_id}"
+                        f"\n --------------------"
+                    )
+                    pg_id, obj = get_omap_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
 
-                # Set the object attribute's value
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-attr $KEY < in_file
-                out = objectstore_obj.set_attribute(
-                    osd_id=osd_id,
-                    obj=obj,
-                    pgid=pg_id,
-                    attr=obj_attr,
-                    in_file="/tmp/attr_value",
-                )
-                log.info(out)
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-omap
+                    log.info(f"Fetch object map for obj {obj}")
+                    out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
+                    log.info(f"List of omap entries for obj {obj}: \n {out}")
+                    assert "key_" in out
 
-                # verify manipulation of object attributes value
-                value = objectstore_obj.get_attribute(
-                    osd_id=osd_id, obj=obj, pgid=pg_id, attr=obj_attr
-                )
-                log.info(
-                    f"Modified value for object attribute {obj_attr} in object {obj}: {value}"
-                )
-                assert mod_value in value
-                log.info(
-                    f"Modified value({value}) for object attribute({obj_attr}) verified for object {obj}"
-                )
+                if operation == "manipulate_omap_header":
+                    # The ceph-objectstore-tool utility will output the object map (OMAP) header
+                    # with the values associated with the object’s keys.
+                    osd_id = random.choice(osd_list)
+                    osd_host = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    pg_id, obj = get_omap_obj(_osd_id=osd_id)
+                    log.info(
+                        f"\n ------------------------------------------------------"
+                        f"\n Manipulate OMAP header for object {obj} in OSD {osd_id} and PG: {pg_id}"
+                        f"\n ------------------------------------------------------"
+                    )
 
-            if operation == "remove_obj_attribute":
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n ----------------------------------"
-                    f"\n Remove an Object attribute for OSD: {osd_id}"
-                    f"\n ----------------------------------"
-                )
-                pg_id, obj = get_bench_obj(_osd_id=osd_id)
-                log.info(f"PG: {pg_id}")
-                log.info(f"Chosen object: {obj}")
-                log.info(f"List attributes for obj {obj}")
-                out = objectstore_obj.list_attributes(
-                    osd_id=osd_id, pgid=pg_id, obj=obj
-                )
-                attr_list = out.split()
-                obj_attr = attr_list[-1]
-                log.info(f"List of attributes for obj {obj}: \n {attr_list}")
-                log.info(f"Chosen attribute for object {obj}: {obj_attr}")
+                    # Get the object map header
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr > out_file
+                    log.info(f"Fetch OMAP header for obj {obj}")
+                    objectstore_obj.get_omap_header(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/omaphdr_org"
+                    )
 
-                # remove the object attribute entry
-                # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-attr $KEY
-                out = objectstore_obj.remove_attribute(
-                    osd_id=osd_id, pgid=pg_id, obj=obj, attr=obj_attr
-                )
-                log.info(out)
+                    # Edit the working copy of object's OMAP header
+                    log.info(f"Modify OMAP header fetched for the object {obj}")
+                    edit_cmd = "echo 'random omap header data' >> /tmp/omaphdr_org"
+                    out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
 
-                # verify removal of object attribute
-                out = objectstore_obj.list_attributes(
-                    osd_id=osd_id, pgid=pg_id, obj=obj
-                )
-                log.info(f"List of object attributes post deletion: {out}")
-                assert obj_attr not in out
+                    # Set the modified object map header
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omaphdr < in_file
+                    out = objectstore_obj.set_omap_header(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, in_file="/tmp/omaphdr_org"
+                    )
+                    log.info(out)
+
+                    # verify manipulation of OMAP header data
+                    log.info(f"Fetch OMAP header for obj {obj} post modification")
+                    objectstore_obj.get_omap_header(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/omaphdr_mod"
+                    )
+
+                    mod_omap_header, _ = osd_host.exec_command(
+                        sudo=True, cmd="cat /tmp/omaphdr_mod"
+                    )
+                    assert "random omap header" in mod_omap_header
+                    log.info(
+                        f"Additional text found in modified OMAP header fetched for object {obj}"
+                    )
+
+                if operation == "manipulate_omap_key":
+                    # Use the ceph-objectstore-tool utility to change the object map (OMAP) key.
+                    # You need to provide the data path, the placement group identifier (PG ID),
+                    # the object, and the key in the OMAP.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n --------------------"
+                        f"\n Manipulation of object map key for OSD: {osd_id}"
+                        f"\n --------------------"
+                    )
+                    osd_host = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    pg_id, obj = get_omap_obj(_osd_id=osd_id)
+
+                    # Get the object map key list
+                    out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
+                    omap_key = out.split()[-1]
+
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+                    log.info(f"Chosen OMAP key: {omap_key}")
+
+                    # fetch the omap key value
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omap $KEY > out_file
+                    value = objectstore_obj.get_omap(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, key=omap_key
+                    )
+                    log.info(f"Value for OMAP key {omap_key} in object {obj}: {value}")
+
+                    # Modify OMAP key's value
+                    log.info(f"Modify OMAP key for the object {obj}")
+                    mod_value = "value_1111"
+                    edit_cmd = f"echo '{mod_value}' > /tmp/omap_value"
+                    out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
+
+                    # Set the object map value for an omap key
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omap $KEY < in_file
+                    out = objectstore_obj.set_omap(
+                        osd_id=osd_id,
+                        obj=obj,
+                        pgid=pg_id,
+                        key=omap_key,
+                        in_file="/tmp/omap_value",
+                    )
+                    log.info(out)
+
+                    # verify manipulation of OMAP key value
+                    log.info(f"Fetch OMAP key's value for obj {obj} post modification")
+                    value = objectstore_obj.get_omap(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, key=omap_key
+                    )
+                    assert mod_value in value
+                    log.info(
+                        f"Modified value({value}) for OMAP key({omap_key}) verified for object {obj}"
+                    )
+
+                if operation == "remove_omap_key":
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n --------------------"
+                        f"\n Remove an Object map key for OSD: {osd_id}"
+                        f"\n --------------------"
+                    )
+                    pg_id, obj = get_omap_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+
+                    # Get the object map key list
+                    out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
+                    omap_key = out.split()[-1]
+                    log.info(f"Chosen omap key: {omap_key}")
+
+                    # remove the object map key
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-omap $KEY
+                    out = objectstore_obj.remove_omap(
+                        osd_id=osd_id, pgid=pg_id, obj=obj, key=omap_key
+                    )
+                    log.info(out)
+
+                    # verify removal of omap key
+                    out = objectstore_obj.list_omap(osd_id=osd_id, pgid=pg_id, obj=obj)
+                    log.info(f"List of omap entries post deletion: {out}")
+                    assert omap_key not in out
+
+                if operation == "list_attributes":
+                    # Use the ceph-objectstore-tool utility to list an object’s attributes.
+                    # The output provides you with the object’s keys and values.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n --------------------------------"
+                        f"\n List attributes of an object within OSD: {osd_id}"
+                        f"\n --------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-attrs
+                    log.info(f"List attributes for obj {obj}")
+                    out = objectstore_obj.list_attributes(
+                        osd_id=osd_id, pgid=pg_id, obj=obj
+                    )
+                    log.info(f"List of attributes for obj {obj}: \n {out}")
+
+                if operation == "manipulate_object_attribute":
+                    # Use the ceph-objectstore-tool utility to change an object’s attribute.
+                    # To manipulate the object’s attributes you need the data and journal paths,
+                    # the placement group identifier (PG ID), the object,
+                    # and the key in the object’s attribute.
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n -----------------------------------"
+                        f"\n Manipulate object attribute for OSD: {osd_id}"
+                        f"\n ------------------------------------"
+                    )
+                    osd_host = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+                    log.info(f"List attributes for obj {obj}")
+                    out = objectstore_obj.list_attributes(
+                        osd_id=osd_id, pgid=pg_id, obj=obj
+                    )
+                    attr_list = out.split()
+                    obj_attr = attr_list[-1]
+                    log.info(f"List of attributes for obj {obj}: \n {attr_list}")
+
+                    log.info(f"Chosen attribute for object {obj}: {obj_attr}")
+
+                    # fetch the value of object's attribute
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-attr $KEY > out_file
+                    value = objectstore_obj.get_attribute(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, attr=obj_attr
+                    )
+                    log.info(
+                        f"Value for object attribute {obj_attr} in object {obj}: {value}"
+                    )
+
+                    # Modify object attribute's value
+                    log.info(f"Modify {obj_attr} object attribute's value for {obj}")
+                    mod_value = (
+                        "Base64:AwIdAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    )
+                    edit_cmd = f"echo '{mod_value}' > /tmp/attr_value"
+                    out, _ = osd_host.exec_command(sudo=True, cmd=edit_cmd)
+
+                    # Set the object attribute's value
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-attr $KEY < in_file
+                    out = objectstore_obj.set_attribute(
+                        osd_id=osd_id,
+                        obj=obj,
+                        pgid=pg_id,
+                        attr=obj_attr,
+                        in_file="/tmp/attr_value",
+                    )
+                    log.info(out)
+
+                    # verify manipulation of object attributes value
+                    value = objectstore_obj.get_attribute(
+                        osd_id=osd_id, obj=obj, pgid=pg_id, attr=obj_attr
+                    )
+                    log.info(
+                        f"Modified value for object attribute {obj_attr} in object {obj}: {value}"
+                    )
+                    assert mod_value in value
+                    log.info(
+                        f"Modified value({value}) for object attribute({obj_attr}) verified for object {obj}"
+                    )
+
+                if operation == "remove_obj_attribute":
+                    osd_id = random.choice(osd_list)
+                    log.info(
+                        f"\n ----------------------------------"
+                        f"\n Remove an Object attribute for OSD: {osd_id}"
+                        f"\n ----------------------------------"
+                    )
+                    pg_id, obj = get_bench_obj(_osd_id=osd_id)
+                    log.info(f"PG: {pg_id}")
+                    log.info(f"Chosen object: {obj}")
+                    log.info(f"List attributes for obj {obj}")
+                    out = objectstore_obj.list_attributes(
+                        osd_id=osd_id, pgid=pg_id, obj=obj
+                    )
+                    attr_list = out.split()
+                    obj_attr = attr_list[-1]
+                    log.info(f"List of attributes for obj {obj}: \n {attr_list}")
+                    log.info(f"Chosen attribute for object {obj}: {obj_attr}")
+
+                    # remove the object attribute entry
+                    # ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-attr $KEY
+                    out = objectstore_obj.remove_attribute(
+                        osd_id=osd_id, pgid=pg_id, obj=obj, attr=obj_attr
+                    )
+                    log.info(out)
+
+                    # verify removal of object attribute
+                    out = objectstore_obj.list_attributes(
+                        osd_id=osd_id, pgid=pg_id, obj=obj
+                    )
+                    log.info(f"List of object attributes post deletion: {out}")
+                    assert obj_attr not in out
 
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")


### PR DESCRIPTION
Jira tracker: [RHCEPHQE-20972](https://issues.redhat.com/browse/RHCEPHQE-20972)

Polarion: [CEPH-83620743](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83620743)

Tier-3 test to verify the functionalities of ceph-objectstore-tool when OSDs are in read-only mode.

Test modules modified:
- `ceph/rados/objectstoretool_workflows.py`
- `ceph/rados/rados_bench.py`
- `tests/rados/test_objectstoretool_workflows.py`

Test suites modified:
- `suites/squid/rados/tier-2_rados_test_cot_cbt.yaml`

Logs:
Upstream tentacle:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>