### PR TITLE
[Upgrade] restrict upgrade suite to have max 20 testcase

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
@@ -209,16 +209,6 @@ tests:
       polarion-id: CEPH-14237
 
   - test:
-      name: S3CMD small and multipart object download post upgrade
-      desc: S3CMD small and multipart object download or GET
-      polarion-id: CEPH-83575477
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_s3cmd.py
-        config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        run-on-haproxy: true
-
-  - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
       desc: test etag verification
       module: sanity_rgw.py
@@ -226,26 +216,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        run-on-haproxy: true
-
-  - test:
-      name: Dynamic Resharding tests post upgrade
-      desc: Resharding test - dynamic
-      polarion-id: CEPH-83571740
-      module: sanity_rgw.py
-      config:
-        script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        run-on-haproxy: true
-
-  - test:
-      name: Manual Resharding tests post upgrade
-      desc: Resharding test - manual
-      polarion-id: CEPH-83571740
-      module: sanity_rgw.py
-      config:
-        script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_manual_resharding_without_bucket_delete.yaml
         run-on-haproxy: true
 
   - test:
@@ -266,25 +236,3 @@ tests:
       module: sanity_rgw.py
       name: unordered listing of buckets post upgrade
       polarion-id: CEPH-83573545
-
-  # configuring vault agent
-  - test:
-      abort-on-fail: true
-      config:
-        install:
-          - agent
-        run-on-rgw: true
-      desc: configure vault agent with transit engine
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-
-  - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-      desc: test_sse_s3_per_bucket_encryption_version_enabled after upgrade
-      module: sanity_rgw.py
-      name: sse-s3 per bucket encryption test on a versiond bucket after upgrade
-      polarion-id: CEPH-83575152 # CEPH-83575150 #CEPH-83574619

--- a/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
@@ -89,28 +89,6 @@ tests:
       module: haproxy.py
       name: "Configure HAproxy"
 
-
-  - test:
-      abort-on-fail: true
-      config:
-        install:
-          - agent
-        run-on-rgw: true
-      desc: Setup and configure vault agent
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-
-  - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-      desc: test_sse_s3_per_bucket_encryption_version_enabled
-      module: sanity_rgw.py
-      name: sse-s3 per bucket encryption test on a versiond bucket
-      polarion-id: CEPH-83574619 # CEPH-83575150
-
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
       desc: test etag verification
@@ -229,16 +207,6 @@ tests:
         run-on-haproxy: true
 
   - test:
-      name: Dynamic Resharding tests with version post upgrade
-      desc: Resharding test - dynamic
-      polarion-id: CEPH-83571740
-      module: sanity_rgw.py
-      config:
-        script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        run-on-haproxy: true
-
-  - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
@@ -257,6 +225,18 @@ tests:
       polarion-id: CEPH-11019
 
   - test:
+      abort-on-fail: true
+      config:
+        install:
+          - agent
+        run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
@@ -264,3 +244,12 @@ tests:
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test
       polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
+      desc: test_sse_s3_per_bucket_encryption_version_enabled
+      module: sanity_rgw.py
+      name: sse-s3 per bucket encryption test on a versiond bucket
+      polarion-id: CEPH-83574619 # CEPH-83575150

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -321,18 +321,6 @@ tests:
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
 
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_swift_basic_ops.py
-            config-file-name: test_swift_basic_ops.yaml
-            verify-io-on-site: ["ceph-sec"]
-      desc: Test object operations with swift
-      module: sanity_rgw_multisite.py
-      name: swift basic operations pre upgrade
-      polarion-id: CEPH-11019
-
   # Bucket Listing Tests
 
   - test:
@@ -345,30 +333,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
       polarion-id: CEPH-83573545
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec"]
-      desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
-      module: sanity_rgw_multisite.py
-      name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
-      polarion-id: CEPH-83574736
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_manual_resharding_brownfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec"]
-      desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
-      module: sanity_rgw_multisite.py
-      name: Create bucket for Testing manual resharding brownfield scenario after upgrade
-      polarion-id: CEPH-83574735
 
   - test:
       clusters:
@@ -449,30 +413,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_swift_basic_ops.py
-            config-file-name: test_swift_object_expire_op.yaml
-            verify-io-on-site: ["ceph-sec"]
-      desc: test object expiration with swift
-      module: sanity_rgw_multisite.py
-      name: swift object expiration post upgrade
-      polarion-id: CEPH-9718
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec"]
-      desc: Test dynamic resharding brownfield scenario after upgrade
-      module: sanity_rgw_multisite.py
-      name: Test dynamic resharding brownfield scenario after upgrade
-      polarion-id: CEPH-83574736
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
@@ -319,9 +319,9 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-      desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
+      desc: Create bucket for Testing dynamic resharding brownfield scenario before upgrade
       module: sanity_rgw_multisite.py
-      name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
+      name: Create bucket for Testing dynamic resharding brownfield scenario before upgrade
       polarion-id: CEPH-83574736
 
   - test:

--- a/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
@@ -229,26 +229,6 @@ tests:
         run-on-haproxy: true
 
   - test:
-      name: Dynamic Resharding tests post upgrade
-      desc: Resharding test - dynamic
-      polarion-id: CEPH-83571740
-      module: sanity_rgw.py
-      config:
-        script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        run-on-haproxy: true
-
-  - test:
-      name: Manual Resharding tests post upgrade
-      desc: Resharding test - manual
-      polarion-id: CEPH-83571740
-      module: sanity_rgw.py
-      config:
-        script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        run-on-haproxy: true
-
-  - test:
       name: Dynamic Resharding tests with version post upgrade
       desc: Resharding test - dynamic
       polarion-id: CEPH-83571740

--- a/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -479,80 +479,6 @@ tests:
       desc: test metadata sync - create buckets
       module: sanity_rgw_multisite.py
 
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            install:
-              - agent
-            run-on-rgw: true
-        ceph-sec:
-          config:
-            install:
-              - agent
-            run-on-rgw: true
-        ceph-arc:
-          config:
-            install:
-              - agent
-            run-on-rgw: true
-      desc: Setup and configure vault agent
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.sec rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_backend vault"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_auth agent"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
-              - "ceph orch restart rgw.shared.sec"
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.pri rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_backend vault"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_auth agent"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
-              - "ceph orch restart rgw.shared.pri"
-        ceph-arc:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.arc rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_backend vault"
-              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
-              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_auth agent"
-              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
-              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
-              - "ceph orch restart rgw.shared.arc"
-      desc: Setting vault configs for sse-s3 on multisite archive
-      module: exec.py
-      name: set sse-s3 vault configs on multisite
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
-      desc: test multipart+encrypt object access at the archive site
-      polarion-id: CEPH-83573390
-      module: sanity_rgw_multisite.py
-      name: test multipart+encrypt object access at the archive site
-
 # Performing cluster upgrade
 
   - test:
@@ -638,3 +564,77 @@ tests:
       module: sanity_rgw_multisite.py
       name: Manual Resharding tests on Primary cluster
       polarion-id: CEPH-83574734
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-sec:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-arc:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.sec rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart rgw.shared.sec"
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.pri rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart rgw.shared.pri"
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.arc rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart rgw.shared.arc"
+      desc: Setting vault configs for sse-s3 on multisite archive
+      module: exec.py
+      name: set sse-s3 vault configs on multisite
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+      desc: test multipart+encrypt object access at the archive site
+      polarion-id: CEPH-83573390
+      module: sanity_rgw_multisite.py
+      name: test multipart+encrypt object access at the archive site

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -377,62 +377,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            install:
-              - agent
-            run-on-rgw: true
-        ceph-sec:
-          config:
-            install:
-              - agent
-            run-on-rgw: true
-      desc: Setup and configure vault agent
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.sec rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_backend vault"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_auth agent"
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
-              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
-              - "ceph orch restart {service_name:shared.sec}"
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.pri rgw_crypt_require_ssl false"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_backend vault"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_auth agent"
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
-              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
-              - "ceph orch restart {service_name:shared.pri}"
-      desc: Setting vault configs for sse-s3 on multisite
-      module: exec.py
-      name: set sse-s3 vault configs on multisite
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_s3_per_object.yaml
-      desc: test_sse_s3_per_object pre upgarde
-      module: sanity_rgw.py
-      name: sse-s3 per object encryption test pre upgarde
-      polarion-id: CEPH-83575153
 
   - test:
       name: NFS export delete
@@ -511,17 +455,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-      desc: test sse-s3 per bucket encryption post upgrade
-      module: sanity_rgw.py
-      name: sse-s3 per bucket encryption test post upgrade
-      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
 
   - test:
       name: Test NFS cluster and export create

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
@@ -105,18 +105,6 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
-      abort-on-fail: true
-      config:
-        install:
-          - agent
-        run-on-rgw: true
-      desc: Setup and configure vault agent
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-
-  - test:
       name: Manual Resharding tests pre upgrade
       desc: Resharding test - manual
       polarion-id: CEPH-83571740
@@ -151,15 +139,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-
-  - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-      desc: test sse-s3 per bucket encryption pre upgrade
-      module: sanity_rgw.py
-      name: sse-s3 per bucket encryption test pre upgrade
-      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
 
   - test:
       name: Test NFS cluster and export create
@@ -220,15 +199,6 @@ tests:
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
 
   - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-      module: sanity_rgw.py
-      desc: test sse-s3 per bucket encryption with multipart post upgrade
-      name: test sse-s3 per bucket encryption with multipart post upgrade
-      polarion-id: CEPH-83575155
-
-  - test:
       name: compresstion_with_zstd_type post upgarde
       desc: test compresstion with zstd type post upgarde
       polarion-id: CEPH-11350
@@ -245,3 +215,33 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+
+  - test:
+      abort-on-fail: true
+      config:
+        install:
+          - agent
+        run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+      desc: test sse-s3 per bucket encryption post upgrade
+      module: sanity_rgw.py
+      name: sse-s3 per bucket encryption test post upgrade
+      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+      module: sanity_rgw.py
+      desc: test sse-s3 per bucket encryption with multipart post upgrade
+      name: test sse-s3 per bucket encryption with multipart post upgrade
+      polarion-id: CEPH-83575155

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -479,6 +479,67 @@ tests:
       desc: test metadata sync - create buckets
       module: sanity_rgw_multisite.py
 
+# Performing cluster upgrade
+
+  - test:
+      abort-on-fail: true
+      desc: Multisite upgrade
+      module: test_cephadm_upgrade.py
+      name: multisite ceph upgrade
+      polarion-id: CEPH-83574647
+      clusters:
+        ceph-sec:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-pri:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-arc:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+
+  - test:
+      name: Verify DBR feature enabled on upgraded cluster
+      desc: Check DBR feature enabled on upgraded cluster
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      polarion-id: CEPH-83573596
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_check_sharding_enabled.py
+            config-file-name: test_check_sharding_enabled_brownfield.yaml
+
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec" , "ceph-arc"]
+      desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      name: Dynamic resharding tests on Primary cluster
+      polarion-id: CEPH-83574737
+
   - test:
       clusters:
         ceph-pri:
@@ -552,64 +613,3 @@ tests:
       polarion-id: CEPH-83573390
       module: sanity_rgw_multisite.py
       name: test multipart+encrypt object access at the archive site
-
-# Performing cluster upgrade
-
-  - test:
-      abort-on-fail: true
-      desc: Multisite upgrade
-      module: test_cephadm_upgrade.py
-      name: multisite ceph upgrade
-      polarion-id: CEPH-83574647
-      clusters:
-        ceph-sec:
-          config:
-            command: start
-            service: upgrade
-            verify_cluster_health: true
-        ceph-pri:
-          config:
-            command: start
-            service: upgrade
-            verify_cluster_health: true
-        ceph-arc:
-          config:
-            command: start
-            service: upgrade
-            verify_cluster_health: true
-
-  - test:
-      name: Verify DBR feature enabled on upgraded cluster
-      desc: Check DBR feature enabled on upgraded cluster
-      abort-on-fail: true
-      module: sanity_rgw_multisite.py
-      polarion-id: CEPH-83573596
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_check_sharding_enabled.py
-            config-file-name: test_check_sharding_enabled_brownfield.yaml
-
-  - test:
-      name: NFS export delete
-      desc: NFS cluster and exports delete
-      polarion-id: CEPH-83574600 # also covers CEPH-83574601
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: ../nfs_ganesha/nfs_cluster.py
-            config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec" , "ceph-arc"]
-      desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
-      abort-on-fail: true
-      module: sanity_rgw_multisite.py
-      name: Dynamic resharding tests on Primary cluster
-      polarion-id: CEPH-83574737

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -354,6 +354,48 @@ tests:
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
   - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+
+ # Performing cluster upgrade
+
+  - test:
+      abort-on-fail: true
+      desc: Multisite upgrade
+      module: test_cephadm_upgrade.py
+      name: multisite ceph upgrade
+      polarion-id: CEPH-83574647
+      clusters:
+        ceph-sec:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-pri:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+
+  - test:
+      name: Test NFS cluster and export create
+      desc: Test NFS cluster and export create
+      polarion-id: CEPH-83574597
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
+  - test:
       clusters:
         ceph-pri:
           config:
@@ -409,46 +451,3 @@ tests:
       module: sanity_rgw.py
       name: sse-s3 per object encryption test pre upgarde
       polarion-id: CEPH-83575153
-
-  - test:
-      name: NFS export delete
-      desc: NFS cluster and exports delete
-      polarion-id: CEPH-83574600 # also covers CEPH-83574601
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: ../nfs_ganesha/nfs_cluster.py
-            config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-
- # Performing cluster upgrade
-
-  - test:
-      abort-on-fail: true
-      desc: Multisite upgrade
-      module: test_cephadm_upgrade.py
-      name: multisite ceph upgrade
-      polarion-id: CEPH-83574647
-      clusters:
-        ceph-sec:
-          config:
-            command: start
-            service: upgrade
-            verify_cluster_health: true
-        ceph-pri:
-          config:
-            command: start
-            service: upgrade
-            verify_cluster_health: true
-
-  - test:
-      name: Test NFS cluster and export create
-      desc: Test NFS cluster and export create
-      polarion-id: CEPH-83574597
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            run-on-rgw: true
-            script-name: ../nfs_ganesha/nfs_cluster.py
-            config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -105,18 +105,6 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
-      abort-on-fail: true
-      config:
-        install:
-          - agent
-        run-on-rgw: true
-      desc: Setup and configure vault agent
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-
-  - test:
       name: Manual Resharding tests pre upgrade
       desc: Resharding test - manual
       polarion-id: CEPH-83571740
@@ -153,15 +141,6 @@ tests:
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
 
   - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-      desc: test sse-s3 per bucket encryption pre upgrade
-      module: sanity_rgw.py
-      name: sse-s3 per bucket encryption test pre upgrade
-      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
-
-  - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create
       polarion-id: CEPH-83574597
@@ -196,15 +175,6 @@ tests:
           - "ceph versions"
 
   - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-      module: sanity_rgw.py
-      desc: test sse-s3 per bucket encryption with multipart post upgrade
-      name: test sse-s3 per bucket encryption with multipart post upgrade
-      polarion-id: CEPH-83575155
-
-  - test:
       name: NFS export delete
       desc: NFS cluster and exports delete
       polarion-id: CEPH-83574600 # also covers CEPH-83574601
@@ -212,3 +182,33 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+
+  - test:
+      abort-on-fail: true
+      config:
+        install:
+          - agent
+        run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+      desc: test sse-s3 per bucket encryption pre upgrade
+      module: sanity_rgw.py
+      name: sse-s3 per bucket encryption test pre upgrade
+      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+      module: sanity_rgw.py
+      desc: test sse-s3 per bucket encryption with multipart post upgrade
+      name: test sse-s3 per bucket encryption with multipart post upgrade
+      polarion-id: CEPH-83575155

--- a/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
@@ -147,6 +147,16 @@ tests:
 # Post upgrade tests
 
   - test:
+      name: Bucket Lifecycle Object_transition_tests multiple rules and different storage class
+      desc: Test Object_transition_tests multiple rules and different storage class
+      polarion-id: CEPH-83574052 # also CEPH-83573372
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_transition_multiple_rules.yaml
+        run-on-haproxy: true
+
+  - test:
       abort-on-fail: true
       config:
         install:
@@ -166,13 +176,3 @@ tests:
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test
       polarion-id: CEPH-83574617 #CEPH-83574615 , CEPH-83575151
-
-  - test:
-      name: Bucket Lifecycle Object_transition_tests multiple rules and different storage class
-      desc: Test Object_transition_tests multiple rules and different storage class
-      polarion-id: CEPH-83574052 # also CEPH-83573372
-      module: sanity_rgw.py
-      config:
-        script-name: test_bucket_lifecycle_object_expiration_transition.py
-        config-file-name: test_lc_transition_multiple_rules.yaml
-        run-on-haproxy: true


### PR DESCRIPTION
# Description
Based on discussion on upgrade bellow changes  added in pr
1. each upgrade suite can have max 20 testcases
2. In upgrade include vault server related testcase at the end
3. These changes intrduced in reef, squid, and tentacle

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
