### PR TITLE
FIX: make build type argument non-required

### DIFF
--- a/run.py
+++ b/run.py
@@ -496,6 +496,11 @@ def run(args):
             raise CephCIArgumentError(
                 "--upstream-build argument not provided Ex: tentacle"
             )
+    else:
+        # TODO: By default, build=released, but Pipelines and environment
+        #       are not ready for this change. Need to revert this code changes
+        #       once we have right build value set across pipelines.
+        build = None
 
     store = args.get("--store") or False
 


### PR DESCRIPTION
As of the test framework, we need build to be always pointed to `released` if none provided for build agrument. 

- We need build arg as mandatory, but thats needs changes in pipelines and environment.
- need to revert this PR, once it is ready.

```
  --build <latest>                  Type of build to be use for testing
                                    eg: latest|tier-0|tier-1|tier-2|released|upstream
                                    [default: released]
```
