### PR TITLE
Revert stretch mode netsplit and site down scenario.

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -4712,6 +4712,15 @@ EOF"""
             return self.set_service_managed_type(
                 service_type=service_type, unmanaged=False
             )
+
+        cmd_export = f"ceph orch ls {service_type} {service_name} --export"
+        _service = self.run_ceph_command(cmd=cmd_export, client_exec=True)
+        if not _service.get("placement", False):
+            log.warning(
+                "Service %s does not have placement entry and cannot be set to 'managed', skipping"
+                % _service["service_name"]
+            )
+            return True
         cmd_set_managed_flag = f"ceph orch set-managed {service_name}"
         self.client.exec_command(sudo=True, cmd=cmd_set_managed_flag)
         base_cmd = "ceph orch ls"

--- a/conf/reef/rados/test-confs/pool-configurations.yaml
+++ b/conf/reef/rados/test-confs/pool-configurations.yaml
@@ -48,7 +48,7 @@ erasure:
     plugin: jerasure
     crush-failure-domain: host
   sample-pool-6:
-    pool_name: ec_pool_22_1
+    pool_name: ec_pool_22_2
     pool_type: erasure
     k: 2
     m: 2

--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
@@ -1,0 +1,268 @@
+# Stretch mode tests for new features
+# conf: 13-node-cluster-4-clients.yaml
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/tentacle/rados/deploy-stretch-cluster-mode.yaml
+
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Cephadm Bootstrap with apply-spec
+      desc: Apply spec in Bootstrap with host location attributes
+      module: test_bootstrap.py
+      polarion-id: CEPH-83575289
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+#          registry-json: registry.redhat.io
+          mon-ip: node1
+          orphan-initial-daemons: true
+          skip-dashboard: true
+          ssh-user: cephuser
+          apply-spec:
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node2
+                - node3
+                - node4
+                - node5
+                - node6
+              location:
+                root: default
+                datacenter: DC1
+            - service_type: host
+              address: true
+              labels: apply-all-labels
+              nodes:
+                - node8
+                - node9
+                - node10
+                - node11
+                - node14
+              location:
+                root: default
+                datacenter: DC2
+            - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=tiebreaker
+                  node3:
+                    - datacenter=DC1
+                  node5:
+                    - datacenter=DC1
+                  node8:
+                    - datacenter=DC2
+                  node9:
+                    - datacenter=DC2
+              placement:
+                label: mon
+            - service_type: mgr
+              placement:
+                label: mgr
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Service deployment with spec
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: all-available-devices
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args: # display OSD tree
+                - "ceph osd tree"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1
+        nodes:
+            # added as a workaround due to ceph-common, ceph-base package
+            # installation issue in tentacle
+            - node7:
+                release: 8
+            - node15:
+                release: 8
+            - node16:
+                release: 8
+            - node17:
+                release: 8
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Deploy stretch Cluster
+      module: test_stretch_deployment_with_placement.py
+      polarion-id: CEPH-83573621
+      config:
+        no_affinity: false
+        stretch_rule_name: stretch_rule
+        tiebreaker_mon_site_name: tiebreaker
+        negative_scenarios: False
+      comments: Pre-deployment -ve scenarios commented due to bug - 2293147
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+#  - test:
+#      name: rgw sanity tests
+#      module: sanity_rgw.py
+#      config:
+#        script-name: test_multitenant_user_access.py
+#        config-file-name: test_multitenant_access.yaml
+#        timeout: 300
+#      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+# Run duration ~ 1 hour 10 minutes
+  - test:
+      name: Revert stretch mode scenarios
+      module: test_stretch_revert.py
+      polarion-id: CEPH-83620057
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario1
+          - scenario2
+      desc: Performs tests related to reverting from stretch mode
+
+# Run duration ~ 45 minutes
+  - test:
+      name: Revert stretch mode netsplit scenarios
+      module: test_stretch_revert.py
+      polarion-id: CEPH-83620057
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario3
+          - scenario4
+      desc: Performs tests related to reverting from stretch mode
+
+  - test:
+      name: Revert stretch mode site down scenarios
+      module: test_stretch_revert.py
+      polarion-id: CEPH-83620057
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario5
+      desc: Performs tests related to reverting from stretch mode

--- a/tests/rados/test_osd_full.py
+++ b/tests/rados/test_osd_full.py
@@ -196,7 +196,7 @@ def run(ceph_cluster, **kw):
 
                 # perform rados bench to trigger nearfull warning
                 nearfull_config = {
-                    "rados_write_duration": 500,
+                    "rados_write_duration": 1000,
                     "byte_size": f"{bench_obj_size_kb}KB",
                     "nocleanup": True,
                     "max_objs": max_obj_nearfull,
@@ -228,7 +228,7 @@ def run(ceph_cluster, **kw):
 
                 # perform rados bench to trigger backfill-full warning
                 backfillfull_config = {
-                    "rados_write_duration": 200,
+                    "rados_write_duration": 400,
                     "byte_size": f"{bench_obj_size_kb}KB",
                     "nocleanup": True,
                     "max_objs": subseq_obj_backfillfull,
@@ -262,7 +262,7 @@ def run(ceph_cluster, **kw):
 
                 # perform rados bench to trigger osd full warning
                 osdfull_config = {
-                    "rados_write_duration": 200,
+                    "rados_write_duration": 400,
                     "byte_size": f"{bench_obj_size_kb}KB",
                     "nocleanup": True,
                     "max_objs": subseq_obj_full,

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -244,12 +244,12 @@ def run(ceph_cluster, **kw):
                 target_osd,
             )
 
-        assert service_obj.add_osds_to_managed_service()
-
         for target_osd in dc_1_osds_to_remove + dc_2_osds_to_remove:
             client = ceph_cluster.get_nodes(role="client")[0]
             log.info(f'Waiting for OSD {target_osd} to be "up" state')
             wait_for_osd_daemon_state(client, target_osd, "up")
+
+        assert service_obj.add_osds_to_managed_service()
 
         log.info(
             f"Successfully removed and added back removed OSDs:\
@@ -598,6 +598,7 @@ def run(ceph_cluster, **kw):
             if dc_1_osd_count != 2 and dc_2_osd_count != 2:
                 log.error(
                     f"PG {pg_stat['pgid']} set does not have 2 OSDs from each of DC1 and DC2"
+                    f"PG acting set -> {pg_stat['acting']}"
                 )
                 return False
         log.info("All PG acting set has 2 OSD from DC1 and 2 OSD from DC2")
@@ -767,7 +768,7 @@ def run(ceph_cluster, **kw):
                 if not rados_obj.set_managed_flag(
                     service_type="osd", service_name=service
                 ):
-                    log_error = f"Service {service} could be set to unmanaged=True"
+                    log_error = f"Service {service} could not be set to managed"
                     raise Exception(log_error)
 
             log.info("Completed the removal and addition of OSD daemons")

--- a/tests/rados/test_stretch_revert.py
+++ b/tests/rados/test_stretch_revert.py
@@ -1,25 +1,29 @@
 """
 This test module is used to test revert stretch mode
 includes:
-1. revert from health stretch mode to default/non-default crush rule
+1. revert from health stretch mode to default crush rule
 2. revert from health stretch mode to custom crush rule
-3. revert from site down stretch mode to default crush rule
-4. revert from site down stretch mode to custome crush rule
-5. revert from netsplit scenario to default/non-default crush rule
-6. revert from netsplit scenario to custom crush rule
+3. revert from netsplit scenario to default crush rule
+4. revert from netsplit scenario to custom crush rule
+5. revert from site down stretch mode to default crush rule
+6. revert from tiebreaker site down stretch mode to custom crush rule
 """
 
+import time
 from collections import namedtuple
 
-from ceph.ceph import CephNode
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.monitor_workflows import MonitorWorkflows
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
+from ceph.utils import find_vm_node_by_hostname
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_stretch_revert_class import RevertStretchModeFunctionalities
 from tests.rados.test_stretch_site_down import stretch_enabled_checks
+from tests.rados.test_stretch_site_reboot import get_host_obj_from_hostname
 from utility.log import Log
+from utility.utils import generate_unique_id
 
 log = Log(__name__)
 
@@ -32,12 +36,12 @@ def run(ceph_cluster, **kw):
     Args:
         ceph_cluster (ceph.ceph.Ceph): ceph cluster
     Scenarios:
-        1. Scenario 1:- revert from health stretch mode to default/non-default crush rule
-        1. Scenario 2:- revert from health stretch mode to custom crush rule
-        2. Scenario 3:- revert from site down stretch mode to default crush rule
-        2. Scenario 4:- revert from site down stretch mode to custome crush rule
-        3. Scenario 5:- revert from netsplit scenario to default/non-default crush rule
-        3. Scenario 6:- revert from netsplit scenario to custom crush rule
+        1. revert from health stretch mode to default crush rule
+        2. revert from health stretch mode to custom crush rule
+        3. revert from netsplit scenario to default crush rule
+        4. revert from netsplit scenario to custom crush rule
+        5. revert from site down stretch mode to default crush rule
+        6. revert from site down stretch mode to custome crush rule
     """
 
     log.info(run.__doc__)
@@ -52,11 +56,16 @@ def run(ceph_cluster, **kw):
     tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
     add_network_delay = config.get("add_network_delay", False)
     client_node = ceph_cluster.get_nodes(role="client")[0]
+    mon_obj = MonitorWorkflows(node=cephadm)
     scenarios_to_run = config.get(
         "scenarios_to_run",
         [
             "scenario1",
             "scenario2",
+            "scenario3",
+            "scenario4",
+            "scenario5",
+            "scenario6",
         ],
     )
     config = {
@@ -64,16 +73,48 @@ def run(ceph_cluster, **kw):
         "pool_obj": pool_obj,
         "tiebreaker_mon_site_name": tiebreaker_mon_site_name,
         "stretch_bucket": stretch_bucket,
+        "client_node": client_node,
     }
     try:
 
         revert_stretch_mode_scenarios = RevertStretchModeScenarios(**config)
+        custom_crush_rule_name = "test_rule"
+        custom_crush_rule_id = (
+            revert_stretch_mode_scenarios.create_or_retrieve_crush_rule(
+                crush_rule_name=custom_crush_rule_name
+            )
+        )
+        custom_crush_rule = {"name": custom_crush_rule_name, "id": custom_crush_rule_id}
+        default_crush_rule = {"id": 0}
+        dc_1_hosts = revert_stretch_mode_scenarios.site_1_hosts
+        dc_2_hosts = revert_stretch_mode_scenarios.site_2_hosts
+        tiebreaker_hosts = revert_stretch_mode_scenarios.tiebreaker_hosts
 
         if "scenario1" in scenarios_to_run:
-            revert_stretch_mode_scenarios.scenario1(client_node=client_node)
+            revert_stretch_mode_scenarios.scenario1(default_crush_rule)
 
         if "scenario2" in scenarios_to_run:
-            revert_stretch_mode_scenarios.scenario2(client_node=client_node)
+            revert_stretch_mode_scenarios.scenario2(custom_crush_rule)
+
+        if "scenario3" in scenarios_to_run:
+            revert_stretch_mode_scenarios.netsplit_scenario(
+                default_crush_rule, dc_1_hosts, dc_2_hosts
+            )
+
+        if "scenario4" in scenarios_to_run:
+            revert_stretch_mode_scenarios.netsplit_scenario(
+                custom_crush_rule, dc_1_hosts, dc_2_hosts
+            )
+
+        if "scenario5" in scenarios_to_run:
+            revert_stretch_mode_scenarios.shutdown_scenario(
+                default_crush_rule, dc_1_hosts, ceph_cluster, config, mon_obj
+            )
+
+        if "scenario6" in scenarios_to_run:
+            revert_stretch_mode_scenarios.shutdown_scenario(
+                custom_crush_rule, tiebreaker_hosts, ceph_cluster, config, mon_obj
+            )
 
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
@@ -126,7 +167,27 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
 
     """
 
-    def scenario1(self, client_node: CephNode):
+    expected_pool_properties = {
+        "size": "3",
+        "min_size": "2",
+        "crush_rule": 0,
+    }
+
+    expected_mon_map_values = {
+        "tiebreaker_mon": "",
+        "stretch_mode": False,
+        "disallowed_leaders": "",
+    }
+
+    expected_osd_map_values = {
+        "stretch_mode_enabled": False,
+        "stretch_bucket_count": 0,
+        "degraded_stretch_mode": 0,
+        "recovering_stretch_mode": 0,
+        "stretch_mode_bucket": 0,
+    }
+
+    def scenario1(self, crush_rule: dict):
         """
         Scenario 1:- Revert stretch mode from health stretch cluster to default crush rules
         Steps:-
@@ -140,7 +201,13 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
         8) Re-enter stretch mode for next scenario
         """
         log.info(self.scenario1.__doc__)
-        log.info("Step 1 -> Check if stretch mode is enabled")
+        log.info(
+            "Step 1 -> Wait for clean PGs before starting scenario and Check if stretch mode is enabled"
+        )
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PG did not reach active+clean before start of site down scenario"
+            )
         if not stretch_enabled_checks(self.rados_obj):
             log.error(
                 "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
@@ -149,36 +216,20 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
 
         log.info("Step 2 -> Create a pool and write IO")
         pool_name = "revert_scenario_1_pool"
-        self.create_pool_and_write_io(pool_name, client_node=client_node)
+        self.create_pool_and_write_io(pool_name, client_node=self.client_node)
 
         log.info("Step 3 ->  Revert from healthy stretch mode")
         self.revert_stretch_mode()
 
         log.info("Step 4 -> Validate all pools are reverted to default rules")
-        expected_pool_properties = {
-            "size": "3",
-            "min_size": "2",
-            "crush_rule": "0",  # default crush rule has a crush rule id of 1
-        }
-        self.validate_pool_configurations_post_revert(expected_pool_properties)
+        self.expected_pool_properties["crush_rule"] = crush_rule["id"]
+        self.validate_pool_configurations_post_revert(self.expected_pool_properties)
 
         log.info("Step 5 -> Validate stretch mode related configs are reset in OSD map")
-        expected_osd_map_values = {
-            "stretch_mode_enabled": False,
-            "stretch_bucket_count": 0,
-            "degraded_stretch_mode": 0,
-            "recovering_stretch_mode": 0,
-            "stretch_mode_bucket": 0,
-        }
-        self.validate_osd_configurations_post_revert(expected_osd_map_values)
+        self.validate_osd_configurations_post_revert(self.expected_osd_map_values)
 
         log.info("Step 6 -> Validate stretch mode related configs are reset in MON map")
-        expected_mon_map_values = {
-            "tiebreaker_mon": "",
-            "stretch_mode": False,
-            "tiebreaker_mon": "",
-        }
-        self.validate_mon_configurations_post_revert(expected_mon_map_values)
+        self.validate_mon_configurations_post_revert(self.expected_mon_map_values)
 
         log.info("Step 7 -> Validate PGs reach active+clean")
         wait_for_clean_pg_sets(rados_obj=self.rados_obj)
@@ -189,7 +240,7 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
         self.enable_stretch_mode(self.tiebreaker_mon)
         wait_for_clean_pg_sets(rados_obj=self.rados_obj)
 
-    def scenario2(self, client_node: CephNode):
+    def scenario2(self, crush_rule: dict):
         """
         Scenario 2:- Revert stretch mode from health stretch cluster to non-default crush rules
         Steps:-
@@ -201,10 +252,16 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
         6) Validate stretch mode related configs are reset in OSD map
         7) Validate stretch mode related configs are reset in MON map
         8) Validate PGs reach active+clean
-        9) Re-enter stretch mode for next scenario
+        9) Re-enter stretch mode for next scenario and wait for active+clean PG
         """
         log.info(self.scenario2.__doc__)
-        log.info("Step 1 -> Check stretch mode is enabled")
+        log.info(
+            "Step 1 -> Wait for clean PGs before starting scenario and Check stretch mode is enabled"
+        )
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PG did not reach active+clean before start of site down scenario"
+            )
         if not stretch_enabled_checks(self.rados_obj):
             log.error(
                 "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
@@ -213,42 +270,20 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
 
         log.info("Step 2 ->  Create a pool and write IO")
         pool_name = "revert_scenario_2_pool"
-        self.create_pool_and_write_io(pool_name, client_node=client_node)
-
-        log.info("Step 3 ->  Create a custom crush rule")
-        custom_crush_rule_name = "test_rule"
-        custom_crush_rule_id = self.create_or_retrieve_crush_rule(
-            crush_rule_name=custom_crush_rule_name
-        )
+        self.create_pool_and_write_io(pool_name, client_node=self.client_node)
 
         log.info("Step 4 -> Revert from healthy stretch mode to non-default crush rule")
-        self.revert_stretch_mode(crush_rule_name=custom_crush_rule_name)
+        self.revert_stretch_mode(crush_rule_name=crush_rule["name"])
 
         log.info("Step 5 -> validate pool configurations are reset")
-        expected_pool_properties = {
-            "size": "3",
-            "min_size": "2",
-            "crush_rule": custom_crush_rule_id,
-        }
-        self.validate_pool_configurations_post_revert(expected_pool_properties)
+        self.expected_pool_properties["crush_rule"] = crush_rule["id"]
+        self.validate_pool_configurations_post_revert(self.expected_pool_properties)
 
         log.info("Step 6 -> validate osd configurations are reset")
-        expected_osd_map_values = {
-            "stretch_mode_enabled": False,
-            "stretch_bucket_count": 0,
-            "degraded_stretch_mode": 0,
-            "recovering_stretch_mode": 0,
-            "stretch_mode_bucket": 0,
-        }
-        self.validate_osd_configurations_post_revert(expected_osd_map_values)
+        self.validate_osd_configurations_post_revert(self.expected_osd_map_values)
 
         log.info("Step 7 -> validate mon configurations are reset")
-        expected_mon_map_values = {
-            "tiebreaker_mon": "",
-            "stretch_mode": False,
-            "tiebreaker_mon": "",
-        }
-        self.validate_mon_configurations_post_revert(expected_mon_map_values)
+        self.validate_mon_configurations_post_revert(self.expected_mon_map_values)
 
         log.info("Step 8 -> validate PG's reached active+clean")
         wait_for_clean_pg_sets(rados_obj=self.rados_obj)
@@ -258,3 +293,299 @@ class RevertStretchModeScenarios(RevertStretchModeFunctionalities):
         )
         self.enable_stretch_mode(self.tiebreaker_mon)
         wait_for_clean_pg_sets(rados_obj=self.rados_obj)
+
+    def netsplit_scenario(self, crush_rule: dict, group_1_hosts: list, group_2_hosts):
+        """
+        Scenario :- Revert from netsplit scenario to default/custom crush rule
+        Polarion:- CEPH-83620057
+        Steps:-
+            1) Check stretch mode is enabled
+            2) Create a pool and write IO
+            3) Simulate a network partition between passed hosts
+            4) Revert from degraded stretch mode
+            5) Validate all pools are reverted to default rules
+            6) Validate stretch mode related configs are reset in OSD map
+            7) Validate stretch mode related configs are reset in MON map
+            8) Remove the simulated network partition
+            9) Validate PGs reach active+clean
+            10)  Write IO to the cluster post revert
+            11) Re-enter stretch mode for next scenario and wait for active+clean PG
+        """
+        log.info(self.netsplit_scenario.__doc__)
+        log_msg = f"Passed crush rule -> {crush_rule}"
+        log.info(log_msg)
+
+        log.info(
+            "Step 1 -> Wait for clean PGs before starting scenario and Check stretch mode is enabled"
+        )
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PG did not reach active+clean before start of netsplit scenario"
+            )
+        if not stretch_enabled_checks(self.rados_obj):
+            log.error(
+                "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
+            )
+            raise Exception("Test pre-execution checks failed")
+
+        log.info("Step 2 ->  Create a pool and write IO")
+        pool_name = "netsplit_scenario_" + generate_unique_id(3)
+        self.create_pool_and_write_io(pool_name, client_node=self.client_node)
+        time.sleep(10)
+        init_objects = self.rados_obj.get_cephdf_stats(pool_name=pool_name)["stats"][
+            "objects"
+        ]
+
+        log.info("Step 3 ->  Simulate a network partition between passed hosts")
+        self.simulate_netsplit_between_hosts(group_1_hosts, group_2_hosts)
+
+        # If the netsplit occurs between all hosts of DC1 and all hosts of DC2.
+        # Cluster enters into degraded stretch mode.
+        # comparing lists as set, since the ordering of the hosts in the list might be differed.
+        # list comparison -> [host2, host1] == [host1, host2] -> False
+        # set comparison -> set([host2, host1]) == set([host1, host2]) -> True
+        if (
+            set(group_1_hosts) == set(self.site_1_hosts)
+            and set(group_2_hosts) == set(self.site_2_hosts)
+        ) or (
+            set(group_1_hosts) == set(self.site_2_hosts)
+            and set(group_2_hosts) == set(self.site_1_hosts)
+        ):
+            time.sleep(120)  # sleep for sometime for cluster to enter degraded mode
+            if self.is_degraded_stretch_mode() is False:
+                raise Exception("Degraded stretch mode is not enabled")
+
+        log.info("Step 4 ->  Revert from degraded stretch mode")
+        if crush_rule["id"] == 0:
+            self.revert_stretch_mode()
+        else:
+            self.revert_stretch_mode(crush_rule_name=crush_rule["name"])
+
+        log.info("Step 5 -> validate pool configurations are reset")
+        self.expected_pool_properties["crush_rule"] = crush_rule["id"]
+        self.validate_pool_configurations_post_revert(self.expected_pool_properties)
+
+        log.info("Step 6 -> validate osd configurations are reset")
+        self.validate_osd_configurations_post_revert(self.expected_osd_map_values)
+
+        log.info("Step 7 -> validate mon configurations are reset")
+        self.validate_mon_configurations_post_revert(self.expected_mon_map_values)
+
+        log.info("Step 8 -> Remove the simulated network partition")
+        self.flush_ip_table_rules_on_all_hosts()
+
+        log.info("Step 9 -> validate PG's reached active+clean")
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception("PG did not reach active+clean post netsplit removal")
+
+        log.info("Step 10 -> Write IO to the cluster post revert")
+        self.write_io_and_validate_objects(
+            pool_name=pool_name, init_objects=init_objects, obj_name="post_revert"
+        )
+
+        log.info(
+            "Step 11 ->  Re-enter stretch mode for next scenario and wait till PGs are active+clean"
+        )
+        self.enable_stretch_mode(self.tiebreaker_mon)
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PG did not reach active+clean post enabling stretch mode for next scenario"
+            )
+
+    def shutdown_scenario(
+        self,
+        crush_rule,
+        hosts_to_shutdown,
+        ceph_cluster,
+        config,
+        mon_obj: MonitorWorkflows,
+    ):
+        """
+        Scenario :- Revert from site down scenario to default/custom crush rule
+        Polarion :- CEPH-83620057
+        Steps:-
+            1) Check stretch mode is enabled
+            2) Create a pool and write IO
+            3) Simulate a site down scenario
+            4) Revert from degraded stretch mode
+            5) Validate all pools are reverted to default rules
+            6) Validate stretch mode related configs are reset in OSD map
+            7) Validate stretch mode related configs are reset in MON map
+            8) Remove the down hosts from the cluster
+            9) Validate PGs reach active+clean
+            10) Write IO to the cluster post revert
+            11) Reboot hosts, Add removed hosts & Re-enter stretch mode for next scenario and wait for active+clean PG
+        """
+
+        # Pre checks and logging details about parameters
+        log.info(self.shutdown_scenario.__doc__)
+        log_msg = (
+            f"Passed crush rule -> {crush_rule}\n"
+            f"Hosts to shutdown -> {hosts_to_shutdown}"
+        )
+        log.info(log_msg)
+        if len(hosts_to_shutdown) == 0:
+            raise Exception("Hosts must be passed for shutdown scenario")
+
+        log.info(
+            "Step 1 -> Wait for clean PGs before starting scenario and Check stretch mode is enabled"
+        )
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PG did not reach active+clean before start of site down scenario"
+            )
+        if not stretch_enabled_checks(self.rados_obj):
+            log.error(
+                "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
+            )
+            raise Exception("Test pre-execution checks failed")
+
+        log.info("Step 2 ->  Create a pool and write IO")
+        pool_name = "site_down_scenario_" + generate_unique_id(3)
+        self.create_pool_and_write_io(pool_name, client_node=self.client_node)
+        time.sleep(10)
+        init_objects = self.rados_obj.get_cephdf_stats(pool_name=pool_name)["stats"][
+            "objects"
+        ]
+
+        # {'host1': ["mon", "osd", "mgr"],....
+        # Storing host labels inorder to identify mon hosts post addition.
+        host_labels_map = {}
+        for host in self.site_1_hosts + self.site_2_hosts + self.tiebreaker_hosts:
+            host_labels_map[host] = mon_obj.get_host_labels(host=host)
+        log_msg = f"Host labels are {host_labels_map}"
+        log.info(log_msg)
+
+        log.info("Step 3 ->  Simulate site down scenario")
+        for host in hosts_to_shutdown:
+            log.debug(f"Proceeding to shutdown host {host}")
+            target_node = find_vm_node_by_hostname(ceph_cluster, host)
+            target_node.shutdown(wait=True)
+        log.info(f"Completed shutdown of all the hosts ->  {hosts_to_shutdown}.")
+
+        # If DC1 site is down or DC2 site is down.
+        # Cluster enters into degraded stretch mode
+        # comparing lists as set, since the ordering of the hosts in the list might be differ.
+        # list comparison -> [host2, host1] == [host1, host2] -> False
+        # set comparison -> set([host2, host1]) == set([host1, host2]) -> True
+        if set(hosts_to_shutdown) == set(self.site_1_hosts) or set(
+            hosts_to_shutdown
+        ) == set(self.site_2_hosts):
+            time.sleep(120)  # sleep for sometime for cluster to enter degraded mode
+            if self.is_degraded_stretch_mode() is False:
+                raise Exception("Degraded stretch mode is not enabled")
+
+        log.info("Step 4 ->  Revert from degraded stretch mode")
+        if crush_rule["id"] == 0:
+            self.revert_stretch_mode()
+        else:
+            self.revert_stretch_mode(crush_rule_name=crush_rule["name"])
+
+        log.info("Step 5 -> validate pool configurations are reset")
+        self.expected_pool_properties["crush_rule"] = crush_rule["id"]
+        self.validate_pool_configurations_post_revert(self.expected_pool_properties)
+
+        log.info("Step 6 -> validate osd configurations are reset")
+        self.validate_osd_configurations_post_revert(self.expected_osd_map_values)
+
+        log.info("Step 7 -> validate mon configurations are reset")
+        self.validate_mon_configurations_post_revert(self.expected_mon_map_values)
+
+        log.info("Step 8 -> Remove the down hosts from the cluster")
+        serviceability_methods = ServiceabilityMethods(cluster=ceph_cluster, **config)
+        for host_name in hosts_to_shutdown:
+            serviceability_methods.remove_offline_host(host_node_name=host_name)
+
+        log.info("Step 9 -> validate PG's reached active+clean")
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PGs did not reach active+clean post revert and offline host removal"
+            )
+
+        log.info("Step 10 -> Write IO to the cluster post revert")
+        self.write_io_and_validate_objects(
+            pool_name=pool_name, init_objects=init_objects, obj_name="post_revert"
+        )
+
+        log.info(
+            "Step 11 -> Reboot hosts, Add removed hosts &"
+            "Re-enter stretch mode for next scenario and wait till PGs are active+clean"
+        )
+        # Reverting back the cluster status for next scenario
+        # 1) Reboot the hosts which were shutdown
+        # 2) Add back the removed hosts back to the cluster
+        # 3) Move the added hosts under datcenter crush bucket
+        # 4) Set mon crush locations
+        # 5) Re-enable stretch mode and wait for clean PGs
+        log.info(f"Proceeding to reboot hosts -> {hosts_to_shutdown}")
+        for host in hosts_to_shutdown:
+            log.debug(f"Proceeding to restart host {host}")
+            target_node = find_vm_node_by_hostname(ceph_cluster, host)
+            target_node.power_on()
+            fsid = self.rados_obj.run_ceph_command(cmd="ceph fsid", client_exec=True)[
+                "fsid"
+            ]
+            host_obj = get_host_obj_from_hostname(
+                hostname=host, rados_obj=self.rados_obj
+            )
+            cmd = f"cephadm rm-cluster --force --zap-osds --fsid {fsid}"
+            host_obj.exec_command(cmd=cmd, sudo=True)
+        log.info(f"Completed restart of all the hosts -> {hosts_to_shutdown}")
+
+        log.info(f"Proceeding to Add back the removed hosts -> {hosts_to_shutdown}")
+        for host in hosts_to_shutdown:
+            self.rados_obj.set_service_managed_type(service_type="osd", unmanaged=True)
+            log.debug(f"Proceeding to add host {host}")
+            serviceability_methods.add_new_hosts(
+                add_nodes=[host], deploy_osd=True, osd_label="osd"
+            )
+        self.rados_obj.set_service_managed_type(service_type="osd", unmanaged=False)
+
+        log.info("Proceeding to move the added hosts under Datacenter buckets")
+        for crush_bucket_name in hosts_to_shutdown:
+            site_name = self.tiebreaker_mon_site_name
+            if crush_bucket_name in self.site_1_hosts:
+                site_name = self.site_1_name
+            elif crush_bucket_name in self.site_2_hosts:
+                site_name = self.site_2_name
+            log_info_msg = f"Moving crush bucket {crush_bucket_name} under crush bucket {site_name}"
+            log.info(log_info_msg)
+            cmd = f"ceph osd crush move {crush_bucket_name} {self.stretch_bucket}={site_name}"
+            if self.rados_obj.run_ceph_command(cmd=cmd) is None:
+                log_msg = f"Failed to move crush bucket {crush_bucket_name} under crush bucket {site_name}"
+                log.error(log_msg)
+                raise Exception(log_msg)
+            log_info_msg = f"Successfully moved crush bucket {crush_bucket_name} under crush bucket {site_name}"
+            log.info(log_info_msg)
+
+        log.info("Setting crush location for each monitor for next scenario")
+        for host in hosts_to_shutdown:
+            if "mon" not in host_labels_map[host]:
+                log_msg = (
+                    f"host {host} did not have mon daemon before removal, Skipping"
+                )
+                log.info(log_msg)
+                continue
+            log_info_msg = f"Setting location for mon {host}"
+            log.info(log_info_msg)
+            site_name = self.tiebreaker_mon_site_name
+            if host in self.site_1_hosts:
+                site_name = self.site_1_name
+            elif host in self.site_2_hosts:
+                site_name = self.site_2_name
+            cmd = f"ceph mon set_location {host} {self.stretch_bucket}={site_name}"
+            if self.rados_obj.run_ceph_command(cmd=cmd) is None:
+                log_msg = f"Failed to set mon location of {host} to {site_name}"
+                log.error(log_msg)
+                raise Exception(log_msg)
+            log_info_msg = f"Successfully set mon location of {host} to {site_name}"
+            log.info(log_info_msg)
+
+        log.info(f"Completed adding all the hosts -> {hosts_to_shutdown}")
+
+        log.info("Proceeding to re-enable stretch mode")
+        self.enable_stretch_mode(self.tiebreaker_mon)
+        if wait_for_clean_pg_sets(rados_obj=self.rados_obj) is False:
+            raise Exception(
+                "PG did not reach active+clean post enabling stretch mode for next scenario"
+            )

--- a/tests/rados/test_stretch_revert_class.py
+++ b/tests/rados/test_stretch_revert_class.py
@@ -1,6 +1,10 @@
+import time
 from collections import namedtuple
 
 from ceph.ceph import CephNode
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.test_stretch_site_down import get_stretch_site_hosts
+from tests.rados.test_stretch_site_reboot import get_host_obj_from_hostname
 from utility.log import Log
 
 log = Log(__name__)
@@ -9,14 +13,38 @@ Hosts = namedtuple("Hosts", ["dc_1_hosts", "dc_2_hosts", "tiebreaker_hosts"])
 
 
 class StretchMode:
+    """
+    Usage:-
+        config = {
+            "rados_obj": rados_obj,
+            "pool_obj": pool_obj,
+            "tiebreaker_mon_site_name": tiebreaker_mon_site_name,
+            "stretch_bucket": stretch_bucket,
+            "client_node": client_node,
+        }
+        stretch_mode = StretchMode(**config)
+        stretch_mode.enable_stretch_mode(tiebreaker_mon)
+    """
+
     def __init__(self, **kwargs):
-        self.rados_obj = kwargs.get("rados_obj")
+        self.rados_obj: RadosOrchestrator = kwargs.get("rados_obj")
         self.tiebreaker_mon_site_name = kwargs.get(
             "tiebreaker_mon_site_name", "tiebreaker"
         )
         self.tiebreaker_mon = self.get_tiebreaker_mon()
         self.pool_obj = kwargs.get("pool_obj")
         self.custom_crush_rule = {}
+        self.stretch_bucket = kwargs.get("stretch_bucket", "datacenter")
+
+        # parameters to be populated by segregate_hosts_based_on_stretch_bucket()
+        self.site_1_hosts = None
+        self.site_2_hosts = None
+        self.tiebreaker_hosts = None
+        self.site_1_name = None
+        self.site_2_name = None
+        self.segregate_hosts_based_on_stretch_bucket()
+
+        self.client_node = kwargs.get("client_node", None)
 
     def get_tiebreaker_mon(self):
         """
@@ -56,7 +84,12 @@ class StretchMode:
         stretch_enable_cmd = (
             f"ceph mon enable_stretch_mode {tiebreaker_mon} stretch_rule datacenter"
         )
-        self.rados_obj.run_ceph_command(cmd=stretch_enable_cmd, print_output=True)
+        if (
+            self.rados_obj.run_ceph_command(cmd=stretch_enable_cmd, print_output=True)
+            is None
+        ):
+            raise Exception("Failed to enable stretch mode")
+        log.info("Successfully enabled stretch mode")
 
     def create_pool_and_write_io(self, pool_name: str, client_node: CephNode):
         """
@@ -103,6 +136,179 @@ class StretchMode:
         self.custom_crush_rule[crush_rule_name] = out["rule_id"]
         return self.custom_crush_rule[crush_rule_name]
 
+    def simulate_netsplit_between_hosts(self, group1, group2):
+        """
+        Method to simulate netsplit between hosts. Netsplit will be simulate by dropping incoming & outgoing
+        traffic using "iptables -A INPUT -s {target_host_ip} -j DROP; iptables -A OUTPUT -d {target_host_ip} -j DROP"
+        group1 : node1, node2, node3
+        group2 : node4, node5
+
+        All incoming/outgoing traffic from group2 hosts will be blocked on group1 hosts.
+        Ip table rules will be added on:-
+         node4 to drop incoming/outgoing packets to/from node1
+         node4 to drop incoming/outgoing packets to/from node2
+         node4 to drop incoming/outgoing packets to/from node3
+         node5 to drop incoming/outgoing packets to/from node1
+         node5 to drop incoming/outgoing packets to/from node2
+         node5 to drop incoming/outgoing packets to/from node3
+
+        Args:
+            group1: List of hosts ( type: list of strings containing hostnames ) ["host1", "host2"]
+            group2: List of hosts ( type: list of strings containing hostnames ) ["host3", "host4"]
+        Returns:
+            None
+        """
+        info_msg = f"Adding IPtable rules between {group1} and {group2}"
+        log.info(info_msg)
+
+        for host1 in group1:
+            target_host_obj = self.rados_obj.get_host_object(hostname=host1)
+            if not target_host_obj:
+                log.error(f"target host : {host1} not found . Exiting...")
+                raise Exception("Test execution Failed")
+            log.debug(
+                f"Proceeding to add IPtables rules to block incoming - outgoing traffic to host {host1} "
+            )
+            for host2 in group2:
+                source_host_obj = self.rados_obj.get_host_object(hostname=host2)
+                log.debug(
+                    f"Proceeding to add IPtables rules to block incoming - outgoing traffic to host {host1} "
+                    f"Applying rules on host : {host2}"
+                )
+                if not source_host_obj:
+                    log.error(f"Source host : {host2} not found . Exiting...")
+                if not self.rados_obj.block_in_out_packets_on_host(
+                    source_host=source_host_obj, target_host=target_host_obj
+                ):
+                    log.error(
+                        f"Failed to add IPtable rules to block {host1} on {host2}"
+                    )
+                    raise Exception("Test execution Failed")
+
+        info_msg = f"Completed adding IPtable rules between {group1} and {group2}"
+        log.info(info_msg)
+
+    def segregate_hosts_based_on_stretch_bucket(self):
+        """
+        Method to segregate hosts based on stretch bucket.
+        Populates site_1_hosts, site_2_hosts and tiebreaker_hosts
+        Populates site_1_name, site_2_name
+        Returns:
+            None
+        """
+        osd_tree_cmd = "ceph osd tree"
+        buckets = self.rados_obj.run_ceph_command(osd_tree_cmd)
+        dc_buckets = [
+            d for d in buckets["nodes"] if d.get("type") == self.stretch_bucket
+        ]
+        dc_1 = dc_buckets.pop()
+        dc_1_name = dc_1["name"]
+        dc_2 = dc_buckets.pop()
+        dc_2_name = dc_2["name"]
+        all_hosts = get_stretch_site_hosts(
+            rados_obj=self.rados_obj,
+            tiebreaker_mon_site_name=self.tiebreaker_mon_site_name,
+        )
+        self.site_1_hosts = all_hosts.dc_1_hosts
+        self.site_2_hosts = all_hosts.dc_2_hosts
+        self.tiebreaker_hosts = all_hosts.tiebreaker_hosts
+        self.site_1_name = dc_1_name
+        self.site_2_name = dc_2_name
+        log.debug(f"Hosts present in Datacenter : {dc_1_name} : {self.site_1_hosts}")
+        log.debug(f"Hosts present in Datacenter : {dc_2_name} : {self.site_2_hosts}")
+        log.debug(
+            f"Hosts present in Datacenter : {self.tiebreaker_mon_site_name} : { self.tiebreaker_hosts}"
+        )
+
+    def flush_ip_table_rules_on_all_hosts(self):
+        """
+        Method to flush iptable rules on all hosts part of the cluster
+        Executes iptables -F and reboots the host
+        Returns:
+            None
+        """
+        log.info("Proceeding to flush IP table rules on all hosts")
+        for hostname in self.site_1_hosts + self.site_2_hosts + self.tiebreaker_hosts:
+            host = get_host_obj_from_hostname(
+                hostname=hostname, rados_obj=self.rados_obj
+            )
+            log.debug(f"Proceeding to flush iptable rules on host : {host.hostname}")
+            host.exec_command(sudo=True, cmd="iptables -F", long_running=True)
+            host.exec_command(sudo=True, cmd="reboot", check_ec=False)
+            time.sleep(20)
+        log.info("Completed flushing IP table rules on all hosts")
+
+    def write_io_and_validate_objects(
+        self, pool_name: str, init_objects: int, obj_name: str
+    ) -> object:
+        """
+        Method to write IO and validate the count of objects.
+        Args:
+            init_objects (int) : Initial number of objects on the pool
+            pool_name (str) : name of the pool to write IO and validate
+            obj_name (str) : name of the objects to write
+        Returns:
+            None
+        Raises:
+            Exception If the number of objects post IO is less than or equal to init_objects
+        """
+        log_msg = (
+            f"\n Writing IO to the pool {pool_name}."
+            f"\n init_objects -> {init_objects}"
+        )
+        log.info(log_msg)
+
+        if (
+            self.pool_obj.do_rados_put(
+                client=self.client_node,
+                pool=pool_name,
+                nobj=200,
+                timeout=100,
+                obj_name=obj_name,
+            )
+            == 1
+        ):
+            err_msg = f"Failed to write IO using rados put command to pool {pool_name}"
+            log.error(err_msg)
+            raise Exception(err_msg)
+
+        log.debug("sleeping for 20 seconds for the objects to be displayed in ceph df")
+        time.sleep(20)
+
+        pool_stat = self.rados_obj.get_cephdf_stats(pool_name=pool_name)
+        current_objects = pool_stat["stats"]["objects"]
+        log.debug(pool_stat)
+
+        # Objects should be more than the initial no of objects
+        if current_objects <= init_objects:
+            log.error(
+                "Write ops should be possible, number of objects in the pool has not changed"
+            )
+            raise Exception(
+                f"Pool {pool_name} has {pool_stat['stats']['objects']} objs"
+            )
+        log_msg = (
+            f"\n Post IO to the pool {pool_name}."
+            f"\n init_objects -> {init_objects}"
+            f"\n current_objects -> {current_objects}"
+        )
+        log.info(log_msg)
+
+    def is_degraded_stretch_mode(self):
+        """
+        Method to check if stretch mode is degraded stretch mode or not.
+        Retuns:
+            True:- If Ceph cluster is in degraded stretch mode
+            False:- If Ceph cluster is not in degraded stretch mode
+        """
+        stretch_details = self.rados_obj.get_stretch_mode_dump()
+        if not stretch_details["degraded_stretch_mode"]:
+            log.error(
+                f"Stretch Cluster is not marked as degraded even though we have DC down : {stretch_details}"
+            )
+            return False
+        return True
+
 
 class RevertStretchModeFunctionalities(StretchMode):
     """
@@ -129,9 +335,12 @@ class RevertStretchModeFunctionalities(StretchMode):
         if crush_rule_name is not None:
             command += f" {crush_rule_name}"
         command += " --yes-i-really-mean-it"
-        _ = self.rados_obj.run_ceph_command(
+        out = self.rados_obj.run_ceph_command(
             command, print_output=True, client_exec=True
         )
+        if out is None:
+            raise Exception("Failed to disable stretch mode")
+        log.info("Successfully disabled stretch mode")
 
     def validate_pool_configurations_post_revert(self, pool_properties):
         """
@@ -155,7 +364,7 @@ class RevertStretchModeFunctionalities(StretchMode):
         log.info("Validating pool properties for each pool : ")
         log.info(pool_properties)
         cmd = "ceph osd pool ls detail"
-        pool_detail = self.rados_obj.run_ceph_command(cmd=cmd)
+        pool_detail = self.rados_obj.run_ceph_command(cmd=cmd, client_exec=True)
         for pool_detail in pool_detail:
             pool_name = pool_detail["pool_name"]
             for property_name, property_value in pool_properties.items():
@@ -195,7 +404,7 @@ class RevertStretchModeFunctionalities(StretchMode):
         """
         cmd = "ceph osd dump"
         ceph_osd_dump_output = self.rados_obj.run_ceph_command(
-            cmd=cmd, print_output=True
+            cmd=cmd, print_output=True, client_exec=True
         )
         osd_map_configs_to_validate = (
             expected_osd_map_values.keys()
@@ -239,7 +448,7 @@ class RevertStretchModeFunctionalities(StretchMode):
         """
         cmd = "ceph mon dump"
         ceph_mon_dump_output = self.rados_obj.run_ceph_command(
-            cmd=cmd, print_output=True
+            cmd=cmd, print_output=True, client_exec=True
         )
 
         mon_map_configs_to_validate = (


### PR DESCRIPTION
PR includes below :- 
(1) Revert during netsplit
```
        Polarion:- CEPH-83620057
        Steps:-
            1) Check stretch mode is enabled
            2) Create a pool and write IO
            3) Simulate a network partition between passed hosts
            4) Revert from degraded stretch mode
            5) Validate all pools are reverted to default rules
            6) Validate stretch mode related configs are reset in OSD map
            7) Validate stretch mode related configs are reset in MON map
            8) Remove the simulated network partition
            9) Validate PGs reach active+clean
            10)  Write IO to the cluster post revert
            11) Re-enter stretch mode for next scenario and wait for active+clean PG
```

(2) Revert during site down
```
        Polarion :- CEPH-83620057
        Steps:-
            1) Check stretch mode is enabled
            2) Create a pool and write IO
            3) Simulate a site down scenario
            4) Revert from degraded stretch mode
            5) Validate all pools are reverted to default rules
            6) Validate stretch mode related configs are reset in OSD map
            7) Validate stretch mode related configs are reset in MON map
            8) Remove the simulated site down scenario
            9) Validate PGs reach active+clean
            10)  Write IO to the cluster post revert
            11) Re-enter stretch mode for next scenario and wait for active+clean PG
```


(3) TFA Fix for failure http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/115/tier-3_rados_test-location-stretch-mode/OSD_replacement_enhancement_-_1_0.log 

credits:- @harshkumarRH 

```
2025-07-22 22:48:37,877 - cephci - ceph:1645 - INFO - Execution of ceph osd metadata osd.30 -f json on 10.0.203.106 took 13.017294 seconds
2025-07-22 22:48:37,878 - cephci - core_workflows:182 - ERROR - Exception hit while command execution. ceph osd metadata osd.30 -f json returned Error ENOENT: 
 and code 2 on 10.0.203.106
2025-07-22 22:48:37,878 - cephci - test_stretch_osd_serviceability_scenarios:1016 - ERROR - Failed with exception: Attribute not found.
2025-07-22 22:48:37,878 - cephci - test_stretch_osd_serviceability_scenarios:1017 - ERROR - 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/115/cephci/tests/rados/test_stretch_osd_serviceability_scenarios.py", line 991, in run
    validate_osd_removal_scenario(dc_1_osds_to_remove, dc_2_osds_to_remove)
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/115/cephci/tests/rados/test_stretch_osd_serviceability_scenarios.py", line 247, in validate_osd_removal_scenario
    assert service_obj.add_osds_to_managed_service()
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/115/cephci/ceph/rados/serviceability_workflows.py", line 440, in add_osds_to_managed_service
    if not self.get_osd_spec(osd_id=osd_id):
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-222/rados/115/cephci/ceph/rados/serviceability_workflows.py", line 362, in get_osd_spec
    return osd_metadata.get("osdspec_affinity", None)
AttributeError: 'NoneType' object has no attribute 'get'
```

(4) TFA fix for migration between EC pool test case failure http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-340/rados/45/tier-3_rados_test-4-node-ecpools/ 
Issue:- Source and target pool had same name in pool-configurations. We write data to source pool, create snapshots of source pool, copy data from source pool to dest pool, after that we expect snapshots to not be copied. Since source and dest had same name, TC failed with snapshots exists for dest pool 
Fix:- Updated pool name
Pass logss:- http://magna002.ceph.redhat.com/cephci-jenkins/vipin-runs/logs_cust_drain_25_07_28_03_02_18/ 

(5) TFA fix for objects not yet written to pools 
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-236/rados/18/tier-2_rados_test-osd-rebalance/Cluster_behaviour_when_OSDs_are_full_0.log 
Increasing write duration
Credits:- Team

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
