### PR TITLE
Include knownissue BZ2360425 for one of the notification tc

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
@@ -73,6 +73,7 @@ tests:
       desc: notify put,copy,delete events with kafka_broker and SSL security
       module: sanity_rgw.py
       polarion-id: CEPH-83575471
+      comments: known issue - Bug 2360425 targetted to 9.0
       config:
         run-on-rgw: true
         extra-pkgs:


### PR DESCRIPTION
# Description
Include knownissue BZ2360425 for one of the notification tc for future reference,
currently to avoid this failure we have work around added,
https://github.com/red-hat-storage/ceph-qe-scripts/pull/800


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
