### PR TITLE
Verification of user initiated scrub priority over osd_scrub_load_threshold parameter

### DIFF
--- a/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -207,7 +207,7 @@ tests:
         delete_pool:
           - replicated_pool
   - test:
-      name: Verification of osd_scrub_load_threshold parameter functionality
+      name: Verification of osd_scrub_load_threshold
       desc: Verification of osd_scrub_load_threshold parameter functionality
       module: test_osd_scrub_load_threshold_parameter.py
       polarion-id: CEPH-83620201


### PR DESCRIPTION
# Description
1. Update the parameter osd_scrub_load_threshold from its default value (10.0) to 0.
2. Perform a user initiated scrub operation using the command:
    _ceph pg deep-scrub <pg_id>_
3. Verify that the scrub operation starts and proceeds without failure.
4. Check the OSD logs and confirm the presence of the following log messages:
     4.1 scrub_load_below_threshold:.* = no
     4.2 active+clean+scrubbing+deep(operator-requested)
     4.3 <pg_id> deep-scrub starts
     
Updated the polarion with the above case - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83620201

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
