### PR TITLE
Fixing mds cache issue

### DIFF
--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -320,7 +320,7 @@ class CephfsMirroringUtils(object):
         The specified path should exist within the source filesystem.
         """
         path = path.rstrip("/")  # to avoid trailing slash mismatch
-        ceph_version = get_ceph_version_from_cluster(source_clients[0])
+        ceph_version = get_ceph_version_from_cluster(source_clients)
 
         log.info(
             f"Adding path '{path}' to mirroring configuration for filesystem '{source_fs}'..."

--- a/tests/cephfs/cephfs_system/mds_cache_trimming_caps_recall.py
+++ b/tests/cephfs/cephfs_system/mds_cache_trimming_caps_recall.py
@@ -247,7 +247,7 @@ def run(ceph_cluster, **kw):
     """
     try:
         fs_util_v1 = FsUtilsV1(ceph_cluster)
-        mds_nodes = ceph_cluster.get_ceph_objects("mds")
+        mds_nodes = ceph_cluster.get_ceph_objects()
         clients = ceph_cluster.get_ceph_objects("client")
         config = kw.get("config")
         osp_cred = config.get("osp_cred")


### PR DESCRIPTION
# Description
Fixing mds cache issue

Problem : 
The mds_cache_trimming_caps_recall test is failing when the active MDS is deployed on a node that is not marked as an MDS node. 

Failed log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-254/cephfs/34/tier-4_cephfs_system/mds_cache_trimming_caps_recall_0.log

Passed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8EHTNY/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
