### PR TITLE
tfa_fix_nfs_test_setting_selinux_context.py_&_nfs_test_selinux_context_moving_files.py

### DIFF
--- a/tests/nfs/nfs_test_selinux_context_moving_files.py
+++ b/tests/nfs/nfs_test_selinux_context_moving_files.py
@@ -48,13 +48,6 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
         )
 
-        # Mount the share on Client 2
-        cmd = f"umount -l {nfs_mount}"
-        clients[1].exec_command(sudo=True, cmd=cmd)
-
-        cmd = f"mount -t nfs {nfs_nodes[0].ip_address}:{nfs_export}_0 {nfs_mount}"
-        clients[1].exec_command(sudo=True, cmd=cmd)
-
         # Create 5 file on Mount point from client 1
         try:
             for i in range(1, num_files + 1):

--- a/tests/nfs/nfs_test_setting_selinux_context.py
+++ b/tests/nfs/nfs_test_setting_selinux_context.py
@@ -46,13 +46,6 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
         )
 
-        # Mount the share on Client 2
-        cmd = f"umount -l {nfs_mount}"
-        clients[1].exec_command(sudo=True, cmd=cmd)
-
-        cmd = f"mount -t nfs {nfs_nodes[0].ip_address}:{nfs_export}_0 {nfs_mount}"
-        clients[1].exec_command(sudo=True, cmd=cmd)
-
         # Create a file on Mount point from client 1
         cmd = f"touch {nfs_mount}/{filename}"
         clients[0].exec_command(cmd=cmd, sudo=True)


### PR DESCRIPTION
# Description

TFA Fixes: nfs_test_selinux_context_moving_files.py and nfs_test_selinux_context_moving_files.py

Issue: Script was checking for an export and mount point which did not exist in the client. The below mentioned chunk of code caused the issue
  # Mount the share on Client 2
        cmd = f"umount -l {nfs_mount}"
        clients[1].exec_command(sudo=True, cmd=cmd)

        cmd = f"mount -t nfs {nfs_nodes[0].ip_address}:{nfs_export}_0 {nfs_mount}"
        clients[1].exec_command(sudo=True, cmd=cmd)

Removed the chunk and executed the test. The test was successful.

Logs- http://magna002.ceph.redhat.com/ceph-qe-logs/manising/tfa_fix_selinux_13/


