### PR TITLE
Support s3 testes for tentacle

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -65,13 +65,6 @@ access_key = {{ data.alt.access_key }}
 secret_key = {{ data.alt.secret_key }}
 email = {{ data.alt.email }}
 
-[s3 tenant]
-display_name = {{ data.tenant.name }}
-user_id = {{ data.tenant.id }}
-access_key = {{ data.tenant.access_key }}
-secret_key = {{ data.tenant.secret_key }}
-email = {{ data.tenant.email }}
-
 {%- if data.iam %}
 [iam]
 display_name = {{ data.iam.name }}
@@ -106,6 +99,24 @@ secret_key = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 user_id = RGW22222222222222222
 email = account2@ceph.com
 {% endif %}
+"""
+S3CONF_TENANT = """
+[s3 tenant]
+display_name = {{ data.tenant.name }}
+user_id = {{ data.tenant.id }}
+access_key = {{ data.tenant.access_key }}
+secret_key = {{ data.tenant.secret_key }}
+email = {{ data.tenant.email }}
+"""
+
+S3CONF_TENANT_Tentacle = """
+[s3 tenant]
+display_name = {{ data.tenant.name }}
+user_id = {{ data.tenant.id }}
+access_key = {{ data.tenant.access_key }}
+secret_key = {{ data.tenant.secret_key }}
+email = {{ data.tenant.email }}
+tenant = {{ data.tenant.name }}
 """
 
 
@@ -454,6 +465,14 @@ def create_s3_conf(
 
     global S3CONF
     global S3CONF_ACC
+    global S3CONF_TENANT_Tentacle
+    global S3CONF_TENANT
+
+    if build.split(".")[0] >= "9":
+        S3CONF = S3CONF + S3CONF_TENANT_Tentacle
+    else:
+        S3CONF = S3CONF + S3CONF_TENANT
+
     if build.split(".")[0] >= "8":
         S3CONF = S3CONF + S3CONF_ACC
 


### PR DESCRIPTION
# Description

in ceph-tentacle,
there is s3 config changes required as per:
https://github.com/ceph/s3-tests/blob/ceph-tentacle/s3tests.conf.SAMPLE#L126C1-L126C15

incorporating same changes in this PR


9.0: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-JH53IX/
8.1: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-PWOR5W/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
