### PR TITLE
change to new DNS zone for all IBM infra execution

### DIFF
--- a/conf/ibmc/ci-vpc-01.yaml
+++ b/conf/ibmc/ci-vpc-01.yaml
@@ -5,7 +5,7 @@ datacenters:
   - au-syd-1
   - au-syd-2
   - au-syd-3
-dns_zone_name: "qe.ceph.au.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   au-syd-1: ci-sn-01
   au-syd-2: ci-sn-02

--- a/conf/ibmc/vpc-block.yaml
+++ b/conf/ibmc/vpc-block.yaml
@@ -3,7 +3,7 @@ datacenters:
   - eu-de-1
   - eu-de-2
   - eu-de-3
-dns_zone_name: "qe.ceph.eu.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   eu-de-1: sn-block-eu-de-1
   eu-de-2: sn-block-eu-de-2

--- a/conf/ibmc/vpc-cephci.yaml
+++ b/conf/ibmc/vpc-cephci.yaml
@@ -3,7 +3,7 @@ datacenters:
   - eu-de-1
   - eu-de-2
   - eu-de-3
-dns_zone_name: "qe.ceph.eu.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   eu-de-1: sn-cephci-eu-de-1
   eu-de-2: sn-cephci-eu-de-2

--- a/conf/ibmc/vpc-cephfs.yaml
+++ b/conf/ibmc/vpc-cephfs.yaml
@@ -3,7 +3,7 @@ datacenters:
   - eu-de-1
   - eu-de-2
   - eu-de-3
-dns_zone_name: "qe.ceph.eu.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   eu-de-1: sn-cephfs-eu-de-1
   eu-de-2: sn-cephfs-eu-de-2

--- a/conf/ibmc/vpc-dmfg.yaml
+++ b/conf/ibmc/vpc-dmfg.yaml
@@ -3,7 +3,7 @@ datacenters:
   - eu-de-1
   - eu-de-2
   - eu-de-3
-dns_zone_name: "qe.ceph.eu.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   eu-de-1: sn-dmfg-eu-de-1
   eu-de-2: sn-dmfg-eu-de-2

--- a/conf/ibmc/vpc-nfsg.yaml
+++ b/conf/ibmc/vpc-nfsg.yaml
@@ -3,7 +3,7 @@ datacenters:
   - eu-de-1
   - eu-de-2
   - eu-de-3
-dns_zone_name: "qe.ceph.eu.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   eu-de-1: sn-nfsg-eu-de-1
   eu-de-2: sn-nfsg-eu-de-2

--- a/conf/ibmc/vpc-rgw.yaml
+++ b/conf/ibmc/vpc-rgw.yaml
@@ -3,7 +3,7 @@ datacenters:
   - eu-de-1
   - eu-de-2
   - eu-de-3
-dns_zone_name: "qe.ceph.eu.lab"
+dns_zone_name: "qe.ceph.lab"
 networks:
   eu-de-1: sn-rgw-eu-de-1
   eu-de-2: sn-rgw-eu-de-2

--- a/conf/inventory/ibm-eu-rhel-10.0.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.0.yaml
@@ -19,18 +19,18 @@ instance:
     yum_repos:
       appstream:
         name: AppStream
-        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/10/0/AppStream/
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/10/0/AppStream/
         enabled: true
         gpgcheck: false
       baseos:
         name: BaseOS
-        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/10/0/BaseOS/
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/10/0/BaseOS/
         gpgcheck: false
         enabled: true
 
       crb:
         name: codeready-builder
-        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/10/0/CRB/
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/10/0/CRB/
         gpgcheck: false
         enabled: true
 
@@ -38,31 +38,31 @@ instance:
     write_files:
       - content: |
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000"
+          location = "nginx-vm-01.qe.ceph.lab:5000"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-stage"
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
           prefix = "registry-proxy.engineering.redhat.com"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-stage"
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
           prefix = "quay.io"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-prod"
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-prod"
           prefix = "registry.redhat.io"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-stage"
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
           prefix = "cp.stg.icr.io"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-prod"
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true
         path: /etc/containers/registries.conf.d/nginx-vm-01.conf

--- a/conf/inventory/ibm-eu-rhel-9.6.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.6.yaml
@@ -19,18 +19,18 @@ instance:
     yum_repos:
       appstream:
         name: AppStream
-        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/AppStream/
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/6/AppStream/
         enabled: true
         gpgcheck: false
       baseos:
         name: BaseOS
-        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/BaseOS/
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/6/BaseOS/
         gpcheck: false
         enabled: true
 
       crb:
         name: codeready-builder
-        baseurl: http://nginx-vm-01.qe.ceph.eu.lab/repos/9/6/CRB/
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/6/CRB/
         gpcheck: false
         enabled: true
 
@@ -38,31 +38,31 @@ instance:
     write_files:
       - content: |
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000"
+          location = "nginx-vm-01.qe.ceph.lab:5000"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-stage"
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
           prefix = "registry-proxy.engineering.redhat.com"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-stage"
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
           prefix = "quay.io"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/rh-prod"
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-prod"
           prefix = "registry.redhat.io"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-stage"
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
           prefix = "cp.stg.icr.io"
           insecure = true
 
           [[registry]]
-          location = "nginx-vm-01.qe.ceph.eu.lab:5000/ibm-prod"
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true
         path: /etc/containers/registries.conf.d/nginx-vm-01.conf


### PR DESCRIPTION
change to new DNS zone for all IBM infra execution from qe.ceph.eu.lab to qe.ceph.lab
