### PR TITLE
Fix: Correct IBM Ceph repo path handling for RHEL 10 and future RHEL versions

### DIFF
--- a/cli/ops/cephadm_ansible.py
+++ b/cli/ops/cephadm_ansible.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from cli.cephadm.ansible import Ansible
 from cli.cephadm.cephadm import CephAdm
@@ -140,10 +141,9 @@ def exec_cephadm_preflight(node, build_type, ibm_build=False, repo=None):
     # Set custom repository
     if repo and "s3.upshift.redhat.com" not in repo:
         if ibm_build and repo.endswith(".repo") and "public.dhe.ibm.com" in repo:
-            if "rhel9" in repo:
-                repo = repo.replace(repo.split("/")[-1], "rhel9/x86_64/")
-            elif "rhel8" in repo:
-                repo = repo.replace(repo.split("/")[-1], "rhel8/x86_64/")
+            match = re.search(r"(rhel\d+)", repo)
+            if match:
+                repo = repo.replace(repo.split("/")[-1], f"{match.group(1)}/x86_64/")
         extra_vars = {
             "ceph_origin": "custom",
             "gpgcheck": "no",


### PR DESCRIPTION
Issue

  CephCI runs were failing on RHEL 10 with errors like:

    Failed to download metadata for repo 'ceph_custom': Cannot download repomd.xml: All mirrors were tried

  This occurred because the code only handled rhel8 and rhel9 repo URLs when transforming .repo paths into base repository directories (e.g., rhel9/x86_64/), but did not include rhel10.

  Example failing repo: https://public.dhe.ibm.com/.../IBM-CEPH-9.0-202510241513.ci.0-rhel10.repo
  Resulted in:  404 for .../IBM-CEPH-9.0-202510241513.ci.0-rhel10.repo/repodata/repomd.xml
  Fail Log: http://magna002.ceph.redhat.com/cephci-jenkins/UBI9-custom-suites/Logs-UBI9-Oct-27/25.log

updated code will:
  - Fixes repomd.xml 404 errors on RHEL 10.
  - Future-proof — automatically supports RHEL 11+ without additional code changes.
  - Keeps logic consistent across all IBM Ceph builds (public.dhe.ibm.com sources).
  Pass Log: https://149.81.216.83/view/Tentacle/job/tentacle-test-executor/41/pipeline-overview/log?nodeId=77
