### PR TITLE
[TFA-fix]fixing intermittent tfa issue in sanity suites

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -326,36 +326,21 @@ tests:
 
   - test:
       abort-on-fail: true
-      name: RGW MS upgarde and IO parallelly
-      desc: PRGW MS upgarde and IO parallelly
-      module: test_parallel.py
-      parallel:
-        - test:
-            clusters:
-              ceph-sec:
-                config:
-                  command: start
-                  service: upgrade
-                  verify_cluster_health: true
-              ceph-pri:
-                config:
-                  command: start
-                  service: upgrade
-                  verify_cluster_health: true
-            desc: Multisite upgrade
-            module: test_cephadm_upgrade.py
-            name: multisite ceph upgrade
-            polarion-id: CEPH-83574647
-        - test:
-            clusters:
-              ceph-pri:
-                config:
-                  script-name: test_Mbuckets_with_Nobjects.py
-                  config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            desc: test to create "M" no of buckets and "N" no of objects with download
-            module: sanity_rgw_multisite.py
-            name: download objects post upgrade
-            polarion-id: CEPH-14237
+      desc: Multisite upgrade
+      module: test_cephadm_upgrade.py
+      name: multisite ceph upgrade
+      polarion-id: CEPH-83574647
+      clusters:
+        ceph-sec:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-pri:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
 
   - test:
       name: Retrieve the versions of the cluster parallelly
@@ -384,3 +369,13 @@ tests:
             polarion-id: CEPH-83575200
             module: exec.py
             name: Retrieve the versions of the cluster in secondary
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      module: sanity_rgw_multisite.py
+      name: download objects post upgrade
+      polarion-id: CEPH-14237


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
 

The "download objects post upgrade" test was failing intermittently, getting stuck during parallel execution and terminating after an hour. To fix this, parallel execution was removed, and the test is now run at the end of the upgrade process. 
jira: https://issues.redhat.com/browse/RHCEPHQE-21304
pass log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.5/Test/19.2.1-245/777/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest
