### PR TITLE
Handle already locked error internally during retries

### DIFF
--- a/tests/cephfs/lib/fscrypt_utils.py
+++ b/tests/cephfs/lib/fscrypt_utils.py
@@ -312,8 +312,11 @@ class FscryptUtils(object):
                 not_successful = 0
             except BaseException as ex:
                 log.info(ex)
+                exp_str_1 = "is already locked"
                 exp_str_2 = "Directory was incompletely locked because some files are"
-                if exp_str_2 in str(ex):
+                if exp_str_1 in str(ex):
+                    not_successful = 0
+                elif exp_str_2 in str(ex):
                     try:
                         cmd_1 = f'find "{encrypt_path}" -print0 | xargs -0 fuser -k'
                         out, _ = client.exec_command(


### PR DESCRIPTION
# Description

JIRA: https://jsw.ibm.com/browse/IBMCEPHQE-374

Failed log: http://10.70.46.153/logs/IBM/9.0/rhel-10/regression/20.1.0-78/cephfs/6/logs/New_Feature_suite___8_1/fscrypt_basic_0.log 

Failure description: Fscrypt takes time to lock if there exists in-use files and we retry, and at sometime it returns already locked as ERROR. Need to handle this under exception.

Log with fix : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-42TPDJ/fscrypt_basic_0.log

There is failure seen after unlock, thats due to BZ 2406981
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
