### PR TITLE
Rhel10 support for tentacle s3tests

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -177,7 +177,8 @@ def execute_setup(cluster: Ceph, config: dict) -> None:
 
     branch = config.get("branch", "ceph-quincy")
     clone_s3_tests(node=client_node, branch=branch)
-    install_s3test_requirements(client_node, branch, os_ver=build[-1])
+    os_ver = build.split("-")[-1]
+    install_s3test_requirements(client_node, branch, os_ver=os_ver)
 
     if not all([host, port]):
         host = rgw_node.shortname
@@ -292,7 +293,7 @@ def install_s3test_requirements(
     Raises:
         CommandFailed:  Whenever a command returns a non-zero value part of the method.
     """
-    if branch in ["ceph-nautilus", "ceph-luminous"] or os_ver == "9":
+    if branch in ["ceph-nautilus", "ceph-luminous"] or int(os_ver) >= 9:
         return _s3tests_req_install(node, os_ver)
 
     _s3tests_req_bootstrap(node)
@@ -564,7 +565,7 @@ def _s3test_req_py3(node: CephNode) -> None:
 
 def _s3tests_req_install(node: CephNode, os_ver: str) -> None:
     """Install S3 prerequisites via pip."""
-    if os_ver == "9":
+    if int(os_ver) >= 9:
         return _s3test_req_py3(node)
 
     packages = [


### PR DESCRIPTION
# Description

Rhel10 support for tentacle s3tests

RCA: 
Failure is due to missing s3tests requirement installation, as per script line:
https://github.com/red-hat-storage/cephci/blob/main/tests/rgw/test_s3.py#L295

Since in this failed log execution was done with Rhel-10 OS , hence as per current code implementation, s3tests requirement installation was got skipped.

Fail log: http://10.70.46.153/logs/RH/9.0/rhel-10/weekly/20.1.0-85/rgw/7/logs/Test_granular_s3test/execute_s3tests_suites_test_s3_0.log

Log post making changes:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-M3K26E/execute_s3tests_suites_test_s3_0.log

here script procssed with package installation,
Failure due to product package issue.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
