### PR TITLE
RHCEPHQE-22074: Increase test coverage of OSD deployment through spec file

### DIFF
--- a/conf/reef/rados/4-node-ec-cluster-1-client.yaml
+++ b/conf/reef/rados/4-node-ec-cluster-1-client.yaml
@@ -8,6 +8,7 @@ globals:
             - _admin
             - installer
             - osd
+            - osd_lv
             - mon
             - mgr
             - rgw
@@ -19,6 +20,7 @@ globals:
             - rgw
             - mon
             - osd
+            - osd_raw
             - mds
             - _admin
           no-of-volumes: 6
@@ -29,11 +31,13 @@ globals:
             - mon
             - mgr
             - osd
+            - osd_encrypt_lv
           no-of-volumes: 6
           disk-size: 15
       node4:
           role:
             - osd
+            - osd_encrypt_raw
             - rgw
             - mds
             - node-exporter

--- a/conf/squid/rados/4-node-ec-cluster-1-client.yaml
+++ b/conf/squid/rados/4-node-ec-cluster-1-client.yaml
@@ -8,6 +8,7 @@ globals:
             - _admin
             - installer
             - osd
+            - osd_lv
             - mon
             - mgr
             - rgw
@@ -19,6 +20,7 @@ globals:
             - rgw
             - mon
             - osd
+            - osd_raw
             - mds
             - _admin
           no-of-volumes: 6
@@ -29,11 +31,13 @@ globals:
             - mon
             - mgr
             - osd
+            - osd_encrypt_lv
           no-of-volumes: 6
           disk-size: 15
       node4:
           role:
             - osd
+            - osd_encrypt_raw
             - rgw
             - mds
             - node-exporter

--- a/conf/tentacle/rados/4-node-ec-cluster-1-client.yaml
+++ b/conf/tentacle/rados/4-node-ec-cluster-1-client.yaml
@@ -8,6 +8,7 @@ globals:
             - _admin
             - installer
             - osd
+            - osd_lv
             - mon
             - mgr
             - rgw
@@ -19,6 +20,7 @@ globals:
             - rgw
             - mon
             - osd
+            - osd_raw
             - mds
             - _admin
           no-of-volumes: 6
@@ -29,11 +31,13 @@ globals:
             - mon
             - mgr
             - osd
+            - osd_encrypt_lv
           no-of-volumes: 6
           disk-size: 15
       node4:
           role:
             - osd
+            - osd_encrypt_raw
             - rgw
             - mds
             - node-exporter

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -45,18 +45,135 @@ tests:
                 placement:
                   label: mon
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              specs:
+              - service_type: crash
+                placement:
+                  host_pattern: "*"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Encrypted OSD deployment on LVMs
+      desc: Deploy encrypted OSDs on LVs
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_encrypted_lv
+                  encrypted: "true"
+                  placement:
+                    label: osd_encrypt_lv
+                  spec:
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: Encrypted OSD deployment on RAW device
+      desc: Deploy encrypted OSDs on RAW devices
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_encrypted_raw
+                  encrypted: "true"
+                  placement:
+                    label: osd_encrypt_raw
+                  spec:
+                    method: raw
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: non-encrypted OSD deployment on LVM
+      desc: Deploy non-encrypted OSDs on LVs
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_lv
+                  placement:
+                    label: osd_lv
+                  spec:
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: non-encrypted OSD deployment on RAW device
+      desc: Deploy non-encrypted OSDs on RAW devices
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_raw
+                  placement:
+                    label: osd_raw
+                  spec:
+                    method: raw
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -65,22 +182,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -90,7 +191,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node7                       # client node
+        node: node6                       # client node
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/squid/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/squid/rados/tier-2-rados-basic-regression.yaml
@@ -46,18 +46,135 @@ tests:
                 placement:
                   label: mon
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              specs:
+              - service_type: crash
+                placement:
+                  host_pattern: "*"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Encrypted OSD deployment on LVMs
+      desc: Deploy encrypted OSDs on LVs
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_encrypted_lv
+                  encrypted: "true"
+                  placement:
+                    label: osd_encrypt_lv
+                  spec:
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: Encrypted OSD deployment on RAW device
+      desc: Deploy encrypted OSDs on RAW devices
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_encrypted_raw
+                  encrypted: "true"
+                  placement:
+                    label: osd_encrypt_raw
+                  spec:
+                    method: raw
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: non-encrypted OSD deployment on LVM
+      desc: Deploy non-encrypted OSDs on LVs
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_lv
+                  placement:
+                    label: osd_lv
+                  spec:
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: non-encrypted OSD deployment on RAW device
+      desc: Deploy non-encrypted OSDs on RAW devices
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_raw
+                  placement:
+                    label: osd_raw
+                  spec:
+                    method: raw
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -66,22 +183,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -91,7 +192,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node7                       # client node
+        node: node6                       # client node
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/tentacle/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/tentacle/rados/tier-2-rados-basic-regression.yaml
@@ -46,18 +46,135 @@ tests:
                 placement:
                   label: mon
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              specs:
+              - service_type: crash
+                placement:
+                  host_pattern: "*"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Encrypted OSD deployment on LVMs
+      desc: Deploy encrypted OSDs on LVs
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_encrypted_lv
+                  encrypted: "true"
+                  placement:
+                    label: osd_encrypt_lv
+                  spec:
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: Encrypted OSD deployment on RAW device
+      desc: Deploy encrypted OSDs on RAW devices
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_encrypted_raw
+                  encrypted: "true"
+                  placement:
+                    label: osd_encrypt_raw
+                  spec:
+                    method: raw
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: non-encrypted OSD deployment on LVM
+      desc: Deploy non-encrypted OSDs on LVs
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_lv
+                  placement:
+                    label: osd_lv
+                  spec:
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: non-encrypted OSD deployment on RAW device
+      desc: Deploy non-encrypted OSDs on RAW devices
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_raw
+                  placement:
+                    label: osd_raw
+                  spec:
+                    method: raw
+                    data_devices:
+                      size: "'1G:'"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -66,22 +183,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -91,7 +192,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node7                       # client node
+        node: node6                       # client node
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node


### PR DESCRIPTION
Jira tracker: [RHCEPHQE-22074](https://issues.redhat.com/browse/RHCEPHQE-22074)

OSD deployment can taken several combination of parameters through spec files, using these combinations, OSDs can be deployed in one of the four ways:
1. non-encrypted + LVM
2. non-encrypted + raw
3. encrypted + LVM
4. encrypted + raw

Automated test coverage already existed for the below 3 in distributed test suites:
- non-encrypted + LVM
- non-encrypted + raw
- encrypted + LVM

Scope of this PR to add coverage for all possible combinations of OSD deployment under a single test suite that can run as part of the sanity pipeline

Logs:
Reef - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7CQUFY
Squid - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UTBCB3/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L0RHTO/
Tentacle - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BQWQDY/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>