### PR TITLE
WIP: Enhanced NFS ops control validation

### DIFF
--- a/suites/squid/nfs/tier1-nfs-ganesha-qos.yaml
+++ b/suites/squid/nfs/tier1-nfs-ganesha-qos.yaml
@@ -300,6 +300,54 @@ tests:
         operation: restart
 
   - test:
+      name: NFS QoS ops control test - cluster level
+      module: test_nfs_qos_ops_control.py
+      desc: Verify QoS ops control at cluster level
+      polarion-id:
+      abort-on-fail: false
+      config:
+          cephfs_volume: cephfs
+          cluster_name: cephfs-nfs
+          nfs_version: 4.2
+          port: "2049"
+          qos_type: PerShare_PerClient
+          operation: restart
+          cluster_ops:
+              max_export_iops: 60
+              max_client_iops: 60
+          dd_parameters:
+              block_size: "1M"
+              count: 64
+              input_file: "/dev/random"
+              iterations: 3
+
+  - test:
+      name: NFS QoS ops control test - export level
+      module: test_nfs_qos_ops_control.py
+      desc: Verify QoS ops control at export level overrides cluster level
+      polarion-id: 
+      abort-on-fail: false
+      config:
+          cephfs_volume: cephfs
+          cluster_name: cephfs-nfs
+          nfs_version: 4.2
+          port: "2049"
+          qos_type: PerShare_PerClient
+          operation: restart
+          cluster_ops:
+              max_export_iops: 60
+              max_client_iops: 60
+          export_ops:
+              max_export_iops: 40
+              max_client_iops: 40
+          dd_parameters:
+              block_size: "2M"
+              count: 32
+              input_file: "/dev/zero"
+              iterations: 3
+          
+
+  - test:
       name: deploy nfs ganesha with qos per share using spec file
       desc: Deploy nfs ganesha with qos per share using spec file and verify
       polarion-id: CEPH-83621553

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -16,6 +16,7 @@ from cli.utilities.filesys import FuseMount, Mount, Unmount
 from cli.utilities.utils import check_coredump_generated, get_ip_from_node, reboot_node
 from utility.log import Log
 from utility.retry import retry
+from cli.exceptions import ConfigError
 
 log = Log(__name__)
 
@@ -1254,3 +1255,105 @@ def nfs_log_parser(client, nfs_node, nfs_name, expect_list):
         return 1
 
     return 0
+
+
+def verify_ops_control_settings(client, cluster_name, export_path=None):
+    """Verify ops control settings at cluster and export level"""
+    try:
+        # Verify cluster settings
+        cluster_settings = json.loads(
+            client.exec_command(cmd=f"ceph nfs cluster qos get {cluster_name}")[0]
+        )
+        log.info(f"Current cluster ops control settings: {cluster_settings}")
+        
+        # Verify export settings if path provided
+        if export_path:
+            export_settings = json.loads(
+                client.exec_command(cmd=f"ceph nfs export qos get {cluster_name} {export_path}")[0]
+            )
+            log.info(f"Current export ops control settings for {export_path}: {export_settings}")
+            return cluster_settings, export_settings
+        return cluster_settings, None
+    except Exception as e:
+        log.error(f"Failed to get ops control settings: {str(e)}")
+        return None, None
+
+
+def extract_dd_time(dd_output):
+    """Extract time taken from dd command output"""
+    try:
+        # Get the last line containing 'copied'
+        for line in dd_output.split('\n')[::-1]:
+            if 'copied' in line:
+                time_str = line.split("copied,")[1].split("s,")[0].strip()
+                return float(time_str)
+        return None
+    except Exception as e:
+        log.error(f"Failed to extract time from dd output: {str(e)}")
+        return None
+
+
+def validate_ops_limit(dd_time, expected_limit):
+    """
+    Validate ops control limit using formula: ops_limit = 278/dd_time
+    Returns: (bool, calculated_limit)
+    """
+    if not dd_time:
+        return False, None
+    
+    calculated_limit = int(278/dd_time)  # Using only integer part as per requirement
+    log.info(f"Validation Summary:")
+    log.info(f"- Time taken: {dd_time} seconds")
+    log.info(f"- Calculated ops limit: {calculated_limit} (278/{dd_time})")
+    log.info(f"- Expected ops limit: {expected_limit}")
+    
+    # Compare with expected limit
+    matches = calculated_limit == expected_limit
+    if matches:
+        log.info(f"✓ Validation PASSED: calculated limit {calculated_limit} matches expected {expected_limit}")
+    else:
+        log.warning(f"✗ Validation FAILED: calculated limit {calculated_limit} differs from expected {expected_limit}")
+    
+    return matches, calculated_limit
+
+
+def validate_ops_control(client, nfs_mount, file_name, dd_params):
+    """Validate ops control by measuring IO operations"""
+    # Create test file
+    cmd = f"touch {nfs_mount}/{file_name}"
+    client.exec_command(sudo=True, cmd=cmd)
+
+    # Run write test
+    write_cmd = (
+        f"dd if={dd_params['input_file']} of={nfs_mount}/{file_name} "
+        f"bs={dd_params['block_size']} count={dd_params['count']} status=progress"
+    )
+    write_results = client.exec_command(sudo=True, cmd=write_cmd)[1]
+    log.info(f"Write test results: {write_results}")
+
+    # Extract time taken for write
+    write_time = extract_dd_time(write_results)
+    log.info(f"Write operation took {write_time} seconds")
+
+    # Drop cache
+    client.exec_command(sudo=True, cmd="echo 3 > /proc/sys/vm/drop_caches")
+    log.info("Cache dropped successfully")
+
+    # Run read test
+    read_cmd = f"dd if={nfs_mount}/{file_name} of=/dev/null bs={dd_params['block_size']} count={dd_params['count']} status=progress"
+    read_results = client.exec_command(sudo=True, cmd=read_cmd)[1]
+    log.info(f"Read test results: {read_results}")
+
+    # Extract time taken for read
+    read_time = extract_dd_time(read_results)
+    log.info(f"Read operation took {read_time} seconds")
+
+    # Cleanup
+    client.exec_command(sudo=True, cmd=f"rm -rf {nfs_mount}/{file_name}")
+
+    return {
+        "write_results": write_results,
+        "read_results": read_results,
+        "write_time": write_time,
+        "read_time": read_time
+    }

--- a/tests/nfs/test_nfs_qos_ops_control.py
+++ b/tests/nfs/test_nfs_qos_ops_control.py
@@ -1,0 +1,237 @@
+import json
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.nfs_operations import (
+    cleanup_cluster, 
+    setup_nfs_cluster,
+    verify_ops_control_settings,
+    validate_ops_control,
+    validate_ops_limit
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def enable_cluster_ops_control(client, cluster_name, qos_type, ops_config):
+    """Enable ops control at cluster level"""
+    cmd = f"ceph nfs cluster qos enable ops_control {cluster_name} {qos_type}"
+    
+    if qos_type.lower() == "pershare":
+        if "max_export_iops" not in ops_config:
+            raise ConfigError("max_export_iops required for PerShare ops control")
+        cmd += f" {ops_config['max_export_iops']}"
+    elif qos_type.lower() == "perclient":
+        if "max_client_iops" not in ops_config:
+            raise ConfigError("max_client_iops required for PerClient ops control")
+        cmd += f" {ops_config['max_client_iops']}"
+    elif qos_type.lower() == "pershare_perclient":
+        if not all(k in ops_config for k in ["max_export_iops", "max_client_iops"]):
+            raise ConfigError("Both max_export_iops and max_client_iops required")
+        cmd += f" {ops_config['max_export_iops']} {ops_config['max_client_iops']}"
+    else:
+        raise ConfigError(f"Invalid ops control type: {qos_type}")
+    
+    client.exec_command(sudo=True, cmd=cmd)
+    return cmd
+
+
+def enable_export_ops_control(client, cluster_name, pseudo_path, qos_type, ops_config):
+    """Enable ops control at export level"""
+    cmd = f"ceph nfs export qos enable ops_control {cluster_name} {pseudo_path}"
+    
+    if qos_type.lower() == "pershare":
+        if "max_export_iops" not in ops_config:
+            raise ConfigError("max_export_iops required for PerShare ops control")
+        cmd += f" {ops_config['max_export_iops']}"
+    elif qos_type.lower() == "pershare_perclient":
+        if not all(k in ops_config for k in ["max_export_iops", "max_client_iops"]):
+            raise ConfigError("Both max_export_iops and max_client_iops required")
+        cmd += f" {ops_config['max_export_iops']} {ops_config['max_client_iops']}"
+    elif qos_type.lower() == "perclient":
+        raise ConfigError("PerClient ops control not allowed at export level")
+    
+    client.exec_command(sudo=True, cmd=cmd)
+    return cmd
+
+
+def run(ceph_cluster, **kw):
+    """Test NFS ops control at cluster and export levels"""
+    config = kw.get("config")
+    if not config:
+        raise ConfigError("Config not found")
+
+    try:
+        # Get nodes
+        nfs_nodes = ceph_cluster.get_nodes("nfs")
+        clients = ceph_cluster.get_nodes("client")
+        if not nfs_nodes:
+            raise OperationFailedError("No NFS nodes found in cluster")
+
+        nfs_node = nfs_nodes[0]
+        no_clients = int(config.get("clients", "1"))
+        if no_clients > len(clients):
+            raise ConfigError("The test requires more clients than available")
+
+        clients = clients[:no_clients]
+        client = clients[0]
+
+        # Setup parameters
+        cluster_name = config.get("cluster_name", "cephfs-nfs")
+        fs_name = config.get("cephfs_volume", "cephfs")
+        nfs_export = "/export_0"
+        nfs_mount = "/mnt/nfs"
+        fs = "cephfs"
+        qos_type = config.get("qos_type")
+        dd_params = config.get("dd_parameters")
+
+        # Setup NFS cluster
+        setup_nfs_cluster(
+            clients=clients,
+            nfs_server=nfs_node.hostname,
+            port=config.get("port", "2049"),
+            version=config.get("nfs_version", "4.2"),
+            nfs_name=cluster_name,
+            nfs_mount=nfs_mount,
+            fs_name=fs_name,
+            export=nfs_export,
+            fs=fs,
+            ceph_cluster=ceph_cluster,
+        )
+
+        # Get baseline performance (no ops control)
+        log.info("=" * 80)
+        log.info("STEP 1: Measuring baseline performance (no ops control)...")
+        baseline = validate_ops_control(
+            client=client,
+            nfs_mount=nfs_mount,
+            file_name="baseline.txt",
+            dd_params=dd_params
+        )
+        log.info("Baseline Results:")
+        log.info(f"- Write time: {baseline['write_time']} seconds")
+        log.info(f"- Read time: {baseline['read_time']} seconds")
+        
+        # Enable cluster level ops control
+        log.info("=" * 80)
+        log.info("STEP 2: Setting up cluster level ops control...")
+        cluster_ops = config.get("cluster_ops", {})
+        log.info(f"Cluster ops control configuration: {cluster_ops}")
+        cluster_cmd = enable_cluster_ops_control(
+            client, cluster_name, qos_type, cluster_ops
+        )
+        log.info(f"Enabled cluster ops control with command: {cluster_cmd}")
+
+        # Verify cluster settings and test performance
+        cluster_settings, _ = verify_ops_control_settings(client, cluster_name)
+        log.info("Testing performance with cluster ops control...")
+        cluster_test = validate_ops_control(
+            client=client,
+            nfs_mount=nfs_mount,
+            file_name="cluster_ops.txt",
+            dd_params=dd_params
+        )
+        
+        # Validate cluster ops control limits
+        if qos_type in ["pershare", "pershare_perclient"]:
+            log.info("Validating cluster level ops control limits:")
+            log.info(f"- Expected limit: {cluster_ops['max_export_iops']} IOPS")
+            log.info(f"- Write time: {cluster_test['write_time']} seconds")
+            matches, calc_limit = validate_ops_limit(
+                cluster_test["write_time"], 
+                cluster_ops["max_export_iops"]
+            )
+            if not matches:
+                raise OperationFailedError(
+                    f"Cluster ops control validation failed: calculated={calc_limit}, "
+                    f"expected={cluster_ops['max_export_iops']}"
+                )
+            log.info("Cluster level ops control validation successful")
+
+        # Enable export level ops control if configured
+        export_ops = config.get("export_ops")
+        nfs_export_path = None
+        if export_ops:
+            log.info("=" * 80)
+            log.info("STEP 3: Setting up export level ops control...")
+            log.info(f"Export ops control configuration: {export_ops}")
+            nfs_export_path = f"{nfs_export}_0"
+            export_cmd = enable_export_ops_control(
+                client, cluster_name, nfs_export_path,
+                qos_type, export_ops
+            )
+            log.info(f"Enabled export ops control with command: {export_cmd}")
+            
+            # Verify settings and test performance
+            cluster_settings, export_settings = verify_ops_control_settings(
+                client, cluster_name, nfs_export_path
+            )
+            log.info("Testing performance with export ops control...")
+            export_test = validate_ops_control(
+                client=client,
+                nfs_mount=nfs_mount,
+                file_name="export_ops.txt",
+                dd_params=dd_params
+            )
+            
+            # Validate export ops control limits
+            if qos_type in ["pershare", "pershare_perclient"]:
+                log.info("Validating export level ops control limits:")
+                log.info(f"- Expected limit: {export_ops['max_export_iops']} IOPS")
+                log.info(f"- Write time: {export_test['write_time']} seconds")
+                matches, calc_limit = validate_ops_limit(
+                    export_test["write_time"], 
+                    export_ops["max_export_iops"]
+                )
+                if not matches:
+                    raise OperationFailedError(
+                        f"Export ops control validation failed: calculated={calc_limit}, "
+                        f"expected={export_ops['max_export_iops']}"
+                    )
+                log.info("Export level ops control validation successful")
+
+        # Handle restart validation
+        if config.get("operation") == "restart":
+            log.info("=" * 80)
+            log.info("STEP 4: Testing ops control persistence after restart...")
+            data = json.loads(Ceph(client).orch.ls(format="json"))
+            service_name = next(
+                (x["service_name"] for x in data if x.get("service_id") == cluster_name),
+                None
+            )
+            
+            if service_name:
+                Ceph(client).orch.restart(service_name)
+                sleep(10)
+
+                # Verify settings persist after restart
+                post_restart_settings, post_restart_export = verify_ops_control_settings(
+                    client, 
+                    cluster_name,
+                    nfs_export_path if export_ops else None
+                )
+                
+                if post_restart_settings != cluster_settings:
+                    raise OperationFailedError("Ops control settings changed after restart")
+                
+                # Verify ops control is still effective
+                post_restart_test = validate_ops_control(
+                    client=client,
+                    nfs_mount=nfs_mount,
+                    file_name="post_restart.txt",
+                    dd_params=dd_params
+                )
+                log.info(f"Post-restart performance: {post_restart_test}")
+        log.info("=" * 80)    
+        log.info("NFS ops control test completed successfully")
+        return 0
+
+    except Exception as e:
+        log.error(f"NFS ops control test failed: {str(e)}")
+        return 1
+
+    finally:
+        log.info("Cleanup in progress")
+        cleanup_cluster(client, nfs_mount, cluster_name, nfs_export)


### PR DESCRIPTION
# Description: Enhanced NFS ops control validation

## Changes
- Implemented formula-based validation (278/dd_time) for ops control limits
- Added step-by-step validation for both cluster and export levels
- Fixed read operation time extraction from dd output
- Added YAML configurations for testing cluster and export level ops control
- Enhanced logging for better test visibility

## Testing Done
- Tested cluster level ops control with PerShare_PerClient
- Tested export level override of cluster settings
- Verified persistence after service restart

## To Do
- Add Polarion IDs to yaml

Logs can be accessed using http://magna002.ceph.redhat.com/ceph-qe-logs/manising/qos_ops_control/ops_control15/


