### PR TITLE
RHCEPHQE-18628: Enable coredump collection during daemon crashes

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -1412,3 +1412,26 @@ def is_client(ceph_node):
     Return True if client node else False
     """
     return len(ceph_node.role.role_list) == 1 and "client" in ceph_node.role.role_list
+
+
+def enable_coredump(node):
+    """
+    Method to enable coredump collection
+    Refer: https://bugzilla.redhat.com/show_bug.cgi?id=2170213#c1
+    Args:
+        node: ceph node object
+    Returns:
+        None
+    """
+    log.info("Enabling coredump collection on %s" % node.hostname)
+    sys_cmds = [
+        "echo 'fs.suid_dumpable = 2' >> /etc/sysctl.conf",
+        "sysctl -p",
+        "sed -i '/DefaultLimitCORE/d' /etc/systemd/system.conf",
+        "echo 'DefaultLimitCORE=infinity' >> /etc/systemd/system.conf",
+        "systemctl daemon-reexec",
+    ]
+
+    for _cmd in sys_cmds:
+        out, err = node.exec_command(cmd=_cmd, sudo=True)
+        log.info("Out: %s \n Err: %s" % (out, err))

--- a/templates/result-email-template.html
+++ b/templates/result-email-template.html
@@ -81,7 +81,11 @@
         {% endif %}
         <tr>
             <th style="color: blue">Cluster Logs</th>
-            <td><a style="color: blue;" href="./ceph_logs">{{ prefix }}</a></td>
+            <td><a style="color: blue;" href="./ceph_logs">{{ prefix }}-cluster-logs</a></td>
+        </tr>
+        <tr>
+            <th style="color: blue">Cluster Core dumps</th>
+            <td><a style="color: blue;" href="./ceph_coredumps">{{ prefix }}-coredump</a></td>
         </tr>
         <tr>
             <th style="color: blue">Results</th>

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -4,7 +4,7 @@ import re
 import time
 
 from ceph.parallel import parallel
-from ceph.utils import config_ntp, is_client, update_ca_cert
+from ceph.utils import config_ntp, enable_coredump, is_client, update_ca_cert
 from ceph.waiter import WaitUntil
 from cli.exceptions import ConfigError
 from cli.utilities.packages import Package
@@ -278,6 +278,9 @@ def install_prereq(
         if get_service_state(ceph, "firewalld").strip() != "active":
             raise ConfigError("Firewall not active")
         log.info("Firewall is active")
+
+    # Enable coredump collection
+    enable_coredump(ceph)
 
 
 def setup_addition_repo(ceph, repo):


### PR DESCRIPTION
# Description

Jira tracker: [RHCEPHQE-18628](https://issues.redhat.com/browse/RHCEPHQE-18628)

At times we have noticed that ceph daemons crash during test execution in CI pipeline where we auto delete the cluster upon test completion
As part of test tear-down in RADOS, we currently have checks to ensure that if any crash is reported during or after the test case execution, the test is reported as failure.

In most of the cases, developers have repeatedly asked to attach the coredump whenever a bug related to daemon crash is reported. Due to the unavailability of concerned cluster and low reproducibility of complex crashes, it gets difficult to furnish these additional details.

Steps to enable coredump collection for containerized ceph deployments - https://bugzilla.redhat.com/show_bug.cgi?id=2170213#c1

- By design, coredump will be enabled on all the nodes as part of `setup install pre-requisistes` but will be collected only during pipeline failure. 
- ~~New flag `--ceph-coredump` introduced in run.py to preserve coredumps regardless of test case failure status.~~
- Custom config option `collect-coredump` added to preserve coredump even if no failure occurs
- Email template modified to include coredump location

cmd:
`python3 run.py --rhbuild 8.1 --global-conf conf/squid/rados/7-node-cluster.yaml --osp-cred /home/hakumar/osp-cred-ceph-systest.yaml --inventory conf/inventory/rhel-9-latest.yaml --suite /home/hakumar/deploy-cluster.yaml --log-level info --platform rhel-9 --skip-sos-report --build latest --store --custom-config collect-coredump=True`

Logs -
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LMNFE2/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-E10I79/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-682GT4/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
