### PR TITLE
Fix RHEL major version extraction logic

### DIFF
--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -71,7 +71,7 @@ def add(cls, config: Dict) -> None:
             else:
                 rhcs_version = "default"
 
-            rhel_version = _node.distro_info["VERSION_ID"][0]
+            rhel_version = _node.distro_info["VERSION_ID"].split(".")[0]
             log.debug(
                 f"RHCS version : {rhcs_version} on host {_node.hostname}\n"
                 f"with RHEL major version as : {rhel_version}"


### PR DESCRIPTION
# Description

Fixed the version parsing logic to correctly extract the major version number from RHEL version strings. The previous implementation was incorrectly parsing version strings, causing issues with multi-digit major versions (e.g., returning "1" instead of "10" for version "10.1").

This fix ensures that the major version is correctly extracted for all RHEL versions, including single-digit (8.x, 9.x) and multi-digit (10.x, 11.x, etc.) major versions.

The issue was discovered when testing with RHEL 10.1, which incorrectly returned "1" as the major version instead of "10".