### PR TITLE
add rgw nodes to ssl upgrade test

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
@@ -55,6 +55,8 @@ tests:
                   service_id: rgw.ssl
                   placement:
                     nodes:
+                      - node3
+                      - node4
                       - node5
                   spec:
                     ssl: true


### PR DESCRIPTION
# Description

ssl upgrade test failing with bucket creation due to rgw not configured in node3, node4

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-IK6YJF/
issue: https://issues.redhat.com/browse/RHCEPHQE-21286

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
