### PR TITLE
Adding firewall open ports 5000-6000 to NVMe new framework

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_fips.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_fips.yaml
@@ -89,11 +89,11 @@ tests:
             bdevs:
               count: 1
               size: 10G
-            listener_port: 4420
+            listener_port: 5001
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 4420
+            listener_port: 5001
             node: node10
       desc: E2E-Test NVMEoF Gateway collocated and Run IOs on targets
       destroy-cluster: false

--- a/tests/nvmeof/workflows/nvme_service.py
+++ b/tests/nvmeof/workflows/nvme_service.py
@@ -7,7 +7,10 @@ from ceph.utils import get_nodes_by_ids
 from tests.cephadm import test_nvmeof
 from tests.nvmeof.workflows.constants import DEFAULT_NVME_METADATA_POOL, DEFAULT_PORT
 from tests.nvmeof.workflows.nvme_gateway import create_gateway
-from tests.nvmeof.workflows.nvme_utils import nvme_gw_cli_version_adapter
+from tests.nvmeof.workflows.nvme_utils import (
+    nvme_gw_cli_version_adapter,
+    setup_firewalld,
+)
 from utility.utils import get_ceph_version_from_cluster
 
 
@@ -173,6 +176,8 @@ class NVMeService:
         """
         Deploy NVMe gateways using orchestrator, then fetch and update daemon and service names for each gateway node.
         """
+        # Open up firewall ports if running.
+        setup_firewalld(self.gw_nodes)
         deploy_config = self._create_spec_deployment_config()
         if deploy_config:
             test_nvmeof.run(self.ceph_cluster, **deploy_config)


### PR DESCRIPTION
Adding firewall open port method to new framework deploy nvme service method.

Success Logs - https://drive.google.com/drive/folders/1Gje7bzUm1Vu5SaDsch8_9xSDfKn2tVnR

Reverting port number changes from PR - #5387  since it is now working with port number 5001 as well.