### PR TITLE
TFA fixes and dbg log enabling, dbg info for regression tests

### DIFF
--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
@@ -128,6 +128,33 @@ tests:
       module: cephfs_upgrade.metadata_version_validation.py
       name: "Metadata collection before upgrade"
       polarion-id: CEPH-83575313
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+        ENABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+        daemon_dbg_level : {'mds':10,'client':10,'osd':5,'mgr':5,'mon':5}
+  - test:
+      abort-on-fail: false
+      desc: "Set size limit for log rotation"
+      name: size limit for log rotation
+      module: cephfs_logs_util.py
+      config:
+        LOG_ROTATE_SIZE : 1
+        log_size : '200M'
+  -
+    test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup : 1
+        daemon_list : ['mds','osd','mgr','mon']
 
   - test:
       name: Upgrade along with IOs
@@ -169,6 +196,24 @@ tests:
             polarion-id: CEPH-83575628
       desc: Running upgrade, mds Failure and i/o's parallelly
       abort-on-fail: true
+  -
+    test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check : 1
+        daemon_list : ['mds','osd','mgr','mon']
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+        DISABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
   - test:
       abort-on-fail: false
       desc: Validates the data after upgrade

--- a/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml
@@ -247,6 +247,33 @@ tests:
       name: "configure client"
   -
     test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+        ENABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+        daemon_dbg_level : {'mds':10,'client':10,'osd':5,'mgr':5,'mon':5}
+  - test:
+      abort-on-fail: false
+      desc: "Set size limit for log rotation"
+      name: size limit for log rotation
+      module: cephfs_logs_util.py
+      config:
+        LOG_ROTATE_SIZE : 1
+        log_size : '200M'
+  -
+    test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup : 1
+        daemon_list : ['mds','osd','mgr','mon']
+  -
+    test:
       abort-on-fail: true
       desc: "CG snap systemic test"
       config:
@@ -255,3 +282,21 @@ tests:
       module: snapshot_clone.cg_snap_system_test.py
       name: "cg_snap_system_test"
       polarion-id: CEPH-83581468
+  -
+    test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check : 1
+        daemon_list : ['mds','osd','mgr','mon']
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+        DISABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_add_datapool_to_existing_fs.py
@@ -41,20 +41,20 @@ def run(ceph_cluster, **kw):
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
         default_fs = "cephfs"
-        if build.startswith("4"):
-            # create EC pool
-            list_cmds = [
-                "ceph fs flag set enable_multiple true",
-                "ceph osd pool create cephfs-data-ec 64 erasure",
-                "ceph osd pool create cephfs-metadata 64",
-                "ceph osd pool set cephfs-data-ec allow_ec_overwrites true",
-                "ceph fs new cephfs-ec cephfs-metadata cephfs-data-ec --force",
-            ]
-            if fs_util.get_fs_info(clients[0], "cephfs_new"):
-                default_fs = "cephfs_new"
-                list_cmds.append("ceph fs volume create cephfs")
-            for cmd in list_cmds:
-                clients[0].exec_command(sudo=True, cmd=cmd)
+
+        # create EC pool
+        list_cmds = [
+            "ceph fs flag set enable_multiple true",
+            "ceph osd pool create cephfs-data-ec 64 erasure",
+            "ceph osd pool create cephfs-metadata 64",
+            "ceph osd pool set cephfs-data-ec allow_ec_overwrites true",
+            "ceph fs new cephfs-ec cephfs-metadata cephfs-data-ec --force",
+            "ceph fs volume create cephfs",
+        ]
+        if fs_util.get_fs_info(clients[0], "cephfs_new"):
+            default_fs = "cephfs_new"
+        for cmd in list_cmds:
+            clients[0].exec_command(sudo=True, cmd=cmd)
 
         log.info("Create SubVolumeGroups on each filesystem")
         subvolumegroup_list = [

--- a/tests/cephfs/snapshot_clone/test_snapshot_visibility_multi_fs_nfs_clients.py
+++ b/tests/cephfs/snapshot_clone/test_snapshot_visibility_multi_fs_nfs_clients.py
@@ -264,6 +264,10 @@ def setup_test_obj(obj_name, obj_type, **kwargs):
             log.info(nfs_server)
             if nfs_server_tmp.node.hostname != kwargs["nfs_server"]:
                 nfs_server1 = nfs_server_tmp.node.hostname
+                out, _ = clients[0].exec_command(
+                    sudo=True, cmd="ceph nfs cluster ls;ceph orch ls"
+                )
+                log.info(out)
                 clients[0].exec_command(
                     sudo=True, cmd=f"ceph nfs cluster create {obj_name} {nfs_server1}"
                 )


### PR DESCRIPTION
# Description

Jira: https://jsw.ibm.com/browse/IBMCEPHQE-474

Fix description:
Failure description : http://10.70.46.153/logs/RH/9.0/rhel-10/regression/20.1.0-85/cephfs/10/logs/New_Feature_suite___9_0/Toggle_snapshot_visibility_functional_test_0.log : second NFS cluster create failure, check exists to ensure it is created on new cluster node, still fails, ceph -s shows HEALTH_ERR state
Fix : Adding dbg info prior to cluster create and enabling dbg logging and crash checks in suite.

Failure description:
http://10.70.46.153/logs/RH/9.0/rhel-10/weekly/20.1.0-85/cephfs/3/logs/Test_Cephfs_CG_Quiesce/cg_snap_system_test_0.log (MDS connection refused) 
Fix : Adding dbg info prior to cluster create and enabling dbg logging and crash checks in suite.

Failure description: Script expects to 'cephfs' to be already present, if not, fails as in below log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VLT8G7
Fix: Create cephfs volume in setup

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
