### PR TITLE
Removed the invalid yaml calls in the Testcase

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -393,8 +393,6 @@ tests:
             config-file-name: ../../s3cmd/multisite_configs/test_rgw_log_details.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
             verify-io-info-configs:
-              - test_multisite_dynamic_resharding_brownfield.yaml
-              - test_multisite_manual_resharding_brownfield.yaml
               - test_rgw_log_details.yaml
       desc: S3CMD tests, rgw log details post upgrade
       module: sanity_rgw_multisite.py


### PR DESCRIPTION
TFA - Fix 
[8.1][TFA][weekly] S3CMD tests, rgw log details post upgrade failed before verification started

Resolved : 

Eliminating the invalid Yaml File  Calls

Logs : http://magna002.ceph.redhat.com/ceph-qe-logs/sohan/logs/PR/RHCEPHQE-21421/