### PR TITLE
adding fix for qos tests - NFS CI

### DIFF
--- a/cli/ceph/nfs/cluster/qos.py
+++ b/cli/ceph/nfs/cluster/qos.py
@@ -126,6 +126,12 @@ class Qos(Cli):
     def _execute_qos_cmd(
         self, action: str, operation: str, cluster_id: str, params: list, qos_type: str
     ) -> str:
+        # Ensure --combined-rw-bw-ctrl is not duplicated
+        if len([x for x in params if x.startswith("--combined")]) > 1:
+            params[-1] = [x for x in params if x.startswith("--combined")][-1].replace(
+                "--combined-rw-bw-ctrl ", ""
+            )
+
         cmd = " ".join(
             [self.base_cmd, action, operation, cluster_id, qos_type, " ".join(params)]
         )

--- a/cli/ceph/nfs/export/qos.py
+++ b/cli/ceph/nfs/export/qos.py
@@ -103,6 +103,12 @@ class Qos(Cli):
     def _execute_qos_cmd(
         self, action: str, operation: str, nfs_name: str, export: int, params: list
     ) -> str:
+        # Ensure --combined-rw-bw-ctrl is not duplicated
+        if len([x for x in params if x.startswith("--combined")]) > 1:
+            params[-1] = [x for x in params if x.startswith("--combined")][-1].replace(
+                "--combined-rw-bw-ctrl ", ""
+            )
+
         cmd = " ".join(
             [self.base_cmd, action, operation, nfs_name, str(export), " ".join(params)]
         )

--- a/tests/nfs/nfs_verify_qos_via_specfile_PerShare.py
+++ b/tests/nfs/nfs_verify_qos_via_specfile_PerShare.py
@@ -31,12 +31,15 @@ def run(ceph_cluster, **kw):
     port = config.get("port", "2049")
     version = config.get("nfs_version")
     nfs_server_name = nfs_nodes[0].hostname
+    subvolume_group = "ganeshagroup"
     read_bw = original_config["spec"]["cluster_qos_config"]["max_export_read_bw"]
     write_bw = original_config["spec"]["cluster_qos_config"]["max_export_write_bw"]
 
     # If the setup doesn't have required number of clients, exit.
     if no_clients > len(clients):
         raise ConfigError("The test requires more clients than available")
+
+    Ceph(clients[0]).fs.sub_volume_group.create(volume=fs_name, group=subvolume_group)
 
     clients = clients[:no_clients]  # Select only the required number of clients
     try:

--- a/tests/nfs/test_nfs_qos_on_export_level_enablement.py
+++ b/tests/nfs/test_nfs_qos_on_export_level_enablement.py
@@ -198,6 +198,14 @@ def run(ceph_cluster, **kw):
                 x["service_name"] for x in data if x.get("service_id") == cluster_name
             ]
 
+            export_data_before_restart = ceph_nfs_client.export.get(
+                nfs_name=nfs_name, nfs_export=nfs_export
+            )
+
+            log.info(
+                "export_data_before_restart: {0}".format(export_data_before_restart)
+            )
+
             # restart the service
             Ceph(client).orch.restart(service_name)
             if cluster_name not in [x["service_name"] for x in data]:


### PR DESCRIPTION
This fix is targeted for failures observed in CI for 9.0 : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Regression/20.1.0-36/nfs/23/tier1-nfs-ganesha-qos/


Problem:
In cli/ceph/nfs/cluster/qos.py(QOS library),line  129 reusulting 2 occurrence of --combined-rw-bw-ctrl  : - failing the tests

cmd in console : - ceph nfs cluster qos enable bandwidth_control cephfs-nfs PerShare_PerClient --combined-rw-bw-ctrl --max_export_combined_bw 100MB --combined-rw-bw-ctrl --max_client_combined_bw 100MB

The FIX:
On detail inspection, method _execute_qos_cmd receiving params 2 --combined-rw-bw-ctrl, So before command creation eliminating the --combined-rw-bw-ctrl in last param
 
        if len([x for x in params if x.startswith("--combined")]) > 1:
            params[-1] = [x for x in params if x.startswith("--combined")][-1].replace(
                "--combined-rw-bw-ctrl ", ""
            )


logs:
1. http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/ci_fix_qos/logs_qos_fix/
2.http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/ci_fix_qos/logs1_qos_fix/
3.http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/ci_fix_qos/logs2_qos_fix/