### PR TITLE
[closeloop] cephci integration: CEPH-83629972

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
@@ -378,3 +378,14 @@ tests:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_user_mode_direc.yaml
             timeout: 5000
+
+  - test:
+      name: modify bucket granular sync policy which has user mode set
+      desc: Test modify bucket granular sync policy which has user mode set
+      polarion-id: CEPH-83629972
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../aws/test_aws_s3_replication.py
+            config-file-name: ../../aws/multisite_configs/test_aws_granular_sync_policy_pipe_modify.yaml

--- a/suites/squid/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
+++ b/suites/squid/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
@@ -316,6 +316,17 @@ tests:
             config-file-name: ../../aws/multisite_configs/test_aws_s3_bucket_replication.yaml
 
   - test:
+      name: modify bucket granular sync policy which has user mode set
+      desc: Test modify bucket granular sync policy which has user mode set
+      polarion-id: CEPH-83629972
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../aws/test_aws_s3_replication.py
+            config-file-name: ../../aws/multisite_configs/test_aws_granular_sync_policy_pipe_modify.yaml
+
+  - test:
       name: bucket granular sync policy with sync to different bucket
       desc: Test bucket granular sync with sync to different bucket
       polarion-id: CEPH-83575141

--- a/suites/tentacle/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
@@ -316,6 +316,17 @@ tests:
             config-file-name: ../../aws/multisite_configs/test_aws_s3_bucket_replication.yaml
 
   - test:
+      name: modify bucket granular sync policy which has user mode set
+      desc: Test modify bucket granular sync policy which has user mode set
+      polarion-id: CEPH-83629972
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../aws/test_aws_s3_replication.py
+            config-file-name: ../../aws/multisite_configs/test_aws_granular_sync_policy_pipe_modify.yaml
+
+  - test:
       name: bucket granular sync policy with sync to different bucket
       desc: Test bucket granular sync with sync to different bucket
       polarion-id: CEPH-83575141


### PR DESCRIPTION
# Description
Modify bucket Granular Sync policy with user mode set during creation
depends on : https://github.com/red-hat-storage/ceph-qe-scripts/pull/788
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_aws_granular_sync_policy_pipe_modify.console.log
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-TVDGKQ/
bz: https://bugzilla.redhat.com/show_bug.cgi?id=2318519

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
