### PR TITLE
[TFA-fix}changes acl tests in tentacle from v1 to v2

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_regression_test.yaml
@@ -384,7 +384,6 @@ tests:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer.yaml
 
-  # v1 tests
   # ACLs tests
   - test:
       name: Basic ACLs Test
@@ -392,7 +391,7 @@ tests:
       polarion-id: CEPH-14239
       module: sanity_rgw.py
       config:
-        test-version: v1
+        test-version: v2
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
@@ -403,7 +402,7 @@ tests:
       polarion-id: CEPH-14242
       module: sanity_rgw.py
       config:
-        test-version: v1
+        test-version: v2
         run-on-rgw: true
         script-name: test_acls_copy_obj.py
         config-file-name: test_acls_copy_obj.yaml
@@ -414,7 +413,7 @@ tests:
       polarion-id: CEPH-14260 # also applies to CEPH-10489
       module: sanity_rgw.py
       config:
-        test-version: v1
+        test-version: v2
         run-on-rgw: true
         script-name: test_acls_reset.py
         config-file-name: test_acls_reset.yaml
@@ -425,7 +424,7 @@ tests:
       polarion-id: CEPH-14240 # also applies to CEPH-14241, CEPH-10487, CEPH-10488
       module: sanity_rgw.py
       config:
-        test-version: v1
+        test-version: v2
         run-on-rgw: true
         script-name: test_acls_all_usrs.py
         config-file-name: test_acls_all_usrs.yaml
@@ -437,7 +436,7 @@ tests:
       polarion-id: CEPH-14266
       module: sanity_rgw.py
       config:
-        test-version: v1
+        test-version: v2
         run-on-rgw: true
         script-name: test_multipart_upload_cancel.py
         config-file-name: test_multipart_upload_cancel.yaml


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

As per the ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/809, I have updated the ACL test cases to change the test_version from v1 to v2 so that they run on v2  on Tentacle.

Failed logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-10/Regression/20.1.0-64/rgw/5/tier-2_rgw_regression_test/
pass logs:
https://ibm.box.com/s/qg0khyvro6ncdddhge2yyulg1ae3griy
