### PR TITLE
[CephFS][RHEL-10] Support for kernel tests 

### DIFF
--- a/tests/cephfs/cephfs_snapshot_management.py
+++ b/tests/cephfs/cephfs_snapshot_management.py
@@ -96,7 +96,7 @@ def run(ceph_cluster, **kw):
         )
         base_path = "/mnt/mycephfs1"
         main_file = "%s/file1" % base_path
-        if LooseVersion(ceph_version) > LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, fs_name, enable=True
             )
@@ -168,15 +168,25 @@ def run(ceph_cluster, **kw):
             log.error("checksum is not matching after snapshot1 revert")
             return 1
 
-        if LooseVersion(ceph_version) > LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, fs_name, enable=False
             )
 
+        log.info(f"Testcase {tc1} passed")
+        return 0
+
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+
+    finally:
+        log.info("cleanup the system")
+
         log.info("unmount the drive")
         client1.exec_command(sudo=True, cmd="fusermount -u /mnt/mycephfs1")
 
-        log.info("cleanup the system")
         commands = [
             f"ceph fs subvolume snapshot rm {fs_name} snap_vol snap_1 --group_name snap_group",
             f"ceph fs subvolume snapshot rm {fs_name} snap_vol snap_2 --group_name snap_group",
@@ -188,15 +198,3 @@ def run(ceph_cluster, **kw):
         ]
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)
-            results.append(f"{command} successfully executed")
-
-        log.info(f"Execution of testcase {tc1} ended")
-        log.info("Testcase Results:")
-        for res in results:
-            log.info(res)
-        return 0
-
-    except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
-        return 1

--- a/tests/cephfs/kernel_update.py
+++ b/tests/cephfs/kernel_update.py
@@ -109,7 +109,7 @@ def run(ceph_cluster, **kw):
                 kernel_cmds.append(kernel_core_package)
                 kernel_cmds.append(kernel_modules_package)
                 kernel_cmds.append(url + kernel_package)
-            if "rhel-9" in url:
+            else:
                 kernel_package = url.split("/")[-1]
                 url = url.strip(kernel_package)
                 kernel_modules_core = "kernel-modules-core" + kernel_package.strip(

--- a/tests/cephfs/lib/xfs_lib/xfs_utils.py
+++ b/tests/cephfs/lib/xfs_lib/xfs_utils.py
@@ -62,6 +62,12 @@ class XfsTestSetup:
                 sudo=True,
                 cmd="subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms",
             )
+        elif 'VERSION_ID="10' in rhel_version:
+            epel_cmd = "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm"
+            self.client.exec_command(
+                sudo=True,
+                cmd="subscription-manager repos --enable codeready-builder-for-rhel-10-$(arch)-rpms",
+            )
         else:
             log.error("Unsupported RHEL version")
             return 1

--- a/tests/cephfs/snapshot_clone/clone_threads.py
+++ b/tests/cephfs/snapshot_clone/clone_threads.py
@@ -136,7 +136,7 @@ def run(ceph_cluster, **kw):
             extra_params=f" -r {subvol_path.strip()} --client_fs {default_fs}",
         )
 
-        if LooseVersion(ceph_version) > LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, default_fs, enable=True
             )
@@ -252,7 +252,7 @@ def run(ceph_cluster, **kw):
                 )
             log.info(f"Iteration {iteration} has been completed")
 
-        if LooseVersion(ceph_version) > LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, default_fs, enable=False
             )

--- a/tests/cephfs/snapshot_clone/snap_schedule.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule.py
@@ -121,7 +121,7 @@ def run(ceph_cluster, **kw):
             extra_params=f",fs={default_fs}",
         )
 
-        if LooseVersion(ceph_version) > LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1.1"):
             ref_inode_utils.allow_referent_inode_feature_enablement(
                 client1, default_fs, enable=True
             )
@@ -213,7 +213,7 @@ def run(ceph_cluster, **kw):
             schedule=f"1{m_granularity}",
         )
 
-        if LooseVersion(ceph_version) > LooseVersion("20.1"):
+        if LooseVersion(ceph_version) > LooseVersion("20.1.1"):
             ref_inode_utils.unlink_hardlinks(
                 client1, default_fs, main_file, ref_base_path
             )


### PR DESCRIPTION
# Description

This PR includes

- Fixes related to RHEL-10 for Kernel suites
- Fixe related to Looseversion for Referrent inodes

## Changes

- tests/cephfs/cephfs_bugs/test_fsstress_on_kernel_and_fuse.py (Generalise the client variable to switch between clients)
- tests/cephfs/cephfs_snapshot_management.py (Fix Loose version to exclude tentacle for enabling referrent inode)
- tests/cephfs/cephfs_snapshot_management.py (Handle cleanup in finally block instead of try)
- tests/cephfs/kernel_update.py (Added else block instead of rhel-9 specific as there is no specific diff between 9 & 10)
- tests/cephfs/lib/xfs_lib/xfs_utils.py (Included logic for RHEL-10)

## Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/IBMCEPHQE-311/

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
