### PR TITLE
Fix incorrect IBM Cloud image names in cephadm test configuration

### DIFF
--- a/conf/tentacle/cephadm/1admin-4node-1client-mix-os.yaml
+++ b/conf/tentacle/cephadm/1admin-4node-1client-mix-os.yaml
@@ -1,14 +1,13 @@
-
 # CephAdm tier-1 test configuration
-# Admin node in RHEL 9 and other host in RHEL 8
+# Admin node in RHEL 10 and other host in RHEL 9
 # Deployment for all the ceph daemons , with 3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
 globals:
   - ceph-cluster:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.6.0-x86_64-ga-latest
-          ibmc: rhel-96-server-amd64-kvm
+          openstack: RHEL-10.0-x86_64-ga-latest
+          ibmc: rhel-100-server-amd64-kvm
         role:
           - _admin
           - installer
@@ -25,8 +24,8 @@ globals:
         disk-size: 15
       node2:
         image-name:
-          openstack: RHEL-8.10.0-x86_64-ga-latest
-          ibmc: rhel-810-server-amd64-kvm
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - osd
           - mon
@@ -38,8 +37,8 @@ globals:
         disk-size: 15
       node3:
         image-name:
-          openstack: RHEL-8.10.0-x86_64-ga-latest
-          ibmc: rhel-810-server-amd64-kvm
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - mon
           - mgr
@@ -50,14 +49,14 @@ globals:
         disk-size: 15
       node4:
         image-name:
-          openstack: RHEL-8.10.0-x86_64-ga-latest
-          ibmc: rhel-810-server-amd64-kvm
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - mds
           - rgw
       node5:
         image-name:
-          openstack: RHEL-8.10.0-x86_64-ga-latest
-          ibmc: rhel-810-server-amd64-kvm
+          openstack: RHEL-9.6.0-x86_64-ga-latest
+          ibmc: rhel-96-server-amd64-kvm
         role:
           - client

--- a/suites/tentacle/cephadm/tier1-mix-os-deployment.yaml
+++ b/suites/tentacle/cephadm/tier1-mix-os-deployment.yaml
@@ -1,5 +1,5 @@
 #=========================================================================================================
-# Test-Suite: Quincy cluster deployment with admian node in RHEL 9 and other host on RHEL 8
+# Test-Suite: Quincy cluster deployment with admian node in RHEL 10 and other host on RHEL 9
 #
 # Conf: conf/tentacle/cephadm/1admin-4node-1client-mix-os.yaml
 # Setup: 3 MONS, 3 MGR, 1 MDS, 3 OSD and 2 RGW service daemon(s)
@@ -10,7 +10,7 @@
 #   Node5 - Client
 #
 # Test Steps:
-#   1. Deploy cluster using cephadm with admin node on rhel 9 and other hosts in rhel 8 with all services.
+#   1. Deploy cluster using cephadm with admin node on rhel 10 and other hosts in rhel 9 with all services.
 #   2. Configure Client
 #   3. Run object, block and filesystem basic operations parallelly.
 #==========================================================================================================
@@ -22,8 +22,8 @@ tests:
       name: setup pre-requisites
 
   - test:
-      name: Deploy rhcs 6.x cluster with admin node on rhel 9 and other hosts in rhel 8
-      desc: Deploy cluster using cephadm with admin node on rhel 9 and other hosts in rhel 8 with all services.
+      name: Deploy Ceph 9.x cluster with admin node on rhel 10 and other hosts in rhel 9
+      desc: Deploy cluster using cephadm with admin node on rhel 10 and other hosts in rhel 9 with all services.
       polarion-id: CEPH-83575549
       module: test_cephadm.py
       config:


### PR DESCRIPTION
Update the cephadm test configuration to replace RHEL 8 with RHEL 9 and RHEL 9 with RHEL 10, aligning with tentacle release requirements that no longer support RHEL 8 configurations.

OS Version Updates:
- **Admin node (node1)**: Updated from RHEL 9 to RHEL 10
- **Other nodes (node2, node3, node4, node5)**: Updated from RHEL 8 to RHEL 9

Log: https://149.81.216.83/view/Tentacle/job/tentacle-test-executor/114/pipeline-overview/log?nodeId=77
log snippet:
````
2025-11-14 08:57:28,935 - cephci - ibm_vpc:491 - INFO - Starting to create VM with name ceph-mte114-crxj-TZEA6E-node1-installer
2025-11-14 08:57:33,940 - cephci - ibm_vpc:491 - INFO - Starting to create VM with name ceph-mte114-crxj-TZEA6E-node2
2025-11-14 08:57:43,955 - cephci - ibm_vpc:491 - INFO - Starting to create VM with name ceph-mte114-crxj-TZEA6E-node3
2025-11-14 08:57:45,282 - cephci - ibm_vpc:757 - INFO - ceph-mte114-crxj-tzea6e-node2 moved to running state in 5 seconds.
2025-11-14 08:57:45,571 - cephci - ibm_vpc:1037 - DEBUG - Creating DNS records for ceph-mte114-crxj-tzea6e-node2 with IP 10.243.49.64
2025-11-14 08:57:46,767 - cephci - ibm_vpc:1119 - INFO - Creating new A record ceph-mte114-crxj-tzea6e-node2 with IP 10.243.49.64
2025-11-14 08:57:46,768 - cephci - ibm_vpc:864 - DEBUG - Creating A record 'ceph-mte114-crxj-tzea6e-node2' (node: ceph-mte114-crxj-tzea6e-node2/10.243.49.64) (rdata: {
  "ip": "10.243.49.64"
}, ttl: 900)
2025-11-14 08:57:47,915 - cephci - ibm_vpc:1132 - INFO - Creating new PTR record 10.243.49.64 with domain ceph-mte114-crxj-tzea6e-node2.qe.ceph.eu.lab
2025-11-14 08:57:47,916 - cephci - ibm_vpc:864 - DEBUG - Creating PTR record '10.243.49.64' (node: ceph-mte114-crxj-tzea6e-node2/10.243.49.64) (rdata: {
  "ptrdname": "ceph-mte114-crxj-tzea6e-node2.qe.ceph.eu.lab"
}, ttl: 900)
2025-11-14 08:57:49,658 - cephci - ibm_vpc:757 - INFO - ceph-mte114-crxj-tzea6e-node1-installer moved to running state in 11 seconds.
2025-11-14 08:57:50,486 - cephci - ibm_vpc:1037 - DEBUG - Creating DNS records for ceph-mte114-crxj-tzea6e-node1-installer with IP 10.243.49.63
2025-11-14 08:57:51,741 - cephci - ibm_vpc:1119 - INFO - Creating new A record ceph-mte114-crxj-tzea6e-node1-installer with IP 10.243.49.63
2025-11-14 08:57:51,741 - cephci - ibm_vpc:864 - DEBUG - Creating A record 'ceph-mte114-crxj-tzea6e-node1-installer' (node: ceph-mte114-crxj-tzea6e-node1-installer/10.243.49.63) (rdata: {
  "ip": "10.243.49.63"
}, ttl: 900)
2025-11-14 08:57:53,091 - cephci - ibm_vpc:1132 - INFO - Creating new PTR record 10.243.49.63 with domain ceph-mte114-crxj-tzea6e-node1-installer.qe.ceph.eu.lab
2025-11-14 08:57:53,092 - cephci - ibm_vpc:864 - DEBUG - Creating PTR record '10.243.49.63' (node: ceph-mte114-crxj-tzea6e-node1-installer/10.243.49.63) (rdata: {
  "ptrdname": "ceph-mte114-crxj-tzea6e-node1-installer.qe.ceph.eu.lab"
}, ttl: 900)
2025-11-14 08:57:55,220 - cephci - ibm_vpc:757 - INFO - ceph-mte114-crxj-tzea6e-node3 moved to running state in 5 seconds.`
```