### PR TITLE
[NFS][RHEL-10]: Repo fix for rhel-10 specifics

### DIFF
--- a/cli/io/cthon.py
+++ b/cli/io/cthon.py
@@ -38,7 +38,7 @@ class Cthon(Cli):
         """Add cthon repos"""
         try:
             SubscriptionManager(self.client).repos.enable(
-                "codeready-builder-for-rhel-9-$(arch)-rpms"
+                "codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms"
             )
             return True
         except Exception as e:
@@ -48,7 +48,7 @@ class Cthon(Cli):
         """Remove cthon repos"""
         try:
             SubscriptionManager(self.client).repos.disable(
-                "codeready-builder-for-rhel-9-$(arch)-rpms"
+                "codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms"
             )
             return True
         except Exception as e:


### PR DESCRIPTION
# Description

TENTACLE-SANITY-CI-RH-20.1.0-69 has failures related to tier0-nfs-ganesha

## Fix:

- Make the cthon logic to pull the rhel version during runtime instead of hardcoding

## Logs:
- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/IBMCEPHQE-348/

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
