### PR TITLE
Added inventory for latest rhel-8

### DIFF
--- a/conf/inventory/ibm-rhel-8.10-server-bx2-4x16.yaml
+++ b/conf/inventory/ibm-rhel-8.10-server-bx2-4x16.yaml
@@ -1,0 +1,44 @@
+---
+version_id: 8.10
+id: rhel
+instance:
+  create:
+    image-name: rhel-810-server-amd64-kvm
+    network_name: ci-sn-01
+    private_key: ceph-qe-sa-svc
+    group_access: sec-grp-ci-vpc-01
+    profile: bx2-4x16
+
+  setup: |
+    #cloud-config
+    no_ssh_fingerprints: true
+    disable_root: false
+    ssh_pwauth: true
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(root) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwmsOkNX16LikH7spbmVVOLhGOSsNSlAYSk0ifhLpaO
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPoKGCTzMmNvHFY4THKNpZYFLeEgB7Do8y2JAEy+ZvIZ ceph-qe-sa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
+
+    chpasswd:
+      expire: false
+      users:
+        - name: cephuser
+          password: $y$j9T$PxJ09a3yVNnPj0Veb8QDT.$bdWoyLq1IdGwlimyJC98P5OsSFE2w7.9ac68z4eoa01
+        - name: root
+          password: $y$j9T$L0/xJyxgqCPIezC0dp/0/0$KawKfTR2FhliH9YrG4/30wot90M3xtF03K1XwGnYz2A
+
+    runcmd:
+      - timedatectl set-timezone Etc/UTC
+      - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
+      - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/50-ceph-qe.conf
+      - systemctl restart sshd
+      - touch /ceph-qa-ready


### PR DESCRIPTION
The suite tier1-mix-os-deployment requires admin node to be RHEL 9.x and rest of the nodes to be RHEL 8.x. While running this test in IBMC, the test fails with TestSetupFailure because of missing RHEL 8.x inventory in IBMC.
