### PR TITLE
Handle missing manifest section gracefully

### DIFF
--- a/run.py
+++ b/run.py
@@ -474,7 +474,18 @@ def run(args):
     product: str = args.get("--product") or "redhat"
     release: str = args.get("--release") or rhbuild
     platform: str = args["--platform"]
-    build: str = args.get("--build") or "released"
+    build: str = args.get("--build")
+
+    # Setting to released by default is not right as there is case wherein it
+    # would be unavailable. Hence switching accordingly to released or nightly.
+    if build == "released":
+        try:
+            tmp_ctm = CephTestManifest(product, release, "released", platform)
+            _ = tmp_ctm.build_info
+        except RuntimeError:
+            build = "nightly"
+
+    # Now handle the manifest. At this point we are allowing failures
     ctm: CephTestManifest = CephTestManifest(product, release, build, platform)
 
     # Upstream


### PR DESCRIPTION
# Description

When there is overrides or missing sections in the manifest, we should not fail abruptly. Here, we are handling the default value and proceeding accordingly.

*Error*
```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-10/bvt/20.1.0-75/96/cephci/run.py", line 1159, in <module>
    rc = run(args)
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-10/bvt/20.1.0-75/96/cephci/run.py", line 557, in run
    ceph_version = [ctm.ceph_version]
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-10/bvt/20.1.0-75/96/cephci/cephci/utils/build_info.py", line 99, in ceph_version
    return self.build_info["version"]
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-10/bvt/20.1.0-75/96/cephci/cephci/utils/build_info.py", line 95, in build_info
    return self.get_build_details()
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-10/bvt/20.1.0-75/96/cephci/cephci/utils/build_info.py", line 212, in get_build_details
    raise RuntimeError("Unknown build_type provided.")
RuntimeError: Unknown build_type provided.
```

- [x] Review the automation design
- [x] Implement the test script and perform test runs

*Unit testing*
[Log](https://149.81.216.83/view/Tentacle/job/tentacle-bvt-ci/98/)

