### PR TITLE
[Test] Add colocation test for Custom Port and IP

### DIFF
--- a/suites/tentacle/smb/tier-1-smb-colocation.yaml
+++ b/suites/tentacle/smb/tier-1-smb-colocation.yaml
@@ -77,8 +77,8 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Deploy samba with custom port
-      desc: Deploy samba with custom port
+      name: Deploy colocation samba services with custom port in active-directory
+      desc: Deploy colocation samba services with custom port in active-directory
       module: smb_deployment_declarative_method.py
       polarion-id: CEPH-83624577
       config:
@@ -98,7 +98,7 @@ tests:
               smbmetrics: 2222
               ctdb: 3333
             custom_dns:
-              - 10.70.47.236
+              - 10.70.46.228
             placement:
               label: smb
           - resource_type: ceph.smb.join.auth
@@ -124,8 +124,8 @@ tests:
               path: /
 
   - test:
-      name: Deploy samba with custom IP
-      desc: Deploy samba with custom IP
+      name: Deploy colocation samba services with custom IP in active-directory
+      desc: Deploy colocation samba services with custom IP in active-directory
       module: smb_deployment_declarative_method.py
       polarion-id: CEPH-83628046
       config:
@@ -147,7 +147,7 @@ tests:
             bind_addrs:
               - network: 10.0.64.0/22
             custom_dns:
-              - 10.70.47.236
+              - 10.70.46.228
             placement:
               label: smb
           - resource_type: ceph.smb.join.auth
@@ -155,6 +155,94 @@ tests:
             auth:
               username: Administrator
               password: Redhat@123
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+
+  - test:
+      name: Deploy colocation samba services with custom PORT in standalone
+      desc: Deploy colocation samba services with custom PORT in standalone
+      module: smb_deployment_declarative_method.py
+      polarion-id: CEPH-83628747
+      config:
+        file_type: yaml
+        file_mount: /tmp
+        spec:
+          - resource_type: ceph.smb.cluster
+            cluster_id: smb1
+            auth_mode: user
+            user_group_settings:
+              - {source_type: resource, ref: ug1}
+            custom_ports:
+              smb: 1111
+              smbmetrics: 2222
+              ctdb: 3333
+            placement:
+              label: smb
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            values:
+              users:
+                - {name: user1, password: passwd}
+              groups: []
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+
+  - test:
+      name: Deploy colocation samba services with custom IP in standalone
+      desc: Deploy colocation samba services with custom IP in standalone
+      module: smb_deployment_declarative_method.py
+      polarion-id: CEPH-83628748
+      config:
+        file_type: yaml
+        file_mount: /tmp
+        spec:
+          - resource_type: ceph.smb.cluster
+            cluster_id: smb1
+            auth_mode: user
+            user_group_settings:
+              - {source_type: resource, ref: ug1}
+            custom_ports:
+              smb: 1111
+              smbmetrics: 2222
+              ctdb: 3333
+            bind_addrs:
+              - network: 10.0.64.0/22
+            placement:
+              label: smb
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            values:
+              users:
+                - {name: user1, password: passwd}
+              groups: []
           - resource_type: ceph.smb.share
             cluster_id: smb1
             share_id: share1

--- a/tests/smb/smb_operations.py
+++ b/tests/smb/smb_operations.py
@@ -196,6 +196,7 @@ def smbclient_check_shares(
                     elif auth_mode == "user":
                         cmd = (
                             f"smbclient -U {smb_user_name}%{smb_user_password}"
+                            f" -p {smb_port} "
                             f" //{public_addr.split('/')[0]}/{smb_share} -c ls"
                         )
                         client.exec_command(
@@ -220,6 +221,7 @@ def smbclient_check_shares(
                     elif auth_mode == "user":
                         cmd = (
                             f"smbclient -U {smb_user_name}%{smb_user_password}"
+                            f" -p {smb_port} "
                             f" //{smb_node.ip_address}/{smb_share} -c ls"
                         )
                         client.exec_command(


### PR DESCRIPTION
Add test for colocation to deploy standalone SMB cluster with custom ports and custom ip.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
