### PR TITLE
fix for nfs bvt

### DIFF
--- a/cli/ceph/nfs/export/export.py
+++ b/cli/ceph/nfs/export/export.py
@@ -40,7 +40,7 @@ class Export(Cli):
         # Step 1: Check if the subvolume group is present.If not, create subvolume group
         cmd = "ceph fs subvolumegroup ls cephfs"
         out = self.execute(sudo=True, cmd=cmd)
-        if "[]" in out[0]:
+        if "ganeshagroup" not in out[0]:
             cmd = "ceph fs subvolumegroup create cephfs ganeshagroup "
             self.execute(sudo=True, cmd=cmd)
             log.info("Subvolume group created successfully")

--- a/suites/squid/smoke/bvt.yaml
+++ b/suites/squid/smoke/bvt.yaml
@@ -86,7 +86,7 @@ tests:
 
 #   Testing stage
   - test:
-      name: Executes RGW, RBD, FS and NFS operations
+      name: Executes RGW, RBD and FS operations
       desc: Run object, block and filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
@@ -141,13 +141,13 @@ tests:
             name: cephfs-basics
             polarion-id: "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295"
 
-        - test:
-            name: Nfs Verify file mv and replace opertaion
-            module: nfs_verify_read_write_operations.py
-            desc: Verify mv is overwrites the content of the existing file with same name
-            polarion-id: CEPH-83575934
-            abort-on-fail: false
-            config:
-              nfs_version: 4.2
-              clients: 1
-              operation: mv_file_overwrite
+  - test:
+      name: Nfs Verify file mv and replace operation
+      module: nfs_verify_read_write_operations.py
+      desc: Verify mv is overwrites - NFS basic
+      polarion-id: CEPH-83575934
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 1
+        operation: mv_file_overwrite

--- a/suites/tentacle/smoke/bvt.yaml
+++ b/suites/tentacle/smoke/bvt.yaml
@@ -86,7 +86,7 @@ tests:
 
   # Testing stage
   - test:
-      name: Executes RGW, RBD, FS and NFS operations
+      name: Executes RGW, RBD and FS operations
       desc: Run object, block and filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
@@ -141,13 +141,13 @@ tests:
             name: cephfs-basics
             polarion-id: "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295"
 
-        - test:
-            name: Nfs Verify file mv and replace opertaion
-            module: nfs_verify_read_write_operations.py
-            desc: Verify mv is overwrites the content of the existing file with same name
-            polarion-id: CEPH-83575934
-            abort-on-fail: false
-            config:
-              nfs_version: 4.2
-              clients: 1
-              operation: mv_file_overwrite
+  - test:
+      name: Nfs Verify file mv and replace opertaion
+      module: nfs_verify_read_write_operations.py
+      desc: Verify mv is overwrites the content of the existing file with same name
+      polarion-id: CEPH-83575934
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 1
+        operation: mv_file_overwrite

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -9,7 +9,6 @@ from time import sleep
 
 import yaml
 
-from ceph.ceph import CommandFailed
 from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
@@ -1263,7 +1262,6 @@ def nfs_log_parser(client, nfs_node, nfs_name, expect_list=None):
             nfs_node = [nfs_node]
         for node in nfs_node:
             try:
-
                 log.info(
                     "\n\n" + "-" * 30 + "Fetching logs and Ganesha confs" + "-" * 30
                 )
@@ -1313,12 +1311,7 @@ def nfs_log_parser(client, nfs_node, nfs_name, expect_list=None):
 
                 for container, logs in zip(nfs_containers_deatail, container_logs):
                     log.info("\nLogs for container {0}:\n{1}\n".format(container, logs))
-            except CommandFailed as e:
-                if nfs_daemon_name in e or nfs_name in e:
-                    log.error(
-                        "Failed to fetch logs for {0} on {1}\n".format(
-                            nfs_daemon_name, node.hostname
-                        )
-                    )
-                else:
-                    raise CommandFailed
+            except Exception:
+                log.info(
+                    "Since we are collecting logs, ignoring the exception will not fail the test"
+                )


### PR DESCRIPTION
Problem:
cli/ceph/nfs/export/export.py - l43. - failing
When there was other subvolume group above line used to fail.

fix:
Now the code specifically check for ganeshagroup subvol group

and 
tests/nfs/nfs_operations.py - l1315 -Failing
IT was a log collecting part and if there are any failures raising exception. 
 
Fix:
removed the clutter of raising exception so test wont fail. due to this

logs:
job: https://149.81.216.83/view/Executor/job/tentacle-test-executor/13/pipeline-overview/?selected-node=70

<img width="1458" height="217" alt="image" src="https://github.com/user-attachments/assets/90bcdf1f-8597-4551-b57e-a5040786aa50" />
