### PR TITLE
[RADOS] RHCEPHQE-22470: Add support for new qe-ceph-manifest file in RADOS test workflows

### DIFF
--- a/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -29,6 +29,7 @@ tests:
               args:
                 rhcs-version: 7.1
                 release: rc
+                platform: rhel-9
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
                 registry-url: registry.redhat.io

--- a/suites/tentacle/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-brownfield.yaml
@@ -25,6 +25,7 @@ tests:
               args:
                 rhcs-version: 7.1
                 release: z1     # deploying old build to verify obj snap deletion
+                platform: rhel-9
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
@@ -167,6 +168,7 @@ tests:
         args:
           rhcs-version: 7.1
           release: z2
+          platform: rhel-9
       abort-on-fail: false
 
   - test:
@@ -193,6 +195,7 @@ tests:
         args:
           rhcs-version: 8.0
           release: rc
+          platform: rhel-9
       abort-on-fail: true
 
   - test:

--- a/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -29,6 +29,7 @@ tests:
               args:
                 rhcs-version: 7.1
                 release: z0
+                platform: rhel-9
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -24,6 +24,7 @@ tests:
               args:
                 rhcs-version: 8.0
                 release: rc
+                platform: rhel-9
                 mon-ip: mero001
                 allow-fqdn-hostname: true
                 yes-i-know: true

--- a/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -25,6 +25,7 @@ tests:
         args:
           rhcs-version: 7.1
           release: rc
+          platform: rhel-9
           mon-ip: node1
           orphan-initial-daemons: true
           registry-url: registry.redhat.io
@@ -220,6 +221,7 @@ tests:
         args:
           rhcs-version: 8.0
           release: rc
+          platform: rhel-9
       abort-on-fail: false
 
   # "cephfs basic operations" and "nfs-ganesha_with_cephfs"

--- a/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -21,6 +21,7 @@ tests:
           mon-ip: node1
           rhcs-version: 8.0
           release: rc
+          platform: rhel-9
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -24,6 +24,7 @@ tests:
                 mon-ip: node1
                 rhcs-version: 8.0
                 release: rc
+                platform: rhel-9
 
   - test:
       name: Add host

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -24,6 +24,7 @@ tests:
                 mon-ip: node1
                 rhcs-version: 7.1
                 release: rc
+                platform: rhel-9
 
   - test:
       name: Add host

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
@@ -33,6 +33,7 @@ tests:
                 mon-ip: node1
                 rhcs-version: 8.1
                 release: rc
+                platform: rhel-9
 
   - test:
       name: Add host

--- a/suites/tentacle/rados/tier-3_rados_test_5+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_5+2_ecpools.yaml
@@ -24,6 +24,7 @@ tests:
                 mon-ip: node1
                 rhcs-version: 8.1
                 release: rc
+                platform: rhel-9
 
   - test:
       name: Add host

--- a/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
@@ -24,6 +24,7 @@ tests:
                 mon-ip: node1
                 rhcs-version: 8.1
                 release: rc
+                platform: rhel-9
 
   - test:
       name: Add host


### PR DESCRIPTION
Adds support for new qe-ceph-manifest file and methods. Removes deprecated methods.

Provides platform as rhel-9 as an explicit argument to bootstrap.py to fetch the appropriate repo to deploy older releases while testing Tentacle and above releases

Signed-off-by: Harsh Kumar <hakumar@redhat.com>