### PR TITLE
Fix CLI precedence

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -275,7 +275,7 @@ class BootstrapMixin:
             if isinstance(custom_image, str):
                 cmd += f" --image {custom_image}"
             else:
-                cmd += f" --image {manifest_obj.ceph_image}"
+                cmd += f" --image {self.config['container_image']}"
 
         cmd += " bootstrap"
 

--- a/run.py
+++ b/run.py
@@ -515,6 +515,7 @@ def run(args):
             tmp_ctm = CephTestManifest(product, release, "released", platform)
             _ = tmp_ctm.build_info
         except RuntimeError:
+            log.debug("Switching to nightly as released section is unavailable.")
             build = "nightly"
 
     # Now handle the manifest. At this point we are allowing failures


### PR DESCRIPTION
# Description

The CLI arguments pertaining to ceph-base image was not considered hence the build provided one was used. As part of this commit, we are fixing the precedence issue.

- [x] Review the automation design
- [x] Implement the test script and perform test runs
