### PR TITLE
TFA fixing fs life cycle ops

### DIFF
--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_life_cycle.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_life_cycle.py
@@ -47,14 +47,13 @@ def run(ceph_cluster, **kw):
             sudo=True, cmd="ceph config set mon mon_allow_pool_delete true"
         )
         for output in output1:
-            log.info(print(output))
+            log.info(output)
             exist_fs = output["name"]
             client1.exec_command(sudo=True, cmd=f"ceph fs fail {exist_fs}")
-            out2, ec2 = client1.exec_command(
+            client1.exec_command(
                 sudo=True, cmd=f"ceph fs rm {exist_fs} --yes-i-really-mean-it"
             )
-            if ec2:
-                raise CommandFailed(f"Removing {exist_fs} fas failed")
+
         pool_data = f"cephfs_data_{rand}"
         pool_meta = f"cephfs_metadata_{rand}"
         pool_list.append(pool_meta)
@@ -68,13 +67,10 @@ def run(ceph_cluster, **kw):
 
         client1.exec_command(sudo=True, cmd=create_cmd)
         client1.exec_command(sudo=True, cmd=f"ceph fs fail {fs_name}")
-        out4, ec4 = client1.exec_command(
+
+        client1.exec_command(
             sudo=True, cmd=f"ceph fs rm {fs_name} --yes-i-really-mean-it"
         )
-
-        log.info(print(out4))
-        if ec4:
-            raise CommandFailed("Removing fs fas failed")
 
         client1.exec_command(sudo=True, cmd=f"ceph osd pool create {pool_data}_1")
         client1.exec_command(sudo=True, cmd=f"ceph osd pool create {pool_meta}_1")
@@ -93,18 +89,16 @@ def run(ceph_cluster, **kw):
         retry_mount([client1], kernel_mounting_dir_1, ",".join(mon_node_ips))
 
         out7, ec7 = client1.exec_command(sudo=True, cmd=f"ceph fs get {fs_name}")
-        log.info(print(out7))
+        log.info(out7)
+        log.info(ec7)
         fs_util.run_ios(
             client1, kernel_mounting_dir_1, ["dd", "smallfile"], file_name=rand
         )
-        if ec7:
-            raise CommandFailed("Getting fs has failed")
+
         out8, ec8 = client1.exec_command(
             sudo=True, cmd=f"ceph fs set {fs_name} max_mds 3"
         )
-        log.info(print(out8))
-        if ec8:
-            raise CommandFailed("Setting fs has failed")
+        log.info(out8)
         # Adding addiotional pool in the cephfs since we can not remove the default pool
         pool_name_remove = "remove_pool"
         client1.exec_command(sudo=True, cmd=f"ceph osd pool create {pool_name_remove}")


### PR DESCRIPTION
# Description
TFA fixing fs life cycle ops

New behavior: 
Remove filesystem is returning output with extra line 
```
[root@ceph-amk-rc-p7jrz6-node8 ~]# ceph fs volume rm fs_1 --yes-i-really-mean-it
metadata pool: cephfs.fs_1.meta data pool: ['cephfs.fs_1.data'] removed.
If there are active snapshot schedules associated with this volume, you might see EIO errors in the mgr logs or at the snap-schedule command-line due to the missing volume. However, these errors are transient and will get auto-resolved.
```
I have removed all the raise commands by default `cephci` framework will error out if there is command failure

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2BX4Y9/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
