### PR TITLE
Switch Jenkins node from RHEL 8 to RHEL 9 for cleanup volume job

### DIFF
--- a/pipeline/rhos_scripts/Jenkinsfile-cleanup-cloud-volumes.groovy
+++ b/pipeline/rhos_scripts/Jenkinsfile-cleanup-cloud-volumes.groovy
@@ -4,7 +4,7 @@
 // Global variables section
 def sharedLib
 
-node("rhel-8-medium") {
+node("rhel-9-medium") {
 
     stage('prepareNode') {
         checkout(


### PR DESCRIPTION
Updated Jenkins node to RHEL 9 to support Python 3.9 for module compatibility.
