### PR TITLE
[RBD] Failover after a non-orderly shutdown with force promote in non default namespace

### DIFF
--- a/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/squid/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -161,7 +161,6 @@ tests:
       name: deploy rbd-mirror daemon
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify demote, promote, resync, rename, resize, remove
         for namespace mirrored images
@@ -207,7 +206,6 @@ tests:
                 io_type: randrw
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify Mirror Image Synchronization Between Differently-Named
         Namespaces in Different Clusters in one way mode
@@ -254,7 +252,6 @@ tests:
                 io_type: randrw
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify Failover after an orderly shutdown
         for non-default to non-default namespace mirroring
@@ -300,7 +297,6 @@ tests:
                 io_type: randrw
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify Disabling and re-enabling a non-default to
         non-default namespace level mirroring
@@ -329,3 +325,46 @@ tests:
               mirrormode: snapshot
               namespace_mirror_type: non-default_to_non-default
             test_function: CEPH-83601542
+
+  - test:
+      desc: >
+        Failover cluster from secondary to primary
+        in non default namespace mirroring with force promote
+      name: Test failover after an non orderly shut-down with force promote
+      module: test_rbd_mirror_namespace_failover.py
+      polarion-id: CEPH-83601545
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            test_function: CEPH-83601545
+            fio:
+              size: 200M
+              ODF_CONFIG:
+                num_jobs: 4
+                iodepth: 32
+                rwmixread: 70
+                direct: 1
+                invalidate: 1
+                io_type: randrw

--- a/suites/tentacle/rbd/tier-2_non_default_namespace_mirroring.yaml
+++ b/suites/tentacle/rbd/tier-2_non_default_namespace_mirroring.yaml
@@ -161,7 +161,6 @@ tests:
       name: deploy rbd-mirror daemon
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify demote, promote, resync, rename, resize,
         remove for namespace mirrored images
@@ -206,7 +205,6 @@ tests:
                 io_type: randrw
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify Mirror Image Synchronization Between Differently-Named
         Namespaces in Different Clusters in one way mode
@@ -253,7 +251,6 @@ tests:
                 io_type: randrw
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify Failover after an orderly shutdown
         for non-default to non-default namespace mirroring
@@ -299,7 +296,6 @@ tests:
                 io_type: randrw
 
   - test:
-      abort-on-fail: True
       desc: >
         Verify Disabling and re-enabling a non-default to
         non-default namespace level mirroring
@@ -328,3 +324,46 @@ tests:
               mirrormode: snapshot
               namespace_mirror_type: non-default_to_non-default
             test_function: CEPH-83601542
+
+  - test:
+      desc: >
+        Failover cluster from secondary to primary
+        in non default namespace mirroring with force promote
+      name: Test failover after an non orderly shut-down with force promote
+      module: test_rbd_mirror_namespace_failover.py
+      polarion-id: CEPH-83601545
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              do_not_create_image: True
+              size: 1G
+              mode: image
+              mirror_level: namespace
+              mirrormode: snapshot
+              namespace_mirror_type: non-default_to_non-default
+              snap_schedule_intervals:
+                - 1m
+            test_function: CEPH-83601545
+            fio:
+              size: 200M
+              ODF_CONFIG:
+                num_jobs: 4
+                iodepth: 32
+                rwmixread: 70
+                direct: 1
+                invalidate: 1
+                io_type: randrw

--- a/tests/rbd_mirror/test_rbd_mirror_namespace_failover.py
+++ b/tests/rbd_mirror/test_rbd_mirror_namespace_failover.py
@@ -983,6 +983,7 @@ def run(**kw):
             "CEPH-83613955": test_failover_orderly_shutdown,
             "CEPH-83613956": test_failover_non_orderly_shutdown,
             "CEPH-83601544": test_failover_orderly_shutdown,
+            "CEPH-83601545": test_failover_non_orderly_shutdown,
         }
 
         test_func = kw["config"]["test_function"]


### PR DESCRIPTION
# Description
Test case automated:
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83601545

Due to `abort-on-fail: True` being set for each test, execution stopped after the first failure.
I’ve removed it so the remaining tests can continue running.

Test results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-562FXX/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
