### PR TITLE
CephFS Mirror - TFA - Temporary fix as referent inodes feature is delayed

### DIFF
--- a/tests/cephfs/cephfs_snapshot_management.py
+++ b/tests/cephfs/cephfs_snapshot_management.py
@@ -96,7 +96,7 @@ def run(ceph_cluster, **kw):
         )
         base_path = "/mnt/mycephfs1"
         main_file = "%s/file1" % base_path
-        if LooseVersion(ceph_version) >= LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, fs_name, enable=True
             )
@@ -168,7 +168,7 @@ def run(ceph_cluster, **kw):
             log.error("checksum is not matching after snapshot1 revert")
             return 1
 
-        if LooseVersion(ceph_version) >= LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, fs_name, enable=False
             )

--- a/tests/cephfs/snapshot_clone/clone_threads.py
+++ b/tests/cephfs/snapshot_clone/clone_threads.py
@@ -136,7 +136,7 @@ def run(ceph_cluster, **kw):
             extra_params=f" -r {subvol_path.strip()} --client_fs {default_fs}",
         )
 
-        if LooseVersion(ceph_version) >= LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, default_fs, enable=True
             )
@@ -252,7 +252,7 @@ def run(ceph_cluster, **kw):
                 )
             log.info(f"Iteration {iteration} has been completed")
 
-        if LooseVersion(ceph_version) >= LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, default_fs, enable=False
             )

--- a/tests/cephfs/snapshot_clone/snap_schedule.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule.py
@@ -121,7 +121,7 @@ def run(ceph_cluster, **kw):
             extra_params=f",fs={default_fs}",
         )
 
-        if LooseVersion(ceph_version) >= LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, default_fs, enable=True
             )
@@ -213,7 +213,7 @@ def run(ceph_cluster, **kw):
             schedule=f"1{m_granularity}",
         )
 
-        if LooseVersion(ceph_version) >= LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1"):
             ref_inode_utils.unlink_hardlinks(
                 client1, default_fs, main_file, ref_base_path
             )


### PR DESCRIPTION
# Description

Expected referent inodes feature in 9.0 and added a few scenarios to validate referent inodes.
Since the feature has been moved out of 9.0, the automation changes made are failing.
Made a temporary fix to validate referent inode beyond ceph version 20.1 - expecting the feature will be made available in the next release.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
