### PR TITLE
[TFA][DMFG] Fix OsTuningProfileError

### DIFF
--- a/suites/tentacle/cephadm/tier1-os-tuning-profiles.yaml
+++ b/suites/tentacle/cephadm/tier1-os-tuning-profiles.yaml
@@ -334,11 +334,12 @@ tests:
             hosts:
               - hostx
           settings:
-            fs.filex: 100000
+            fs.file-max: 100000
         result: "Please check 'ceph orch host ls' for available hosts"
   - test:
       name: no_profile_name
       desc: Verify cephadm gives error if profile_name is not mentioned in YAML spec.
+      comments: Known issue BZ 2423855
       polarion-id: CEPH-83575327
       module: test_os_tuning_profile.py
       config:
@@ -350,5 +351,5 @@ tests:
               - node1
               - node2
           settings:
-            fs.filex: 100000
+            fs.file-max: 100000
         result: "Failed to apply tuned profile"


### PR DESCRIPTION
# Description

Failing logs - 
https://149.81.216.83/job/tentacle-dmfg-regression-ci/23/pipeline-overview/log?nodeId=294 

Error Traceback -
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/RH/9.0/rhel-10/regression/20.1.0-95/dmfg/23/cephci/run.py", line 923, in run
    rc = test_mod.run(
  File "/data/jenkins/ceph-builds/RH/9.0/rhel-10/regression/20.1.0-95/dmfg/23/cephci/tests/cephadm/test_os_tuning_profile.py", line 97, in run
    raise OsTuningProfileError("Fail to apply tuned profile")
test_os_tuning_profile.OsTuningProfileError: Fail to apply tuned profile

TFA fix includes changes to the test_os_tuning_profile.py to ensure that test logic doesn't properly distinguish between positive and negative test cases, and tests are not mixing multiple invalid conditions.

Also, added change to the failing tests as below -
**error_host_setting test** - changed spec "fs.filex: 100000" to "fs.file-max: 100000" so that it tests for only host error
**no_profile_name test** - changed spec "fs.filex: 100000" to "fs.file-max: 100000" so that it tests only profile name error


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
