### PR TITLE
[NFS][Sanity]: Fix cluster creation failure

### DIFF
--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -265,7 +265,7 @@ def setup_custom_nfs_cluster_multi_export_client(
         ha=ha,
         vip=vip,
         active_standby=active_standby,
-        **{"in-file": kwargs.get("in-file", None)},
+        **({"in-file": kwargs["in-file"]} if "in-file" in kwargs else {}),
     )
     sleep(3)
 


### PR DESCRIPTION
# Description

Sanity failed - http://10.70.46.153/logs/IBM/9.0/rhel-10/sanity/20.1.0-75/79/logs/Tier_0_NFS_Ganesha/
Changes made to the BYOK has caused regression to the sanity runs

## Fix

- tests/nfs/nfs_operations.py (Ignore passing None for the in-file kwargs if it does not exist)

## Logs

- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/tfa-sanity-07112025/
- https://149.81.216.83/view/Executor/job/tentacle-test-executor/51/pipeline-overview/log?nodeId=77

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
