### PR TITLE
[Bluestore compression] Adds osd/osd host down during IO scenarios

### DIFF
--- a/suites/tentacle/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_bluestore.yaml
@@ -281,10 +281,47 @@ tests:
             - -4000
 
   - test:
-        name: Bluestore data recompression
+        name: Bluestore target blob size variation test
         module: test_bluestore_comp_enhancements.py
         desc: Positive workflows for bluestore data compression enhancements
         polarion-id: CEPH-83620071
         config:
           scenarios_to_run:
             - scenario-6
+
+  - test:
+        name: Bluestore blob size tests
+        module: test_bluestore_comp_enhancements.py
+        desc: Positive workflows for bluestore data compression enhancements
+        polarion-id: CEPH-83620071
+        config:
+          scenarios_to_run:
+            - scenario-7
+
+  - test:
+        name: Bluestore OSD down during IO scenaario
+        module: test_bluestore_comp_enhancements.py
+        desc: Positive workflows for bluestore data compression enhancements
+        polarion-id: CEPH-83620071
+        config:
+          scenarios_to_run:
+            - scenario-9
+
+  - test:
+        name: Bluestore OSD host down during IO scenario
+        module: test_bluestore_comp_enhancements.py
+        desc: Positive workflows for bluestore data compression enhancements
+        polarion-id: CEPH-83620071
+        config:
+          scenarios_to_run:
+            - scenario-10
+
+ # scenario-8 disables bluestore_write_v2
+  - test:
+        name: Bluestore disable bluestore_write_v2 and validate
+        module: test_bluestore_comp_enhancements.py
+        desc: Positive workflows for bluestore data compression enhancements
+        polarion-id: CEPH-83620071
+        config:
+          scenarios_to_run:
+            - scenario-8


### PR DESCRIPTION
PR includes 2 Scenarios for bluestore compression :- 

```
            Test compression validation when primary OSD is down.
            Steps:
            1) Create Pool
            2) Enable compression
            3) Shutdown primary osd
            4) Write IO to the pools
            5) Read the collections from the secondary and tertiary OSD and check if they are compressed
            6) Restart the primary OSD
            7) Check all the objects in primary OSD
            8) They should be compressed
            9) Clean up the pool
```

```
            Test compression validation when primary OSD host is down.
            Steps:
            1) Create pool
            2) Fetch primary OSD, secondary, tertiary OSD
            3) Shutdown OSD host of primary OSD
            4) Enable compression
            5) Write IO to the pool
            6) Check the secondary_osd and tertiary_osd for compression
            7) Restart primary OSD host
            8) Validate that the object written to pool is stored compressed in primary OSD
            9) Cleanup
```

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
