### PR TITLE
TFA fix for fscrypt script

### DIFF
--- a/tests/cephfs/cephfs_fscrypt/test_fscrypt_negative.py
+++ b/tests/cephfs/cephfs_fscrypt/test_fscrypt_negative.py
@@ -270,6 +270,8 @@ def fscrypt_key_remove_diff_clients(fscrypt_test_params):
     }
     log.info("Mount the same subvolume %s in client2", sv_name)
     mnt_pt_2, _ = cephfs_common_utils.mount_ceph("fuse", mount_params)
+    if fscrypt_util.setup(mnt_client_2, mnt_pt_2):
+        return 1
     encrypt_info = fscrypt_util.encrypt_dir_setup(mount_details)
     encrypt_path_1 = encrypt_info[sv_name]["path"]
     encrypt_params = encrypt_info[sv_name]["encrypt_params"]

--- a/tests/cephfs/lib/fscrypt_utils.py
+++ b/tests/cephfs/lib/fscrypt_utils.py
@@ -106,6 +106,7 @@ class FscryptUtils(object):
             return 0
         except BaseException as ex:
             if "command not found" in str(ex):
+                log.error(ex)
                 return 1
 
     def setup(self, client, mnt_pt, validate=True):


### PR DESCRIPTION
# Description

JIRA: https://jsw.ibm.com/browse/IBMCEPHQE-329

Failed logs: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-282/cephfs/135/8_1_features_suite/fscrypt_negative_0.log
fscrypt was not setup on corresponding client, its script issue, fixed it

Passed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YTZF61/snapshot_visibility_basic_0.log


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
