### PR TITLE
Test Automation: CEPH-83601544 : Failover after an orderly shutdown

### DIFF
--- a/suites/squid/rbd/tier-2_default_namespace_mirroring.yaml
+++ b/suites/squid/rbd/tier-2_default_namespace_mirroring.yaml
@@ -355,7 +355,7 @@ tests:
         Failover cluster from secondary to primary
         in deafult namespace mirroring
       name: Test failover after an orderly shut-down of client IOPS
-      module: test_rbd_mirror_default_namespace_failover.py
+      module: test_rbd_mirror_namespace_failover.py
       polarion-id: CEPH-83613955
       clusters:
         ceph-rbd1:
@@ -397,7 +397,7 @@ tests:
         Failover cluster from secondary to primary
         in deafult namespace mirroring with force promote
       name: Test failover after an non orderly shut-down with force promote
-      module: test_rbd_mirror_default_namespace_failover.py
+      module: test_rbd_mirror_namespace_failover.py
       polarion-id: CEPH-83613956
       clusters:
         ceph-rbd1:

--- a/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -203,3 +203,94 @@ tests:
                 direct: 1
                 invalidate: 1
                 io_type: randrw
+
+  - test:
+      abort-on-fail: True
+      desc: >
+        Verify Mirror Image Synchronization Between Differently-Named
+        Namespaces in Different Clusters in one way mode
+      name: >
+        Test Non Default to non default one way mode
+      module: test_namespace_mirror_operations.py
+      polarion-id: CEPH-83601537
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83601537
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              namespace_mirror_type: non-default_to_non-default
+              mirrormode: snapshot
+              snap_schedule_intervals:
+                - 1m
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              namespace_mirror_type: non-default_to_non-default
+              mirrormode: snapshot
+              snap_schedule_intervals:
+                - 1m
+            fio:
+              size: 100M
+              ODF_CONFIG:
+                num_jobs: 4
+                iodepth: 32
+                rwmixread: 70
+                direct: 1
+                invalidate: 1
+                io_type: randrw
+
+  - test:
+      abort-on-fail: True
+      desc: >
+        Verify Failover after an orderly shutdown
+        for non-default to non-default namespace mirroring
+      name: >
+        Failover after an orderly shutdown in non-default
+        namespace mirroring
+      module: test_rbd_mirror_namespace_failover.py
+      polarion-id: CEPH-83601544
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            test_function: CEPH-83601544
+            fio:
+              size: 200M
+              ODF_CONFIG:
+                num_jobs: 4
+                iodepth: 32
+                rwmixread: 70
+                direct: 1
+                invalidate: 1
+                io_type: randrw

--- a/suites/tentacle/rbd/tier-2_default_namespace_mirroring.yaml
+++ b/suites/tentacle/rbd/tier-2_default_namespace_mirroring.yaml
@@ -355,7 +355,7 @@ tests:
         Failover cluster from secondary to primary
         in deafult namespace mirroring
       name: Test failover after an orderly shut-down of client IOPS
-      module: test_rbd_mirror_default_namespace_failover.py
+      module: test_rbd_mirror_namespace_failover.py
       polarion-id: CEPH-83613955
       clusters:
         ceph-rbd1:
@@ -397,7 +397,7 @@ tests:
         Failover cluster from secondary to primary
         in deafult namespace mirroring with force promote
       name: Test failover after an non orderly shut-down with force promote
-      module: test_rbd_mirror_default_namespace_failover.py
+      module: test_rbd_mirror_namespace_failover.py
       polarion-id: CEPH-83613956
       clusters:
         ceph-rbd1:

--- a/suites/tentacle/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/tentacle/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -203,3 +203,94 @@ tests:
                 direct: 1
                 invalidate: 1
                 io_type: randrw
+
+  - test:
+      abort-on-fail: True
+      desc: >
+        Verify Mirror Image Synchronization Between Differently-Named
+        Namespaces in Different Clusters in one way mode
+      name: >
+        Test Non Default to non default one way mode
+      module: test_namespace_mirror_operations.py
+      polarion-id: CEPH-83601537
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83601537
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              namespace_mirror_type: non-default_to_non-default
+              mirrormode: snapshot
+              snap_schedule_intervals:
+                - 1m
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              namespace_mirror_type: non-default_to_non-default
+              mirrormode: snapshot
+              snap_schedule_intervals:
+                - 1m
+            fio:
+              size: 100M
+              ODF_CONFIG:
+                num_jobs: 4
+                iodepth: 32
+                rwmixread: 70
+                direct: 1
+                invalidate: 1
+                io_type: randrw
+
+  - test:
+      abort-on-fail: True
+      desc: >
+        Verify Failover after an orderly shutdown
+        for non-default to non-default namespace mirroring
+      name: >
+        Failover after an orderly shutdown in non-default
+        namespace mirroring
+      module: test_rbd_mirror_namespace_failover.py
+      polarion-id: CEPH-83601544
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            test_function: CEPH-83601544
+            fio:
+              size: 200M
+              ODF_CONFIG:
+                num_jobs: 4
+                iodepth: 32
+                rwmixread: 70
+                direct: 1
+                invalidate: 1
+                io_type: randrw

--- a/tests/rbd_mirror/test_rbd_mirror_namespace_failover.py
+++ b/tests/rbd_mirror/test_rbd_mirror_namespace_failover.py
@@ -982,6 +982,7 @@ def run(**kw):
         test_map = {
             "CEPH-83613955": test_failover_orderly_shutdown,
             "CEPH-83613956": test_failover_non_orderly_shutdown,
+            "CEPH-83601544": test_failover_orderly_shutdown,
         }
 
         test_func = kw["config"]["test_function"]


### PR DESCRIPTION
Test: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83601544

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G45TY4/