### PR TITLE
[TFA-fix] removed zonegroup_hostnames parameter from rgw deployment.

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -66,8 +66,6 @@ tests:
                       spec:
                         generate_cert: true
                         ssl: true
-                        zonegroup_hostnames:
-                          - s3.example.com
                       placement:
                         nodes:
                           - node5
@@ -116,8 +114,6 @@ tests:
                       spec:
                         generate_cert: true
                         ssl: true
-                        zonegroup_hostnames:
-                          - s3.example.com
                       placement:
                         nodes:
                           - node5


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

When deployed rgw with  zonegroup_hostnames the rgw is starting / unknown status which is resulting in realm pull from secondary site 
jira:
https://issues.redhat.com/browse/RHCEPHQE-21376 
Log : 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.5/Test/19.2.1-245/788/tier-2_rgw_ssl_cephadm_gen_cert 