### PR TITLE
Changes for test execution in new VPC

### DIFF
--- a/conf/ibmc/ci-vpc-01.yaml
+++ b/conf/ibmc/ci-vpc-01.yaml
@@ -1,0 +1,17 @@
+---
+# Virtual Private Cloud details.
+# Don't include IDs or image name.
+datacenters:
+  - au-syd-1
+  - au-syd-2
+  - au-syd-3
+dns_zone_name: "qe.ceph.au.lab"
+networks:
+  au-syd-1: ci-sn-01
+  au-syd-2: ci-sn-02
+  au-syd-3: ci-sn-03
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sec-grp-ci-vpc-01"
+service_url: "https://au-syd.iaas.cloud.ibm.com/v1"
+vpc_name: "ci-vpc-01"

--- a/conf/ibmc/vpc-block.yaml
+++ b/conf/ibmc/vpc-block.yaml
@@ -1,0 +1,15 @@
+---
+datacenters:
+  - eu-de-1
+  - eu-de-2
+  - eu-de-3
+dns_zone_name: "qe.ceph.eu.lab"
+networks:
+  eu-de-1: sn-block-eu-de-1
+  eu-de-2: sn-block-eu-de-2
+  eu-de-3: sn-block-eu-de-3
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sg-block"
+service_url: "https://eu-de.iaas.cloud.ibm.com/v1"
+vpc_name: "vpc-block"

--- a/conf/ibmc/vpc-cephci.yaml
+++ b/conf/ibmc/vpc-cephci.yaml
@@ -1,0 +1,15 @@
+---
+datacenters:
+  - eu-de-1
+  - eu-de-2
+  - eu-de-3
+dns_zone_name: "qe.ceph.eu.lab"
+networks:
+  eu-de-1: sn-cephci-eu-de-1
+  eu-de-2: sn-cephci-eu-de-2
+  eu-de-3: sn-cephci-eu-de-3
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sg-cephci"
+service_url: "https://eu-de.iaas.cloud.ibm.com/v1"
+vpc_name: "vpc-cephci"

--- a/conf/ibmc/vpc-cephfs.yaml
+++ b/conf/ibmc/vpc-cephfs.yaml
@@ -1,0 +1,15 @@
+---
+datacenters:
+  - eu-de-1
+  - eu-de-2
+  - eu-de-3
+dns_zone_name: "qe.ceph.eu.lab"
+networks:
+  eu-de-1: sn-cephfs-eu-de-1
+  eu-de-2: sn-cephfs-eu-de-2
+  eu-de-3: sn-cephfs-eu-de-3
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sg-cephfs"
+service_url: "https://eu-de.iaas.cloud.ibm.com/v1"
+vpc_name: "vpc-cephfs"

--- a/conf/ibmc/vpc-dmfg.yaml
+++ b/conf/ibmc/vpc-dmfg.yaml
@@ -1,0 +1,15 @@
+---
+datacenters:
+  - eu-de-1
+  - eu-de-2
+  - eu-de-3
+dns_zone_name: "qe.ceph.eu.lab"
+networks:
+  eu-de-1: sn-dmfg-eu-de-1
+  eu-de-2: sn-dmfg-eu-de-2
+  eu-de-3: sn-dmfg-eu-de-3
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sg-dmfg"
+service_url: "https://eu-de.iaas.cloud.ibm.com/v1"
+vpc_name: "vpc-dmfg"

--- a/conf/ibmc/vpc-nfsg.yaml
+++ b/conf/ibmc/vpc-nfsg.yaml
@@ -1,0 +1,15 @@
+---
+datacenters:
+  - eu-de-1
+  - eu-de-2
+  - eu-de-3
+dns_zone_name: "qe.ceph.eu.lab"
+networks:
+  eu-de-1: sn-nfsg-eu-de-1
+  eu-de-2: sn-nfsg-eu-de-2
+  eu-de-3: sn-nfsg-eu-de-3
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sg-nfsg"
+service_url: "https://eu-de.iaas.cloud.ibm.com/v1"
+vpc_name: "vpc-nfsg"

--- a/conf/ibmc/vpc-rgw.yaml
+++ b/conf/ibmc/vpc-rgw.yaml
@@ -1,0 +1,15 @@
+---
+datacenters:
+  - eu-de-1
+  - eu-de-2
+  - eu-de-3
+dns_zone_name: "qe.ceph.eu.lab"
+networks:
+  eu-de-1: sn-rgw-eu-de-1
+  eu-de-2: sn-rgw-eu-de-2
+  eu-de-3: sn-rgw-eu-de-3
+private_key: ceph-qe-sa-svc
+profile: bx2-2x8
+security_group: "sg-rgw"
+service_url: "https://eu-de.iaas.cloud.ibm.com/v1"
+vpc_name: "vpc-rgw"

--- a/conf/inventory/ibm-eu-rhel-9.6.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.6.yaml
@@ -1,0 +1,102 @@
+---
+version_id: 9.6
+id: rhel
+instance:
+  create:
+    image-name: rhel-96-server-amd64-kvm
+    private_key: ceph-qe-sa-svc
+
+  setup: |
+    #cloud-config
+    no_ssh_fingerprints: true
+    disable_root: false
+    ssh_pwauth: true
+
+    # We are forcing an update of the packages
+    package_update: true
+
+    # Create the base repositories
+    yum_repos:
+      appstream:
+        name: AppStream
+        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/AppStream/
+        enabled: true
+        gpgcheck: false
+      baseos:
+        name: BaseOS
+        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/BaseOS/
+        gpcheck: false
+        enabled: true
+
+      crb:
+        name: codeready-builder
+        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/CRB/
+        gpcheck: false
+        enabled: true
+
+    # write the mirror registry details
+    write_files:
+      - content: |
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.eu.lab:5000"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-stage"
+          prefix = "registry-proxy.engineering.redhat.com"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-prod"
+          prefix = "registry.redhat.io"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-stage"
+          prefix = "cp.stg.icr.io"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-prod"
+          prefix = "cp.icr.io"
+          insecure = true
+        path: /etc/containers/registries.conf.d/nginx-vm-01.conf
+        owner: root:root
+        permissions: '0644'
+        defer: true
+      - content: |
+          net.core.default_qdisc=netem
+        path: /etc/sysctl.d/1000-qdisc.conf
+        owner: root:root
+        permissions: '0644'
+      - content: |
+          PermitRootLogin yes
+        path: /etc/ssh/sshd_config.d/50-cephci.conf
+        owner: root:root
+        permissions: '0644'
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(root) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwmsOkNX16LikH7spbmVVOLhGOSsNSlAYSk0ifhLpaO
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPoKGCTzMmNvHFY4THKNpZYFLeEgB7Do8y2JAEy+ZvIZ ceph-qe-sa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
+
+    chpasswd:
+      expire: false
+      users:
+        - name: cephuser
+          password: $y$j9T$PxJ09a3yVNnPj0Veb8QDT.$bdWoyLq1IdGwlimyJC98P5OsSFE2w7.9ac68z4eoa01
+        - name: root
+          password: $y$j9T$L0/xJyxgqCPIezC0dp/0/0$KawKfTR2FhliH9YrG4/30wot90M3xtF03K1XwGnYz2A
+
+    runcmd:
+      - timedatectl set-timezone Etc/UTC
+      - systemctl restart sshd
+      - touch /ceph-qa-ready

--- a/run.py
+++ b/run.py
@@ -173,8 +173,31 @@ def create_nodes(
     cloud_type="openstack",
     instances_name=None,
     enable_eus=False,
+    custom_config=None,
 ):
-    """Creates the system under test environment."""
+    """Creates the system under test environment.
+
+    Args:
+        conf            Platform
+        inventory       Test environment
+        osp_cred        Platform access information
+        run_id          execution identifier
+        cloud_type      The platform to be used for deployment.
+        instances_name  system names
+        enable_eus      Extended OS support
+        custom_config   list of <key>=<value>
+
+    Notes:
+        use custom_config to specify the environments or configuration to
+        be used when using generic inventory files. Ensure to prefix the
+        platform. For exmaple
+
+            --custom-config ibmc_vpc=ci-vpc-01
+            --custom-config ibmc_profile=bx2-2x8
+
+        If these values are not provided then the defaults would be used.
+        The defaults are the ones used in the example.
+    """
 
     validate_conf(conf)
     validate_image(conf, cloud_type)
@@ -197,7 +220,7 @@ def create_nodes(
             )
         elif cloud_type == "ibmc":
             ceph_vmnodes = create_ibmc_ceph_nodes(
-                cluster, inventory, osp_cred, run_id, instances_name
+                cluster, inventory, osp_cred, run_id, instances_name, custom_config
             )
         elif "baremetal" in cloud_type:
             ceph_vmnodes = create_baremetal_ceph_nodes(cluster)


### PR DESCRIPTION
# Description

in this pull request, we are making the necessary modifications to `cephci` to enable the CI to consume the new environments. 

Though the project is the same, the environments vary based on tags hence we need to ensure variability in resources being passed while trying to keep a generic inventory file. At the same time not breaking the existing behavior.

## Changes
- Adding a generic inventory file that can be used in the new IBM Cloud centralized region.
- Add Virtual Private Cloud details in separate conf
- Add support for selection of known VPC profile via `--custom-config ibmc_{vpc,profile}`

## Examples

```
python run.py ... \
    --custom-config ibmc_vpc=ci-vpc-01 \  # The VPC to be used for deploying the test environment
    --custom-config ibmc_profile=bx2-8x16  # The VM flavor to be used to create the virtual instances.
```


## Tasks

- [x] Create a design/automation approach doc. [Link](https://miro.com/app/board/uXjVJa6VJ-4=/)
- [x] Review the automation design
- [x] unit testing


## Testing

### Test scenarios

- [x] Verify deployment using `--custom-config ibmc_vpc=` --> Passed
- [x] Verify deployment without using `--custom-config ibmc_vpc` --> Passed
- [x] Verify cleanup of instances deployed  with & without `custom-config` --> Passed
- [x] Verify the generic inventory file --> Passed

```
[root@ceph-psathyan-zr7sz9-node4 ~]# ls -l /etc/yum.repos.d/
total 12
-rw-r--r--. 1 root root 179 Jul 27 02:40 appstream.repo
-rw-r--r--. 1 root root 169 Jul 27 02:40 baseos.repo
-rw-r--r--. 1 root root 174 Jul 27 02:40 crb.repo
[root@ceph-psathyan-zr7sz9-node4 ~]# cat /etc/yum.repos.d/appstream.repo
# Created by cloud-init on Sun, 27 Jul 2025 02:40:39 +0000
[appstream]
baseurl = http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/AppStream/
enabled = 1
gpgcheck = 0
name = AppStream

[root@ceph-psathyan-zr7sz9-node4 ~]# cat /etc/containers/registries.conf.d/nginx-vm-01.conf
[[registry]]
location = "nginx-vm-01.qe.ceph.eu.lab:5000"
insecure = true

[[registry]]
location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-stage"
prefix = "registry-proxy.engineering.redhat.com"
insecure = true

[[registry]]
location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-prod"
prefix = "registry.redhat.io"
insecure = true

[[registry]]
location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-stage"
prefix = "cp.stg.icr.io"
insecure = true

[[registry]]
location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-prod"
prefix = "cp.icr.io"
insecure = true
``` 