### PR TITLE
[TFA] Fix upgrade test intermittent failure

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -4714,7 +4714,7 @@ EOF"""
             )
 
         cmd_export = f"ceph orch ls {service_type} {service_name} --export"
-        _service = self.run_ceph_command(cmd=cmd_export, client_exec=True)
+        _service = self.run_ceph_command(cmd=cmd_export, client_exec=True)[0]
         if not _service.get("placement", False):
             log.warning(
                 "Service %s does not have placement entry and cannot be set to 'managed', skipping"


### PR DESCRIPTION
PR includes below :-
 
(1) Fixes intermittent automation issue with test_upgrade_warn 
Fail log:- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-236/rados/116/tier-3_rados_test-4-node-ecpools/Upgrade_cluster_to_latest_8.x_ceph_version_0.log 

```
2025-07-28 14:38:34,184 - cephci - test_upgrade_warn:269 - INFO - Upgrade in progress, sleeping for 5 seconds and checking cluster state again
2025-07-28 14:38:39,191 - cephci - ceph:1615 - INFO - Execute ceph orch upgrade status on 10.0.195.228
2025-07-28 14:38:41,197 - cephci - ceph:1645 - INFO - Execution of ceph orch upgrade status on 10.0.195.228 took 2.004958 seconds
2025-07-28 14:38:41,197 - cephci - test_upgrade_warn:369 - ERROR - Could not upgrade the cluster. error : argument of type 'CommandFailed' is not iterable
2025-07-28 14:38:41,198 - cephci - test_upgrade_warn:372 - DEBUG - ---------------- In Finally Block -------------
```

(2) Fixes the output of "ceph orch ls {service_type} {service_name} --export". Returns a list and using get method with list causes error
```
2025-08-01 10:47:50,404 - cephci - ceph:1645 - INFO - Execution of ceph orch ls osd osd.all-available-devices --export -f json on 10.0.203.204 took 1.003721 seconds
2025-08-01 10:47:50,404 - cephci - test_stretch_osd_serviceability_scenarios:1017 - ERROR - Failed with exception: Attribute not found.
2025-08-01 10:47:50,404 - cephci - test_stretch_osd_serviceability_scenarios:1018 - ERROR - 'list' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-242/rados/117/cephci/tests/rados/test_stretch_osd_serviceability_scenarios.py", line 949, in run
    validate_osd_removal_scenario(dc_1_osds_to_remove, dc_2_osds_to_remove)
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-242/rados/117/cephci/tests/rados/test_stretch_osd_serviceability_scenarios.py", line 313, in validate_osd_removal_scenario
    rados_obj.set_managed_flag(service_type="osd", service_name=service)
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Regression/19.2.1-242/rados/117/cephci/ceph/rados/core_workflows.py", line 4718, in set_managed_flag
    if not _service.get("placement", False):
AttributeError: 'list' object has no attribute 'get'
```
Failure logs:- 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-242/rados/117/tier-3_rados_test-location-stretch-mode/OSD_replacement_enhancement_-_1_0.log 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
