### PR TITLE
[TFA][RADOS] Fix test cases continuing to execute post upgrade test failure

### DIFF
--- a/suites/reef/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/reef/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -135,7 +135,7 @@ tests:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       abort-on-fail: true
       config:
         command: start

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -179,7 +179,7 @@ tests:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       abort-on-fail: true
       config:
         command: start

--- a/suites/reef/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -189,7 +189,7 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
-      comments: Intermittent active bug 2277111
+      comments: Intermittent active bug 2277111, 2299659
 
   - test:
       name: Inconsistent objects in replicated pool functionality check

--- a/suites/squid/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/squid/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -136,7 +136,7 @@ tests:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -216,7 +216,7 @@ tests:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade
@@ -224,6 +224,7 @@ tests:
           verbose: true
         verify_cluster_health: true
       destroy-cluster: false
+      abort-on-fail: true
 
   # - test:
   #     name: EC Pool Recovery Improvement

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -180,7 +180,7 @@ tests:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade
@@ -188,6 +188,7 @@ tests:
           verbose: true
         verify_cluster_health: true
       destroy-cluster: false
+      abort-on-fail: true
 
 # 2+2@4 specific scenarios:
 #        scenario-1: Test the effects of bulk flag and no IO stoppage

--- a/suites/squid/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -189,7 +189,7 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
-      comments: Intermittent active bug 2277111
+      comments: Intermittent active bug 2277111, 2299659
 
   - test:
       name: Inconsistent objects in replicated pool functionality check

--- a/suites/squid/rados/tier-4_rados_tests.yaml
+++ b/suites/squid/rados/tier-4_rados_tests.yaml
@@ -158,6 +158,12 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: OSD Fragmentation tests
+      polarion-id: CEPH-83607852
+      module: test_fragmentation_warnings.py
+      desc: Generate Fragmentation on OSDs and verify health warning + logs
+
+  - test:
       name: OSD addition on an unavailable disk
       desc: Add new OSD on an pre-occupied OSD disk
       module: test_add_new_osd.py
@@ -307,9 +313,3 @@ tests:
       polarion-id: CEPH-9388
       module: test_mon_system_operations.py
       desc: Performing system tests with mon daemons
-
-  - test:
-      name: OSD Fragmentation tests
-      polarion-id: CEPH-83607852
-      module: test_fragmentation_warnings.py
-      desc: Generate Fragmentation on OSDs and verify health warning + logs

--- a/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -136,7 +136,7 @@ tests:
       name: Upgrade cluster to latest 9.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -216,7 +216,7 @@ tests:
       name: Upgrade cluster to latest 9.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade
@@ -224,6 +224,7 @@ tests:
           verbose: true
         verify_cluster_health: true
       destroy-cluster: false
+      abort-on-fail: true
 
   # - test:
   #     name: EC Pool Recovery Improvement

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -179,7 +179,7 @@ tests:
       name: Upgrade cluster to latest 9.x ceph version
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade
@@ -187,6 +187,7 @@ tests:
           verbose: true
         verify_cluster_health: true
       destroy-cluster: false
+      abort-on-fail: true
 
 # 2+2@4 specific scenarios:
 #        scenario-1: Test the effects of bulk flag and no IO stoppage

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -189,7 +189,7 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
-      comments: Intermittent active bug 2277111
+      comments: Intermittent active bug 2277111, 2299659
 
   - test:
       name: Inconsistent objects in replicated pool functionality check

--- a/suites/tentacle/rados/tier-3_rados_test_5+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_5+2_ecpools.yaml
@@ -167,7 +167,7 @@ tests:
       name: Upgrade cluster to latest 9.x ceph version (Tentacle release)
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade
@@ -175,6 +175,7 @@ tests:
           verbose: true
         verify_cluster_health: true
       destroy-cluster: false
+      abort-on-fail: true
 
 # 5+2@8 specific scenarios:
 #        scenario-1: Test the effects of bulk flag and no IO stoppage

--- a/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
@@ -165,7 +165,7 @@ tests:
       name: Upgrade cluster to latest 9.x ceph version (Tentacle release)
       desc: Upgrade cluster to latest version
       module: test_upgrade_warn.py
-      polarion-id: CEPH-83574934,CEPH-83573790
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade
@@ -173,6 +173,7 @@ tests:
           verbose: true
         verify_cluster_health: true
       destroy-cluster: false
+      abort-on-fail: true
 
   - test:
       name: EC Pool Recovery Improvement

--- a/suites/tentacle/rados/tier-4_rados_tests.yaml
+++ b/suites/tentacle/rados/tier-4_rados_tests.yaml
@@ -158,6 +158,12 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: OSD Fragmentation tests
+      polarion-id: CEPH-83607852
+      module: test_fragmentation_warnings.py
+      desc: Generate Fragmentation on OSDs and verify health warning + logs
+
+  - test:
       name: OSD addition on an unavailable disk
       desc: Add new OSD on an pre-occupied OSD disk
       module: test_add_new_osd.py
@@ -307,9 +313,3 @@ tests:
       polarion-id: CEPH-9388
       module: test_mon_system_operations.py
       desc: Performing system tests with mon daemons
-
-  - test:
-      name: OSD Fragmentation tests
-      polarion-id: CEPH-83607852
-      module: test_fragmentation_warnings.py
-      desc: Generate Fragmentation on OSDs and verify health warning + logs

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -562,9 +562,13 @@ def run(ceph_cluster, **kw):
                 log.info(test["desc"])
                 log.info(test["expectation"])
 
-                if rhbuild.startswith("8") and not (test["unmanaged"] or test["zap"]):
+                if (
+                    rhbuild
+                    and rhbuild.split(".")[0] >= "8"
+                    and not (test["unmanaged"] or test["zap"])
+                ):
                     log.info(
-                        "Skipping this Scenario as it fails in Squid. Bug: 2368108"
+                        "Skipping this Scenario as it fails in Squid and Tentacle. Bug: 2368108"
                     )
                     continue
 


### PR DESCRIPTION
PR includes:- 

1) Test case continuing to execute post failure in upgrade test suites, leading to increased Failed test case count
Fix:- Added abort-on-fail: true to upgrade tests

2) Upgrade tests having multiple Polarion ID leading to increased failed test case count 
Fix:- Removed one off the Polarion ID based on previous slack group discussion. https://ibm-systems-storage.slack.com/archives/C05CQSN4M5E/p1757660575953299 

3) Adds Bug ID to "Inconsistent objects in EC pool functionality check " Test 

4) Replacing of OSD was zapping OSDs in Tentacle. Squid BZ exists and test case commented in Squid. 
Updated the same for Tentacle. 
Fix:- Replace rhbuild.startswith("8") with rhbuild.split(".")[0] >= "8"

5) Move OSD fragmentation tests above, Since test case passes when executed post deployment. Test case was failing when executed at end. Few OSDs were left with high fragmentation due to previous Test cases

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
