### PR TITLE
Wrong arguments used in mon apply command

### DIFF
--- a/suites/squid/cephfs/tier-2_fs_erasure.yaml
+++ b/suites/squid/cephfs/tier-2_fs_erasure.yaml
@@ -130,7 +130,7 @@ tests:
       abort-on-fail: false
   - test:
       name: mds service stop & start test
-      module: mon_rm_add.py
+      module: mds_rm_add.py
       polarion-id: CEPH-83574339
       desc: mds service stop & start test
       abort-on-fail: false

--- a/suites/tentacle/cephfs/tier-2_fs_erasure.yaml
+++ b/suites/tentacle/cephfs/tier-2_fs_erasure.yaml
@@ -130,7 +130,7 @@ tests:
       abort-on-fail: false
   - test:
       name: mds service stop & start test
-      module: mon_rm_add.py
+      module: mds_rm_add.py
       polarion-id: CEPH-83574339
       desc: mds service stop & start test
       abort-on-fail: false

--- a/tests/cephfs/mon_rm_add.py
+++ b/tests/cephfs/mon_rm_add.py
@@ -65,11 +65,11 @@ def mon_rm_add(fs_util, mons, client, fs_name="cephfs"):
         initial_mon_count = str(len(mon_hosts))
         initial_mon_count.rstrip()
         count = str(int(initial_mon_count) - 1)
-        cmd = f"ceph orch --verbose apply mon {fs_name} --placement='{mons_hosts}'"
+        cmd = f"ceph orch --verbose apply mon --placement='{mons_hosts}'"
         client.exec_command(sudo=True, cmd=cmd)
         wait_for_cmd(client, "mon", count)
         mons_hosts = " ".join([str(elem) for elem in mon_hosts])
-        cmd = f"ceph orch  --verbose apply mon {fs_name} --placement='{mons_hosts}'"
+        cmd = f"ceph orch --verbose apply mon --placement='{mons_hosts}'"
         client.exec_command(sudo=True, cmd=cmd)
         wait_for_cmd(client, "mon", initial_mon_count)
         stop_flag = True


### PR DESCRIPTION
# Description
Wrong arguments used in mon apply command


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
