### PR TITLE
[Enhancement]: Fix xUnit duration reporting for parallel testcases by converting duration strings to timedelta

### DIFF
--- a/run.py
+++ b/run.py
@@ -918,6 +918,17 @@ def run(args):
                             run_config=run_config,
                             tc=tc,
                         )
+
+                        # Convert duration string to timedelta object for updating xunit
+                        for ptc in parallel_tcs:
+                            val = ptc.get("duration", "00:00:00")
+                            if isinstance(val, str):
+                                hrs, mins, secs = val.split(":")
+                                ptc["duration"] = datetime.timedelta(
+                                    hours=int(hrs),
+                                    minutes=int(mins),
+                                    seconds=float(secs),
+                                )
                         tcs.extend(parallel_tcs)
                     else:
                         rc = test_mod.run(


### PR DESCRIPTION
# Description

## Issue Summary

During xUnit report generation, testcases executed inside a parallel block were consistently reported with a duration of 0 seconds, even though the tests themselves executed for a measurable amount of time.
This problem was isolated to parallel testcases only—sequential testcases always displayed the correct duration.

## Root Cause

Sequential tests store execution time directly as a Python datetime.timedelta object:
```
elapsed = datetime.datetime.now() - start
tc["duration"] = elapsed
```
However, for parallel test execution, the underlying test modules were returning duration as a string

The xUnit generator expects a timedelta object so that it can correctly extract the total number of seconds. When a string is provided instead, the conversion fails silently and defaults to 0 seconds in the XML output:

## Why This Happens

create_xunit_results() internally calls `duration.total_seconds()`
When given a string, the code treats it as invalid input and defaults to time 0
Thus, all parallel testcases were incorrectly recorded as taking 0 seconds.

## Solution

A normalization step was added immediately after parallel test execution to ensure all parallel testcase durations are consistently stored as `datetime.timedelta`.

## Impact

Prevents misleading reports where long-running parallel tests appear in the mailbox result as bvt result

## Log
https://149.81.216.83/job/test-bvt-report-tc/4

## Snippet

![Uploading image.png…]()


## Snippet:
<img width="834" height="767" alt="image" src="https://github.com/user-attachments/assets/4352e5de-a518-4443-9c0d-4ad47e323a97" />

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
