### PR TITLE
[TFA] Fixed missing namespaces issues by removing lb_group in 8.1 suite files

### DIFF
--- a/suites/squid/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
+++ b/suites/squid/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
@@ -95,7 +95,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode2
                 no-group-append: True
                 listener_port: 4420
@@ -104,7 +103,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -127,7 +125,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode4
                 no-group-append: True
                 listener_port: 4420
@@ -136,7 +133,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -159,7 +155,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node10
               - nqn: nqn.2016-06.io.spdk:cnode6
                 no-group-append: True
                 listener_port: 4420
@@ -168,7 +163,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node11
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node10
@@ -234,7 +228,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node6, node7]
@@ -242,7 +235,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -265,7 +257,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node8, node9]
@@ -273,7 +264,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -360,7 +350,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node6, node7]
@@ -368,7 +357,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -391,7 +379,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node8, node9]
@@ -399,7 +386,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -485,7 +471,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node6, node7]
@@ -493,7 +478,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -515,7 +499,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node8, node9]
@@ -523,7 +506,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -610,7 +592,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node6, node7]
@@ -618,7 +599,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -641,7 +621,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
                 listener_port: 4420
                 listeners: [node8, node9]
@@ -649,7 +628,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node8

--- a/suites/squid/nvmeof/tier-1_nvmeof_ha_sanity.yaml
+++ b/suites/squid/nvmeof/tier-1_nvmeof_ha_sanity.yaml
@@ -92,7 +92,6 @@ tests:
             bdevs:
             - count: 2
               size: 4G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -103,7 +102,6 @@ tests:
             bdevs:
             - count: 2
               size: 4G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -145,7 +143,6 @@ tests:
             bdevs:
             - count: 2
               size: 4G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -156,7 +153,6 @@ tests:
             bdevs:
             - count: 2
               size: 4G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -78,12 +78,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 4
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node5
             listener_port: 4420
             listeners:
               - node6
@@ -195,7 +191,6 @@ tests:
             bdevs:
             - count: 512
               size: 1G
-              lb_group: node5
             listener_port: 4420
             listeners:
               - node5
@@ -206,7 +201,6 @@ tests:
             bdevs:
             - count: 512
               size: 1G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node5
@@ -238,7 +232,6 @@ tests:
             bdevs:
             - count: 10
               size: 5G
-              lb_group: node5
             listener_port: 4420
             listeners:
               - node5
@@ -373,7 +366,6 @@ tests:
             bdevs:
               - count: 1024
                 size: 1G
-                lb_group: node5
             listener_port: 4420
             listeners:
               - node5
@@ -405,7 +397,6 @@ tests:
             bdevs:
               - count: 5
                 size: 1G
-                lb_group: node5
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -150,18 +150,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -209,18 +199,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -266,18 +246,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -325,7 +295,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -338,7 +307,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -351,7 +319,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -364,7 +331,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -411,18 +377,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -473,18 +429,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -535,12 +481,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 4
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -551,12 +493,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 1
             bdevs:
-            - count: 2
+            - count: 4
               size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -609,7 +547,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -622,7 +559,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -635,7 +571,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -648,7 +583,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -701,7 +635,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -714,7 +647,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -727,7 +659,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -740,7 +671,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -795,7 +725,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -808,7 +737,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -821,7 +749,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -834,7 +761,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -885,7 +811,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -898,7 +823,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -911,7 +835,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -924,7 +847,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
@@ -109,18 +109,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -163,18 +153,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 2
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
@@ -116,18 +116,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -171,18 +161,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 2
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
@@ -108,18 +108,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -162,18 +152,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 3
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
@@ -109,18 +109,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -164,18 +154,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 4
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_rest_sanity.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_rest_sanity.yaml
@@ -84,7 +84,6 @@ tests:
             bdevs:
             - count: 2
               size: 2G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-3_nvmeof_4gwgroup_8gw_cluster.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_4gwgroup_8gw_cluster.yaml
@@ -147,18 +147,8 @@ tests:
                 listeners: [node14, node15, node16, node17]
                 allow_host: "*"
                 bdevs:
-                  - count: 2
+                  - count: 8
                     size: 4G
-                    lb_group: node14
-                  - count: 2
-                    size: 5G
-                    lb_group: node15
-                  - count: 2
-                    size: 2G
-                    lb_group: node16
-                  - count: 2
-                    size: 3G
-                    lb_group: node17
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node14

--- a/suites/tentacle/nvmeof/tier-1_nvmeof_ha_sanity.yaml
+++ b/suites/tentacle/nvmeof/tier-1_nvmeof_ha_sanity.yaml
@@ -92,7 +92,6 @@ tests:
             bdevs:
             - count: 2
               size: 2G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -103,7 +102,6 @@ tests:
             bdevs:
             - count: 2
               size: 2G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -145,7 +143,6 @@ tests:
             bdevs:
             - count: 2
               size: 2G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -156,7 +153,6 @@ tests:
             bdevs:
             - count: 2
               size: 2G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -78,12 +78,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 4
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node5
             listener_port: 4420
             listeners:
               - node6
@@ -201,7 +197,6 @@ tests:
             bdevs:
             - count: 512
               size: 1G
-              lb_group: node5
             listener_port: 4420
             listeners:
               - node5
@@ -212,7 +207,6 @@ tests:
             bdevs:
             - count: 512
               size: 1G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node5
@@ -245,7 +239,6 @@ tests:
             bdevs:
             - count: 10
               size: 5G
-              lb_group: node5
             listener_port: 4420
             listeners:
               - node5
@@ -385,7 +378,6 @@ tests:
             bdevs:
               - count: 1024
                 size: 1G
-                lb_group: node5
             listener_port: 4420
             listeners:
               - node5
@@ -418,7 +410,6 @@ tests:
             bdevs:
               - count: 5
                 size: 1G
-                lb_group: node5
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -151,7 +151,7 @@ tests:
             serial: 1
             bdevs:
             - count: 8
-              size: 2G
+              size: 5G
             listener_port: 4420
             listeners:
               - node6
@@ -200,7 +200,7 @@ tests:
             serial: 1
             bdevs:
             - count: 8
-              size: 2G
+              size: 5G
             listener_port: 4420
             listeners:
               - node6
@@ -247,7 +247,7 @@ tests:
             serial: 1
             bdevs:
             - count: 8
-              size: 2G
+              size: 5G
             listener_port: 4420
             listeners:
               - node6
@@ -378,7 +378,7 @@ tests:
             serial: 1
             bdevs:
             - count: 8
-              size: 2G
+              size: 8G
             listener_port: 4420
             listeners:
               - node6
@@ -430,7 +430,7 @@ tests:
             serial: 1
             bdevs:
             - count: 8
-              size: 2G
+              size: 5G
             listener_port: 4420
             listeners:
               - node6
@@ -482,7 +482,7 @@ tests:
             serial: 1
             bdevs:
             - count: 4
-              size: 2G
+              size: 5G
             listener_port: 4420
             listeners:
               - node6
@@ -494,7 +494,7 @@ tests:
             serial: 1
             bdevs:
             - count: 4
-              size: 2G
+              size: 5G
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
@@ -109,18 +109,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -163,18 +153,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 2
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
@@ -116,18 +116,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -171,18 +161,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 2
             bdevs:
-              - count: 2
+              - count: 8
                 size: 5G
-                lb_group: node6
-              - count: 2
-                size: 5G
-                lb_group: node7
-              - count: 2
-                size: 5G
-                lb_group: node8
-              - count: 2
-                size: 5G
-                lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
@@ -108,18 +108,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -162,18 +152,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 3
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
@@ -109,18 +109,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -164,18 +154,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 4
             bdevs:
-            - count: 2
+            - count: 8
               size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_rest_sanity.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_rest_sanity.yaml
@@ -84,7 +84,6 @@ tests:
             bdevs:
             - count: 2
               size: 2G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-3_nvmeof_4gwgroup_8gw_cluster.yaml
+++ b/suites/tentacle/nvmeof/tier-3_nvmeof_4gwgroup_8gw_cluster.yaml
@@ -147,18 +147,8 @@ tests:
                 listeners: [node14, node15, node16, node17]
                 allow_host: "*"
                 bdevs:
-                  - count: 2
+                  - count: 8
                     size: 4G
-                    lb_group: node14
-                  - count: 2
-                    size: 5G
-                    lb_group: node15
-                  - count: 2
-                    size: 2G
-                    lb_group: node16
-                  - count: 2
-                    size: 3G
-                    lb_group: node17
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node14

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -252,20 +252,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                     )
 
         if config.get("initiators"):
-            targets, rhel_version = initiators(
+            paths, rhel_version = initiators(
                 ceph_cluster, nvmegwcli, config["initiators"]
             )
-            LOG.info(f"Targets discovered: {targets}")
-
-            if rhel_version == "9.5":
-                paths = [target["DevicePath"] for target in targets]
-            elif rhel_version == "9.6":
-                paths = [
-                    f"/dev/{ns['NameSpace']}"
-                    for device in targets
-                    for subsys in device.get("Subsystems", [])
-                    for ns in subsys.get("Namespaces", [])
-                ]
+            LOG.info(f"Targets discovered: {paths}")
 
             if not paths:
                 raise RuntimeError("No paths")
@@ -347,20 +337,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 time.sleep(10)
                 # Connect to Initiator
                 if config.get("initiators"):
-                    targets, rhel_version = initiators(
+                    paths, rhel_version = initiators(
                         ceph_cluster, nvmegwcli, config["initiators"]
                     )
-                    LOG.info(f"Targets discovered: {targets}")
-
-                    if rhel_version == "9.5":
-                        paths = [target["DevicePath"] for target in targets]
-                    elif rhel_version == "9.6":
-                        paths = [
-                            f"/dev/{ns['NameSpace']}"
-                            for device in targets
-                            for subsys in device.get("Subsystems", [])
-                            for ns in subsys.get("Namespaces", [])
-                        ]
+                    LOG.info(f"Targets discovered: {paths}")
 
                 path = paths[0]
                 # mount the NVMe target

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -635,7 +635,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
     )
     client = get_node_by_id(ceph_cluster, config["initiator_node"])
     initiator = NVMeInitiator(client)
-    initiator_nqn = initiator.nqn()
+    initiator_nqn = initiator.initiator_nqn()
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -720,7 +720,8 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
                 LOG.info("Deletion of host is successful")
 
         sleep(20)
-        targets = initiator.list_devices()
+        LOG.info("Check targets are not found on client")
+        targets = initiator.list_spdk_drives()
         if targets:
             raise Exception(f"NVMe Targets found on {client.hostname}!!!")
         LOG.info(f"NVMe targets not found on {client.hostname} as expected..")

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -17,6 +17,7 @@ class NVMeInitiator(Initiator):
         self.discovery_port = 8009
         self.subsys_key = None
         self.host_key = None
+        # TODO: Need to cosume initiator nqn rather than getting from outside
         self.nqn = nqn
         self.auth_mode = ""
 


### PR DESCRIPTION
# Description

Fixed missing namespaces issues by removing lb_group in suite files for squid and Tentacle

Fixed the getting paths issues in data integrity script

Fixed nqn issue in nqn in negative tests

Logs for script issue fixing:-
Failure log:- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/8.1/rhel-9/Regression/19.2.1-267/nvmeotcp/61/tier-2_nvmeof_functional_Regression/Test_to_perform_Data_Integrity_test_over_NVMe-OF_targets_0.log

Pass log after fix:-
1.  http://magna002.ceph.redhat.com/cephci-jenkins/tfa_fix_data_integrity_test/
2. http://magna002.ceph.redhat.com/cephci-jenkins/tfa_fix_data_integrity_test_2/


