### PR TITLE
fix: reconnect service URL before API invocation

### DIFF
--- a/compute/ibm_vpc.py
+++ b/compute/ibm_vpc.py
@@ -687,6 +687,10 @@ class CephVMNodeIBM:
                     self.node["name"], node_id
                 )
             )
+            self.service = get_ibm_service(
+                access_key=self._os_cred_ibm["accesskey"],
+                service_url=self._os_cred_ibm["service_url"],
+            )
             self.service.create_instance_action(node_id, type="stop")
             if wait:
                 try:
@@ -714,6 +718,10 @@ class CephVMNodeIBM:
             node_id = self.node["id"]
             LOG.info(
                 "Powering on IBM node: {} (ID: {})".format(self.node["name"], node_id)
+            )
+            self.service = get_ibm_service(
+                access_key=self._os_cred_ibm["accesskey"],
+                service_url=self._os_cred_ibm["service_url"],
             )
             self.service.create_instance_action(node_id, type="start")
             self._wait_until_vm_state(node_id, target_state="running")


### PR DESCRIPTION
# Description
fix: reconnect service URL before API invocation

Reinitialize the IBM service connection before triggering stop/start actions.
Prevents failures caused by expired or outdated service clients during VPC power operations.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
