### PR TITLE
Updating RADOS EC pool suites, removing unneeded tests

### DIFF
--- a/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
@@ -199,8 +199,9 @@ tests:
         bluefs-spillover: true
       desc: Verify BlueFS Spillover warning with dedicated wal/db
 
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+# COT tests underneath run only on RE pools, commenting workflow for now
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities

--- a/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -387,28 +387,6 @@ tests:
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
 #  - test:
-#      name: Autoscaler test - pool target size ratio
-#      module: pool_tests.py
-#      polarion-id: CEPH-83573424
-#      config:
-#        verify_pool_target_ratio:
-#          configurations:
-#            pool-1:
-#              profile_name: ec86_10
-#              pool_name: ec86_pool10
-#              pool_type: erasure
-#              pg_num: 32
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#              plugin: jerasure
-#              target_size_ratio: 0.8
-#              max_objs: 300
-#              rados_read_duration: 10
-#              delete_pool: true
-#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
-
-#  - test:
 #      name: Autoscaler test - pool pg_num_min
 #      module: pool_tests.py
 #      polarion-id: CEPH-83573425

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -452,11 +452,12 @@ tests:
       desc: Verify ceph-bluestore-tool functionalities
 
 # below Commented in squid as it's covered in 8+6 suite
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+# COT tests underneath run only on RE pools, commenting workflow for now
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
   - test:
       name: Verify premerge PGS during PG split

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -366,41 +366,17 @@ tests:
       desc: Verification of the effect of compression on erasure coded pools
 
   - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_7
-              pool_name: ec86_pool7
-              pool_type: erasure
-              pg_num: 32
-              k: 8
-              m: 6
-              create_rule: false
-              crush-osds-per-failure-domain: 4
-              crush-num-failure-domains: 4
-              plugin: jerasure
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              max_objs: 300
-              rados_read_duration: 10
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
-
-  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
 
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+# COT tests underneath run only on RE pools, commenting workflow for now
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
 #  - test:
 #      name: Verify premerge PGS during PG split

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -366,41 +366,17 @@ tests:
       desc: Verification of the effect of compression on erasure coded pools
 
   - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_7
-              pool_name: ec86_pool7
-              pool_type: erasure
-              pg_num: 32
-              k: 8
-              m: 6
-              create_rule: false
-              crush-osds-per-failure-domain: 4
-              crush-num-failure-domains: 4
-              plugin: jerasure
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              max_objs: 300
-              rados_read_duration: 10
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
-
-  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
 
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+# COT tests underneath run only on RE pools, commenting workflow for now
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
 #  - test:
 #      name: Verify premerge PGS during PG split

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -501,27 +501,6 @@ tests:
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
 #  - test:
-#      name: Autoscaler test - pool target size ratio
-#      module: pool_tests.py
-#      polarion-id: CEPH-83573424
-#      config:
-#        verify_pool_target_ratio:
-#          configurations:
-#            pool-1:
-#              profile_name: ec86_10
-#              pool_name: ec86_pool10
-#              pool_type: erasure
-#              pg_num: 32
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#              target_size_ratio: 0.8
-#              rados_write_duration: 50
-#              rados_read_duration: 10
-#              delete_pool: true
-#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
-
-#  - test:
 #      name: Autoscaler test - pool pg_num_min
 #      module: pool_tests.py
 #      polarion-id: CEPH-83573425

--- a/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
@@ -295,38 +295,17 @@ tests:
       desc: Verification of the effect of compression on erasure coded pools
 
   - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec62_7
-              pool_name: ec62_pool7
-              pool_type: erasure
-              pg_num: 32
-              k: 6
-              m: 2
-              plugin: isa
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              max_objs: 300
-              rados_read_duration: 10
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
-
-  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
 
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+# COT tests underneath run only on RE pools, commenting workflow for now
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
   - test:
       name: Verify premerge PGS during PG split
@@ -386,28 +365,6 @@ tests:
               conf: sample-pool-9
         pool_configs_path: "conf/tentacle/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
-
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec62_10
-              pool_name: ec62_pool10
-              pool_type: erasure
-              pg_num: 32
-              k: 6
-              m: 2
-              plugin: isa
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              max_objs: 300
-              rados_read_duration: 10
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
   - test:
       name: Autoscaler test - pool target size ratio


### PR DESCRIPTION
1. Removing COT tests from EC pool test suites.
2. Removing duplicate tests