### PR TITLE
adding Ganesha logs

### DIFF
--- a/tests/nfs/nfs_client_permission_export.py
+++ b/tests/nfs/nfs_client_permission_export.py
@@ -101,5 +101,5 @@ def run(ceph_cluster, **kw):
             client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_client_addr_mount}")
             Ceph(client).nfs.export.delete(nfs_name, nfs_export_client)
 
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_edit_export_config_with_1client_access.py
+++ b/tests/nfs/nfs_edit_export_config_with_1client_access.py
@@ -181,5 +181,5 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_client)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_edit_export_config_with_access_none.py
+++ b/tests/nfs/nfs_edit_export_config_with_access_none.py
@@ -102,5 +102,5 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_access_none)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_edit_export_config_with_ro.py
@@ -140,5 +140,5 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_readonly)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_export_rootsquash_windows.py
+++ b/tests/nfs/nfs_export_rootsquash_windows.py
@@ -128,5 +128,7 @@ def run(ceph_cluster, **kw):
         Ceph(linux_clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(linux_clients[0], nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients[0], nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_failover_with_rm_operation_windows.py
+++ b/tests/nfs/nfs_failover_with_rm_operation_windows.py
@@ -141,4 +141,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_file_append.py
+++ b/tests/nfs/nfs_file_append.py
@@ -82,5 +82,5 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_file_truncate.py
+++ b/tests/nfs/nfs_file_truncate.py
@@ -81,5 +81,5 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_ha_client_update_permission_windows.py
+++ b/tests/nfs/nfs_ha_client_update_permission_windows.py
@@ -160,4 +160,6 @@ def run(ceph_cluster, **kw):
         log.info("Cleanup")
         cmd = f"umount {window_nfs_mount}"
         windows_clients[1].exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_ha_export_delete_windows.py
+++ b/tests/nfs/nfs_ha_export_delete_windows.py
@@ -154,4 +154,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_ha_failover_delete_export.py
+++ b/tests/nfs/nfs_ha_failover_delete_export.py
@@ -2,7 +2,7 @@ import json
 from threading import Thread
 from time import sleep
 
-from nfs_operations import perform_failover
+from nfs_operations import nfs_log_parser, perform_failover
 
 from cli.ceph.ceph import Ceph
 from cli.exceptions import ConfigError, OperationFailedError
@@ -118,6 +118,7 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
+        nfs_log_parser(client=clients[0], nfs_node=nfs_nodes, nfs_name=servers)
         Ceph(clients[0]).nfs.cluster.delete(nfs_name)
         # Delete the subvolume
         for i in range(len(clients)):

--- a/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
@@ -131,5 +131,5 @@ def run(ceph_cluster, **kw):
             log.info("Removing nfs-ganesha client addr dir on client:")
             client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_client_mount}")
             Ceph(client).nfs.export.delete(nfs_name, nfs_export_client)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
@@ -147,5 +147,5 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_readonly)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_ha_failover_with_untar.py
+++ b/tests/nfs/nfs_ha_failover_with_untar.py
@@ -88,5 +88,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(100)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_ha_readdir_operation.py
+++ b/tests/nfs/nfs_ha_readdir_operation.py
@@ -150,5 +150,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(100)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_ha_reboot_with_file_modify.py
+++ b/tests/nfs/nfs_ha_reboot_with_file_modify.py
@@ -133,4 +133,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_hard_links_delete_file.py
+++ b/tests/nfs/nfs_hard_links_delete_file.py
@@ -91,5 +91,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -89,5 +89,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_hard_symbolic_links_rename.py
+++ b/tests/nfs/nfs_hard_symbolic_links_rename.py
@@ -105,5 +105,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_multi_mount_version_4x.py
+++ b/tests/nfs/nfs_multi_mount_version_4x.py
@@ -69,4 +69,4 @@ def run(ceph_cluster, **kw):
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_multiple_xattr_set_and_delete.py
+++ b/tests/nfs/nfs_multiple_xattr_set_and_delete.py
@@ -117,5 +117,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_multivolume_rootsquash.py
+++ b/tests/nfs/nfs_multivolume_rootsquash.py
@@ -163,5 +163,7 @@ def run(ceph_cluster, **kw):
         Ceph(linux_clients[0]).nfs.export.delete(nfs_name, nfs_export2)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(linux_clients[0], nfs_mount1, nfs_name, nfs_export1)
+        cleanup_cluster(
+            linux_clients[0], nfs_mount1, nfs_name, nfs_export1, nfs_nodes=servers
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
+++ b/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
@@ -118,4 +118,6 @@ def run(ceph_cluster, **kw):
         # Cleanup
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_rootsquash_using_conf.py
+++ b/tests/nfs/nfs_rootsquash_using_conf.py
@@ -146,5 +146,7 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients[0], nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients[0], nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
+++ b/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
@@ -105,5 +105,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_spec_storage.py
+++ b/tests/nfs/nfs_spec_storage.py
@@ -64,5 +64,5 @@ def run(ceph_cluster, **kw):
     finally:
         sleep(30)
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_test_allocation_beyond_size.py
+++ b/tests/nfs/nfs_test_allocation_beyond_size.py
@@ -73,5 +73,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_test_multiple_filesystem_exports.py
+++ b/tests/nfs/nfs_test_multiple_filesystem_exports.py
@@ -165,5 +165,7 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         cleanup_exports_and_filesystems(clients[0])
-        cleanup_cluster(clients[0], "/mnt/nfs", "cephfs-nfs", "/export")
+        cleanup_cluster(
+            clients[0], "/mnt/nfs", "cephfs-nfs", "/export", nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleanup successful")

--- a/tests/nfs/nfs_test_remount_windows.py
+++ b/tests/nfs/nfs_test_remount_windows.py
@@ -101,4 +101,6 @@ def run(ceph_cluster, **kw):
         # Cleanup
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes
+        )

--- a/tests/nfs/nfs_test_selinux_context_moving_files.py
+++ b/tests/nfs/nfs_test_selinux_context_moving_files.py
@@ -136,5 +136,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_test_setting_selinux_context.py
+++ b/tests/nfs/nfs_test_setting_selinux_context.py
@@ -71,5 +71,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_test_space_allocation_diff_sizes.py
+++ b/tests/nfs/nfs_test_space_allocation_diff_sizes.py
@@ -95,5 +95,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_test_xattr_across_file_operations.py
+++ b/tests/nfs/nfs_test_xattr_across_file_operations.py
@@ -110,5 +110,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_validate_cmount_path_export_conf.py
+++ b/tests/nfs/nfs_validate_cmount_path_export_conf.py
@@ -65,5 +65,7 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_bonnie.py
+++ b/tests/nfs/nfs_verify_bonnie.py
@@ -77,5 +77,7 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
+++ b/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
@@ -123,4 +123,6 @@ def run(ceph_cluster, **kw):
         # Cleanup
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_failover_with_file_ops.py
+++ b/tests/nfs/nfs_verify_failover_with_file_ops.py
@@ -134,4 +134,4 @@ def run(ceph_cluster, **kw):
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_verify_failover_with_io.py
+++ b/tests/nfs/nfs_verify_failover_with_io.py
@@ -80,4 +80,4 @@ def run(ceph_cluster, **kw):
         log.error(f"Failed to perform faiolver while IO in progress. Error: {e}")
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
+++ b/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
@@ -116,4 +116,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_file_access_with_rootsquash.py
+++ b/tests/nfs/nfs_verify_file_access_with_rootsquash.py
@@ -92,5 +92,5 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_file_lock.py
+++ b/tests/nfs/nfs_verify_file_lock.py
@@ -139,5 +139,5 @@ def run(ceph_cluster, **kw):
         client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_lock_mount}")
     Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_lock_export)
 
-    cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+    cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
     return 0

--- a/tests/nfs/nfs_verify_file_lock_ha.py
+++ b/tests/nfs/nfs_verify_file_lock_ha.py
@@ -158,5 +158,5 @@ def run(ceph_cluster, **kw):
         log.info("Removing nfs-ganesha lock mount dir on client:")
         client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_lock_mount}")
     Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_lock_export)
-    cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+    cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
     return 0

--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -193,5 +193,5 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_file_modification.py
+++ b/tests/nfs/nfs_verify_file_modification.py
@@ -101,5 +101,5 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_file_operations.py
+++ b/tests/nfs/nfs_verify_file_operations.py
@@ -118,7 +118,7 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")
     return 0
 

--- a/tests/nfs/nfs_verify_file_ops_hard_links.py
+++ b/tests/nfs/nfs_verify_file_ops_hard_links.py
@@ -85,5 +85,5 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_file_ops_soft_links.py
+++ b/tests/nfs/nfs_verify_file_ops_soft_links.py
@@ -109,5 +109,5 @@ def run(ceph_cluster, **kw):
         log.error(f"Error : {e}")
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_ha_readonly_windows.py
+++ b/tests/nfs/nfs_verify_ha_readonly_windows.py
@@ -143,4 +143,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_hard_links_inode.py
+++ b/tests/nfs/nfs_verify_hard_links_inode.py
@@ -85,5 +85,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
+++ b/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
@@ -105,4 +105,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
+++ b/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
@@ -103,4 +103,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
+++ b/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
@@ -103,4 +103,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_multi_client_failover_windows.py
+++ b/tests/nfs/nfs_verify_multi_client_failover_windows.py
@@ -98,4 +98,6 @@ def run(ceph_cluster, **kw):
         # Cleanup
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
+++ b/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
@@ -113,4 +113,6 @@ def run(ceph_cluster, **kw):
         # Cleanup
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
+++ b/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
@@ -92,5 +92,5 @@ def run(ceph_cluster, **kw):
         log.error(f"Failed to validate nfs dir operations and permission checks : {e}")
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_multi_mount_version.py
+++ b/tests/nfs/nfs_verify_multi_mount_version.py
@@ -70,4 +70,4 @@ def run(ceph_cluster, **kw):
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_verify_multi_node_cluster.py
+++ b/tests/nfs/nfs_verify_multi_node_cluster.py
@@ -72,5 +72,11 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients,
+            nfs_mount,
+            nfs_name,
+            nfs_export,
+            nfs_nodes=nfs_nodes[:no_cluster_nodes],
+        )
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
+++ b/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
@@ -96,5 +96,7 @@ def run(ceph_cluster, **kw):
             import time
 
             time.sleep(20)
-            cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+            cleanup_cluster(
+                clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+            )
             log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_nfs_ha.py
+++ b/tests/nfs/nfs_verify_nfs_ha.py
@@ -62,4 +62,4 @@ def run(ceph_cluster, **kw):
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_verify_nfs_kill_process_failover.py
+++ b/tests/nfs/nfs_verify_nfs_kill_process_failover.py
@@ -102,4 +102,4 @@ def run(ceph_cluster, **kw):
         )
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
+++ b/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
@@ -95,5 +95,7 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -82,5 +82,5 @@ def run(ceph_cluster, **kw):
         return 1
 
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_pynfs_ha.py
+++ b/tests/nfs/nfs_verify_pynfs_ha.py
@@ -96,5 +96,5 @@ def run(ceph_cluster, **kw):
         return 1
 
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_qos_via_specfile_PerShare.py
+++ b/tests/nfs/nfs_verify_qos_via_specfile_PerShare.py
@@ -115,5 +115,5 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_read_write_operations.py
+++ b/tests/nfs/nfs_verify_read_write_operations.py
@@ -176,5 +176,5 @@ def run(ceph_cluster, **kw):
         log.error(f"Failed to validate read write operations : {e}")
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_readdir_operation.py
+++ b/tests/nfs/nfs_verify_readdir_operation.py
@@ -129,4 +129,6 @@ def run(ceph_cluster, **kw):
     finally:
         # Cleanup
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export1)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export1, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -89,5 +89,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(30)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_scale.py
+++ b/tests/nfs/nfs_verify_scale.py
@@ -170,5 +170,5 @@ def run(ceph_cluster, **kw):
                     )
                 log.info("Removing nfs-ganesha mount dir on client:")
                 client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_mounting_dir}")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -195,4 +195,6 @@ def run(ceph_cluster, **kw):
             log.info("Removing nfs-ganesha squash mount dir on client:")
             client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_squash_mount}")
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )

--- a/tests/nfs/nfs_verify_stress.py
+++ b/tests/nfs/nfs_verify_stress.py
@@ -108,5 +108,5 @@ def run(ceph_cluster, **kw):
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
         pass

--- a/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
+++ b/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
@@ -80,5 +80,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_symbolic_links_permissions.py
+++ b/tests/nfs/nfs_verify_symbolic_links_permissions.py
@@ -80,5 +80,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_symbolic_links_users.py
+++ b/tests/nfs/nfs_verify_symbolic_links_users.py
@@ -79,5 +79,5 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_v3_mount_window_linux.py
+++ b/tests/nfs/nfs_verify_v3_mount_window_linux.py
@@ -103,4 +103,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
+++ b/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
@@ -108,4 +108,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_windows_client.py
+++ b/tests/nfs/nfs_verify_windows_client.py
@@ -87,4 +87,4 @@ def run(ceph_cluster, **kw):
         # Unmount windows mount
         cmd = r"umount Z:"
         execute_command_on_windows_node(win_clients[0], cmd)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/nfs_verify_windows_parallel_readdir.py
+++ b/tests/nfs/nfs_verify_windows_parallel_readdir.py
@@ -116,4 +116,6 @@ def run(ceph_cluster, **kw):
             windows_client.exec_command(cmd=cmd)
             cmd = f"umount {window_nfs_mount}"
             windows_client.exec_command(cmd=cmd)
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/nfs_verify_xattr_readonly_file.py
+++ b/tests/nfs/nfs_verify_xattr_readonly_file.py
@@ -91,5 +91,5 @@ def run(ceph_cluster, **kw):
         for i in range(1, 3):
             cmd = f"userdel Test{i}"
             clients[0].exec_command(cmd=cmd, sudo=True)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/test_earmark_feature.py
+++ b/tests/nfs/test_earmark_feature.py
@@ -1,7 +1,7 @@
 from time import sleep
 
 from cli.ceph.ceph import Ceph
-from tests.nfs.nfs_operations import check_nfs_daemons_removed
+from tests.nfs.nfs_operations import check_nfs_daemons_removed, nfs_log_parser
 from tests.nfs.nfs_test_multiple_filesystem_exports import create_nfs_export
 from utility.log import Log
 
@@ -121,6 +121,7 @@ def run(ceph_cluster, **kw):
             volume=fs_name, subvolume=subvolume_name, group=subvolume_group
         )
         log.info(f"Removed the subvolume {subvolume_name} from group {subvolume_group}")
+        nfs_log_parser(clients[0], nfs_name, nfs_node)
         Ceph(clients[0]).nfs.cluster.delete(nfs_name)
         sleep(30)
         check_nfs_daemons_removed(clients[0])

--- a/tests/nfs/test_export_readonly.py
+++ b/tests/nfs/test_export_readonly.py
@@ -108,5 +108,7 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_readonly)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients[0], nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients[0], nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/test_export_rootsquash.py
+++ b/tests/nfs/test_export_rootsquash.py
@@ -130,5 +130,7 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients[0], nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients[0], nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/test_file_ops_copy.py
+++ b/tests/nfs/test_file_ops_copy.py
@@ -127,5 +127,7 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/test_file_ops_renames.py
+++ b/tests/nfs/test_file_ops_renames.py
@@ -139,5 +139,7 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/test_nfs_export_readonly_windows.py
+++ b/tests/nfs/test_nfs_export_readonly_windows.py
@@ -123,4 +123,6 @@ def run(ceph_cluster, **kw):
         # Cleanup
         log.info("Cleanup")
         linux_clients[0].exec_command(sudo=True, cmd=f"rm -rf  {nfs_mount}/*")
-        cleanup_cluster(linux_clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            linux_clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers
+        )

--- a/tests/nfs/test_nfs_extended_attribute_rootsquash.py
+++ b/tests/nfs/test_nfs_extended_attribute_rootsquash.py
@@ -138,5 +138,7 @@ def run(ceph_cluster, **kw):
             )
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients[0], nfs_mount1, nfs_name, nfs_export1)
+        cleanup_cluster(
+            clients[0], nfs_mount1, nfs_name, nfs_export1, nfs_nodes=nfs_node
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/test_nfs_get_set_attr_operation.py
+++ b/tests/nfs/test_nfs_get_set_attr_operation.py
@@ -86,5 +86,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
+++ b/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
@@ -328,4 +328,6 @@ def run(ceph_cluster, **kw):
     finally:
         if operation == "after_upgrade":
             # Cleanup NFS Cluster
-            cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+            cleanup_cluster(
+                clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node
+            )

--- a/tests/nfs/test_nfs_partial_deallocation.py
+++ b/tests/nfs/test_nfs_partial_deallocation.py
@@ -86,11 +86,11 @@ def run(ceph_cluster, **kw):
         log.error(
             f"Failed to  verify the partial space deallocation test on NFS v4.2 : {e}"
         )
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")
         return 1
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/test_nfs_qos_on_cluster_level_enablement.py
+++ b/tests/nfs/test_nfs_qos_on_cluster_level_enablement.py
@@ -355,4 +355,4 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleanup in progress")
         log.debug("deleting NFS cluster {0}".format(cluster_name))
-        cleanup_cluster(client, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(client, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)

--- a/tests/nfs/test_nfs_qos_on_export_level_enablement.py
+++ b/tests/nfs/test_nfs_qos_on_export_level_enablement.py
@@ -333,4 +333,4 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleanup in progress")
         log.debug("deleting NFS cluster {0}".format(cluster_name))
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)

--- a/tests/nfs/test_nfs_qos_update_on_export_level_pershare.py
+++ b/tests/nfs/test_nfs_qos_update_on_export_level_pershare.py
@@ -224,4 +224,4 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleanup in progress")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)

--- a/tests/nfs/test_nfs_qos_update_on_export_level_pershare_perclient.py
+++ b/tests/nfs/test_nfs_qos_update_on_export_level_pershare_perclient.py
@@ -290,4 +290,4 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Cleanup in progress")
         log.debug(f"Deleting NFS cluster {cluster_name}")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes)

--- a/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
+++ b/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
@@ -105,5 +105,7 @@ def run(ceph_cluster, **kw):
             Ceph(client).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/test_nfs_selinux_context_symlinks.py
+++ b/tests/nfs/test_nfs_selinux_context_symlinks.py
@@ -91,5 +91,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")

--- a/tests/nfs/test_nfs_selinux_label_while_mounting.py
+++ b/tests/nfs/test_nfs_selinux_label_while_mounting.py
@@ -104,5 +104,5 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleaning up")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")


### PR DESCRIPTION
This code will collect ganesha logs and conf file, at the end of the test cases. it will help CI triage to analyse. in failures quickly

Main logic is in nfs_log_parser  -> nfs_operataions.py ,
added nfs_log_parser in cluster cleanup method.  Since this required 1 more parameter. i have updated all the files

logs: 
http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/misc/ganesha_logs/log_log/

  