### PR TITLE
TFA FIX- To minimize the time during inconsistent object creation and in handling failure cases.

### DIFF
--- a/suites/reef/rados/test_rados_all_generic_features.yaml
+++ b/suites/reef/rados/test_rados_all_generic_features.yaml
@@ -491,17 +491,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools
@@ -1469,15 +1460,7 @@ tests:
       module: test_inconsistency_osd_epoch.py
       polarion-id: CEPH-9947
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool_name: test_pool_4
-            pool_type: replicated
-          omap_config:
-            obj_start: 0
-            obj_end: 50
-            num_keys_obj: 100
-        delete_pool: true
+        pool_name: test_pool
 
   - test:
       name: Omap creations on objects

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -147,15 +147,8 @@ tests:
       module: test_inconsistency_osd_epoch.py
       polarion-id: CEPH-9947
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool_name: test_pool_4
-            pool_type: replicated
-          omap_config:
-            obj_start: 0
-            obj_end: 50
-            num_keys_obj: 100
-        delete_pool: true
+        pool_name: test_pool
+
   - test:
       name: Preempt scrub messages checks
       desc: Checking preempt messages in the OSDs

--- a/suites/reef/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/reef/rados/tier-2_rados_trim_tests.yaml
@@ -129,17 +129,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools

--- a/suites/reef/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -192,18 +192,74 @@ tests:
       comments: Intermittent active bug 2277111, 2299659
 
   - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      name: Case 1-Inconsistent objects  verification
+      desc: Scrub:Inconsistent objects>auto repair errors count & auto_repair is true
       module: test_osd_replicated_inconsistency_scenario.py
       polarion-id: CEPH-83586175
       config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
+        pool_name: replicated_pool
+        pg_num_max: 1
         inconsistent_obj_count: 4
         debug_enable: False
-        delete_pool:
-          - replicated_pool
-
+        case_to_run:
+          - case1
+  - test:
+      name: Case 2-Inconsistent objects  verification
+      desc: Scrub:Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case2
+  - test:
+      name: Case 3-Inconsistent objects verification
+      desc: Scrub:Inconsistent objects<auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case3
+  - test:
+      name: Case 4-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects>auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case4
+  - test:
+      name: Case 5-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case5
+  - test:
+      name: Case 6-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects<auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case6

--- a/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -320,17 +320,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools

--- a/suites/squid/rados/tier-2_rados_test_omap.yaml
+++ b/suites/squid/rados/tier-2_rados_test_omap.yaml
@@ -148,15 +148,7 @@ tests:
       module: test_inconsistency_osd_epoch.py
       polarion-id: CEPH-9947
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool_name: test_pool_4
-            pool_type: replicated
-          omap_config:
-            obj_start: 0
-            obj_end: 50
-            num_keys_obj: 100
-        delete_pool: true
+        pool_name: test_pool
 
   - test:
       name: Preempt scrub messages checks

--- a/suites/squid/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/squid/rados/tier-2_rados_trim_tests.yaml
@@ -130,17 +130,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools

--- a/suites/squid/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -192,41 +192,74 @@ tests:
       comments: Intermittent active bug 2277111, 2299659
 
   - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      name: Case 1-Inconsistent objects  verification
+      desc: Scrub:Inconsistent objects>auto repair errors count & auto_repair is true
       module: test_osd_replicated_inconsistency_scenario.py
       polarion-id: CEPH-83586175
       config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
+        pool_name: replicated_pool
+        pg_num_max: 1
         inconsistent_obj_count: 4
         debug_enable: False
-        delete_pool:
-          - replicated_pool
+        case_to_run:
+          - case1
   - test:
-      name: Verification of the scrub store replicated pool
-      desc: Verification of scrub and deep-scrub msgs in scrub store on replicated pool
-      module: test_scrub_store_errors.py
-      polarion-id: CEPH-83620501
+      name: Case 2-Inconsistent objects  verification
+      desc: Scrub:Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
       config:
-        create: true
-        pool_name: scrub_pool
+        pool_name: replicated_pool
         pg_num_max: 1
-        is_ecpool: False
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case2
   - test:
-      name: Verification of the scrub store on Ec pool
-      desc: Verification of scrub and deep-scrub msgs in scrub store on Ec pool
-      module: test_scrub_store_errors.py
-      polarion-id: CEPH-83620501
+      name: Case 3-Inconsistent objects verification
+      desc: Scrub:Inconsistent objects<auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
       config:
-        pool_name: ec_pool
-        pool_type: erasure
-        pg_num: 1
+        pool_name: replicated_pool
         pg_num_max: 1
-        k: 2
-        m: 2
-        crush-failure-domain: host
-        is_ecpool: True
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case3
+  - test:
+      name: Case 4-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects>auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case4
+  - test:
+      name: Case 5-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case5
+  - test:
+      name: Case 6-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects<auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case6

--- a/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -320,17 +320,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools

--- a/suites/tentacle/rados/test_rados_all_generic_features_upstream.yaml
+++ b/suites/tentacle/rados/test_rados_all_generic_features_upstream.yaml
@@ -480,17 +480,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools
@@ -1577,15 +1568,7 @@ tests:
       module: test_inconsistency_osd_epoch.py
       polarion-id: CEPH-9947
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool_name: test_pool_4
-            pool_type: replicated
-          omap_config:
-            obj_start: 0
-            obj_end: 50
-            num_keys_obj: 100
-        delete_pool: true
+        pool_name: test_pool
 
   - test:
       name: Omap creations on objects

--- a/suites/tentacle/rados/tier-2_rados_test_omap.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_omap.yaml
@@ -148,15 +148,7 @@ tests:
       module: test_inconsistency_osd_epoch.py
       polarion-id: CEPH-9947
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool_name: test_pool_4
-            pool_type: replicated
-          omap_config:
-            obj_start: 0
-            obj_end: 50
-            num_keys_obj: 100
-        delete_pool: true
+        pool_name: test_pool
 
   - test:
       name: Preempt scrub messages checks

--- a/suites/tentacle/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/tentacle/rados/tier-2_rados_trim_tests.yaml
@@ -130,17 +130,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-scrub-tests.yaml
@@ -192,20 +192,77 @@ tests:
       comments: Intermittent active bug 2277111, 2299659
 
   - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      name: Case 1-Inconsistent objects  verification
+      desc: Scrub:Inconsistent objects>auto repair errors count & auto_repair is true
       module: test_osd_replicated_inconsistency_scenario.py
       polarion-id: CEPH-83586175
       config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
+        pool_name: replicated_pool
+        pg_num_max: 1
         inconsistent_obj_count: 4
         debug_enable: False
-        delete_pool:
-          - replicated_pool
+        case_to_run:
+          - case1
+  - test:
+      name: Case 2-Inconsistent objects  verification
+      desc: Scrub:Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case2
+  - test:
+      name: Case 3-Inconsistent objects verification
+      desc: Scrub:Inconsistent objects<auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case3
+  - test:
+      name: Case 4-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects>auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case4
+  - test:
+      name: Case 5-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case5
+  - test:
+      name: Case 6-Inconsistent objects verification
+      desc: Deep-Scrub:Inconsistent objects<auto repair errors count & auto_repair is true
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        pool_name: replicated_pool
+        pg_num_max: 1
+        inconsistent_obj_count: 4
+        debug_enable: False
+        case_to_run:
+          - case6
   - test:
       name: Verification of osd_scrub_load_threshold
       desc: Verification of osd_scrub_load_threshold parameter functionality

--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -320,17 +320,8 @@ tests:
       module: test_osd_inconsistency_pg.py
       polarion-id: CEPH-9924
       config:
-        verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: Inconsistent_pool
-              pool_type: replicated
-              pg_num: 1
-          omap_config:
-            obj_start: 0
-            obj_end: 5
-            num_keys_obj: 10
-        delete_pool: true
+        pool_name: Inconsistent_pool
+        pg_num_max: 1
 
   - test:
       name: Inconsistent object pg check using pool snapshot for RE pools

--- a/tests/rados/test_inconsistency_osd_epoch.py
+++ b/tests/rados/test_inconsistency_osd_epoch.py
@@ -3,12 +3,12 @@ This file contains the  methods to generate inconsistent objects, collect the OS
  and then change the epoch to check if the inconsistency persists.
 """
 
-import random
 import traceback
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
 from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.objectstoretool_workflows import objectstoreToolWorkflows
 from ceph.rados.pool_workflows import PoolFunctions
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
@@ -30,120 +30,109 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     pool_obj = PoolFunctions(node=cephadm)
+    objectstore_obj = objectstoreToolWorkflows(node=cephadm, nostart=True)
     bluestore_obj = BluestoreToolWorkflows(node=cephadm)
-    pool_target_configs = config["verify_osd_omap_entries"]["configurations"]
-    omap_target_configs = config["verify_osd_omap_entries"]["omap_config"]
+    pool_name = config["pool_name"]
+    primary_osd = ""
     try:
         method_should_succeed(
             rados_obj.create_pool,
-            **pool_target_configs,
+            **config,
         )
-        pool_name = pool_target_configs["pool_name"]
+        msg_pg_autoscale_mode = (
+            f"Setting the pg autoscale mode to off on {pool_name} pool"
+        )
+        log.info(msg_pg_autoscale_mode)
+        rados_obj.set_pool_property(
+            pool=pool_name, props="pg_autoscale_mode", value="off"
+        )
+
+        epoch_cmd = "ceph osd dump"
+        epoch_incon = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+        log.info(f"OSD epoch when Inconsistent object is generated : {epoch_incon}")
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=300)
         log.info(f"Created the pool {pool_name} to generate inconsistent objects")
 
-        # Creating omaps
-        if not pool_obj.fill_omap_entries(pool_name=pool_name, **omap_target_configs):
-            log.error(f"Omap entries not generated on pool {pool_name}")
-            return 1
-        log.debug("Completed writing omap entries onto the pool")
-
-        # Fetching all objects and selecting one object to generate inconsistency
-        obj_list = rados_obj.get_object_list(pool_name)
-        log.debug(f"All the objects added onto the pool are : {obj_list}")
-
-        oname_list = random.choices(obj_list, k=10)
-        log.debug(
-            f"Selected objects {oname_list} at random to generate inconsistent objects."
+        obj_pg_map = rados_obj.create_inconsistent_object(
+            objectstore_obj, pool_name, no_of_objects=1
         )
-        inconsistent_obj_count = 0
-        for oname in oname_list:
+        if obj_pg_map is None:
+            log.error(
+                "Inconsistent objects are not created.Not executing the further test"
+            )
+            return 1
+
+        for oname, pg_id in obj_pg_map.items():
+            msg_pgid = f"The inconsistent object created in{pg_id} pg and the pool is {pool_name}"
+            log.info(msg_pgid)
+            msg_obj = (
+                f"The objects in the {pool_name} pool is - {list(obj_pg_map.keys())}"
+            )
+            log.info(msg_obj)
+
+            # Checking for inconsistency in the PG list
+            inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
+
+            if any(pg_id in search for search in inconsistent_pg_list):
+                log.info(f"Inconsistent PG is{pg_id}  ")
+            else:
+                log.error("Inconsistent PG is not generated")
+                raise Exception("Inconsistent object not generated error")
+
             primary_osd = rados_obj.get_osd_map(pool=pool_name, obj=oname)[
                 "acting_primary"
             ]
-            log.debug(f"The object stored in the primary osd number-{primary_osd}")
 
-            # getting the OSD epoch before generating inconsistent objects
-            epoch_cmd = "ceph osd dump"
-            init_epoch = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
-            log.info(f"Initial epoch before generating inconsistency is {init_epoch}")
+            log.debug(
+                f"Marking the primary OSD with inconsistency, OSD.{primary_osd} down and out"
+            )
+            rados_obj.change_osd_state(action="stop", target=primary_osd)
+            rados_obj.run_ceph_command(cmd=f"ceph osd out {primary_osd}")
+            if not wait_for_clean_pg_sets(rados_obj, timeout=600):
+                log.error("Cluster cloud not reach active+clean state within 600 secs")
+                raise Exception("Cluster cloud not reach active+clean state")
 
-            # Create inconsistency objects
-            try:
-                pg_id = rados_obj.create_inconsistent_object(pool_name, oname)
-                inconsistent_obj_count = inconsistent_obj_count + 1
-            except Exception as err:
+            # Checking for inconsistency in the PG list
+            inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
+            # Checking for the inconsistent pg's
+            if any(pg_id in search for search in inconsistent_pg_list):
                 log.error(
-                    f"Failed to generate inconsistent object.Trying to convert another object. Error : {err}"
+                    "Inconsistent pg exists in the cluster even after the OSD epoch was changed with OSD down"
                 )
-                continue
-            if inconsistent_obj_count == 1:
-                log.info(f"The inconsistent object is created in the PG - {pg_id}")
-                break
-        if inconsistent_obj_count == 0:
-            log.error(
-                "The inconsistent object is  not created.Not performing the further tests"
+                raise Exception("Inconsistent PG on cluster Error")
+            log.info("Inconsistent pg does not exist on the cluster post epoch change.")
+
+            epoch_osd = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+            log.info(f"OSD epoch when affected OSD is marked out & down: {epoch_osd}")
+
+            if epoch_incon == epoch_osd:
+                log.error(
+                    "The osd epoch has not changed post bringing down the affected OSD"
+                )
+                raise Exception("OSD epoch not changed error")
+
+            # Marking the OSD in the cluster and bringing it up.
+            log.debug(
+                f"Marking the primary OSD with inconsistency, OSD.{primary_osd} Up and In"
             )
-            return 1
+            rados_obj.change_osd_state(action="start", target=primary_osd)
+            rados_obj.run_ceph_command(cmd=f"ceph osd in {primary_osd}")
 
-        # Checking for inconsistency in the PG list
-        inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
-        if any(pg_id in search for search in inconsistent_pg_list):
-            log.info(f"Inconsistent PG is{pg_id}  ")
-        else:
-            log.error("Inconsistent PG is not generated")
-            raise Exception("Inconsistent object not generated error")
+            # Repairing the OSD using CBT
+            log.info(f"Performing the repair on the osd.{primary_osd}")
+            op = bluestore_obj.repair(primary_osd)
+            log.info(f"CBT repair status :{op}")
 
-        epoch_incon = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
-        log.info(f"OSD epoch when Inconsistent object is generated : {epoch_incon}")
-
-        log.debug(
-            f"Marking the primary OSD with inconsistency, OSD.{primary_osd} down and out"
-        )
-        rados_obj.change_osd_state(action="stop", target=primary_osd)
-        rados_obj.run_ceph_command(cmd=f"ceph osd out {primary_osd}")
-        if not wait_for_clean_pg_sets(rados_obj, timeout=600):
-            log.error("Cluster cloud not reach active+clean state within 600 secs")
-            raise Exception("Cluster cloud not reach active+clean state")
-        # Checking for the inconsistent pg's
-        inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
-        if any(pg_id in search for search in inconsistent_pg_list):
-            log.error(
-                "Inconsistent pg exists in the cluster even after the OSD epoch was changed with OSD down"
+            epoch_final = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+            log.info(
+                f"OSD epoch when Inconsistent object is repaiered + affected OSD is brought up : {epoch_final}"
             )
-            raise Exception("Inconsistent PG on cluster Error")
-        log.info("Inconsistent pg does not exist on the cluster post epoch change.")
 
-        epoch_osd = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
-        log.info(f"OSD epoch when affected OSD is marked out & down: {epoch_osd}")
-
-        if epoch_incon == epoch_osd:
-            log.error(
-                "The osd epoch has not changed post bringing down the affected OSD"
-            )
-            raise Exception("OSD epoch not changed error")
-
-        # Marking the OSD in the cluster and bringing it up.
-        log.debug(
-            f"Marking the primary OSD with inconsistency, OSD.{primary_osd} Up and In"
-        )
-        rados_obj.change_osd_state(action="start", target=primary_osd)
-        rados_obj.run_ceph_command(cmd=f"ceph osd in {primary_osd}")
-
-        # Repairing the OSD using CBT
-        log.info(f"Performing the repair on the osd.{primary_osd}")
-        op = bluestore_obj.repair(primary_osd)
-        log.info(f"CBT repair status :{op}")
-
-        epoch_final = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
-        log.info(
-            f"OSD epoch when Inconsistent object is repaiered + affected OSD is brought up : {epoch_final}"
-        )
-
-        if epoch_final == epoch_osd:
-            log.error(
-                "The osd epoch has not changed post PG repair of the affected OSD"
-            )
-            raise Exception("OSD epoch not changed error")
+            if epoch_final == epoch_osd:
+                log.error(
+                    "The osd epoch has not changed post PG repair of the affected OSD"
+                )
+                raise Exception("OSD epoch not changed error")
         log.info("Completed the test. Pass")
     except Exception as e:
         log.info(e)
@@ -151,9 +140,8 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("------------Execution of finally block-----------------")
-        if config.get("delete_pool"):
-            method_should_succeed(rados_obj.delete_pool, pool_name)
-            log.info("deleted the pool successfully")
+        method_should_succeed(rados_obj.delete_pool, pool_name)
+        log.info("deleted the pool successfully")
         if "primary_osd" in locals() or "primary_osd" in globals():
             rados_obj.change_osd_state(action="start", target=primary_osd)
         rados_obj.run_ceph_command(cmd=f"ceph osd in {primary_osd}")

--- a/tests/rados/test_osd_inconsistency_pg.py
+++ b/tests/rados/test_osd_inconsistency_pg.py
@@ -5,14 +5,14 @@ AS part of verification the script  perform the following tasks-
    2. Convert the object in to inconsistent object
 """
 
-import random
 import time
 import traceback
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
 from ceph.rados.core_workflows import RadosOrchestrator
-from ceph.rados.pool_workflows import PoolFunctions
+from ceph.rados.objectstoretool_workflows import objectstoreToolWorkflows
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed
 
@@ -30,81 +30,32 @@ def run(ceph_cluster, **kw):
 
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
-    pool_obj = PoolFunctions(node=cephadm)
     client_node = ceph_cluster.get_nodes(role="client")[0]
     bluestore_obj = BluestoreToolWorkflows(node=cephadm)
-    pool_target_configs = config["verify_osd_omap_entries"]["configurations"]
-    omap_target_configs = config["verify_osd_omap_entries"]["omap_config"]
-    pools = []
+    objectstore_obj = objectstoreToolWorkflows(node=cephadm, nostart=True)
+    pool_name = config["pool_name"]
     try:
-        # Creating pools and starting the test
-        for entry in pool_target_configs.values():
-            log.debug(
-                f"Creating {entry['pool_type']} pool on the cluster with name {entry['pool_name']}"
-            )
-            if entry["pool_type"] == "replicated":
-                method_should_succeed(
-                    rados_obj.create_pool,
-                    **entry,
-                )
-            else:
-                method_should_succeed(
-                    rados_obj.create_erasure_pool,
-                    name=entry["pool_name"],
-                    **entry,
-                )
-            pool_name = entry["pool_name"]
-            pool_type = entry["pool_type"]
-            pools.append(pool_name)
-            log.info(
-                f"Created the pool {entry['pool_name']}. beginning to create large number of entries on the pool"
-            )
-
-            if pool_type == "replicated":
-                # Creating omaps on Replicated pools
-                if not pool_obj.fill_omap_entries(
-                    pool_name=pool_name, **omap_target_configs
-                ):
-                    log.error(f"Omap entries not generated on pool {pool_name}")
-                    return 1
-            else:
-                # Creating rados bench objects
-                if not rados_obj.bench_write(
-                    pool_name=pool_name,
-                    byte_size="1000KB",
-                    max_objs=50,
-                    rados_write_duration=30,
-                    verify_stats=False,
-                ):
-                    log.error(f"Objects not written on pool {pool_name}")
-                    return 1
-
-        pool_name = random.choice(pools)
-        obj_list = rados_obj.get_object_list(pool_name)
-
-        oname_list = random.choices(obj_list, k=10)
-        log.debug(
-            f"Selected objects {oname_list} at random to generate inconsistent objects."
+        if not rados_obj.create_pool(**config):
+            log.error("Failed to create the replicated Pool")
+            return 1
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=300)
+        obj_pg_map = rados_obj.create_inconsistent_object(
+            objectstore_obj, pool_name, no_of_objects=1
         )
-        inconsistent_obj_count = 0
-        for oname in oname_list:
-            try:
-                # Create inconsistency objects
-                pg_id = rados_obj.create_inconsistent_object(pool_name, oname)
-                inconsistent_obj_count = inconsistent_obj_count + 1
-            except Exception as err:
-                log.error(
-                    f"Failed to generate inconsistent object.Trying to convert another object. Error : {err}"
-                )
-                continue
-            if inconsistent_obj_count == 1:
-                log.info(f"The inconsistent object is created in the PG - {pg_id}")
-                break
-        if inconsistent_obj_count == 0:
+        if obj_pg_map is None:
             log.error(
-                "The inconsistent object is  not created.Not performing the further tests"
+                "Inconsistent objects are not created.Not executing the further test"
             )
             return 1
+
+        pg_id = list(set(obj_pg_map.values()))[0]
+        oname = list(obj_pg_map.keys())[0]
+        msg_pgid = (
+            f"The inconsistent object created in{pg_id} pg and the pool is {pool_name}"
+        )
+        log.info(msg_pgid)
+        msg_obj = f"The objects in the {pool_name} pool is - {list(obj_pg_map.keys())}"
+        log.info(msg_obj)
         # Restarting the mon
         log.info("Restarting the mon services")
         mon_service = client_node.exec_command(cmd="ceph orch ls | grep mon")
@@ -180,13 +131,11 @@ def run(ceph_cluster, **kw):
         log.info(traceback.format_exc())
         return 1
     finally:
-        log.info("Execution of finally block")
-        if config.get("delete_pool"):
-            for pool_name in pools:
-                method_should_succeed(rados_obj.delete_pool, pool_name)
-                log.info(f"Pool {pool_name} deleted the pool successfully")
-                time.sleep(2)
-        # log cluster health
+        log.info(
+            "==============================Execution of finally block============================="
+        )
+        method_should_succeed(rados_obj.delete_pool, pool_name)
+        log.info("deleted the pool successfully")
         rados_obj.log_cluster_health()
         # check for crashes after test execution
         if rados_obj.check_crash_status():


### PR DESCRIPTION
# Description

Providing the fix for the following issue-

_We can observe string "Cannot able to convert the object-omap_obj_" is being printed 35 times and each runs for 20 minutes leading to 10 hours of execution time. 

http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-261/rados/23/tier-3_rados_test-4-node-scrub-tests/Inconsistent_objects_in_replicated_pool_functionality_check_0.log_ 

Jira ticket - https://issues.redhat.com/browse/RHCEPHQE-21677


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
