### PR TITLE
Updated the repository URL to align with the newly mirrored repo structure.

### DIFF
--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -371,15 +371,14 @@ def get_tools_repo(repo, ibm_build=False):
         repo (str): Ceph tools repo URL
         ibm_build (bool): IBM build tag
     """
+    repo = repo.rstrip("/")
     if ibm_build:
-        repo = repo.rstrip("/")
         return f"{repo}/Tools"
 
     elif repo.endswith("repo"):
         return repo
 
-    else:
-        return f"{repo}/compose/Tools/x86_64/os"
+    return f"{repo}/Tools"
 
 
 def add_centos_epel_repo(nodes, platform):


### PR DESCRIPTION

- [ ] Review the automation design
Log: https://149.81.216.83/view/Tentacle/job/tentacle-test-executor/160/

Log Snippet:
```
2025-11-19 08:19:38,918 - cephci - ceph:1623 - INFO - Execute yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.138
2025-11-19 08:19:39,922 - cephci - ceph:1653 - INFO - Execution of yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.138 took 1.003866 seconds
2025-11-19 08:19:39,924 - cephci - ceph:1623 - INFO - Execute yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.139
2025-11-19 08:19:40,928 - cephci - ceph:1653 - INFO - Execution of yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.139 took 1.003949 seconds
2025-11-19 08:19:40,929 - cephci - ceph:1623 - INFO - Execute yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.140
2025-11-19 08:19:41,934 - cephci - ceph:1653 - INFO - Execution of yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.140 took 1.004161 seconds
2025-11-19 08:19:41,936 - cephci - ceph:1623 - INFO - Execute yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.141
2025-11-19 08:19:42,940 - cephci - ceph:1653 - INFO - Execution of yum-config-manager --add-repo http://repo.qe.ceph.lab/repos/ceph/testing/redhat/9/rhel10/20.1.0-95/Tools on 10.243.58.141 took 1.003918 seconds
```