### PR TITLE
TFA fix - tier-2_rbd_group

### DIFF
--- a/tests/rbd/test_rbd_groups_image_clone.py
+++ b/tests/rbd/test_rbd_groups_image_clone.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 from ceph.rbd.initial_config import initial_rbd_config
 from ceph.rbd.utils import getdict, random_string
@@ -71,7 +72,7 @@ def test_rbd_groups_image_clone(rbd_obj, client, **kw):
 
     for pool_type in rbd_obj.get("pool_types"):
         rbd_config = kw.get("config", {}).get(pool_type, {})
-        multi_pool_config = getdict(rbd_config)
+        multi_pool_config = deepcopy(getdict(rbd_config))
         for pool, pool_config in multi_pool_config.items():
             if "data_pool" in pool_config.keys():
                 _ = pool_config.pop("data_pool")

--- a/tests/rbd/test_rbd_groups_image_usecase.py
+++ b/tests/rbd/test_rbd_groups_image_usecase.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from ceph.rbd.initial_config import initial_rbd_config
 from ceph.rbd.utils import getdict
 from ceph.rbd.workflows.cleanup import cleanup
@@ -25,7 +27,7 @@ def test_group_creation_images_add(rbd_obj, client, **kw):
 
     for pool_type in rbd_obj.get("pool_types"):
         rbd_config = kw.get("config", {}).get(pool_type, {})
-        multi_pool_config = getdict(rbd_config)
+        multi_pool_config = deepcopy(getdict(rbd_config))
         for pool, pool_config in multi_pool_config.items():
             if "data_pool" in pool_config.keys():
                 _ = pool_config.pop("data_pool")


### PR DESCRIPTION
# Description

Failed log:

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-245/rbd/116/tier-2_rbd_group/

The test was failing because the previous test was not cleaninng up the pools properly.
Have fixed cleanup isses in two tests
Pass log:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-B4YD29/

Note: One of the test in the above log failed due to IO issues which is not related to the fix here. That IO issues intermittent due to prevailing network issues on my side. Please look for cleanup where it deleted all the pools
