### PR TITLE
Decoupling Initiator Module: Separating out IO and Initiator setup

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -1,5 +1,5 @@
 tests:
-# Set up the cluster
+# # Set up the cluster
   - test:
       abort-on-fail: true
       module: install_prereq.py
@@ -401,6 +401,8 @@ tests:
               count: 1
               size: 5G
             listener_port: 4420
+            hosts:
+              node: node10
         initiators: # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:ceph-83575455
             listener_port: 4420

--- a/tests/nvmeof/test_io_perf.py
+++ b/tests/nvmeof/test_io_perf.py
@@ -12,8 +12,9 @@ import yaml
 from ceph.ceph import Ceph
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
-from tests.nvmeof.test_ceph_nvmeof_gateway import disconnect_initiator, initiators
+from tests.nvmeof.test_ceph_nvmeof_gateway import disconnect_initiator
 from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.initiator import prepare_initiator_and_run_fio
 from tests.nvmeof.workflows.nvme_service import NVMeService
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.io.fio_profiles import IO_Profiles
@@ -509,7 +510,9 @@ def nvmeof(ceph_cluster, **args):
                     # apply overrides
                     initiator_cfg["io_args"].update(args.get("io_overrides", {}))
 
-                    i = initiators(ceph_cluster, nvmegwcli, initiator_cfg)
+                    i = prepare_initiator_and_run_fio(
+                        ceph_cluster, nvmegwcli, initiator_cfg
+                    )
                     parse_fio_output(
                         get_node_by_id(ceph_cluster, args["initiator_node"]), i[0]
                     )


### PR DESCRIPTION
Pass log: 
1) http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XXKAHV/ : test_io_perf.py
2) http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KWKQIR/Perform_restart_of_NVMeOF_gateway_0.log
2) http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JVOIVP/Perform_cluster_operations_when_IO_operations_are_in_progress._0.log
2) http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEI90K/Remove-image_ops_on_NVMe_Namespace_0.log
2) http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEI90K/Perform_restart_of_NVMeOF_gateway_0.log
2) http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEI90K/RBD_operations_shrink_and_expand_on_images_0.log
