### PR TITLE
TFA fix for cephfs byok test

### DIFF
--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_byok_functional.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_byok_functional.py
@@ -138,6 +138,11 @@ def run(ceph_cluster, **kw):
         if cephfs_common_utils.wait_for_healthy_ceph(client, 300):
             log.error("Cluster health is not OK even after waiting for 300secs")
             return 1
+        log.info("Cleanup existing nfs clusters")
+        out, _ = client.exec_command(sudo=True, cmd="ceph nfs cluster ls")
+        nfscluster_ls = out.split("\n")
+        for nfs_cluster_name in nfscluster_ls:
+            fs_util.remove_nfs_cluster(client, nfs_cluster_name)
         byok_setup_params = {
             "gklm_ip": gklm_ip,
             "gklm_user": gklm_user,
@@ -209,7 +214,7 @@ def run(ceph_cluster, **kw):
                 if enctag is not None:
                     clean_up_gklm(
                         gklm_rest_client=byok_setup_params["gklm_rest_client"],
-                        gkml_client_name=byok_test_params["gklm_client_name"],
+                        gkml_client_name=byok_setup_params["gklm_client_name"],
                         gklm_cert_alias=byok_setup_params["gklm_cert_alias"],
                     )
                 if byok_test_params is not None:
@@ -217,7 +222,7 @@ def run(ceph_cluster, **kw):
                         clean_up_gklm(
                             gklm_rest_client=byok_setup_params["gklm_rest_client"],
                             gkml_client_name=byok_test_params["gklm_client_name_1"],
-                            gklm_cert_alias=byok_setup_params["gklm_cert_alias_1"],
+                            gklm_cert_alias=byok_test_params["gklm_cert_alias_1"],
                         )
 
             except Exception as ex:
@@ -230,7 +235,7 @@ def run(ceph_cluster, **kw):
                             sv["nfs_client"].exec_command(
                                 sudo=True, cmd=f"umount -l {sv['nfs_mount_dir']}"
                             )
-                        except CommandFailed as ex:
+                        except Exception as ex:
                             log.error(ex)
                 if byok_test_params.get("export_list"):
                     for export in byok_test_params["export_list"]:
@@ -292,6 +297,7 @@ def nfs_byok_cephfs_test_run():
             if op == "set" and op_status:
                 log.error("Enctag set failed")
                 return 1
+
     log.info("Create NFS export to subvolume using enctag as kmip_key_id")
     extra_args = f" --kmip_key_id {byok_test_params['byok_params']['enctag']}"
     for sv in sv_list:


### PR DESCRIPTION
# Description

Jira: https://jsw.ibm.com/browse/IBMCEPHQE-90

Failed log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regressio[…]55/cephfs/128/regression_suite_nfs/cephfs_nfs_byok_0.log
Reason:
NFS deploy had failed. may be due to sni testlib changes required or because existing nfs cluster on same node creating conflict. 
Fix:
nfs cluster cleanup before test to ensure existing nfs cluster from previous tests doesn't create an issue. Discussed with [@Harish Acharya](https://ibm.enterprise.slack.com/team/U07LMFMPS4V) for sni changes because https://github.com/red-hat-storage/cephci/pull/5161/ has byok testlib and sni fixes identified can be added into this.

Local run passed logs(with sni fixes) on [ceph-19.2.1-245.0.hotfix.BYOK.el9cp](https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/ceph-19.2.1-245.0.hotfix.BYOK.el9cp/) : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-31CW5X

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
