### PR TITLE
Fixing the index.html for parallel runs

### DIFF
--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -176,14 +176,20 @@ def execute(test, args, results, parallel_tcs):
         if rc == -1:
             tc["status"] = "Skipped"
 
-        parallel_tcs.append(tc)
     except KeyError as e:
         parallel_log.error(f"Missing required argument: {e}")
         raise
     except Exception as e:
         test_logger.error(f"Test {test_name} failed with error: {e}")
+        elapsed = datetime.datetime.now() - start
+        tc["duration"] = str(elapsed)
+        tc["status"] = "Failed"
+        tc["err_type"] = "exception"
+        tc["err_msg"] = str(e)
         results[test_name] = 1
     finally:
+        # Always append tc to results, even if test failed with exception
+        parallel_tcs.append(tc)
         # Reset root logger configuration to avoid conflicts
         for handler in logging.getLogger().handlers[:]:
             logging.getLogger().removeHandler(handler)


### PR DESCRIPTION
# Description
Fixing the index.html for parallel runs

**Problem:** 
When a parallel test (like SMB BVT) throws an exception during execution (not just returns a failure code), the test case was never added to the parallel_tcs list. This caused it to be missing from:

- The HTML report (index.html)
- The xunit.xml file
- Email notifications

**Solution:**
Moved parallel_tcs.append(tc) to the finally block 

BVT run : https://149.81.216.83/job/tentacle-bvt-ci/132/pipeline-overview/?selected-node=99

<img width="1291" height="361" alt="image" src="https://github.com/user-attachments/assets/eb0126a7-5056-4de8-8b96-d1ef68d900e2" />




Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
