### PR TITLE
Add support for cleanup in IBMC multiple VPC

### DIFF
--- a/run.py
+++ b/run.py
@@ -95,6 +95,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--disable-console-log]
   run.py --cleanup=name --osp-cred <file> [--cloud <str>]
         [--log-level <LEVEL>]
+        [--custom-config <key>=<value>]...
 
 Options:
   -h --help                         show this screen
@@ -204,7 +205,7 @@ def create_nodes(
     if cloud_type == "openstack":
         cleanup_ceph_nodes(osp_cred, instances_name)
     elif cloud_type == "ibmc":
-        cleanup_ibmc_ceph_nodes(osp_cred, instances_name)
+        cleanup_ibmc_ceph_nodes(osp_cred, instances_name, custom_config=None)
 
     ceph_cluster_dict = {}
     clients = []
@@ -445,7 +446,9 @@ def run(args):
         if cloud_type == "openstack":
             cleanup_ceph_nodes(osp_cred, cleanup_name)
         elif cloud_type == "ibmc":
-            cleanup_ibmc_ceph_nodes(osp_cred, cleanup_name)
+            cleanup_ibmc_ceph_nodes(
+                osp_cred, cleanup_name, custom_config=args.get("--custom-config")
+            )
         else:
             log.warning("Unknown cloud type.")
 
@@ -644,6 +647,7 @@ def run(args):
                 cloud_type,
                 instances_name,
                 enable_eus=enable_eus,
+                custom_config=custom_config,
             )
         except Exception as err:
             log.error(err)


### PR DESCRIPTION
# Description

The cleanup method was unable to handle the support for multiple VPCs when there are missing keys in the global credential file.

As part of this commit, we are introducing support for multi VPCs via --custom-config.

- [x] Review the automation design
- [x] Unit test

## Usage

For cleaning with a generic `global credential` file, the following options are required 

```
python run.py --cleanup <substring> --osp-cred <file> --cloud ibmc --custom-config ibmc_vpc=ci-vpc-01
```

## Test scenarios

- [x] Verify cleanup behavior with `--custom-config` and `--cloud ibmc`
- [x] Verify cleanup behavior without `--custom-config`
- [x] Verify cleanup behavior in `openstack` environment
- [x] Verify cleanup behavior when `--cloud ibmc` inside run.py during test execution.

### Log Snippet

- Clean

```
2025-07-28 14:50:03,806 - cephci - ibm_vpc:646 - INFO - Deleting PTR record 10.243.96.7
2025-07-28 14:50:04,109 - cephci - ibm_vpc:655 - INFO - Deleting Address record ceph-psathyan-8imb3b-node4.qe.ceph.eu.lab
2025-07-28 14:50:04,280 - cephci - ibm_vpc:501 - INFO - Preparing to remove ceph-psathyan-8imb3b-node4
```

- Provision

```
2025-07-28 14:46:50,267 - cephci - utils:43 - INFO - Destroying existing IBM instances..
2025-07-28 14:46:52,357 - cephci - utils:62 - INFO - Cleaning up instances : []
2025-07-28 14:46:52,357 - cephci - utils:90 - INFO - Done cleaning up nodes with pattern psathyan
2025-07-28 14:46:52,359 - cephci - utils:211 - INFO - Creating IBM instances
2025-07-28 14:46:52,380 - cephci - ibm_vpc:319 - INFO - Starting to create VM with name ceph-psathyan-8IMB3B-node1-installer
2025-07-28 14:46:57,399 - cephci - ibm_vpc:319 - INFO - Starting to create VM with name ceph-psathyan-8IMB3B-node2
2025-07-28 14:47:07,397 - cephci - ibm_vpc:319 - INFO - Starting to create VM with name ceph-psathyan-8IMB3B-node3
2025-07-28 14:47:22,413 - cephci - ibm_vpc:319 - INFO - Starting to create VM with name ceph-psathyan-8IMB3B-node4
2025-07-28 14:48:33,048 - cephci - ibm_vpc:607 - INFO - ceph-psathyan-8imb3b-node1-installer moved to running state in 92 seconds.
2025-07-28 14:48:33,458 - cephci - ibm_vpc:423 - DEBUG - Adding DNS records for ceph-psathyan-8IMB3B-node1-installer
```
