### PR TITLE
changing  release version from rc to released as per qe-manifest

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_archive_ms_upgrade_61GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_archive_ms_upgrade_61GA_to_7x_latest.yaml
@@ -21,7 +21,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -67,7 +67,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -113,7 +113,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_5_3GA_to_7x_latest.yaml
@@ -27,7 +27,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 5.3
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -74,7 +74,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 5.3
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_6_1GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_6_1GA_to_7x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -73,7 +73,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_7_0GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_7_0GA_to_7x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -73,7 +73,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_multirealm_61GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_multirealm_61GA_to_7x_latest.yaml
@@ -23,7 +23,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -79,7 +79,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 5.3
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.0
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
@@ -21,7 +21,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -67,7 +67,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -113,7 +113,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
@@ -27,7 +27,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -89,7 +89,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -73,7 +73,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
@@ -23,7 +23,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -79,7 +79,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -76,7 +76,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -21,7 +21,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -87,7 +87,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -153,7 +153,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -92,7 +92,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.0
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.0
-                    release: sanity
+                    release: stable
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -73,7 +73,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: sanity
+                    release: stable
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.0
-                release: sanity
+                release: stable
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_archive_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_archive_ms_upgrade_81GA_to_9x_latest.yaml
@@ -21,7 +21,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -67,7 +67,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -113,7 +113,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_71GA_to_9x_latest.yaml
@@ -27,7 +27,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -89,7 +89,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -73,7 +73,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest.yaml
@@ -23,7 +23,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -79,7 +79,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -76,7 +76,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -21,7 +21,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -87,7 +87,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -153,7 +153,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -92,7 +92,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 9.0
-                    release: sanity
+                    release: stable
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -73,7 +73,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 9.0
-                    release: sanity
+                    release: stable
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 9.0
-                release: sanity
+                release: stable
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>


Removed Rc and released tag for the release version for normal upgrade suites.  and removed sanity and added stable in sanity   upgrade suites

Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Async/20.1.0-85/39/tier-1_rgw_upgrade_71GA_to_9x_latest/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Async/20.1.0-85/39/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Async/20.1.0-85/40/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Async/20.1.0-85/36/tier-2_rgw_upgrade_9xsanity_to_9xlatest/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Async/20.1.0-85/36/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest/