### PR TITLE
Adding the test-cases for BYOK sighup(updating certs shouldn't restart NFS)

### DIFF
--- a/suites/squid/nfs/tier0-nfs-ganesha-byok.yaml
+++ b/suites/squid/nfs/tier0-nfs-ganesha-byok.yaml
@@ -232,3 +232,19 @@ tests:
                 longevity: true
                 # longevity_duration: 1 # in hours
                 longevity_loop: 3 # 3 iterations/loops
+
+   - test:
+      name: Test SIGHUP-reload after KMIP and nfs update (single cluster)
+      module: byok.test_byok_single_multi_restart.py
+      desc: Confirm nfs receives SIGHUP and reloads after KMIP certs in existing NFS service spec update
+      polarion-id: CEPH-83628800
+      abort-on-fail: true
+      config:
+        nfs_version: 4.2
+        total_export_num: 4
+        clients: 1
+        nfs_replication_number: 1           # Single cluster mode
+        nfs_mount: /mnt/nfs_byok
+        nfs_export: /export_byok
+        nfs_instance_name: nfs_byok
+        check_sighup: true

--- a/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
+++ b/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
@@ -358,11 +358,11 @@ def gklm_setup():
     log.info("Creating symmetric key encryption tag in GKLM")
     enctag = get_enctag(
         gklm_rest_client,
-        created_client_data,
         gklm_client_name,
         gklm_cert_alias,
         gklm_user,
         cert,
+        created_client_data,
     )
 
     # ------------------- Prerequisites and Certificate Export -------------------

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -1100,6 +1100,103 @@ def dynamic_cleanup_common_names(
     log.info("Dynamic cleanup of NFS resources completed")
 
 
+def get_ganesha_info_from_container(installer, nfs_service_name, nfs_host_node):
+    """
+    Retrieves Ganesha NFS daemon information from a containerized NFS service.
+    This function extracts the process ID (PID) and related container information
+    for a Ganesha NFS daemon running inside a container managed by Ceph orchestrator.
+    Args:
+        installer: CephAdm installer object used to execute ceph orchestrator commands
+        nfs_service_name (str): Name of the NFS service to query (without 'nfs.' prefix)
+        nfs_host_node: Host node object where the NFS container is running, used for
+                       executing commands on the host system
+    Returns:
+        tuple: A tuple containing:
+            - int or None: Host PID of the Ganesha process, or None if not found
+            - dict or None: Dictionary containing container information with keys:
+                - 'container_id': Container ID of the NFS service
+                - 'hostname': Hostname where the container is running
+                - 'container_pid': PID of the container process on the host
+                - 'ganesha_pid_in_container': PID of Ganesha process inside container
+                - 'host_ganesha_pid': Host PID of the Ganesha process
+              Returns None if information cannot be retrieved
+    Raises:
+        Exception: Catches and logs any exceptions that occur during the process,
+                   returning (None, None) on failure
+    Note:
+        This function uses podman commands to inspect containers and find process IDs.
+        It requires sudo privileges on the host node to execute container inspection
+        and process listing commands.
+
+    """
+    try:
+        log.info(f"Getting Ganesha PID for service: {nfs_service_name}")
+
+        # Get NFS service container information
+        out = CephAdm(installer).ceph.orch.ps(
+            service_name=f"nfs.{nfs_service_name}", format="json"
+        )
+
+        nfs_processes = json.loads(out)
+
+        if not nfs_processes:
+            log.error(f"No running processes found for NFS service {nfs_service_name}")
+            return (None, None)
+
+        nfs_process = nfs_processes[0]
+        container_id = nfs_process.get("container_id", "")
+        hostname = nfs_process.get("hostname", "")
+
+        if not container_id:
+            log.error("Container ID not found for NFS service")
+            return (None, None)
+
+        log.info(f"NFS container ID: {container_id} on host: {hostname}")
+
+        # Method 1: Get PID from container inspection
+        cmd = f"podman inspect {container_id} --format '{{{{.State.Pid}}}}'"
+        out, err = nfs_host_node.exec_command(cmd=cmd, sudo=True)
+
+        if not err and out.strip().isdigit():
+            container_pid = int(out.strip())
+            log.info(f"Container PID: {container_pid}")
+
+            # Method 2: Find Ganesha process inside container
+            cmd = f"podman exec {container_id} ps aux | grep '[g]anesha.nfsd' | awk '{{print $2}}'"
+            out, err = nfs_host_node.exec_command(cmd=cmd, sudo=True)
+
+            if not err and out.strip():
+                ganesha_pid_in_container = out.strip()
+                log.info(f"Ganesha PID inside container: {ganesha_pid_in_container}")
+
+                # Get the actual host PID (container PID + offset usually)
+                # For most container runtimes, we can find the host PID through /proc
+                cmd = "ps -ef | grep '[g]anesha.nfsd' | grep -v grep | awk '{print $2}'"
+                out, err = nfs_host_node.exec_command(cmd=cmd, sudo=True)
+
+                if not err and out.strip():
+                    host_ganesha_pid = out.strip().split("\n")[0]
+                    log.info(f"Ganesha host PID: {host_ganesha_pid}")
+
+                    return (
+                        int(host_ganesha_pid),
+                        {
+                            "container_id": container_id,
+                            "hostname": hostname,
+                            "container_pid": container_pid,
+                            "ganesha_pid_in_container": ganesha_pid_in_container,
+                            "host_ganesha_pid": host_ganesha_pid,
+                        },
+                    )
+
+        log.error("Could not determine Ganesha PID")
+        return (None, None)
+
+    except Exception as e:
+        log.error(f"Failed to get Ganesha PID: {e}")
+        return (None, None)
+
+
 def nfs_log_parser(client, nfs_node, nfs_name, expect_list):
     """
     This method parses the nfs debug log for given list of strings and returns 0 on Success


### PR DESCRIPTION
Adding the test-cases for BYOK sighup(updating certs shouldn't restart NFS)

Steps:
	•	Generate certs, keys, and retrieve ca_cert from GKLM server — Certs should be created
	•	Create a NFS cluster for BYOK using kmip_cert, kmip_key, kmip_ca_cert, and kmip hosts fields — NFS cluster  should be created
	•	Replace certs in kmip_cert, kmip_key, and kmip_ca_cert fields — Update should be successful
	•	Create exports using enctag key, and mount the export to clients — Exports should be created and mounted on clients
	•	Ensure `ceph orch apply` sends SIGHUP to Ganesha, not a full restart — For SIGHUP, PID shouldn’t change
	•	Validate ongoing exports remain mounted and functional after signal-based reload — Mounts should be stable
	•	Run IO — IO should happen successfully
	•	Remove NFS cluster and its artifacts — Cleanup should happen without any errors


logs:
1. http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/byok/sighup/logs-test/
2. http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/byok/sighup/logs-test1/
3. http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/byok/sighup/logs-test3/