### PR TITLE
fix for regression failures in build 20.1.0-68

### DIFF
--- a/suites/squid/nfs/tier1-nfs-ganesha-phase2-v4-2.yaml
+++ b/suites/squid/nfs/tier1-nfs-ganesha-phase2-v4-2.yaml
@@ -210,6 +210,7 @@ tests:
       desc: Perform read write without permissions on nfs share
       polarion-id: CEPH-83575941
       abort-on-fail: false
+      comments: might fail in IBM or RH builds due to BZ - 2402035
       config:
         nfs_version: 4.2
         clients: 3
@@ -266,6 +267,7 @@ tests:
       desc: Perform different mount versions on clients and validate the behavior
       polarion-id: CEPH-83577595
       abort-on-fail: true
+      comments: few tests might fail in IBM or RH builds due to BZ - 2402035
       config:
         clients: 3
         nfs_version: [4.2: 2, 3: 1]  # Out of the 3 clients, 2 will be mounted with v4.2 and other with v3

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -1227,11 +1227,11 @@ def nfs_log_parser(client, nfs_node, nfs_name, expect_list=None):
     nfs_name : Name of nfs cluster
     expect_list : List of strings to be parsed
     """
-    cmd = f"ceph orch ps | grep {nfs_name}"
-    out = list(client.exec_command(sudo=True, cmd=cmd))[0]
-    nfs_daemon_name = out.split()[0]
     results = {"expect": {}}
     if expect_list:
+        cmd = f"ceph orch ps | grep {nfs_name}"
+        out = list(client.exec_command(sudo=True, cmd=cmd))[0]
+        nfs_daemon_name = out.split()[0]
         for search_str in expect_list:
             cmd = f"cephadm logs --name {nfs_daemon_name} > nfs_log"
             nfs_node.exec_command(sudo=True, cmd=cmd)

--- a/tests/nfs/nfs_verify_multi_mount_version.py
+++ b/tests/nfs/nfs_verify_multi_mount_version.py
@@ -64,10 +64,8 @@ def run(ceph_cluster, **kw):
         for th in threads:
             th.join()
         return 0
-
     except Exception as e:
         log.error(f"Failed to setup nfs-ganesha cluster {e}")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-        return 1
     finally:
+        log.info("Cleaning up the NFS cluster and unmounting the mounts")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)

--- a/tests/nfs/test_earmark_feature.py
+++ b/tests/nfs/test_earmark_feature.py
@@ -121,7 +121,7 @@ def run(ceph_cluster, **kw):
             volume=fs_name, subvolume=subvolume_name, group=subvolume_group
         )
         log.info(f"Removed the subvolume {subvolume_name} from group {subvolume_group}")
-        nfs_log_parser(clients[0], nfs_name, nfs_node)
+        nfs_log_parser(client=clients[0], nfs_name=nfs_name, nfs_node=nfs_node)
         Ceph(clients[0]).nfs.cluster.delete(nfs_name)
         sleep(30)
         check_nfs_daemons_removed(clients[0])


### PR DESCRIPTION
fix for regression failures in build 20.1.0-68

problem : 
position args were causing issue + current product bugs.

resolution:
replacing pos-args to kw-args. added comments to the tests that might failiing due to product bug. BZ - 2402035

job:
https://149.81.216.83/job/tentacle-nfs-ganesha-regression-ci/21/
<img width="1109" height="988" alt="image" src="https://github.com/user-attachments/assets/41e5147e-2e8c-4791-9b0b-9478c98cb3db" />

Can observe repetition of comments  in above screen shot, I have minimized the repetition to 2