### PR TITLE
[RBD] CEPH-83613954 - Changing the mirror mode for the existing mirror configured cluster

### DIFF
--- a/suites/squid/rbd/tier-2_default_namespace_mirroring.yaml
+++ b/suites/squid/rbd/tier-2_default_namespace_mirroring.yaml
@@ -210,6 +210,7 @@ tests:
   - test:
       abort-on-fail: True
       desc: Verify default to non-default namespace mirroring
+      comments: Product bug 2358634
       name: >
         Snapshot based Namespace level mirroring from
         default to non-default namespace

--- a/suites/tentacle/rbd/tier-2_default_namespace_mirroring.yaml
+++ b/suites/tentacle/rbd/tier-2_default_namespace_mirroring.yaml
@@ -210,6 +210,7 @@ tests:
   - test:
       abort-on-fail: True
       desc: Verify default to non-default namespace mirroring
+      comments: Product bug 2358634
       name: >
         Snapshot based Namespace level mirroring from
         default to non-default namespace


### PR DESCRIPTION
# Description
Combined this test step of removing peer and disabling mirror from one mode and enabling it to another mode
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83613954
Under this test case: CEPH-83612872

Due to this product issue
https://bugzilla.redhat.com/show_bug.cgi?id=2358634

Test got failed
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-17MD2S/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
