### PR TITLE
TFA fix for error message failure in test_group_mirror_neg_case.py

### DIFF
--- a/tests/rbd_mirror/test_group_mirror_neg_case.py
+++ b/tests/rbd_mirror/test_group_mirror_neg_case.py
@@ -357,7 +357,7 @@ def test_group_mirroring_neg_case(
                     enable_group_mirroring_and_verify_state(rbd_primary, **group_config)
                     mirror_state = "Enabled"
             except Exception as e:
-                if "image is in a different pool" in str(e):
+                if "different pool" in str(e):
                     log.info(
                         "Successfully verified that group mirroring cannot be enabled "
                         "on group containing images from multiple pools"


### PR DESCRIPTION
Fail log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Regression/20.1.0-18/rbd/7/tier-2_rbd_group_mirror/Test_negative_test_cases_Consistency_Group_Mirroring_0.log

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EPZA81