### PR TITLE
Added node3 and node4 to fix endpoint connection issue

### DIFF
--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -58,6 +58,8 @@ tests:
                   service_id: rgw.ssl
                   placement:
                     nodes:
+                      - node3
+                      - node4
                       - node5
                   spec:
                     ssl: true


### PR DESCRIPTION
# Description
 Node 3 and Node 4 were not included in placement nodes for rgw service . As a result, the endpoint is pointing to Node 3, while RGW is actually configured on Node 5

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-GDE8EW/

issue: https://issues.redhat.com/browse/RHCEPHQE-21795
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
