### PR TITLE
[RBD] TFA fix for non default namespace mirror test suite

### DIFF
--- a/suites/reef/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/reef/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -282,6 +282,7 @@ tests:
                 size: 2G
                 io_total: 10
       name: Testing change of image feature reflection from primary to secondary
+      comments: Product bug 2177167
       polarion-id: CEPH-9520
 
   - test:

--- a/suites/reef/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+++ b/suites/reef/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
@@ -268,4 +268,5 @@ tests:
       desc: Test to verify rbd mirroring failback
       module: rbd_mirror_reconfigure_secondary_cluster.py
       polarion-id: CEPH-9477
+      comments: Product bug 2188227
       name: Reconfigure mirror with newly created cluster as secondary

--- a/suites/squid/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/squid/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -282,6 +282,7 @@ tests:
                 size: 2G
                 io_total: 10
       name: Testing change of image feature reflection from primary to secondary
+      comments: Product bug 2177167
       polarion-id: CEPH-9520
 
   - test:

--- a/suites/squid/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+++ b/suites/squid/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
@@ -268,4 +268,5 @@ tests:
       desc: Test to verify rbd mirroring failback
       module: rbd_mirror_reconfigure_secondary_cluster.py
       polarion-id: CEPH-9477
+      comments: Product bug 2188227
       name: Reconfigure mirror with newly created cluster as secondary

--- a/suites/tentacle/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/tentacle/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -282,6 +282,7 @@ tests:
                 size: 2G
                 io_total: 10
       name: Testing change of image feature reflection from primary to secondary
+      comments: Product bug 2177167
       polarion-id: CEPH-9520
 
   - test:

--- a/suites/tentacle/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+++ b/suites/tentacle/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
@@ -268,4 +268,5 @@ tests:
       desc: Test to verify rbd mirroring failback
       module: rbd_mirror_reconfigure_secondary_cluster.py
       polarion-id: CEPH-9477
+      comments: Product bug 2188227
       name: Reconfigure mirror with newly created cluster as secondary


### PR DESCRIPTION
# Description
Fixes this TFA issue
https://issues.redhat.com/browse/RHCEPHQE-21501

The test was failing because the snapshot schedule wasn’t being added and removed properly. 
I’ve now handled both cases wherever required

Test results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2SJDRR/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
