### PR TITLE
TFA fix for nfs cleanup issues due to fstab updates

### DIFF
--- a/tests/cephfs/cephfs_fscrypt/test_fscrypt_basic.py
+++ b/tests/cephfs/cephfs_fscrypt/test_fscrypt_basic.py
@@ -95,7 +95,9 @@ def run(ceph_cluster, **kw):
         setup_params.update({"cephfs_common_utils": cephfs_common_utils})
         fs_name = setup_params["fs_name"]
         log.info("Mount subvolumes")
-        mount_details = cephfs_common_utils.test_mount(clients, setup_params)
+        mount_details = cephfs_common_utils.test_mount(
+            clients, setup_params, mnt_type_list=["kernel", "fuse"]
+        )
         mon_node_ips = [node.ip_address for node in ceph_cluster.get_nodes(role="mon")]
         mon_node_ip = ",".join(mon_node_ips)
         log.info("Add mountpoint to fstab due to BZ 2406981")
@@ -189,7 +191,6 @@ def fscrypt_lifecycle(fscrypt_test_params):
     test_status = 0
 
     mnt_type = random.choice(["kernel", "fuse"])
-
     log.info("Create 2 test directories in each subvolume")
     for sv_name in mount_details:
         mountpoint = mount_details[sv_name][mnt_type]["mountpoint"]

--- a/tests/cephfs/cephfs_fscrypt/test_fscrypt_functional.py
+++ b/tests/cephfs/cephfs_fscrypt/test_fscrypt_functional.py
@@ -86,7 +86,9 @@ def run(ceph_cluster, **kw):
         setup_params = cephfs_common_utils.test_setup(default_fs, client)
         fs_name = setup_params["fs_name"]
         log.info("Mount subvolumes")
-        mount_details = cephfs_common_utils.test_mount(clients, setup_params)
+        mount_details = cephfs_common_utils.test_mount(
+            clients, setup_params, mnt_type_list=["kernel", "fuse"]
+        )
         log.info("Verify Cluster is healthy before test")
         if cephfs_common_utils.wait_for_healthy_ceph(client, 300):
             log.error("Cluster health is not OK even after waiting for 300secs")
@@ -207,7 +209,9 @@ def fscrypt_enctag(fscrypt_test_params):
     sv_list_tmp.extend(sv_list)
     fscrypt_test_params["setup_params"].update({"sv_list": sv_list_tmp})
     setup_params["sv_list"] = sv_list
-    mnt_details = cephfs_common_utils.test_mount(clients, setup_params)
+    mnt_details = cephfs_common_utils.test_mount(
+        clients, setup_params, mnt_type_list=["kernel", "fuse"]
+    )
     mount_details.update(mnt_details)
     log.info("Run CRUD ops on enctag")
     if enc_tag_crud_ops(client, cephfs_common_utils, sv_list):

--- a/tests/cephfs/cephfs_fscrypt/test_fscrypt_negative.py
+++ b/tests/cephfs/cephfs_fscrypt/test_fscrypt_negative.py
@@ -85,7 +85,9 @@ def run(ceph_cluster, **kw):
         setup_params = cephfs_common_utils.test_setup(default_fs, client)
         fs_name = setup_params["fs_name"]
         log.info("Mount subvolumes")
-        mount_details = cephfs_common_utils.test_mount(clients, setup_params)
+        mount_details = cephfs_common_utils.test_mount(
+            clients, setup_params, mnt_type_list=["kernel", "fuse"]
+        )
         test_case_name = config.get("test_name", "all_tests")
         test_negative = [
             "fscrypt_filename_length",

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -144,7 +144,9 @@ class CephFSCommonUtils(FsUtils):
         }
         return setup_params
 
-    def test_mount(self, clients, setup_params):
+    def test_mount(
+        self, clients, setup_params, mnt_type_list=["kernel", "fuse", "nfs"]
+    ):
         """
         This method is to run mount on test subvolumes
         Params:
@@ -164,7 +166,6 @@ class CephFSCommonUtils(FsUtils):
                 for _ in list(range(4))
             )
 
-            mnt_type_list = ["kernel", "fuse", "nfs"]
             mount_details = {}
             sv_list = setup_params["sv_list"]
             fs_name = setup_params["fs_name"]


### PR DESCRIPTION
# Description

Fix TFA issues in facrypt seen due to nfs mount error,
- NFS mount fscrypt test is NZ, so removed from setup
- New fstab code caused stale nfs mounts that was anyways not used in testing, so added nfs mount as option in test_mount in common testlib.

Logs: https://drive.google.com/drive/folders/1km8vNwmOT7qFxWcxWPf-dBs7XGqesvgb?usp=sharing

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
