### PR TITLE
TFA fix for cg quiesce failures

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -107,6 +107,7 @@ class FsUtils(object):
                 "python3-devel",
                 "git",
                 "lua",
+                "acl",
             ]
             if build.endswith("7") or build.startswith("3"):
                 pkgs.extend(


### PR DESCRIPTION
# Description
Jira: https://jsw.ibm.com/browse/IBMCEPHQE-347

Failed log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-10/Regression/20.1.0-64/cephfs/8/regression_suite_2/cg_snap_func_workflow_4_0.log
Failure: " getfacl command not found" 
Fix : Fixed the error by installing acl through prepare_clients()
Passed logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YAQHN4/CG_quiesce_0.log.1
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YAQHN4/CG_quiesce_0.log

Note : nfs error is due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=2406194

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
