### PR TITLE
Added fix for ns masking suites found in regression in 9.0

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_ns-masking.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_ns-masking.yaml
@@ -71,98 +71,64 @@ tests:
   - test:
       abort-on-fail: true
       config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: shell
-              args:
-                - ceph osd pool create nvmeof_pool
-          - config:
-              command: shell
-              args:
-                - rbd pool init nvmeof_pool
-          - config:
-              command: apply
-              service: nvmeof
-              args:
-                placement:
-                  nodes:
-                  - node4
-                  - node5
-                  - node6
-                  - node7
-              pos_args:
-                - nvmeof_pool
-                - group1
-          - config:
-              command: shell
-              args:
-                - ceph osd pool create rbd
-          - config:
-              command: shell
-              args:
-                - rbd pool init rbd
-      desc: deploy NVMeoF service for GW group 1
-      destroy-cluster: false
-      do-not-skip-tc: true
-      module: test_cephadm.py
-      name: deploy NVMeoF service for GW group 1
-      polarion-id: CEPH-83595696
-
-  - test:
-      abort-on-fail: true
-      config:
-        node: node4
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        steps:
-          - config:
-              service: subsystem
-              command: add
-              args:
-                subsystems: 5
-                max-namespaces: 1024
-          - config:
-              service: listener
-              command: add
-              args:
-                subsystems: 5
-                port: 4420
-                group: group1
-                nodes:
-                  - node4
-                  - node5
-                  - node6
-                  - node7
-          - config:
-              service: host
-              command: add
-              args:
-                subsystems: 5
-                group: group1
-      desc: GW group with 4 GWs and 5 subsystems
-      destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Configure subsystems
-      polarion-id: CEPH-83595512
-
-  - test:
-      abort-on-fail: true
-      config:
-        nodes:
+        gw_nodes:
           - node4
-        rbd_pool: rbd
+          - node5
+          - node6
+          - node7
+        rbd_pool: pool1
+        gw_group: group1
+        install: true  
+        cleanup:
+          - initiators
+          - gateway
+          - pool
         do_not_create_image: true
         rep-pool-only: true
         service: namespace
+        subsystems:  # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 4420
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            listener_port: 4420
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            listener_port: 4420
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            listener_port: 4420
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            listener_port: 4420
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
         steps:
           - config:
               command: add
               args:
                 subsystems: 5
                 namespaces: 50
-                pool: rbd
+                pool: pool1
                 image_size: 1T
                 no-auto-visible: true
                 group: group1


### PR DESCRIPTION
Changes:-
Changed nvme deployment and configuration of subsystems, listeners
Changed nvme list output in ha.py according to latest changes in nvme list output
commented serial number validation 

Unable to collect the logs because of BZ https://bugzilla.redhat.com/show_bug.cgi?id=2416780

Logs with failures:- http://magna002.ceph.redhat.com/cephci-jenkins/ns_masking_changes/