### PR TITLE
add support for rhel-10

### DIFF
--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -111,6 +111,10 @@ def add(cls, config: Dict) -> None:
                     "rhel-9-for-x86_64-appstream-rpms",
                     "rhel-9-for-x86_64-baseos-rpms",
                 ],
+                "10": {
+                    "rhel-10-for-x86_64-appstream-rpms",
+                    "rhel-10-for-x86_64-baseos-rpms",
+                },
             }
 
             # Collecting already enabled repos

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -367,11 +367,12 @@ def enable_rhel_rpms(ceph, distro_ver):
         "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
         "8": ["rhel-8-for-x86_64-appstream-rpms", "rhel-8-for-x86_64-baseos-rpms"],
         "9": ["rhel-9-for-x86_64-appstream-rpms", "rhel-9-for-x86_64-baseos-rpms"],
+        "10": ["rhel-10-for-x86_64-appstream-rpms", "rhel-10-for-x86_64-baseos-rpms"],
     }
 
     ceph.exec_command(sudo=True, cmd=f"subscription-manager release --set {distro_ver}")
 
-    for repo in repos.get(distro_ver[0]):
+    for repo in repos.get(distro_ver.split(".")[0]):
         ceph.exec_command(
             sudo=True,
             cmd="subscription-manager repos --enable={r}".format(r=repo),


### PR DESCRIPTION
# Description
 Add support for RHEL 10 for ceph 9.0 deployments.

As there is change on the way the distro is picked, provided the logs for both rhel-10 & rhel-9 deployments.
Pass logs: 
rhel10 logs -  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9QWF9S 
rhel9 logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-53UO0P


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
