### PR TITLE
Ignore nvmeof_cli image

### DIFF
--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -143,7 +143,7 @@ class CephTestManifest:
             - cephcsi
             - nvmeof-cli
         """
-        remove_list = ["cephcsi", "nvmeof-cli", "crimson", "ceph-base-rhel9"]
+        remove_list = ["cephcsi", "nvmeof_cli", "crimson"]
         rst = {}
         _images = deepcopy(self.images)
 


### PR DESCRIPTION
# Description

Incorrect key was provided for nvmeof_cli key and it is fixed in this commit.

- [x] Review the automation design
- [x] Implement the test script and perform test runs
