### PR TITLE
addding tests for rgw checksum testing with aws-sdk-go-v2

### DIFF
--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -363,3 +363,14 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
+
+
+  # checksum tests with go
+  - test:
+      name: test checksum with go script
+      desc: test checksum with go script. rgw ssl required for chunked upload with trailing checksum
+      module: sanity_rgw.py
+      polarion-id: CEPH-83591699
+      config:
+        script-name: ../go_scripts/test_rgw_using_go.py
+        config-file-name: ../../go_scripts/configs/test_checksum_using_go.yaml

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -363,3 +363,13 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
+
+  # checksum tests with go
+  - test:
+      name: test checksum with go script
+      desc: test checksum with go script. rgw ssl required for chunked upload with trailing checksum
+      module: sanity_rgw.py
+      polarion-id: CEPH-83591699
+      config:
+        script-name: ../go_scripts/test_rgw_using_go.py
+        config-file-name: ../../go_scripts/configs/test_checksum_using_go.yaml


### PR DESCRIPTION
this PR is to add support for testing checksum feature with go script with aws-go-sdk-v2.

the workflow is to test all permutations of:
1. with supported 5 checksum algorithms: sha1, sha256, crc32, crc32c, crc64nvme
2. with small and medium sized objects
3. with upload types - normal, chunked and multipart
4. with operations - copy, download, get-object-attributes, delete

bz's:
[Bug 2367319](https://bugzilla.redhat.com/show_bug.cgi?id=2367319) - [rgw][cksum] failure to compute/verify checksums with recent aws-go-sdk-v2 versions
[Bug 2370002](https://bugzilla.redhat.com/show_bug.cgi?id=2370002) - [rgw][checksum]: with aws-go-sdk-v2, chunked object upload with trailing checksum of SHA1 or SHA256 is failing with 400 error


tracker:
https://tracker.ceph.com/issues/63153


pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_checksum_go/new_logs/cephci-run-LY7LZG/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
