### PR TITLE
removed zonegroup_hostnames in tier-2_rgw_ssl_cephadm_gen_cert.yaml to avoid ms setup failure

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -66,8 +66,6 @@ tests:
                       spec:
                         generate_cert: true
                         ssl: true
-                        zonegroup_hostnames:
-                          - s3.example.com
                       placement:
                         nodes:
                           - node5
@@ -116,8 +114,6 @@ tests:
                       spec:
                         generate_cert: true
                         ssl: true
-                        zonegroup_hostnames:
-                          - s3.example.com
                       placement:
                         nodes:
                           - node5


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCEPHQE-21904
failed log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Weekly/20.1.0-21/rgw/1/tier-2_rgw_ssl_cephadm_gen_cert/
pass log: 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9.5/Test/20.1.0-25/16/tier-2_rgw_ssl_cephadm_gen_cert 
removed the parameter zonegroup_hostname :  because of that the rgw deployment is failing . 