### PR TITLE
[CephFS][TFA]: Ignore validating httpd_t

### DIFF
--- a/tests/cephfs/clients/test_selinux_relabel.py
+++ b/tests/cephfs/clients/test_selinux_relabel.py
@@ -269,7 +269,8 @@ def run(ceph_cluster, **kw):
             "nfs_t": "nfs_share",
             "samba_share_t": "samba_share",
             "tmp_t": "tmp",
-            "httpd_t": "httpd_process",
+            # "httpd_t": "httpd_process",  # Commented out after discussion:
+            # requires httpd service to be running
             "device_t": "device",
         }
 


### PR DESCRIPTION
# Description

As per the discussion, commenting httpd_t validation as it requires the http server to be running

## Changes

- tests/cephfs/clients/test_selinux_relabel.py (Comment the validation of httpd_t)

## Logs
http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/tfa-07112025/

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
