### PR TITLE
Fix CLI precedence when build type is released

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -235,10 +235,14 @@ class BootstrapMixin:
 
         if build_type == "upstream" or manifest_obj.product == "community":
             self.setup_upstream_repository()
-        elif build_type == "released" or custom_repo.lower() == "cdn":
+        elif build_type == "cdn" or custom_repo.lower() == "cdn":
             custom_image = False
-            self.set_cdn_tool_repo(_ceph_version, manifest_obj)
             self.cluster.use_cdn = True
+            self.set_cdn_tool_repo(_ceph_version, manifest_obj)
+        elif build_type == "released" and base_url == manifest_obj.repository:
+            custom_image = False
+            self.cluster.use_cdn = True
+            self.set_cdn_tool_repo()
         elif custom_repo:
             self.set_tool_repo(repo=custom_repo)
         else:
@@ -260,6 +264,8 @@ class BootstrapMixin:
                 extra_vars=ansible_run.get("extra-vars"),
                 extra_args=ansible_run.get("extra-args"),
             )
+        elif base_url != manifest_obj.repository:
+            self.install()
         else:
             _os_major = manifest_obj.platform.split("-")[-1]
             _ceph_version = manifest_obj.ceph_version

--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -99,8 +99,11 @@ class CephTestManifest:
         return self.build_info["version"]
 
     @property
-    def repository(self) -> str:
-        return self.build_info["repositories"][self.datacenter][self.platform]
+    def repository(self) -> Optional[str]:
+        try:
+            return self.build_info["repositories"][self.datacenter][self.platform]
+        except KeyError:
+            return None
 
     @property
     def repo_id(self) -> Optional[str]:


### PR DESCRIPTION
# Description

When the user does not provide `--build` then the build_type value is `released`. The current thought process didn't consider that they can be overridden.

To address this scenario, this commit attempts to respect the overrides.

*Error Snippet*

```
2025-11-07 00:48:24,682 - cephci - run:938 - ERROR - cephadm shell -- ceph status returned bash: line 1: cephadm: command not found
 and code 127 on 10.243.56.123
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/regression/19.2.1-292/nvmeof/3/cephci/tests/ceph_installer/test_cephadm.py", line 172, in run
    func(cfg)
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/regression/19.2.1-292/nvmeof/3/cephci/ceph/ceph_admin/bootstrap.py", line 240, in bootstrap
    self.set_cdn_tool_repo(_ceph_version, manifest_obj)
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/regression/19.2.1-292/nvmeof/3/cephci/ceph/ceph_admin/__init__.py", line 163, in set_cdn_tool_repo
    _repo = ctm.build_info["released"]["repositories"]["default"]
KeyError: 'released'
```

## Checklist

- [x] Review the automation design
- [x] Implement the test script and perform test runs

## Unit testing

*Scenario 1* - Using the same set of options like no `--build` and with `--custom-configs`

[Log](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-runs-NLT3GT/)

*Scenario 2* - Using pipelines
[Log](https://149.81.216.83/view/Squid/job/squid-sanity-ci/9/)
[Different platform](https://149.81.216.83/view/Squid/job/squid-sanity-ci/9/)
