### PR TITLE
[RBD] TFA Fix for one-way mirroring

### DIFF
--- a/ceph/rbd/workflows/rbd_mirror.py
+++ b/ceph/rbd/workflows/rbd_mirror.py
@@ -616,8 +616,10 @@ def config_mirror_multi_pool(
             pool_config["rbd_client"] = pool_config.get("rbd_client", "client.admin")
             if pool_config.get("mode") == "image":
                 kw["wait_for_status"] = False
-            if kw.get("way"):
-                pool_config["way"] = kw.get("way")
+
+            if pool_config.get("way"):
+                kw["way"] = pool_config.get("way")
+
             config_mirror(
                 rbd_primary,
                 rbd_secondary,
@@ -650,12 +652,12 @@ def config_mirror_multi_pool(
                     }
                     # for image, image_config in multi_image_config.items():
                     for image, image_config_val in image_config.items():
-
                         image_enable_config = {
                             "pool": pool,
                             "image": image,
                             "mirrormode": mirrormode,
                             "io_total": image_config_val.get("io_total", None),
+                            "way": pool_config.get("way"),
                         }
                         out = enable_image_mirroring(
                             primary_config, secondary_config, **image_enable_config

--- a/suites/pacific/rbd/tier-3_snap_mirroring.yaml
+++ b/suites/pacific/rbd/tier-3_snap_mirroring.yaml
@@ -191,32 +191,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -255,36 +229,6 @@ tests:
               io_size: 200M
               test_config:
                 ignore_rollback: True
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-              test_config:
-                ignore_rollback: True
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
-              test_config:
-                ignore_rollback: True
 
   - test:
       abort-on-fail: True
@@ -294,38 +238,6 @@ tests:
       polarion-id: CEPH-83574862
       clusters:
         ceph-rbd1:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-              way: "one-way"
-              test_config:
-                ignore_rollback: True
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
-              way: "one-way"
-              test_config:
-                ignore_rollback: True
-        ceph-rbd2:
           config:
             rep_pool_config:
               num_pools: 1

--- a/suites/quincy/rbd/tier-3_snap_mirroring.yaml
+++ b/suites/quincy/rbd/tier-3_snap_mirroring.yaml
@@ -191,32 +191,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -251,32 +225,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -286,34 +234,6 @@ tests:
       polarion-id: CEPH-83574862
       clusters:
         ceph-rbd1:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-              way: "one-way"
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
-              way: "one-way"
-        ceph-rbd2:
           config:
             rep_pool_config:
               num_pools: 1

--- a/suites/reef/rbd/tier-3_snap_mirroring.yaml
+++ b/suites/reef/rbd/tier-3_snap_mirroring.yaml
@@ -191,32 +191,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -251,32 +225,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -286,34 +234,6 @@ tests:
       polarion-id: CEPH-83574862
       clusters:
         ceph-rbd1:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-              way: "one-way"
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
-              way: "one-way"
-        ceph-rbd2:
           config:
             rep_pool_config:
               num_pools: 1

--- a/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -230,6 +230,7 @@ tests:
               mirrormode: snapshot
               snap_schedule_intervals:
                 - 1m
+              way: "one-way"
             ec_pool_config:
               num_pools: 1
               num_images: 1
@@ -241,6 +242,7 @@ tests:
               mirrormode: snapshot
               snap_schedule_intervals:
                 - 1m
+              way: "one-way"
             fio:
               size: 100M
               ODF_CONFIG:

--- a/suites/squid/rbd/tier-3_snap_mirroring.yaml
+++ b/suites/squid/rbd/tier-3_snap_mirroring.yaml
@@ -191,32 +191,7 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
+
 
   - test:
       abort-on-fail: True
@@ -251,32 +226,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -286,34 +235,6 @@ tests:
       polarion-id: CEPH-83574862
       clusters:
         ceph-rbd1:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-              way: "one-way"
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
-              way: "one-way"
-        ceph-rbd2:
           config:
             rep_pool_config:
               num_pools: 1

--- a/suites/tentacle/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/tentacle/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -229,6 +229,7 @@ tests:
               mirrormode: snapshot
               snap_schedule_intervals:
                 - 1m
+              way: "one-way"
             ec_pool_config:
               num_pools: 1
               num_images: 1
@@ -240,6 +241,7 @@ tests:
               mirrormode: snapshot
               snap_schedule_intervals:
                 - 1m
+              way: "one-way"
             fio:
               size: 100M
               ODF_CONFIG:

--- a/suites/tentacle/rbd/tier-3_snap_mirroring.yaml
+++ b/suites/tentacle/rbd/tier-3_snap_mirroring.yaml
@@ -191,32 +191,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -251,32 +225,6 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
-        ceph-rbd2:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
 
   - test:
       abort-on-fail: True
@@ -286,34 +234,6 @@ tests:
       polarion-id: CEPH-83574862
       clusters:
         ceph-rbd1:
-          config:
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-              way: "one-way"
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 2G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals:
-                - 1m
-              io_size: 200M
-              way: "one-way"
-        ceph-rbd2:
           config:
             rep_pool_config:
               num_pools: 1


### PR DESCRIPTION
# Description
Provided a fix to resolve the one-way configured RBD mirroring health status issue. I also noticed some tests were being repeated multiple times due to extra configurations in the test suite, and I have addressed that as well.


Test Failed:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-254/rbd/37/tier-3_snap_mirroring/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WQ21IA/

Test Results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BKRRYP/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2OI345/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YULF0C/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IX4W97/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
