### PR TITLE
CephNode.exec_command: Return all if verbose option is set

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1720,7 +1720,7 @@ class CephNode(object):
 
             logger.info(msg)
 
-        if "verbose" in kw:
+        if kw.get("verbose", False):
             return _out, _err, _exit, _time
 
         # Historically, we are only providing command exit code for long


### PR DESCRIPTION
Currently "verbose" in exec_command key args is returning all (stdout, stderr, exit_status, time_duration) without validation
- Fix is to check boolean value to return verbose output.
- Fixes one of the `fio_cmd` function which passes `verbose` parameter.




