### PR TITLE
Set the keystone and LDAP config options only when needed

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -266,6 +266,7 @@ tests:
       polarion-id: CEPH-9793
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_ldap_auth.py
         config-file-name: ../../aws/configs/test_ldap_auth.yaml
         run-on-rgw: true

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -642,6 +642,7 @@ tests:
       polarion-id: CEPH-83572907
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_unified_namespace.py
         config-file-name: ../../aws/configs/test_unified_namespace.yaml
 
@@ -651,6 +652,7 @@ tests:
       polarion-id: CEPH-10169
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_keystone_auth.py
         config-file-name: ../../aws/configs/test_keystone_integration.yaml
 

--- a/suites/squid/rgw/baremetal/tier-2-rgw_regression_test_baremetal.yaml
+++ b/suites/squid/rgw/baremetal/tier-2-rgw_regression_test_baremetal.yaml
@@ -1441,6 +1441,7 @@ tests:
       polarion-id: CEPH-83572907
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_unified_namespace.py
         config-file-name: ../../aws/configs/test_unified_namespace_baremetal.yaml
         test-config:
@@ -1454,6 +1455,7 @@ tests:
       polarion-id: CEPH-10169
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_keystone_auth.py
         config-file-name: ../../aws/configs/test_keystone_integration_baremetal.yaml
         test-config:
@@ -1468,6 +1470,7 @@ tests:
       polarion-id: CEPH-83572657
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../s3_swift/test_swift_acl_with_keystone.py
         config-file-name: ../../s3_swift/configs/test_swift_acl_with_keystone.yaml
 

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -252,6 +252,7 @@ tests:
       polarion-id: CEPH-9793
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_ldap_auth.py
         config-file-name: ../../aws/configs/test_ldap_auth.yaml
         run-on-rgw: true

--- a/suites/squid/rgw/tier-2_rgw_single_site_regression.yaml
+++ b/suites/squid/rgw/tier-2_rgw_single_site_regression.yaml
@@ -265,6 +265,7 @@ tests:
       polarion-id: CEPH-83572907
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_unified_namespace.py
         config-file-name: ../../aws/configs/test_unified_namespace.yaml
 
@@ -274,6 +275,7 @@ tests:
       polarion-id: CEPH-10169
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_keystone_auth.py
         config-file-name: ../../aws/configs/test_keystone_integration.yaml
 
@@ -284,6 +286,7 @@ tests:
       polarion-id: CEPH-83572657
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../s3_swift/test_swift_acl_with_keystone.py
         config-file-name: ../../s3_swift/configs/test_swift_acl_with_keystone.yaml
 

--- a/suites/tentacle/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_regression_extended.yaml
@@ -243,6 +243,7 @@ tests:
       polarion-id: CEPH-9793
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_ldap_auth.py
         config-file-name: ../../aws/configs/test_ldap_auth.yaml
         run-on-rgw: true

--- a/suites/tentacle/rgw/tier-2_rgw_single_site_regression.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_single_site_regression.yaml
@@ -265,6 +265,7 @@ tests:
       polarion-id: CEPH-83572907
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_unified_namespace.py
         config-file-name: ../../aws/configs/test_unified_namespace.yaml
 
@@ -274,6 +275,7 @@ tests:
       polarion-id: CEPH-10169
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../aws/test_keystone_auth.py
         config-file-name: ../../aws/configs/test_keystone_integration.yaml
 
@@ -284,6 +286,7 @@ tests:
       polarion-id: CEPH-83572657
       module: sanity_rgw.py
       config:
+        install_keystone_ldap: true
         script-name: ../s3_swift/test_swift_acl_with_keystone.py
         config-file-name: ../../s3_swift/configs/test_swift_acl_with_keystone.yaml
 

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -87,6 +87,7 @@ def run(ceph_cluster, **kw):
     extra_pkgs = config.get("extra-pkgs")
     install_start_kafka_broker = config.get("install_start_kafka")
     configure_kafka_broker_security = config.get("configure_kafka_security")
+    install_keystone_ldap = config.get("install_keystone_ldap")
     cloud_type = config.get("cloud-type")
     log.info(f"Cloud Type is {cloud_type}")
     test_config = {"config": config.get("test-config", {})}
@@ -161,7 +162,7 @@ def run(ceph_cluster, **kw):
     if configure_kafka_broker_security:
         configure_kafka_security(rgw_node, cloud_type)
 
-    if cloud_type:
+    if install_keystone_ldap:
         config_keystone_ldap(rgw_node, cloud_type)
 
     out, err = exec_from.exec_command(cmd="ls -l venv", check_ec=False)


### PR DESCRIPTION
We get a config option from the tests as part of the suite , and based on that set the keystone and ldap config options in the cluster.

Pass log: http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-SNM26T/

Some failures are due to a different issue on my local setup for cephCI and not related to this PR.