### PR TITLE
[Tentacle][SMB][grpc][Automation]Add new gRPC scenarios

### DIFF
--- a/suites/tentacle/smb/tier-1-grpc.yaml
+++ b/suites/tentacle/smb/tier-1-grpc.yaml
@@ -1,0 +1,168 @@
+tests:
+  - test:
+      name: setup pre-requisites
+      desc: Install software pre-requisites for cluster deployment
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Deploy cluster using cephadm
+      desc: Bootstrap and deploy services
+      module: test_cephadm.py
+      polarion-id: CEPH-83573713
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: configure client
+      desc: Configure client system
+      module: test_client.py
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - samba-client
+          - cifs-utils
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Test create SMB cluster with mTLS enabled to set up the remote control server.
+      desc: Test create SMB cluster with mTLS enabled to set up the remote control server.
+      module: smb_grpc_setup.py
+      polarion-id: CEPH-83627778
+      config:
+        file_type: yaml
+        file_mount: /tmp
+        spec:
+          - resource_type: ceph.smb.cluster
+            cluster_id: smb1
+            auth_mode: user
+            user_group_settings:
+              - { source_type: resource, ref: ug1 }
+            placement:
+              label: smb
+            remote_control:
+              cert: { ref: cert1 }
+              key: { ref: key1 }
+              ca_cert: { ref: cacert1 }
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            values:
+              users:
+                - { name: user1, password: passwd }
+              groups: [ ]
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+
+  - test:
+      name: Test grpcurl command to describe all the gRPC Service calls.
+      desc: Test grpcurl command to describe all the gRPC Service calls.
+      module: smb_grpc_operations.py
+      polarion-id: CEPH-83627779
+      config:
+        smb_cluster_id: smb1
+        grpc_operation: describe_all_service_calls
+
+  - test:
+      name: Test grpcurl command to show samba and container Info.
+      desc: Test grpcurl command to show samba and container Info.
+      module: smb_grpc_operations.py
+      polarion-id: CCEPH-83627781
+      config:
+        smb_cluster_id: smb1
+        grpc_operation: service_info
+
+  - test:
+      name: Test grpcurl command to list connected clients Status, when no client is connected.
+      desc: Test grpcurl command to list connected clients Status, when no client is connected.
+      module: smb_grpc_operations.py
+      polarion-id: CEPH-83631059
+      config:
+        smb_cluster_id: smb1
+        grpc_operation: status_when_no_clients
+
+  - test:
+      name: Test grpcurl command to list connected clients Status, when client is connected.
+      desc: Test grpcurl command to list connected clients Status, when linux client is connected.
+      module: smb_grpc_operations.py
+      olarion-id: CCEPH-83631060
+      config:
+        smb_cluster_id: smb1
+        cifs_mount_point: /mnt/smb
+        grpc_operation: status_with_linux_client
+
+  - test:
+      name: Test grpcurl command to kill specific client connection.
+      desc: Test grpcurl command to kill specific linux client connection.
+      module: smb_grpc_operations.py
+      polarion-id: CEPH-83627783
+      config:
+        smb_cluster_id: smb1
+        grpc_operation: kill_linux_client
+        smb_cluster_cleanup: true

--- a/tests/smb/smb_grpc_operations.py
+++ b/tests/smb/smb_grpc_operations.py
@@ -1,0 +1,150 @@
+from smb_operations import (
+    check_smb_cluster,
+    get_smb_shares,
+    smb_cifs_mount,
+    smb_cleanup,
+    verify_smb_service,
+)
+
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Deploy samba with auth_mode 'user' using imperative style(CLI Commands)
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    # Get config
+    config = kw.get("config")
+
+    # Get installer node
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
+
+    # Get smb nodes
+    smb_nodes = ceph_cluster.get_nodes("smb")
+
+    # Get client node
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    # Get gRPC operations to perform
+    grpc_operation = config.get("grpc_operation")
+
+    # Get smb cluster id
+    smb_cluster_id = config.get("smb_cluster_id")
+
+    # Check smb cluster
+    check_smb_cluster(installer_node, smb_cluster_id)
+
+    # Check smb service
+    verify_smb_service(installer_node, service_name="smb")
+
+    # Get smb shares
+    smb_shares = get_smb_shares(installer_node, smb_cluster_id)
+    log.info("smb_shares: {}".format(smb_shares))
+    print(type(smb_shares))
+
+    # Get auth_mode
+    auth_mode = config.get("auth_mode", "user")
+
+    # Get domain_realm
+    domain_realm = config.get("domain_realm", None)
+
+    # Get smb user name
+    smb_user_name = config.get("smb_user_name", "user1")
+
+    # Get smb user password
+    smb_user_password = config.get("smb_user_password", "passwd")
+
+    # Get cifs mount point
+    cifs_mount_point = config.get("cifs_mount_point", "/mnt/smb")
+
+    # Get cleanup value, True if cleanup has to be done, False by default
+    smb_cluster_cleanup = config.get("smb_cluster_cleanup", False)
+
+    try:
+        if grpc_operation == "describe_all_service_calls":
+            cmd = (
+                "cd sambacc && grpcurl -import-path sambacc/grpc/protobufs/ -proto control.proto "
+                "describe SambaControl"
+            )
+            out = installer_node.exec_command(sudo=True, cmd=cmd)
+            log.info("Describe Samba Control : {}".format(out))
+
+        elif grpc_operation == "service_info":
+            cmd = (
+                f"cd sambacc && grpcurl -cacert /root/grpc_ca.ca -cert /root/grpc_cert.crt  -key /root/grpc_key.key "
+                f"-import-path sambacc/grpc/protobufs/ "
+                f"-proto control.proto  {installer_node.ip_address}:54445  SambaControl/Info"
+            )
+            out = installer_node.exec_command(sudo=True, cmd=cmd)
+            log.info("Print Samba and container Info Samba Control : {}".format(out))
+
+        elif grpc_operation == "status_when_no_clients":
+            cmd = (
+                f"cd sambacc && grpcurl -cacert /root/grpc_ca.ca -cert /root/grpc_cert.crt  -key /root/grpc_key.key "
+                f"-import-path sambacc/grpc/protobufs/ "
+                f"-proto control.proto  {installer_node.ip_address}:54445  SambaControl/Status"
+            )
+            out = installer_node.exec_command(sudo=True, cmd=cmd)
+            log.info("grpcurl status : {}".format(out))
+
+        elif grpc_operation == "status_with_linux_client":
+            # Mount smb share with cifs
+            smb_cifs_mount(
+                smb_nodes[0],
+                client,
+                smb_shares[0],
+                smb_user_name,
+                smb_user_password,
+                auth_mode,
+                domain_realm,
+                cifs_mount_point,
+            )
+            cmd = (
+                f"cd sambacc && grpcurl -cacert /root/grpc_ca.ca -cert /root/grpc_cert.crt  -key /root/grpc_key.key "
+                f"-import-path sambacc/grpc/protobufs/ "
+                f"-proto control.proto  {installer_node.ip_address}:54445  SambaControl/Status"
+            )
+            out = installer_node.exec_command(sudo=True, cmd=cmd)
+            log.info("grpcurl status : {}".format(out))
+            client.exec_command(
+                sudo=True,
+                cmd=f"umount {cifs_mount_point}",
+            )
+            client.exec_command(sudo=True, cmd=f"rm -rf {cifs_mount_point}")
+        elif grpc_operation == "kill_linux_client":
+            # Mount smb share with cifs
+            smb_cifs_mount(
+                smb_nodes[0],
+                client,
+                smb_shares[0],
+                smb_user_name,
+                smb_user_password,
+                auth_mode,
+                domain_realm,
+                cifs_mount_point,
+            )
+            cmd = (
+                f"cd sambacc && grpcurl -cacert /root/grpc_ca.ca -cert /root/grpc_cert.crt  -key /root/grpc_key.key "
+                f"-import-path sambacc/grpc/protobufs/ -proto control.proto "
+                f'-d \'{{"ip_address": "{client.ip_address}"}}\' {installer_node.ip_address}:54445 '
+                f"SambaControl/KillClientConnection"
+            )
+            out = installer_node.exec_command(sudo=True, cmd=cmd)
+            log.info("grpcurl status : {}".format(out))
+            client.exec_command(
+                sudo=True,
+                cmd=f"umount {cifs_mount_point}",
+            )
+            client.exec_command(sudo=True, cmd=f"rm -rf {cifs_mount_point}")
+
+    except Exception as e:
+        log.error(f"Failed to perform gRPC operations {grpc_operation} : {e}")
+        return 1
+    finally:
+        if smb_cluster_cleanup:
+            smb_cleanup(installer_node, smb_shares, smb_cluster_id)
+
+    return 0

--- a/tests/smb/smb_grpc_setup.py
+++ b/tests/smb/smb_grpc_setup.py
@@ -1,0 +1,229 @@
+from smb_operations import deploy_smb_service_declarative, smbclient_check_shares
+
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+from utility.utils import generate_self_signed_certificate
+
+log = Log(__name__)
+
+
+def generate_self_signed_certificate_for_smb_node(installer_node):
+    """Generate self signed certificates for samba node
+    Args:
+        installer_node (obj): samba server node installer node obj
+    """
+    subject = {
+        "common_name": installer_node.hostname,
+        "ip_address": installer_node.ip_address,
+    }
+    key, cert, ca = generate_self_signed_certificate(subject=subject)
+
+    key_file = installer_node.remote_file(
+        sudo=True, file_name="grpc_key.key", file_mode="w+"
+    )
+    key_file.write(key)
+    key_file.flush()
+    cert_file = installer_node.remote_file(
+        sudo=True, file_name="grpc_cert.crt", file_mode="w+"
+    )
+    cert_file.write(cert)
+    cert_file.flush()
+    ca_file = installer_node.remote_file(
+        sudo=True, file_name="grpc_ca.ca", file_mode="w+"
+    )
+    ca_file.write(ca)
+    ca_file.flush()
+    return key, cert, ca
+
+
+def install_grpcurl(smb_node):
+    """Install grpcurl package"""
+    log.info("install grpcurl package")
+    wget_cmd = (
+        "curl -LO "
+        "https://github.com/fullstorydev/grpcurl/releases/download/v1.8.9/grpcurl_1.8.9_linux_x86_64.tar.gz"
+    )
+
+    tar_cmd = "tar -xvzf grpcurl_1.8.9_linux_x86_64.tar.gz"
+    chmod_cmd = "chmod +x grpcurl"
+    rename_cmd = "sudo mv grpcurl /usr/local/bin/"
+    version_cmd = "grpcurl --version"
+    out = smb_node.exec_command(sudo=True, cmd=wget_cmd)
+    log.info(out)
+    smb_node.exec_command(
+        sudo=True,
+        cmd=f"{tar_cmd} && {chmod_cmd} && {rename_cmd}",
+    )
+    out = smb_node.exec_command(
+        sudo=True,
+        cmd=version_cmd,
+    )
+    log.info(out)
+    if "grpcurl" not in out[1]:
+        raise Exception("grpcurl not installed")
+
+
+def clone_the_samba_in_kubernetes_repo(node):
+    """clone the repo on to the node.
+
+    Args:
+        node (obj): ceph node
+    """
+    log.info("cloning the https://github.com/samba-in-kubernetes/sambacc.git repo")
+    git_clone_cmd = "git clone https://github.com/samba-in-kubernetes/sambacc.git"
+    node.exec_command(cmd=git_clone_cmd, sudo=True)
+
+
+def check_remotectl_service(smb_node):
+    """Check if grpc remotectl service is running
+    Args:
+        smb_node (obj): samba installer server node obj
+    """
+    # Get grpc remotectl service
+    cmd = "systemctl list-units --type=service | grep remotectl"
+    out = smb_node.exec_command(sudo=True, cmd=cmd)[0].strip()
+    log.info(out)
+
+    if "remotectl" in out:
+        log.info(f"gRPC remotectl service has been loaded: {out}")
+    else:
+        raise OperationFailedError(f"gRPC remotectl service has not been loaded {out}")
+
+    if "remotectl" in out and "active" in out and "running" in out:
+        log.info(
+            f"gRPC remotectl service is running activetly: {out}, grpc smd cluster is created successfully"
+        )
+    else:
+        raise OperationFailedError(
+            f"gRPC remotectl service has been loaded but failed {out}"
+        )
+
+
+def run(ceph_cluster, **kw):
+    """Deploy samba with auth_mode 'user' using imperative style(CLI Commands)
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    # Get config
+    config = kw.get("config")
+
+    # Check mandatory parameter file_type
+    if not config.get("file_type"):
+        raise ConfigError("Mandatory config 'file_type' not provided")
+
+    # Get spec file type
+    file_type = config.get("file_type")
+
+    # Check mandatory parameter spec
+    if not config.get("spec"):
+        raise ConfigError("Mandatory config 'spec' not provided")
+
+    # Get smb spec file mount path
+    file_mount = config.get("file_mount", "/tmp")
+
+    # Get smb subvolume mode
+    smb_subvolume_mode = config.get("smb_subvolume_mode", "0777")
+
+    # Get smb spec
+    smb_spec = config.get("spec")
+    log.info("smb_spec_log: {} ".format(smb_spec))
+
+    # Get smb service value from spec file
+    smb_shares = []
+    smb_subvols = []
+    for spec in smb_spec:
+        if spec["resource_type"] == "ceph.smb.cluster":
+            smb_cluster_id = spec["cluster_id"]
+            auth_mode = spec["auth_mode"]
+            cert_tls_credential_id = spec["remote_control"]["cert"]["ref"]
+            key_tls_credential_id = spec["remote_control"]["key"]["ref"]
+            cacert_tls_credential_id = spec["remote_control"]["ca_cert"]["ref"]
+            if "domain_settings" in spec:
+                domain_realm = spec["domain_settings"]["realm"]
+            else:
+                domain_realm = None
+        elif spec["resource_type"] == "ceph.smb.usersgroups":
+            smb_user_name = spec["values"]["users"][0]["name"]
+            smb_user_password = spec["values"]["users"][0]["password"]
+        elif spec["resource_type"] == "ceph.smb.join.auth":
+            smb_user_name = spec["auth"]["username"]
+            smb_user_password = spec["auth"]["password"]
+        elif spec["resource_type"] == "ceph.smb.share":
+            cephfs_vol = spec["cephfs"]["volume"]
+            smb_subvol_group = spec["cephfs"]["subvolumegroup"]
+            smb_subvols.append(spec["cephfs"]["subvolume"])
+            smb_shares.append(spec["share_id"])
+
+    # Get installer node
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
+
+    # Get smb nodes
+    smb_nodes = ceph_cluster.get_nodes("smb")
+
+    # Get client node
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    # Generate self signed certificates crt, cacrt, key
+    key, cert, ca = generate_self_signed_certificate_for_smb_node(installer_node)
+
+    grpc_spec_tld_credential_dict = [
+        {
+            "resource_type": "ceph.smb.tls.credential",
+            "tls_credential_id": cert_tls_credential_id,
+            "credential_type": "cert",
+            "value": "|\n" + cert.rstrip("\\n"),
+        },
+        {
+            "resource_type": "ceph.smb.tls.credential",
+            "tls_credential_id": key_tls_credential_id,
+            "credential_type": "cert",
+            "value": "|\n" + key.rstrip("\\n"),
+        },
+        {
+            "resource_type": "ceph.smb.tls.credential",
+            "tls_credential_id": cacert_tls_credential_id,
+            "credential_type": "ca-cert",
+            "value": "|\n" + ca.rstrip("\\n"),
+        },
+    ]
+    smb_spec.extend(grpc_spec_tld_credential_dict)
+    log.info("smb_spec: {}".format(smb_spec))
+
+    try:
+        # deploy smb services
+        deploy_smb_service_declarative(
+            installer_node,
+            cephfs_vol,
+            smb_subvol_group,
+            smb_subvols,
+            smb_cluster_id,
+            smb_subvolume_mode,
+            file_type,
+            smb_spec,
+            file_mount,
+        )
+
+        # Check smb share using smbclient
+        smbclient_check_shares(
+            smb_nodes,
+            client,
+            smb_shares,
+            smb_user_name,
+            smb_user_password,
+            auth_mode,
+            domain_realm,
+        )
+
+        # Install grpcurl
+        install_grpcurl(installer_node)
+
+        # Clone samba in kubernetes repo
+        clone_the_samba_in_kubernetes_repo(installer_node)
+
+        # Check grpc remotectl service
+        check_remotectl_service(installer_node)
+
+    except Exception as e:
+        log.error(f"Failed to deploy samba with auth_mode {auth_mode} : {e}")
+        return 1
+    return 0

--- a/tests/smb/smb_operations.py
+++ b/tests/smb/smb_operations.py
@@ -440,6 +440,19 @@ def create_smb_share(
         raise CephadmOpsExecutionError(f"Fail to create smb shares, Error {e}")
 
 
+def get_smb_shares(installer, smb_cluster_id):
+    """Get SMB shares
+    Args:
+        installer (obj): Installer node obj
+        smb_cluster_id (str): Smb cluster id
+    Return:
+        List of shares
+    """
+    shares = CephAdm(installer).ceph.smb.share.ls(smb_cluster_id)
+    list_shares = json.loads(shares)
+    return list_shares
+
+
 def verify_smb_service(node, service_name):
     """
     Verifies service is up


### PR DESCRIPTION
# Description

Added gRPC set up methods like install_grpcurl, create_self_signed_certs_for_smb, clone_samba_in_kubernetes_repo, check_remotectl_service and code to create samba cluster with mTLS credentials.
Added new gRPC Scenarios
Test create SMB cluster with mTLS enabled to set up the remote control server.
Test grpcurl command to describe all the gRPC Service calls.
Test grpcurl command to show samba and container Info.
Test grpcurl command to list connected clients Status, when no client is connected.
Test grpcurl command to list connected clients Status, when client is connected.
Test grpcurl command to kill specific client connection.

# Test results:
http://magna002.ceph.redhat.com/ceph-qe-logs/ahallur/downstream_9.0/test1/
Latest execution: http://magna002.ceph.redhat.com/ceph-qe-logs/ahallur/grpc/test/
