### PR TITLE
Changed listener port to default in nvmeof_e2e_fips suite

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_fips.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_fips.yaml
@@ -89,11 +89,11 @@ tests:
             bdevs:
               count: 1
               size: 10G
-            listener_port: 5001
+            listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
+            listener_port: 4420
             node: node10
       desc: E2E-Test NVMEoF Gateway collocated and Run IOs on targets
       destroy-cluster: false


### PR DESCRIPTION
Problem facing before fix:-
```
2025-11-17 18:36:39,821 - cephci - ceph:1653 - INFO - Execution of modprobe nvme-fabrics on 10.0.67.74 took 1.243317 seconds
2025-11-17 18:36:40,054 - cephci - ceph:1623 - INFO - Execute nvme discover  --transport tcp --traddr 10.0.64.181 --trsvcid 8009 --output-format json on 10.0.67.74
2025-11-17 18:36:41,291 - cephci - ceph:1653 - INFO - Execution of nvme discover  --transport tcp --traddr 10.0.64.181 --trsvcid 8009 --output-format json on 10.0.67.74 took 1.235982 seconds
2025-11-17 18:36:41,292 - cephci - test_ceph_nvmeof_gateway:53 - DEBUG - {
  "genctr":1,
  "records":[
    {
      "trtype":"tcp",
      "adrfam":"ipv4",
      "subtype":"nvme subsystem",
      "treq":"not required",
      "portid":0,
      "trsvcid":"5001",
      "subnqn":"nqn.2016-06.io.spdk:cnode1",
      "traddr":"10.0.64.181",
      "eflags":"none",
      "sectype":"none"
    }
  ]
}

2025-11-17 18:36:41,521 - cephci - ceph:1623 - INFO - Execute nvme connect  --transport tcp --traddr 10.0.64.181 --nqn nqn.2016-06.io.spdk:cnode1 --trsvcid 5001 on 10.0.67.74
2025-11-17 18:36:42,758 - cephci - ceph:1653 - INFO - Execution of nvme connect  --transport tcp --traddr 10.0.64.181 --nqn nqn.2016-06.io.spdk:cnode1 --trsvcid 5001 on 10.0.67.74 took 1.235908 seconds
2025-11-17 18:36:42,758 - cephci - test_ceph_nvmeof_gateway:64 - DEBUG - ('', 'could not add new controller: failed to write to nvme-fabrics device\n')
2025-11-17 18:36:42,987 - cephci - ceph:1623 - INFO - Execute nvme list  --output-format json on 10.0.67.74
2025-11-17 18:36:44,218 - cephci - ceph:1653 - INFO - Execution of nvme list  --output-format json on 10.0.67.74 took 1.230154 seconds
2025-11-17 18:36:44,219 - cephci - nvme_cli:101 - DEBUG - "{\n  \"Devices\":[]\n}\n"
2025-11-17 18:36:44,220 - cephci - nvme_cli:105 - DEBUG - No NVMe devices found.
2025-11-17 18:36:44,220 - cephci - retry:47 - WARNING - NVMeInitiator.list_devices raised NoDevicesFound, Retrying in 3 seconds... (Attempt 1/4)
2025-11-17 18:36:44,229 - cephci - retry:55 - DEBUG - Full exception details for NVMeInitiator.list_devices:
Exception: NoDevicesFound
Message: NVMe Targets not found on ceph-jp-test-90-9pdgt1-node7
```

No issues after changing to default port and logs:
```
2025-11-17 18:42:08,052 - cephci - ceph:1623 - INFO - Execute nvme discover  --transport tcp --traddr 10.0.64.181 --trsvcid 8009 --output-format json on 10.0.67.74
2025-11-17 18:42:09,330 - cephci - ceph:1653 - INFO - Execution of nvme discover  --transport tcp --traddr 10.0.64.181 --trsvcid 8009 --output-format json on 10.0.67.74 took 1.277434 seconds
2025-11-17 18:42:09,331 - cephci - test_ceph_nvmeof_gateway:53 - DEBUG - {
  "genctr":1,
  "records":[
    {
      "trtype":"tcp",
      "adrfam":"ipv4",
      "subtype":"nvme subsystem",
      "treq":"not required",
      "portid":0,
      "trsvcid":"4420",
      "subnqn":"nqn.2016-06.io.spdk:cnode1",
      "traddr":"10.0.64.181",
      "eflags":"none",
      "sectype":"none"
    }
  ]
}

2025-11-17 18:42:09,564 - cephci - ceph:1623 - INFO - Execute nvme connect  --transport tcp --traddr 10.0.64.181 --nqn nqn.2016-06.io.spdk:cnode1 --trsvcid 4420 on 10.0.67.74
2025-11-17 18:42:10,798 - cephci - ceph:1653 - INFO - Execution of nvme connect  --transport tcp --traddr 10.0.64.181 --nqn nqn.2016-06.io.spdk:cnode1 --trsvcid 4420 on 10.0.67.74 took 1.233477 seconds
2025-11-17 18:42:10,799 - cephci - test_ceph_nvmeof_gateway:64 - DEBUG - ('connecting to device: nvme0\n', '')
2025-11-17 18:42:11,029 - cephci - ceph:1623 - INFO - Execute nvme list  --output-format json on 10.0.67.74
2025-11-17 18:42:12,265 - cephci - ceph:1653 - INFO - Execution of nvme list  --output-format json on 10.0.67.74 took 1.235755 seconds
2025-11-17 18:42:12,266 - cephci - nvme_cli:101 - DEBUG - "{\n  \"Devices\":[\n    {\n      \"HostNQN\":\"nqn.2014-08.org.nvmexpress:uuid:b075647d-f760-4e7c-b26f-8150c1b18e2c\",\n      \"HostID\":\"b075647d-f760-4e7c-b26f-8150c1b18e2c\",\n      \"Subsystems\":[\n        {\n          \"Subsystem\":\"nvme-subsys0\",\n          \"SubsystemNQN\":\"nqn.2016-06.io.spdk:cnode1\",\n          \"Controllers\":[\n            {\n              \"Controller\":\"nvme0\",\n              \"Cntlid\":\"1\",\n              \"SerialNumber\":\"Ceph20396988815992\",\n              \"ModelNumber\":\"Ceph bdev Controller\",\n              \"Firmware\":\"25.05\",\n              \"Transport\":\"tcp\",\n              \"Address\":\"traddr=10.0.64.181,trsvcid=4420,src_addr=10.0.67.74\",\n              \"Slot\":\"\",\n              \"Namespaces\":[],\n              \"Paths\":[\n                {\n                  \"Path\":\"nvme0c0n1\",\n                  \"ANAState\":\"optimized\"\n                }\n              ]\n            }\n          ],\n          \"Namespaces\":[\n            {\n              \"NameSpace\":\"nvme0n1\",\n              \"Generic\":\"ng0n1\",\n              \"NSID\":1,\n              \"UsedBytes\":10737418240,\n              \"MaximumLBA\":20971520,\n              \"PhysicalSize\":10737418240,\n              \"SectorSize\":512\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n"
2025-11-17 18:42:12,267 - cephci - initiator:143 - DEBUG - ['/dev/nvme0n1']
2025-11-17 18:42:12,267 - cephci - utils:2212 - DEBUG - Config Received for fio: {'size': '100%', 'device_name': '/dev/nvme0n1', 'client_node': <ceph.ceph.CephNode object at 0x108fee310>, 'long_running': True, 'cmd_timeout': 'notimeout'}
2025-11-17 18:42:12,496 - cephci - ceph:1623 - INFO - Execute fio  --ioengine libaio --filename /dev/nvme0n1 --size 100% --name test-1 --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.0.67.74
```