### PR TITLE
Removing sos report from tentacle sanity suite

### DIFF
--- a/suites/tentacle/cephfs/tier-0_fs.yaml
+++ b/suites/tentacle/cephfs/tier-0_fs.yaml
@@ -125,8 +125,3 @@ tests:
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false
-  -
-    test:
-      desc: "generate sosreport"
-      module: sosreport.py
-      name: "generate sosreport"


### PR DESCRIPTION
# Description

Removing sos report test from tentacle sanity suite
Sanity Failure : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Sanity/20.1.0-2/1/tier-0_fs/

As this is not part of cephfs so removing it as it raises false alarm

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
