### PR TITLE
Add Host scenarios to disable stretch mode

### DIFF
--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
@@ -282,6 +282,19 @@ tests:
       desc: Performs tests related to reverting from stretch mode mon failure scenarios
 
   - test:
+      name: Revert stretch mode mon failure scenarios
+      module: test_stretch_revert.py
+      polarion-id: CEPH-83620057
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario10
+          - scenario11
+      desc: Performs tests related to reverting from stretch mode mon failure scenarios
+
+  - test:
       name: Netsplit detection and warning
       module: test_netsplit_detection_and_warning.py
       polarion-id: CEPH-83620060

--- a/tests/rados/test_netsplit_detection_and_warning.py
+++ b/tests/rados/test_netsplit_detection_and_warning.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.monitor_workflows import MonitorWorkflows
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from cli.utilities.operations import wait_for_cluster_health
@@ -63,12 +64,14 @@ def run(ceph_cluster, **kw):
     )
     separator = "-" * 40
     scenarios_to_run = config.get("scenarios_to_run", [])
+    mon_obj = MonitorWorkflows(node=cephadm)
     config = {
         "rados_obj": rados_obj,
         "pool_obj": pool_obj,
         "tiebreaker_mon_site_name": tiebreaker_mon_site_name,
         "stretch_bucket": stretch_bucket,
         "client_node": client_node,
+        "mon_obj": mon_obj,
     }
     try:
 

--- a/tests/rados/test_stretch_revert_class.py
+++ b/tests/rados/test_stretch_revert_class.py
@@ -98,7 +98,9 @@ class StretchMode:
             f"ceph mon enable_stretch_mode {tiebreaker_mon} stretch_rule datacenter"
         )
         if (
-            self.rados_obj.run_ceph_command(cmd=stretch_enable_cmd, print_output=True)
+            self.rados_obj.run_ceph_command(
+                cmd=stretch_enable_cmd, print_output=True, client_exec=True
+            )
             is None
         ):
             raise Exception("Failed to enable stretch mode")
@@ -164,10 +166,10 @@ class StretchMode:
         ]
         while len(dc_buckets) > 2:
             dc_buckets.pop()
-        dc_2 = dc_buckets.pop()
-        dc_2_name = dc_2["name"]
         dc_1 = dc_buckets.pop()
         dc_1_name = dc_1["name"]
+        dc_2 = dc_buckets.pop()
+        dc_2_name = dc_2["name"]
         all_hosts = get_stretch_site_hosts(
             rados_obj=self.rados_obj,
             tiebreaker_mon_site_name=self.tiebreaker_mon_site_name,
@@ -177,8 +179,12 @@ class StretchMode:
         self.tiebreaker_hosts = all_hosts.tiebreaker_hosts
         self.site_1_name = dc_1_name
         self.site_2_name = dc_2_name
-        log.debug(f"Hosts present in Datacenter : {dc_1_name} : {self.site_1_hosts}")
-        log.debug(f"Hosts present in Datacenter : {dc_2_name} : {self.site_2_hosts}")
+        log.debug(
+            f"Hosts present in Datacenter : {self.site_1_name} : {self.site_1_hosts}"
+        )
+        log.debug(
+            f"Hosts present in Datacenter : {self.site_2_name} : {self.site_2_hosts}"
+        )
         log.debug(
             f"Hosts present in Datacenter : {self.tiebreaker_mon_site_name} : { self.tiebreaker_hosts}"
         )


### PR DESCRIPTION
PR includes:- 
1)  Shut down 1 MON host in DC1 and disable stretch mode
2) Shut down 1 MON host in DC1 and 1 MON host in DC2 and  disable stretch mode
3) Stop 1 OSD and  disable stretch mode

PASS logs:- 
[revert_feature_25_10_20_22_00_28.zip](https://github.com/user-attachments/files/23012688/revert_feature_25_10_20_22_00_28.zip)
(Could not login to magna002)

Note:- PR to merge after https://github.com/red-hat-storage/cephci/pull/5291 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
