### PR TITLE
[TFA-fix] The certificate is not trusted on RGW node , causing s3cmd testcases to fail

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
@@ -105,6 +105,44 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
+      abort-on-fail: true
+      config:
+        commands:
+          - "ceph config set client.rgw.rgw.ssl rgw_verify_ssl False"
+          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
+          - "sudo yum install -y sshpass"
+          - "sleep 20"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node7}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node8}:/etc/pki/ca-trust/source/anchors/"
+      name: copy-crt to rgw and client node
+      desc: Copying crt to rgw and client node
+      polarion-id: CEPH-83575227
+      module: exec.py
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: rgw
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on rgw node
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on rgw node
+  - test:
+      abort-on-fail: true
+      config:
+        role: client
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on client node
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on client node
+
+  - test:
       name: Manual Resharding tests pre upgrade
       desc: Resharding test - manual
       polarion-id: CEPH-83571740


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>



the s3cmd testcase was failing because the crt was not trusted so added steps to copy and trust the crt on rgw and client nodes

fail log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Upgrade/19.2.1-290/145/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest/

pass log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-292/972/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-292/976/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest/