### PR TITLE
[TFA][DMFG] Add relevant RHEL image names for mix-os deployment

### DIFF
--- a/conf/quincy/cephadm/1admin_4node_1client_mix_os.yaml
+++ b/conf/quincy/cephadm/1admin_4node_1client_mix_os.yaml
@@ -7,7 +7,8 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.5.0-x86_64-ga-latest
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - _admin
           - installer
@@ -25,6 +26,7 @@ globals:
       node2:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - osd
           - mon
@@ -37,6 +39,7 @@ globals:
       node3:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mon
           - mgr
@@ -48,11 +51,13 @@ globals:
       node4:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mds
           - rgw
       node5:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - client

--- a/conf/reef/cephadm/1admin_4node_1client_mix_os.yaml
+++ b/conf/reef/cephadm/1admin_4node_1client_mix_os.yaml
@@ -7,7 +7,8 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.5.0-x86_64-ga-latest
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - _admin
           - installer
@@ -25,6 +26,7 @@ globals:
       node2:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - osd
           - mon
@@ -37,6 +39,7 @@ globals:
       node3:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mon
           - mgr
@@ -48,11 +51,13 @@ globals:
       node4:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mds
           - rgw
       node5:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - client

--- a/conf/squid/cephadm/1admin-4node-1client-mix-os.yaml
+++ b/conf/squid/cephadm/1admin-4node-1client-mix-os.yaml
@@ -7,7 +7,8 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.5.0-x86_64-ga-latest
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - _admin
           - installer
@@ -25,6 +26,7 @@ globals:
       node2:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - osd
           - mon
@@ -37,6 +39,7 @@ globals:
       node3:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mon
           - mgr
@@ -48,11 +51,13 @@ globals:
       node4:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mds
           - rgw
       node5:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - client

--- a/conf/tentacle/cephadm/1admin-4node-1client-mix-os.yaml
+++ b/conf/tentacle/cephadm/1admin-4node-1client-mix-os.yaml
@@ -7,7 +7,8 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.5.0-x86_64-ga-latest
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - _admin
           - installer
@@ -25,6 +26,7 @@ globals:
       node2:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - osd
           - mon
@@ -37,6 +39,7 @@ globals:
       node3:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mon
           - mgr
@@ -48,11 +51,13 @@ globals:
       node4:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - mds
           - rgw
       node5:
         image-name:
           openstack: RHEL-8.10.0-x86_64-ga-latest
+          ibmc: rhel-810-server-amd64-kvm
         role:
           - client


### PR DESCRIPTION
# Description

The details for the IBMC `image_name` were missing from the conf file of the mix-os deployment suites which were causing failure when running the tests in IBMC environment.
Added the details and updated the RHEL versions to the latest available.