### PR TITLE
[RADOS] Add ENOSPC coverage in Squid & fix for fetch_object_dump method

### DIFF
--- a/ceph/rados/objectstoretool_workflows.py
+++ b/ceph/rados/objectstoretool_workflows.py
@@ -377,7 +377,7 @@ class objectstoreToolWorkflows:
         _cmd = f"--pgid {pgid} '{obj}' rm-attr {attr}"
         return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
 
-    def fetch_object_dump(self, osd_id: int, pgid: str, obj: str):
+    def fetch_object_dump(self, osd_id: int, obj: str, pgid: str = None):
         """Module to fetch object dump
         Args:
             osd_id: OSD ID for which cot will be executed
@@ -387,7 +387,9 @@ class objectstoreToolWorkflows:
             Returns the output of
             ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT dump
         """
-        _cmd = f"--pgid {pgid} '{obj}' dump"
+        _cmd = f" '{obj}' dump"
+        if pgid:
+            _cmd = f" --pgid {pgid} {_cmd}"
         return self.run_cot_command(cmd=_cmd, osd_id=osd_id)
 
     def get_superblock(self, osd_id: int):
@@ -412,7 +414,7 @@ class objectstoreToolWorkflows:
             Returns the output of
             ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op get-osdmap
         """
-        # Extracting the osdmap from the osd
+        # Extracting the osdmap for the input obj from the osd
         _cmd = "--op get-osdmap"
         if pgid:
             _cmd = f"{_cmd} --pgid {pgid}"
@@ -448,7 +450,7 @@ class objectstoreToolWorkflows:
             Returns the output of
             ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op meta-list
         """
-        # Extracting the incremental osdmap from the osd
+        # Extracting the meta-list for the object
         _cmd = "--op meta-list"
         if pgid:
             _cmd = f"{_cmd} --pgid {pgid}"
@@ -466,7 +468,7 @@ class objectstoreToolWorkflows:
             Returns the output of
             ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op export
         """
-        # Extracting the incremental osdmap from the osd
+        # Extracting the content of OSD
         _cmd = "--op export"
         if pgid:
             _cmd = f"{_cmd} --pgid {pgid}"

--- a/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
@@ -48,6 +48,13 @@ tests:
               args:
                 placement:
                   label: mon
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+              - service_type: crash
+                placement:
+                  host_pattern: "*"
       destroy-cluster: false
       abort-on-fail: true
 
@@ -205,3 +212,11 @@ tests:
       module: test_objectstoretool_workflows.py
       polarion-id: CEPH-83581811
       desc: Verify ceph-objectstore-tool functionalities
+
+  - test:
+      name: ceph-objectstore-tool functionalities during enospc
+      module: test_objectstoretool_workflows.py
+      polarion-id: CEPH-83620743
+      config:
+        bluestore-enospc: true
+      desc: Verify ceph-objectstore-tool functionalities during ENOSPC

--- a/suites/tentacle/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_cot_cbt.yaml
@@ -49,11 +49,12 @@ tests:
                 placement:
                   label: mon
           - config:
-              command: apply
-              service: crash
-              args:
+              command: apply_spec
+              service: orch
+              specs:
+              - service_type: crash
                 placement:
-                  label: crash
+                  host_pattern: "*"
       destroy-cluster: false
       abort-on-fail: true
 
@@ -216,7 +217,7 @@ tests:
   - test:
       name: ceph-objectstore-tool functionalities during enospc
       module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
+      polarion-id: CEPH-83620743
       config:
         bluestore-enospc: true
       desc: Verify ceph-objectstore-tool functionalities during ENOSPC


### PR DESCRIPTION
### TFA Fix

With recent changes introduced with PR #5134 , the method fetch_object_dump was modified to accept PG ID as a mandatory parameter.
This parameter should only be identified if the complete object json is not provided.
At other instances in legacy test cases, the method was being called with complete object json and no pg_id was provided, thus the method call started failing as the new argument was introduced as a mandatory one.

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L3RVQA/ObjectStore_block_stats_verification_0.log

### [BZ-2291317](https://bugzilla.redhat.com/show_bug.cgi?id=2291317)
As part of the fix provided for the above BZ, the feature "Ability to extract data during enospc" was backported to Squid. This feature is targeted for 9.0 and the test workflow was already automated for Tentacle, the same test is being added to the appropriate Squid test suite `suites/squid/rados/tier-2_rados_test_cot_cbt.yaml`

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-81TN8M/ceph-objectstore-tool_functionalities_during_enospc_0.log

Signed-off-by: Harsh Kumar <hakumar@redhat.com>