### PR TITLE
CephFS 9.0 - Ref-Inode - Integrated hardlinks and ref-inode validations within existing tests

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -2499,8 +2499,9 @@ os.system('sudo systemctl start  network')
         :return:
         """
         out, rc = client.exec_command(
-            sudo=True, cmd=f"cd {directory};ls -lrt |  awk {{'print $9'}}"
+            sudo=True, cmd=f"find {directory} -maxdepth 1 -type f -printf '%f\n'"
         )
+
         file_list = out.strip().split()
         file_dict = {}
         for file in file_list:


### PR DESCRIPTION

Integrated creation of hardlinks and validation of referent inodes to the existing snap, snap_schedule and clone tests so the feature doesn't break the existing code.

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RK2OZY/ 

 
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
