### PR TITLE
Ignore crimson and ceph-base-rhel9

### DIFF
--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -140,7 +140,7 @@ class CephTestManifest:
             - cephcsi
             - nvmeof-cli
         """
-        remove_list = ["cephcsi", "nvmeof-cli"]
+        remove_list = ["cephcsi", "nvmeof-cli", "crimson", "ceph-base-rhel9"]
         rst = {}
         _images = deepcopy(self.images)
 


### PR DESCRIPTION
# Description

Add support for ignoring crimson and ceph-base-rhel9 entries if found.

- [x] Review the automation design
- [x] Implement the test script and perform test runs
