### PR TITLE
adding testcases for checksum with awscli_v1_v2

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -403,6 +403,34 @@ tests:
   #       config-file-name: test_public_access_block_restricted_public_buckets.yaml
   #     comments: known issue - Bug 2344730 atrgetted to 9.0
 
+  # test checksum with awscli v1 and v2
+
+  - test:
+      name: test checksum with awscli_v1_v2 small objects
+      desc: test checksum with awscli_v1_v2 small objects
+      polarion-id: CEPH-83591699
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
+  - test:
+      name: test checksum with awscli_v1_v2 non-multipart objects
+      desc: test checksum with awscli_v1_v2 non-multipart objects
+      polarion-id: CEPH-83591699
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
+  - test:
+      name: test checksum with awscli_v1_v2 multipart objects
+      desc: test checksum with awscli_v1_v2 multipart objects
+      polarion-id: CEPH-83591699
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
+
+
   - test:
       name: test_bi_purge for a bucket
       desc: test bi_purge should not error

--- a/suites/squid/rgw/tier-2_rgw_single_site_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_single_site_regression_extended.yaml
@@ -283,40 +283,32 @@ tests:
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
         run-on-haproxy: true
 
-  # server-access-logging tests
+  # test checksum with awscli v1 and v2
 
   - test:
-      name: test bucket logging with Journal mode, SimplePrefix, rgw_admin_flush
-      desc: test bucket logging with Journal mode, SimplePrefix, rgw_admin_flush
-      polarion-id: CEPH-83623532
+      name: test checksum with awscli_v1_v2 small objects
+      desc: test checksum with awscli_v1_v2 small objects
+      polarion-id: CEPH-83591699
       module: sanity_rgw.py
       config:
-        script-name: test_server_access_logging.py
-        config-file-name: test_bucket_logging_journal_mode.yaml
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
   - test:
-      name: test bucket logging with Journal mode, multipart_objects, PartitionedPrefix, rest_api_flush
-      desc: test bucket logging with Journal mode, multipart_objects, PartitionedPrefix, rest_api_flush
-      polarion-id: CEPH-83623532
+      name: test checksum with awscli_v1_v2 non-multipart objects
+      desc: test checksum with awscli_v1_v2 non-multipart objects
+      polarion-id: CEPH-83591699
       module: sanity_rgw.py
       config:
-        script-name: test_server_access_logging.py
-        config-file-name: test_bucket_logging_journal_mode_multipart.yaml
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
   - test:
-      name: test bucket logging with Standard mode, PartitionedPrefix, rgw_admin_flush
-      desc: test bucket logging with Standard mode, PartitionedPrefix, rgw_admin_flush
-      polarion-id: CEPH-83623532
+      name: test checksum with awscli_v1_v2 multipart objects
+      desc: test checksum with awscli_v1_v2 multipart objects
+      polarion-id: CEPH-83591699
       module: sanity_rgw.py
       config:
-        script-name: test_server_access_logging.py
-        config-file-name: test_bucket_logging_standard_mode.yaml
-  - test:
-      name: test bucket logging with Standard mode, multipart_objects, SimplePrefix, rest_api_flush
-      desc: test bucket logging with Standard mode, multipart_objects, SimplePrefix, rest_api_flush
-      polarion-id: CEPH-83623532
-      module: sanity_rgw.py
-      config:
-        script-name: test_server_access_logging.py
-        config-file-name: test_bucket_logging_standard_mode_multipart.yaml
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
 
   - test:
       name: Test large omap creation and clearance

--- a/suites/tentacle/rgw/tier-2_rgw_single_site_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_single_site_regression_extended.yaml
@@ -283,6 +283,35 @@ tests:
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
         run-on-haproxy: true
 
+
+  # test checksum with awscli v1 and v2
+
+  - test:
+      name: test checksum with awscli_v1_v2 small objects
+      desc: test checksum with awscli_v1_v2 small objects
+      polarion-id: CEPH-83591699
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
+  - test:
+      name: test checksum with awscli_v1_v2 non-multipart objects
+      desc: test checksum with awscli_v1_v2 non-multipart objects
+      polarion-id: CEPH-83591699
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
+  - test:
+      name: test checksum with awscli_v1_v2 multipart objects
+      desc: test checksum with awscli_v1_v2 multipart objects
+      polarion-id: CEPH-83591699
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
+        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
+
+
   - test:
       name: Test large omap creation and clearance
       desc: Test large omap creation and clearance


### PR DESCRIPTION
this PR is to add support for testing checksum feature with

1. awscli - v1 and v2
2. default checksum enabled and disabled
3. with all 5 supported checksums - "sha1", "sha256", "crc32", "crc32c", "crc64nvme"
4. with small, non-multipart and multipart objects

Bz's automated:

[2353296](https://bugzilla.redhat.com/show_bug.cgi?id=2353296) [[rgw] small objects download failing with checksum-mismatch error using client aws-cli/2.24.22](https://bugzilla.redhat.com/show_bug.cgi?id=2353296)
[2355689](https://bugzilla.redhat.com/show_bug.cgi?id=2355689) [rgw][checksum]: complete-multipart-upload is not returning ChecksumType in the response
[2370002](https://bugzilla.redhat.com/show_bug.cgi?id=2370002) rgw][checksum]: with aws-go-sdk-v2, chunked object upload with trailing checksum of SHA1 or SHA256 is failing with 400 error
[2355038](https://bugzilla.redhat.com/show_bug.cgi?id=2355038) [rgw][checksum]: get-object-attributes for multipart objects uploaded with SHA1 or SHA256 algorithm is returning FULL_OBJECT for ChecksumType instead of COMPOSITE
[Bug 2349928](https://bugzilla.redhat.com/show_bug.cgi?id=2349928) - [RGW] RGW crashes when performing multipart upload using AWS CLI.
[Bug 2345505](https://bugzilla.redhat.com/show_bug.cgi?id=2345505) - [RGW] RGW crashes when performing multipart upload using AWS CLI

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_checksum_awscli/new_logs/cephci-run-34R3PW/



also removed server-access-logging tests present in regression_extended suite as they are now moved to a new suite with this PR: https://github.com/red-hat-storage/cephci/pull/5125

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
