### PR TITLE
Ignore images at ceph configuration

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -382,8 +382,12 @@ class BootstrapMixin:
 
                 images_dict[key] = value
 
+        ignore_images = ["cephcsi", "nvmeof_cli", "crimson"]
+        check_ignored_images = lambda image: image in ignore_images
         for image, value in images_dict.items():
             _image = image.removesuffix("_image")
+            if check_ignored_images(_image):
+                continue
             cmd = "cephadm shell -- ceph config set mgr"
             cmd += f" mgr/cephadm/container_image_{_image} {value}"
             self.installer.exec_command(sudo=True, cmd=cmd)

--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -135,6 +135,10 @@ class CephTestManifest:
         return _image_without_dtr.split(":")[0]
 
     @property
+    def nvme_cli_image(self) -> str:
+        return self.images.get("nvmeof_cli_image", "")
+
+    @property
     def custom_images(self) -> dict[str, str]:
         """Custom images to be configured with the cluster.
 
@@ -143,7 +147,11 @@ class CephTestManifest:
             - cephcsi
             - nvmeof-cli
         """
-        remove_list = ["cephcsi", "nvmeof-cli", "crimson"]
+        remove_list = [
+            "cephcsi",
+            "nvmeof-cli",
+            "crimson",
+        ]
         rst = {}
         _images = deepcopy(self.images)
 


### PR DESCRIPTION
Ignore images which cant be configured at ceph system like, ceph-csi, nvmeof-cli and few other at mgr/cephadm


