### PR TITLE
[RBD] Cover the multiple snap scheduling in existing test

### DIFF
--- a/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -184,6 +184,7 @@ tests:
               mirrormode: snapshot
               snap_schedule_intervals:
                 - 1m
+                - 5m
             ec_pool_config:
               num_pools: 1
               num_images: 1


### PR DESCRIPTION
# Description
This test case on snapshot scheduling at multiple schedulers
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83601538
Covered under this test case 
[CEPH-83601539](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83601538)


Test Result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5MNL7E/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
