### PR TITLE
fixing false results in CI pipeline

### DIFF
--- a/tests/nfs/nfs_client_permission_export.py
+++ b/tests/nfs/nfs_client_permission_export.py
@@ -84,7 +84,7 @@ def run(ceph_cluster, **kw):
             pass
         else:
             log.error(f"Mount passed on unauthorized client: {clients[0].hostname}")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to perform export client addr validation : {e}")
         return 1
@@ -103,4 +103,3 @@ def run(ceph_cluster, **kw):
 
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_edit_export_config_with_1client_access.py
+++ b/tests/nfs/nfs_edit_export_config_with_1client_access.py
@@ -158,7 +158,7 @@ def run(ceph_cluster, **kw):
                     f"Failed to mount nfs on {clients[0].hostname}"
                 )
         log.info("Mount succeeded on client0")
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -183,4 +183,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_edit_export_config_with_access_none.py
+++ b/tests/nfs/nfs_edit_export_config_with_access_none.py
@@ -93,6 +93,7 @@ def run(ceph_cluster, **kw):
             )
 
         log.info("Export update succeeded with access_type updated as NONE")
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -103,4 +104,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_edit_export_config_with_ro.py
@@ -116,6 +116,7 @@ def run(ceph_cluster, **kw):
         else:
             log.error("failed to create file on RW export")
             return 1
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -133,4 +134,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_export_rootsquash_windows.py
+++ b/tests/nfs/nfs_export_rootsquash_windows.py
@@ -110,7 +110,7 @@ def run(ceph_cluster, **kw):
         else:
             log.error("Failed to validate export rootsquash")
             return 1
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate export rootsquash: {e}")
         return 1
@@ -130,4 +130,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(linux_clients[0], nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_failover_with_rm_operation_windows.py
+++ b/tests/nfs/nfs_failover_with_rm_operation_windows.py
@@ -122,7 +122,7 @@ def run(ceph_cluster, **kw):
                 log.info("File does not exist on mount point")
             else:
                 raise OperationFailedError(f"Deleted file still exist- win_file{i}")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate file delete with failover on a ha cluster: {e}")
         # Cleanup
@@ -142,4 +142,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_file_append.py
+++ b/tests/nfs/nfs_file_append.py
@@ -76,7 +76,7 @@ def run(ceph_cluster, **kw):
         # Wait for io to complete on all clients
         for th in thread_pool:
             th.join()
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate file append operation : {e}")
         return 1
@@ -84,4 +84,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_file_truncate.py
+++ b/tests/nfs/nfs_file_truncate.py
@@ -75,7 +75,7 @@ def run(ceph_cluster, **kw):
                     break
                 if w.expired:
                     raise ValueError("The file created is not truncated")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to perform truncate operations : {e}")
         return 1
@@ -83,4 +83,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_ha_client_update_permission_windows.py
+++ b/tests/nfs/nfs_ha_client_update_permission_windows.py
@@ -145,7 +145,7 @@ def run(ceph_cluster, **kw):
             log.info("Export is readonly")
         else:
             raise OperationFailedError("File created on Readonly export")
-
+        return 0
     except Exception as e:
         log.error(
             f"Failed to validate export delete with failover on a ha cluster: {e}"
@@ -161,4 +161,3 @@ def run(ceph_cluster, **kw):
         cmd = f"umount {window_nfs_mount}"
         windows_clients[1].exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_ha_export_delete_windows.py
+++ b/tests/nfs/nfs_ha_export_delete_windows.py
@@ -132,6 +132,7 @@ def run(ceph_cluster, **kw):
         # Wait for the ops to complete
         for op in operations:
             op.join()
+        return 0
 
     except Exception as e:
         log.error(
@@ -154,4 +155,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_ha_failover_delete_export.py
+++ b/tests/nfs/nfs_ha_failover_delete_export.py
@@ -95,7 +95,7 @@ def run(ceph_cluster, **kw):
         if out != "[]":
             raise OperationFailedError("All export not deleted")
             return 1
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         log.info("Cleaning up")
@@ -116,7 +116,6 @@ def run(ceph_cluster, **kw):
         cmd = "ceph fs subvolumegroup rm cephfs ganeshagroup --force"
         clients[0].exec_command(sudo=True, cmd=cmd)
         return 1
-
     finally:
         log.info("Cleaning up")
         Ceph(clients[0]).nfs.cluster.delete(nfs_name)
@@ -135,4 +134,3 @@ def run(ceph_cluster, **kw):
         # Delete the subvolume group
         cmd = "ceph fs subvolumegroup rm cephfs ganeshagroup --force"
         clients[0].exec_command(sudo=True, cmd=cmd)
-    return 0

--- a/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
@@ -115,7 +115,7 @@ def run(ceph_cluster, **kw):
             pass
         else:
             log.error(f"Mount passed on unauthorized client: {clients[0].hostname}")
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -133,4 +133,3 @@ def run(ceph_cluster, **kw):
             Ceph(client).nfs.export.delete(nfs_name, nfs_export_client)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
@@ -131,6 +131,7 @@ def run(ceph_cluster, **kw):
         else:
             log.error("failed to create file on RW export")
             return 1
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -148,4 +149,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_ha_failover_with_untar.py
+++ b/tests/nfs/nfs_ha_failover_with_untar.py
@@ -77,7 +77,7 @@ def run(ceph_cluster, **kw):
 
         # Wait to complete linux untar
         th.join()
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         log.info("Cleaning up")
@@ -90,4 +90,3 @@ def run(ceph_cluster, **kw):
         sleep(100)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_ha_readdir_operation.py
+++ b/tests/nfs/nfs_ha_readdir_operation.py
@@ -143,7 +143,7 @@ def run(ceph_cluster, **kw):
         # Wait to complete operations
         for Thread_operation in Thread_operations:
             Thread_operation.join()
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -152,4 +152,3 @@ def run(ceph_cluster, **kw):
         sleep(100)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_ha_reboot_with_file_modify.py
+++ b/tests/nfs/nfs_ha_reboot_with_file_modify.py
@@ -112,7 +112,7 @@ def run(ceph_cluster, **kw):
         # Wait for the ops to complete
         for op in operations:
             op.join()
-
+        return 0
     except Exception as e:
         log.error(
             f"Failed to validate export delete with failover on a ha cluster: {e}"
@@ -134,4 +134,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_hard_links_delete_file.py
+++ b/tests/nfs/nfs_hard_links_delete_file.py
@@ -85,6 +85,7 @@ def run(ceph_cluster, **kw):
             return 1
         else:
             log.info("iNode match for original and hard link file")
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -92,4 +93,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -83,6 +83,7 @@ def run(ceph_cluster, **kw):
             return 1
         else:
             log.info("iNode match for original and hard link file")
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -90,4 +91,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_hard_symbolic_links_rename.py
+++ b/tests/nfs/nfs_hard_symbolic_links_rename.py
@@ -99,7 +99,7 @@ def run(ceph_cluster, **kw):
             return 1
         else:
             log.info("Successfully created symbolic links to file")
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -107,4 +107,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_multi_mount_version_4x.py
+++ b/tests/nfs/nfs_multi_mount_version_4x.py
@@ -63,11 +63,10 @@ def run(ceph_cluster, **kw):
             threads.append(io)
         for th in threads:
             th.join()
-
+        return 0
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_multiple_xattr_set_and_delete.py
+++ b/tests/nfs/nfs_multiple_xattr_set_and_delete.py
@@ -108,7 +108,7 @@ def run(ceph_cluster, **kw):
         # Fetch the extended attribute of the file
         out = getfattr(client=clients[0], file_path=f"{nfs_mount}/{filename}")
         log.info("Listing all the attributes on {filename} ")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate multiple xttars on file : {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -119,4 +119,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_multivolume_rootsquash.py
+++ b/tests/nfs/nfs_multivolume_rootsquash.py
@@ -145,7 +145,7 @@ def run(ceph_cluster, **kw):
 
         # Validate if the files are created by root user
         validate_file_owner(mount_dir_lin, linux_clients, owner=owner[1])
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate export rootsquash: {e}")
         return 1
@@ -165,4 +165,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(linux_clients[0], nfs_mount1, nfs_name, nfs_export1)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
+++ b/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
@@ -107,7 +107,7 @@ def run(ceph_cluster, **kw):
             if "squashuser" not in out:
                 raise OperationFailedError("File is not created by squashed user")
         log.info("File created by squashed user")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -119,4 +119,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_rootsquash_using_conf.py
+++ b/tests/nfs/nfs_rootsquash_using_conf.py
@@ -128,7 +128,7 @@ def run(ceph_cluster, **kw):
         if "squashuser" not in out:
             raise OperationFailedError("File is not created by squashed user")
         log.info("File created by squashed user")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate export rootsquash: {e}")
         return 1
@@ -148,4 +148,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients[0], nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_scale_with_multi_io.py
+++ b/tests/nfs/nfs_scale_with_multi_io.py
@@ -250,7 +250,7 @@ def run(ceph_cluster, **kw):
         # Get RSS value
         log.info("RSS value post IO")
         get_mem_usage(vip_node)
-
+        return 0
     except Exception as e:
         log.error(f"Failed to perform scale ops : {e}")
         return 1
@@ -300,5 +300,3 @@ def run(ceph_cluster, **kw):
         # Delete the subvolumegroup
         cmd = "ceph fs subvolumegroup rm cephfs ganeshagroup --force"
         client.exec_command(sudo=True, cmd=cmd)
-
-    return 0

--- a/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
+++ b/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
@@ -96,7 +96,7 @@ def run(ceph_cluster, **kw):
         # Wait for all get attribute threads to complete
         for thread_get in get_attributes:
             thread_get.join()
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate extended attribute with parallel clients : {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -107,4 +107,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_spec_storage.py
+++ b/tests/nfs/nfs_spec_storage.py
@@ -57,6 +57,7 @@ def run(ceph_cluster, **kw):
         ):
             raise OperationFailedError("SPECstorage run failed")
         log.info("SPECstorage run completed")
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
         return 1
@@ -65,4 +66,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_test_allocation_beyond_size.py
+++ b/tests/nfs/nfs_test_allocation_beyond_size.py
@@ -64,7 +64,7 @@ def run(ceph_cluster, **kw):
             raise OperationFailedError(
                 f"File '{filename}' took incorrect space utilization. Expected: 10G , Actual: {file_size}"
             )
-
+        return 0
     except Exception as e:
         log.error(f"Failed to  verify the space allocation test on NFS v4.2 : {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -75,4 +75,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_test_multiple_filesystem_exports.py
+++ b/tests/nfs/nfs_test_multiple_filesystem_exports.py
@@ -156,6 +156,7 @@ def run(ceph_cluster, **kw):
             mount_and_validate_export(
                 clients[0], version, port, nfs_server_name, nfs_export_name, i
             )
+        return 0
     except Exception as e:
         log.error(
             f"Failed to validate multiple export creation from multiple filesystems: {e}"
@@ -166,4 +167,3 @@ def run(ceph_cluster, **kw):
         cleanup_exports_and_filesystems(clients[0])
         cleanup_cluster(clients[0], "/mnt/nfs", "cephfs-nfs", "/export")
         log.info("Cleanup successful")
-    return 0

--- a/tests/nfs/nfs_test_remount_windows.py
+++ b/tests/nfs/nfs_test_remount_windows.py
@@ -90,7 +90,7 @@ def run(ceph_cluster, **kw):
                     log.info(f"File win_file{i} is present.")
             except Exception:
                 raise OperationFailedError("File not found on NFS share")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -102,4 +102,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_test_selinux_context_moving_files.py
+++ b/tests/nfs/nfs_test_selinux_context_moving_files.py
@@ -127,7 +127,7 @@ def run(ceph_cluster, **kw):
             raise OperationFailedError(
                 f"failed to get the selinux label for file {filename}_{i}"
             )
-
+        return 0
     except Exception as e:
         log.error(f"Failed to set the selinux label on NFS v4.2 : {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -138,4 +138,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_test_setting_selinux_context.py
+++ b/tests/nfs/nfs_test_setting_selinux_context.py
@@ -62,7 +62,7 @@ def run(ceph_cluster, **kw):
             log.info(f"selinux lable is set correctly: {out[0]}")
         else:
             raise OperationFailedError("Failed to set/get the selinux context")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to set the selinux label on NFS v4.2 : {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -73,4 +73,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_test_space_allocation_diff_sizes.py
+++ b/tests/nfs/nfs_test_space_allocation_diff_sizes.py
@@ -86,7 +86,7 @@ def run(ceph_cluster, **kw):
 
         # Validate the total disk usage of mount point
         verify_disk_usage(client=clients[0], mount_point=nfs_mount, size="6G")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to  verify the space allocation test on NFS v4.2 : {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -97,4 +97,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_test_xattr_across_file_operations.py
+++ b/tests/nfs/nfs_test_xattr_across_file_operations.py
@@ -98,6 +98,7 @@ def run(ceph_cluster, **kw):
 
         # Fetch the extended attribute of the file
         fetch_xattr(client=clients[0], file_path=f"{nfs_mount}/{copy_filename}")
+        return 0
 
     except Exception as e:
         log.error(
@@ -111,4 +112,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_validate_cmount_path_export_conf.py
+++ b/tests/nfs/nfs_validate_cmount_path_export_conf.py
@@ -55,6 +55,7 @@ def run(ceph_cluster, **kw):
             log.info("Test Passed: 'cmount_path': '/' is present.")
         else:
             log.info("Test Failed: 'cmount_path': '/' is not present.")
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate the cmount_param in export file : {e}")
@@ -66,5 +67,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-
-    return 0

--- a/tests/nfs/nfs_verify_bonnie.py
+++ b/tests/nfs/nfs_verify_bonnie.py
@@ -71,6 +71,7 @@ def run(ceph_cluster, **kw):
             for cmd in cmds:
                 client.exec_command(cmd=cmd, sudo=True)
         log.info("Successfully completed pynfs tests on nfs cluster")
+        return 0
     except Exception as e:
         log.error(f"Failed to run bonnie tests : {e}")
         return 1
@@ -78,4 +79,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
+++ b/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
@@ -111,6 +111,7 @@ def run(ceph_cluster, **kw):
             if "squashuser" not in out:
                 raise OperationFailedError("File is not created by squashed user")
         log.info("File created by squashed user")
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
@@ -123,4 +124,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_failover_with_file_ops.py
+++ b/tests/nfs/nfs_verify_failover_with_file_ops.py
@@ -125,6 +125,7 @@ def run(ceph_cluster, **kw):
         # Wait to complete operations
         for Thread_operation in Thread_operations:
             Thread_operation.join()
+        return 0
 
     except Exception as e:
         log.error(
@@ -134,4 +135,3 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_failover_with_io.py
+++ b/tests/nfs/nfs_verify_failover_with_io.py
@@ -74,9 +74,10 @@ def run(ceph_cluster, **kw):
 
         # Wait for IO to complete
         th.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to perform faiolver while IO in progress. Error: {e}")
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
+++ b/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
@@ -97,6 +97,7 @@ def run(ceph_cluster, **kw):
                         "Deleted file present in windows client v3"
                     )
                     return 1
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
@@ -116,4 +117,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_file_access_with_rootsquash.py
+++ b/tests/nfs/nfs_verify_file_access_with_rootsquash.py
@@ -85,6 +85,7 @@ def run(ceph_cluster, **kw):
             return 1
         except Exception as e:
             log.info(f"Expected. Failed to create file when rootsquash enabled. {e}")
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate read dir operations : {e}")
@@ -93,4 +94,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -170,6 +170,8 @@ def run(ceph_cluster, **kw):
         log.info(
             "Expected: Successfully acquired lock from client 2 while client 1 lock is released"
         )
+        return 0
+
     except Exception as e:
         log.error(
             f"Unexpected: Failed to acquire lock from client 2 while client 1 lock is in removed {e}"
@@ -193,4 +195,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_file_modification.py
+++ b/tests/nfs/nfs_verify_file_modification.py
@@ -94,6 +94,7 @@ def run(ceph_cluster, **kw):
         # Wait for all operation to finish
         for operation in operations:
             operation.join()
+        return 0
 
     except Exception as e:
         log.error(f"Fail to perform file operation in nfs mount : {e}")
@@ -102,4 +103,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_file_operations.py
+++ b/tests/nfs/nfs_verify_file_operations.py
@@ -111,6 +111,7 @@ def run(ceph_cluster, **kw):
         # Wait to complete operations
         for Thread_operation in Thread_operations:
             Thread_operation.join()
+        return 0
 
     except Exception as e:
         log.error(f"Error : {e}")

--- a/tests/nfs/nfs_verify_file_ops_hard_links.py
+++ b/tests/nfs/nfs_verify_file_ops_hard_links.py
@@ -78,6 +78,7 @@ def run(ceph_cluster, **kw):
         # Wait for all operation to finish
         for operation in operations:
             operation.join()
+        return 0
 
     except Exception as e:
         log.error(f"Fail to perform file operation in nfs mount : {e}")
@@ -86,4 +87,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_file_ops_soft_links.py
+++ b/tests/nfs/nfs_verify_file_ops_soft_links.py
@@ -103,6 +103,7 @@ def run(ceph_cluster, **kw):
         # Wait for all operation to finish
         for operation in operations:
             operation.join()
+        return 0
 
     except Exception as e:
         log.error(f"Error : {e}")
@@ -110,4 +111,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_ha_readonly_windows.py
+++ b/tests/nfs/nfs_verify_ha_readonly_windows.py
@@ -123,6 +123,7 @@ def run(ceph_cluster, **kw):
             log.info("Export is readonly")
         else:
             raise OperationFailedError("File created on Readonly export")
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate readonly with failover on a ha cluster: {e}")
@@ -143,4 +144,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_hard_links_inode.py
+++ b/tests/nfs/nfs_verify_hard_links_inode.py
@@ -79,6 +79,7 @@ def run(ceph_cluster, **kw):
             return 1
         else:
             log.info("iNode match for original and hard link file")
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -86,4 +87,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
+++ b/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
@@ -86,6 +86,8 @@ def run(ceph_cluster, **kw):
 
         linux_io.join()
         windows_io.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -104,4 +106,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
+++ b/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
@@ -84,6 +84,8 @@ def run(ceph_cluster, **kw):
 
         linux_io.join()
         windows_io.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -102,4 +104,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
+++ b/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
@@ -84,6 +84,8 @@ def run(ceph_cluster, **kw):
 
         linux_io.join()
         windows_io.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -102,4 +104,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_multi_client_failover_windows.py
+++ b/tests/nfs/nfs_verify_multi_client_failover_windows.py
@@ -86,6 +86,7 @@ def run(ceph_cluster, **kw):
         # Wait for IO to complete
         for _th in io:
             _th.join()
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
@@ -98,4 +99,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
+++ b/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
@@ -101,6 +101,7 @@ def run(ceph_cluster, **kw):
 
         readdir1.join()
         readdir2.join()
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
@@ -113,4 +114,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
+++ b/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
@@ -87,11 +87,10 @@ def run(ceph_cluster, **kw):
                     raise OperationFailedError(
                         f"File permission is different than default {out}"
                     )
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate nfs dir operations and permission checks : {e}")
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_multi_mount_version.py
+++ b/tests/nfs/nfs_verify_multi_mount_version.py
@@ -63,6 +63,7 @@ def run(ceph_cluster, **kw):
             threads.append(io)
         for th in threads:
             th.join()
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
@@ -70,4 +71,3 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_multi_node_cluster.py
+++ b/tests/nfs/nfs_verify_multi_node_cluster.py
@@ -65,6 +65,7 @@ def run(ceph_cluster, **kw):
         # Test 2: Perform readir operation from other client (du -sh)
         cmd = f"du -sh {nfs_mount}"
         clients[2].exec_command(cmd=cmd, sudo=True)
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate multi node deployment operations : {e}")
@@ -73,4 +74,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
+++ b/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
@@ -86,7 +86,7 @@ def run(ceph_cluster, **kw):
 
             th1.join()
             th2.join()
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate multiple ios and lookups : {e}")
         return 1
@@ -98,4 +98,3 @@ def run(ceph_cluster, **kw):
             time.sleep(20)
             cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
             log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_nfs_ha.py
+++ b/tests/nfs/nfs_verify_nfs_ha.py
@@ -55,10 +55,11 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
         )
         log.info("Successfully setup NFS HA cluster")
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs ha cluster {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_nfs_kill_process_failover.py
+++ b/tests/nfs/nfs_verify_nfs_kill_process_failover.py
@@ -94,6 +94,8 @@ def run(ceph_cluster, **kw):
                 "The failover process failed and vip is not assigned to the available nodes"
             )
         log.info("VIP assigned to other nfs node successfully")
+        return 0
+
     except Exception as e:
         log.error(
             f"Failed to validate nfs process kill and failover on a ha cluster: {e}"
@@ -101,4 +103,3 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
+++ b/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
@@ -88,6 +88,7 @@ def run(ceph_cluster, **kw):
         # Wait for the ops to complete
         for op in operations:
             op.join()
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate parallel write, lookup and rm : {e}")
@@ -96,4 +97,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -75,6 +75,7 @@ def run(ceph_cluster, **kw):
         if failed_tests:
             log.error(f"Unexpected pynfs test failures: {failed_tests}")
             return 1
+        return 0
 
     except Exception as e:
         log.error(f"Failed to run pynfs on {clients[0].hostname}, Error: {e}")
@@ -83,4 +84,3 @@ def run(ceph_cluster, **kw):
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_pynfs_ha.py
+++ b/tests/nfs/nfs_verify_pynfs_ha.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
 
         # Wait for pynfs to complete
         pynfs.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to run pynfs with HA on {clients[0].hostname}, Error: {e}")
         return 1
@@ -96,4 +98,3 @@ def run(ceph_cluster, **kw):
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_read_write_operations.py
+++ b/tests/nfs/nfs_verify_read_write_operations.py
@@ -171,11 +171,10 @@ def run(ceph_cluster, **kw):
                     "Mv operation doesn't overwrite the content of existing file"
                 )
             log.info("Expected: mv operation has overwritten the file")
-
+        return 0
     except Exception as e:
         log.error(f"Failed to validate read write operations : {e}")
         return 1
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_readdir_operation.py
+++ b/tests/nfs/nfs_verify_readdir_operation.py
@@ -118,6 +118,7 @@ def run(ceph_cluster, **kw):
         readdir1.join()
         readdir2.join()
         readdir3.join()
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate export rootsquash: {e}")
@@ -129,4 +130,3 @@ def run(ceph_cluster, **kw):
         # Cleanup
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export1)
-    return 0

--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -81,6 +81,8 @@ def run(ceph_cluster, **kw):
         # Perform Linux untar from 1 client and do readir operation from other client (finds)
         cmd = f"find {nfs_mount} -name *.txt"
         clients[3].exec_command(cmd=cmd, sudo=True)
+        return 0
+
     except Exception as e:
         log.error(f"Failed to validate read dir operations : {e}")
         return 1
@@ -89,4 +91,3 @@ def run(ceph_cluster, **kw):
         sleep(30)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_scale.py
+++ b/tests/nfs/nfs_verify_scale.py
@@ -152,6 +152,7 @@ def run(ceph_cluster, **kw):
         for th in threads:
             th.join()
         log.info("Completed running IO on all mounts")
+        return 0
 
     except Exception as e:
         log.error(f"Failed to perform scale ops : {e}")
@@ -171,4 +172,3 @@ def run(ceph_cluster, **kw):
                 client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_mounting_dir}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -176,6 +176,7 @@ def run(ceph_cluster, **kw):
         # Wait to complete operations
         for Thread_operation in Thread_operations:
             Thread_operation.join()
+        return 0
 
     except Exception as e:
         log.error(
@@ -195,4 +196,3 @@ def run(ceph_cluster, **kw):
             client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_squash_mount}")
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_stress.py
+++ b/tests/nfs/nfs_verify_stress.py
@@ -101,6 +101,7 @@ def run(ceph_cluster, **kw):
 
         # Wait for the IO to complete
         th.join()
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")
@@ -109,4 +110,3 @@ def run(ceph_cluster, **kw):
     finally:
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         pass
-    return 0

--- a/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
+++ b/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
@@ -74,7 +74,7 @@ def run(ceph_cluster, **kw):
             log.info(
                 "Successfully created symbolic links to files from local file systems to NFS"
             )
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -82,4 +82,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_symbolic_links_permissions.py
+++ b/tests/nfs/nfs_verify_symbolic_links_permissions.py
@@ -74,7 +74,7 @@ def run(ceph_cluster, **kw):
                 raise OperationFailedError(
                     f"Failed with an error other than permission denied: {e}"
                 )
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -82,4 +82,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_symbolic_links_users.py
+++ b/tests/nfs/nfs_verify_symbolic_links_users.py
@@ -73,7 +73,7 @@ def run(ceph_cluster, **kw):
             return 1
         else:
             log.info("Expected! owner of target and sym link files are different")
-
+        return 0
     except Exception as e:
         log.error(f"Error : {e}")
     finally:
@@ -81,4 +81,3 @@ def run(ceph_cluster, **kw):
         sleep(3)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/nfs_verify_v3_mount_window_linux.py
+++ b/tests/nfs/nfs_verify_v3_mount_window_linux.py
@@ -84,6 +84,8 @@ def run(ceph_cluster, **kw):
 
         linux_io.join()
         windows_io.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -102,4 +104,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
+++ b/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
 
         rename.join()
         lookups.join()
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -107,4 +109,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_windows_client.py
+++ b/tests/nfs/nfs_verify_windows_client.py
@@ -77,6 +77,8 @@ def run(ceph_cluster, **kw):
         log.info("Successfully setup NFS HA cluster")
 
         # Mount windows client
+        return 0
+
     except Exception as e:
         log.error(f"Failed to setup nfs ha cluster {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
@@ -86,4 +88,3 @@ def run(ceph_cluster, **kw):
         cmd = r"umount Z:"
         execute_command_on_windows_node(win_clients[0], cmd)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_windows_parallel_readdir.py
+++ b/tests/nfs/nfs_verify_windows_parallel_readdir.py
@@ -98,6 +98,7 @@ def run(ceph_cluster, **kw):
         readdir1.join()
         readdir2.join()
 
+        return 0
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
         # Cleanup
@@ -116,4 +117,3 @@ def run(ceph_cluster, **kw):
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/nfs_verify_xattr_readonly_file.py
+++ b/tests/nfs/nfs_verify_xattr_readonly_file.py
@@ -73,6 +73,7 @@ def run(ceph_cluster, **kw):
             log.info("Expected : Attributes cannot be set on readpnly file")
         else:
             raise OperationFailedError("Unexpected: Attributes set on Readonly file")
+        return 0
 
     except Exception as e:
         log.error(
@@ -92,4 +93,3 @@ def run(ceph_cluster, **kw):
             clients[0].exec_command(cmd=cmd, sudo=True)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/nfs_window_scale_fio_support.py
+++ b/tests/nfs/nfs_window_scale_fio_support.py
@@ -211,6 +211,7 @@ def run(ceph_cluster, **kw):
         log.info("RSS value post IO")
         get_mem_usage(vip_node)
 
+        return 0
     except Exception as e:
         log.error(f"Failed to perform scale ops : {e}")
         return 1
@@ -241,5 +242,3 @@ def run(ceph_cluster, **kw):
         # Delete the subvolumegroup
         cmd = "ceph fs subvolumegroup rm cephfs ganeshagroup --force"
         client.exec_command(sudo=True, cmd=cmd)
-
-    return 0

--- a/tests/nfs/test_export_readonly.py
+++ b/tests/nfs/test_export_readonly.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd=f"touch {nfs_mount}/file_rw",
         )
+        return 0
+
     except Exception as e:
         log.error(f"Failed to validate export readonly: {e}")
         return 1
@@ -108,4 +110,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients[0], nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/test_export_rootsquash.py
+++ b/tests/nfs/test_export_rootsquash.py
@@ -115,6 +115,7 @@ def run(ceph_cluster, **kw):
         else:
             log.error("Failed to validate export rootsquash")
             return 1
+        return 0
 
     finally:
         log.info("Cleaning up")
@@ -131,4 +132,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients[0], nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/test_file_ops_copy.py
+++ b/tests/nfs/test_file_ops_copy.py
@@ -123,9 +123,9 @@ def run(ceph_cluster, **kw):
             operation.join()
 
         log.info("Successfully completed the copy tests for files and dirs")
+        return 0
 
     finally:
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/test_file_ops_renames.py
+++ b/tests/nfs/test_file_ops_renames.py
@@ -135,9 +135,9 @@ def run(ceph_cluster, **kw):
             )
 
         log.info("Successfully completed the rename tests for files and dirs")
+        return 0
 
     finally:
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/test_nfs_export_readonly_windows.py
+++ b/tests/nfs/test_nfs_export_readonly_windows.py
@@ -111,6 +111,7 @@ def run(ceph_cluster, **kw):
         permission(
             client, nfs_name, nfs_export, old_permission="RO", new_permission="RW"
         )
+        return 0
 
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
@@ -123,4 +124,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
         cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
-    return 0

--- a/tests/nfs/test_nfs_extended_attribute_rootsquash.py
+++ b/tests/nfs/test_nfs_extended_attribute_rootsquash.py
@@ -122,6 +122,7 @@ def run(ceph_cluster, **kw):
 
         # Fetch the extended attribute of the file
         out = getfattr(client=clients[0], file_path=f"{nfs_mount1}/{filename}")
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate export rootsquash: {e}")
@@ -139,4 +140,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients[0], nfs_mount1, nfs_name, nfs_export1)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/test_nfs_get_set_attr_operation.py
+++ b/tests/nfs/test_nfs_get_set_attr_operation.py
@@ -76,6 +76,7 @@ def run(ceph_cluster, **kw):
             else:
                 log.info("Attribute 'myattr' set to 'value' not found in the output.")
                 return 1
+        return 0
 
     except Exception as e:
         log.error(f"Failed to perform export client addr validation : {e}")
@@ -87,4 +88,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/test_nfs_io_operations_during_upgrade.py
+++ b/tests/nfs/test_nfs_io_operations_during_upgrade.py
@@ -118,6 +118,11 @@ def create_export_and_mount_for_existing_nfs_cluster(
                             nfs_export=export_name,
                             fs=_fs,
                         )
+                    all_exports = Ceph(clients[0]).nfs.export.ls(nfs_name)
+                    if export_name not in all_exports:
+                        raise OperationFailedError(
+                            f"Export {export_name} not found in the list of exports {all_exports}"
+                        )
                     sleep(1)
 
                     # Get the mount versions specific to clients

--- a/tests/nfs/test_nfs_partial_deallocation.py
+++ b/tests/nfs/test_nfs_partial_deallocation.py
@@ -81,7 +81,7 @@ def run(ceph_cluster, **kw):
                 raise OperationFailedError(
                     f"File {filename}{i} took incorrect space utilization. Expected: 1.0G , Actual: {file_size}"
                 )
-
+        return 0
     except Exception as e:
         log.error(
             f"Failed to  verify the partial space deallocation test on NFS v4.2 : {e}"
@@ -94,4 +94,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
+++ b/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
@@ -86,6 +86,7 @@ def run(ceph_cluster, **kw):
 
         # Try accessing the file from client 2
         perform_lookups(clients[1], nfs_squash_mount, 1)
+        return 0
 
     except Exception as e:
         log.error(f"Failed to validate export rootsquash: {e}")
@@ -106,4 +107,3 @@ def run(ceph_cluster, **kw):
         # Cleaning up the remaining export and deleting the nfs cluster
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successfull")
-    return 0

--- a/tests/nfs/test_nfs_selinux_context_symlinks.py
+++ b/tests/nfs/test_nfs_selinux_context_symlinks.py
@@ -79,6 +79,7 @@ def run(ceph_cluster, **kw):
             log.info(f"selinux lable is set correctly for hardlink file: {out[0]}")
         else:
             raise OperationFailedError("Selinux label is not the same as parent file")
+        return 0
 
     except Exception as e:
         log.error(
@@ -92,4 +93,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0

--- a/tests/nfs/test_nfs_selinux_label_while_mounting.py
+++ b/tests/nfs/test_nfs_selinux_label_while_mounting.py
@@ -92,6 +92,7 @@ def run(ceph_cluster, **kw):
                 raise OperationFailedError(
                     "Selinux label is not the same as the NFS mount point"
                 )
+        return 0
 
     except Exception as e:
         log.error(
@@ -105,4 +106,3 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         log.info("Cleaning up successful")
-    return 0


### PR DESCRIPTION
THis PR is to fix false results in CI - for nfs
example:
in this run : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Regression/20.1.0-12/nfs/18/tier1-nfs-ganesha-v4-2/ , few tests are returning PASS, even though its failed.

this is due to the design:
try:
except:
finally:

return 0 
if return 1/failed scenarios are not defined, then the test will return PASS, even though test failed.

the fix as of my knowledge:
try:
 return 0
except:
 
finally:

Since by default CI framework will return  return 0/ fail, So its better to define return 0/pass signal:


logs with changes:
failed results :
http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/false_results/try1/logs/.  - 9.0

pass results:
http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/false_results/try1/logs-pass-false-1/ - 8.1
http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/false_results/try1/false-results-pass2/ - 8.1
