### PR TITLE
TFA fix in 7.1 runs(In nvme gwcli Host-nqn param is host in 7.1 version)

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -50,14 +50,14 @@ def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
     # All host to subsystem
     if config.get("allow_host"):
         nvmegwcli.host.add(
-            **{"args": {**sub_args, **{"host-nqn": repr(config["allow_host"])}}}
+            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
         )
 
     if config.get("hosts"):
         for host in config["hosts"]:
             initiator_node = get_node_by_id(ceph_cluster, host)
             initiator = NVMeInitiator(initiator_node)
-            host_nqn = initiator.nqn()
+            host_nqn = initiator.initiator_nqn()
             nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
 
     if config.get("bdevs"):

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -52,15 +52,15 @@ def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
     nvmegwcli.listener.add(**{"args": {**listener_cfg, **sub_args}})
     if config.get("allow_host"):
         nvmegwcli.host.add(
-            **{"args": {**sub_args, **{"host-nqn": repr(config["allow_host"])}}}
+            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
         )
 
     if config.get("hosts"):
         for host in config["hosts"]:
             initiator_node = get_node_by_id(ceph_cluster, host)
             initiator = NVMeInitiator(initiator_node)
-            host_nqn = initiator.nqn()
-            nvmegwcli.host.add(**{"args": {**sub_args, **{"host-nqn": host_nqn}}})
+            host_nqn = initiator.initiator_nqn()
+            nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
 
     if config.get("bdevs"):
         name = generate_unique_id(length=4)

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -87,15 +87,15 @@ def configure_subsystems(pool, ha, config):
     # Add Host access
     if config.get("allow_host"):
         nvmegwcli.host.add(
-            **{"args": {**sub_args, **{"host-nqn": repr(config["allow_host"])}}}
+            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
         )
 
     if config.get("hosts"):
         for host in config["hosts"]:
             initiator_node = get_node_by_id(ceph_cluster, host)
             initiator = NVMeInitiator(initiator_node)
-            host_nqn = initiator.nqn()
-            nvmegwcli.host.add(**{"args": {**sub_args, **{"host-nqn": host_nqn}}})
+            host_nqn = initiator.initiator_nqn()
+            nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
 
     # Add Namespaces
     if config.get("bdevs"):

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -706,9 +706,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         # Create a file to check IO failure on mount point
         LOG.info("Remove client host access to the namespaces")
         try:
-            host_args = {
-                "args": {"subsystem": subsystem["nqn"], "host-nqn": initiator_nqn}
-            }
+            host_args = {"args": {"subsystem": subsystem["nqn"], "host": initiator_nqn}}
             nvmegwcli.host.delete(**host_args)
         except Exception as host_del_err:
             if (


### PR DESCRIPTION
In nvme gwcli Host-nqn param is host in 7.1 version
In nvme ceph cli or gwcli host-nqn is host-nqn or host.

Last we changed from host to host-nqn and we have executed in 8.1 and Tentacle versions it working and we missed to check on 7.1 versions. Fixed the same now

Logs:- 
 sanity e2e test logs with 7.1 build :-  http://magna002.ceph.redhat.com/cephci-jenkins/tfa_fix_71_nvme_sanity_e2e/
sanity ha  test  logs with 7.1 build :- http://magna002.ceph.redhat.com/cephci-jenkins/tfa_fix_71_nvme_sanity_ha_suite/
 sanity e2e test logs with 8.1 build:- http://magna002.ceph.redhat.com/cephci-jenkins/tfa_fix_81_nvme_sanity_e2e/