### PR TITLE
Removing deprecated fields in results

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1078,7 +1078,7 @@ def email_results(test_result):
     run_status = get_run_status(results_list)
     msg["Subject"] = "[{run_status}]  Suite:{suite}  Build:{compose}  ID:{id}".format(
         suite=results_list[0]["suite-name"],
-        compose=results_list[0]["compose-id"],
+        compose=results_list[0]["ceph-version"],
         run_status=run_status,
         id=run_id,
     )
@@ -1090,7 +1090,7 @@ def email_results(test_result):
 
     props_content = f"""
     run_status=\"{run_status}\"
-    compose=\"{results_list[0]['compose-id']}\"
+    compose=\"{results_list[0]['ceph-version']}\"
     suite=\"{results_list[0]['suite-name']}\"
     """
 

--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -82,14 +82,10 @@ def create_xunit_results(suite_name, test_cases, test_run_metadata):
     run_id = test_run_metadata["run-id"]
     xml_file = f"{run_dir}/xunit.xml"
     ceph_version = test_run_metadata["ceph-version"]
-    ansible_version = test_run_metadata["ceph-ansible-version"]
     distribution = test_run_metadata["distro"]
     build = test_run_metadata["build"]
     test_run_id = f"RHCS-{build}-{_file}-{run_id}".replace(".", "-")
-    test_group_id = (
-        f"ceph-build: {ceph_version} "
-        f"ansible-build: {ansible_version} OS distro: {distribution}"
-    )
+    test_group_id = f"ceph-build: {ceph_version} " f"OS distro: {distribution}"
     log.info(f"Creating xUnit {_file} for test run-id {test_run_id}")
 
     suite = TestSuite(_file)

--- a/utility/xunit2gsheet.py
+++ b/utility/xunit2gsheet.py
@@ -65,7 +65,6 @@ PREFERRED_PROPERTIES = [
     "conf-file",
     "container-registry",
     "container-image",
-    "compose-id",
     "instance-name",
 ]
 


### PR DESCRIPTION
# Description

The following fields are deprecated in IBM Cloud environment

- compose
- ceph-ansible-version

Tasks
- [x] Review the automation design
- [x] Implement the test script and perform test runs

*Log*
[Log](https://149.81.216.83/view/Tentacle/job/tentacle-bvt-ci/103/)