### PR TITLE
Reorder the swift at root test which is causing the keystone tests to…

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -210,14 +210,6 @@ tests:
         script-name: test_swift_basic_ops.py
         config-file-name: test_upload_large_obj_with_same_obj_name.yaml
 
-  - test:
-      name: Test the swift URL at root
-      desc: Test the swift URL at root
-      polarion-id: CEPH-83572699
-      module: sanity_rgw.py
-      config:
-        script-name: test_swift_basic_ops.py
-        config-file-name: test_swift_at_root.yaml
 
   # Versioning Tests
 
@@ -663,3 +655,12 @@ tests:
       config:
         script-name: ../s3_swift/test_swift_static_large_object_expiration.py
         config-file-name: ../../s3_swift/configs/test_swift_slo_expiry.yaml
+
+  - test:
+      name: Test the swift URL at root
+      desc: Test the swift URL at root
+      polarion-id: CEPH-83572699
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_at_root.yaml


### PR DESCRIPTION
… fail

Swift at root parameter causes all S3 tests to fail, so I am moving this test to the end of the suite in reef only . We have bifurcated the suites in squid and further so that this issue is not seen.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9.5/Test/18.2.1-350/338/tier-2_rgw_regression_test/
