### PR TITLE
Enhance namespace masking for more flexibility of namespaces and initiator numbers

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof_e2e_ns-masking.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_e2e_ns-masking.yaml
@@ -155,13 +155,13 @@ tests:
         rbd_pool: rbd
         do_not_create_image: true
         rep-pool-only: true
+        subsystems: 5
+        namespaces: 50
         service: namespace
         steps:
           - config:
               command: add
               args:
-                subsystems: 5
-                namespaces: 50
                 pool: rbd
                 image_size: 1T
                 no-auto-visible: true
@@ -170,8 +170,6 @@ tests:
           - config:
               command: add_host
               args:
-                subsystems: 5
-                namespaces: 50
                 initiators:
                   - node8
                   - node9
@@ -183,8 +181,6 @@ tests:
           - config:
               command: del_host
               args:
-                subsystems: 5
-                namespaces: 50
                 initiators:
                   - node8
                   - node9
@@ -196,16 +192,12 @@ tests:
           - config:
               command: change_visibility
               args:
-                subsystems: 5
-                namespaces: 50
                 auto-visible: 'yes'
                 group: group1
                 validate_ns_masking_initiators: true
           - config:
               command: change_visibility
               args:
-                subsystems: 5
-                namespaces: 50
                 auto-visible: 'no'
                 group: group1
                 validate_ns_masking_initiators: true

--- a/tests/nvmeof/workflows/ha.py
+++ b/tests/nvmeof/workflows/ha.py
@@ -1264,68 +1264,56 @@ class HighAvailability:
         self,
         nsid,
         subnqn,
-        namespaces_sub,
-        hostnqn_dict,
         ns_visibility,
         command,
-        expected_visibility,
+        host_nqn,
     ):
         """Validate that the namespace visibility is correct."""
 
         if command == "add_host":
             LOG.info(command)
-            num_namespaces_per_node = namespaces_sub // len(hostnqn_dict)
-
-            # Determine the initiator node responsible for this nsid based on the calculated range
-            node_index = (nsid - 1) // num_namespaces_per_node
-            expected_host = list(hostnqn_dict.values())[node_index]
 
             # Log the visibility of the namespace
-            if expected_host in ns_visibility:
+            if host_nqn in ns_visibility:
                 LOG.info(
                     f"Validated - Namespace {nsid} of {subnqn} has the correct nqn {ns_visibility}"
                 )
             else:
                 LOG.error(
-                    f"Namespace {nsid} of {subnqn} has incorrect NQN. Expected {expected_host}, but got {ns_visibility}"
+                    f"Namespace {nsid} of {subnqn} has incorrect NQN. Expected {host_nqn}, but got {ns_visibility}"
                 )
                 raise Exception(
-                    f"Namespace {nsid} of {subnqn} has incorrect NQN. Expected {expected_host}, but got {ns_visibility}"
+                    f"Namespace {nsid} of {subnqn} has incorrect NQN. Expected {host_nqn}, but got {ns_visibility}"
                 )
 
         elif command == "del_host":
             LOG.info(command)
-            num_namespaces_per_node = namespaces_sub // len(hostnqn_dict)
-
-            # Determine the initiator node responsible for this nsid based on the calculated range
-            node_index = (nsid - 1) // num_namespaces_per_node
-            expected_host = list(hostnqn_dict.values())[node_index]
 
             # Log the visibility of the namespace
-            if expected_host not in ns_visibility:
+            if host_nqn not in ns_visibility:
                 LOG.info(
-                    f"Validated - Namespace {nsid} of {subnqn} does not has {expected_host}"
+                    f"Validated - Namespace {nsid} of {subnqn} does not has {host_nqn}"
                 )
             else:
                 LOG.error(
                     f"Namespace {nsid} of {subnqn} has {ns_visibility} which was removed"
                 )
                 raise Exception(
-                    f"Namespace {nsid} of {subnqn} has incorrect NQN. Not expecting {ns_visibility} in {expected_host}"
+                    f"Namespace {nsid} of {subnqn} has incorrect NQN. Not expecting {ns_visibility} in {host_nqn}"
                 )
 
         else:
             # Validate visibility based on the expected value (for non-add/del host commands)
-            if str(ns_visibility).lower() == str(expected_visibility).lower():
+            if str(ns_visibility).lower() == str(host_nqn).lower():
                 LOG.info(
                     f"Validated - Namespace {nsid} has correct visibility: {ns_visibility}"
                 )
             else:
                 LOG.error(
-                    f"NS {nsid} of {subnqn} has wrong visibility.Expected {expected_visibility} got {ns_visibility}"
+                    f"NS {nsid} of {subnqn} has wrong visibility.Expected {host_nqn} got {ns_visibility}"
                 )
                 raise Exception(
-                    f"NS {nsid} of {subnqn} has wrong visibility.Expected {expected_visibility} got {ns_visibility}"
+                    f"NS {nsid} of {subnqn} has wrong visibility.Expected {host_nqn} got {ns_visibility}"
                 )
 
     def run(self):


### PR DESCRIPTION
Enhance namespace masking for more flexibility of namespaces and initiator numbers

Decouple mapping of namespaces per initiator logic and rework on dynamic assignment

5 subsystems, 50 NS and 5 initiators log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L2I018/
2 subsystems, 10 NS and 5 initiators log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TLM730/Test_E2E_nvmeof_namespace_masking_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-69SXQ0/

2 initiators
 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-95NPY7/Test_E2E_nvmeof_namespace_masking_0.log  - 2 subsystems 10 ns and 2 init


http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0UR7KQ/Test_E2E_nvmeof_namespace_masking_0.log     - 5 subsystems 50 NS and 2 init but this abruptly halted due to network issues but this came until del_host