### PR TITLE
[CephFS]:[Enhancement]: To fallback to single function usage for nfs create

### DIFF
--- a/cli/ceph/nfs/cluster/cluster.py
+++ b/cli/ceph/nfs/cluster/cluster.py
@@ -23,6 +23,7 @@ class Cluster(Cli):
         vip=None,
         active_standby=False,
         nfs_nodes_obj=None,
+        check_ec=True,
         **kwargs,
     ):
         """
@@ -46,7 +47,10 @@ class Cluster(Cli):
             cmd += " --ingress --virtual-ip {0}".format(vip)
 
         cmd = "".join(cmd + build_cmd_from_args(**kwargs))
-        out = self.execute(sudo=True, cmd=cmd)
+        try:
+            out = self.execute(sudo=True, cmd=cmd, check_ec=check_ec)
+        except Exception as e:
+            raise RuntimeError(f"Failed to create NFS cluster: {e}")
         if isinstance(out, tuple):
             return out[0].strip()
         return out

--- a/tests/cephfs/cephfs_bugs/clone_no_wait_if_max_concurrent.py
+++ b/tests/cephfs/cephfs_bugs/clone_no_wait_if_max_concurrent.py
@@ -31,8 +31,10 @@ def test_setup(fs_util, ceph_cluster, client):
     nfs_server = nfs_servers[0].node.hostname
     nfs_name = "cephfs-nfs"
 
-    client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+    fs_util.create_nfs(
+        client,
+        nfs_cluster_name=nfs_name,
+        nfs_server_name=nfs_server,
     )
     if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
         log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_bugs/test_create_unlink_ops_concorrently.py
+++ b/tests/cephfs/cephfs_bugs/test_create_unlink_ops_concorrently.py
@@ -117,8 +117,10 @@ def run(ceph_cluster, **kw):
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
         clients[0].exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        clients[0].exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util_v1.create_nfs(
+            clients[0],
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=clients[0], process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_bugs/test_fs_recovery_dir_rm.py
+++ b/tests/cephfs/cephfs_bugs/test_fs_recovery_dir_rm.py
@@ -27,8 +27,10 @@ def test_setup(fs_util, ceph_cluster, client):
     nfs_server = nfs_servers[0].node.hostname
     nfs_name = "cephfs-nfs"
 
-    client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+    fs_util.create_nfs(
+        client,
+        nfs_cluster_name=nfs_name,
+        nfs_server_name=nfs_server,
     )
     if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
         log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/2_node_nfs.py
+++ b/tests/cephfs/cephfs_nfs/2_node_nfs.py
@@ -74,8 +74,10 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
 
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs1},{nfs2}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[nfs1, nfs2],
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/data_backup_restore_bw_nfs_and_local_mounts.py
+++ b/tests/cephfs/cephfs_nfs/data_backup_restore_bw_nfs_and_local_mounts.py
@@ -58,8 +58,10 @@ def run(ceph_cluster, **kw):
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/existing_path_nfs_export.py
+++ b/tests/cephfs/cephfs_nfs/existing_path_nfs_export.py
@@ -60,8 +60,10 @@ def run(ceph_cluster, **kw):
         if not fs_details:
             fs_util.create_fs(client1, default_fs)
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/modifying_nfs_cluster_invalid_value.py
+++ b/tests/cephfs/cephfs_nfs/modifying_nfs_cluster_invalid_value.py
@@ -41,8 +41,10 @@ def run(ceph_cluster, **kw):
         nfs_name = "cephfs-nfs"
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/move_data_bw_nfs_and_cephfs_mounts.py
+++ b/tests/cephfs/cephfs_nfs/move_data_bw_nfs_and_cephfs_mounts.py
@@ -56,8 +56,10 @@ def run(ceph_cluster, **kw):
         nfs_name = "cephfs-nfs"
         default_fs = "cephfs" if not erasure else "cephfs-ec"
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/nfs_config_reset.py
+++ b/tests/cephfs/cephfs_nfs/nfs_config_reset.py
@@ -76,8 +76,10 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/nfs_export_config.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_config.py
@@ -66,8 +66,10 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/nfs_export_path.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_path.py
@@ -57,8 +57,10 @@ def run(ceph_cluster, **kw):
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/nfs_fuse_kernel_same_subvolume.py
+++ b/tests/cephfs/cephfs_nfs/nfs_fuse_kernel_same_subvolume.py
@@ -62,8 +62,10 @@ def run(ceph_cluster, **kw):
 
         if not fs_details:
             fs_util.create_fs(client1, fs_name)
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
+++ b/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
@@ -74,8 +74,10 @@ def run(ceph_cluster, **kw):
         )
 
         passed = []
-        client1.exec_command(
-            sudo=True, cmd=f'ceph nfs cluster create {cluster_id} "{nfs_target_node}"'
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=cluster_id,
+            nfs_server_name=nfs_target_node,
         )
         cmd_nfs_export = (
             f"ceph nfs export create cephfs {cluster_id} {bind} {fs_name} --path={path}"

--- a/tests/cephfs/cephfs_nfs/nfs_io_network_failures.py
+++ b/tests/cephfs/cephfs_nfs/nfs_io_network_failures.py
@@ -83,8 +83,10 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/nfs_mount_with_fstab.py
+++ b/tests/cephfs/cephfs_nfs/nfs_mount_with_fstab.py
@@ -68,8 +68,10 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/nfs_multiple_export_using_single_conf.py
+++ b/tests/cephfs/cephfs_nfs/nfs_multiple_export_using_single_conf.py
@@ -43,8 +43,10 @@ def run(ceph_cluster, **kw):
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         ceph_version = get_ceph_version_from_cluster(clients[0])
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/nfs_non_exist_export_path.py
+++ b/tests/cephfs/cephfs_nfs/nfs_non_exist_export_path.py
@@ -54,8 +54,10 @@ def run(ceph_cluster, **kw):
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
@@ -67,8 +67,10 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/nfs_update_cluster_node_changes.py
+++ b/tests/cephfs/cephfs_nfs/nfs_update_cluster_node_changes.py
@@ -67,9 +67,10 @@ def run(ceph_cluster, **kw):
         cluster_name = f"nfs_{rand}"
         # create a nfs cluster with 2 hosts
         log.info(f"Deplying nfs cluster with {candidate_1} {candidate_2}")
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {cluster_name} "{candidate_1} {candidate_2}"',
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=cluster_name,
+            nfs_server_name=[candidate_1, candidate_2],
         )
         verify_host_nfs(client1, [candidate_1, candidate_2], cluster_name)
         # reduce host to 1

--- a/tests/cephfs/cephfs_nfs/recreate_same_name_nfs.py
+++ b/tests/cephfs/cephfs_nfs/recreate_same_name_nfs.py
@@ -65,8 +65,10 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        out, rc = client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/subvolume_export.py
+++ b/tests/cephfs/cephfs_nfs/subvolume_export.py
@@ -59,8 +59,10 @@ def run(ceph_cluster, **kw):
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_nfs/test_all_nfs_vers_mount_and_perform_failover.py
+++ b/tests/cephfs/cephfs_nfs/test_all_nfs_vers_mount_and_perform_failover.py
@@ -74,11 +74,17 @@ def run(ceph_cluster, **kw):
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
 
         log.info("Create NFS Cluster with Ingress")
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
         log.info("validate the services have started on nfs")
         fs_util_v1.validate_services(client1, f"nfs.{nfs_name}")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_active_power_off.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_active_power_off.py
@@ -77,11 +77,17 @@ def run(ceph_cluster, **kw):
         client1 = clients[0]
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_name = "cephnfs"
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
 
         log.info("validate the services have started on nfs")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_cli.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_cli.py
@@ -59,13 +59,18 @@ def run(ceph_cluster, **kw):
         client1 = clients[0]
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_name = "cephnfs"
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
-
         log.info("validate the services hace started on nfs")
         fs_util_v1.validate_services(client1, f"nfs.{nfs_name}")
         fs_util_v1.validate_services(client1, f"ingress.nfs.{nfs_name}")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_with_non_default_port.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_with_non_default_port.py
@@ -61,11 +61,18 @@ def run(ceph_cluster, **kw):
 
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet} --port {non_default_port}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
+            port=non_default_port,
         )
 
         log.info("validate the services have started on nfs")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_failover.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_failover.py
@@ -64,13 +64,18 @@ def run(ceph_cluster, **kw):
         client1 = clients[0]
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_name = "cephnfs"
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
-
         log.info("validate the services have started on nfs")
         fs_util_v1.validate_services(client1, f"nfs.{nfs_name}")
         fs_util_v1.validate_services(client1, f"ingress.nfs.{nfs_name}")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_keeplive_services.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_keeplive_services.py
@@ -88,13 +88,18 @@ spec:
             )
         )
 
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
-
         filename = "nfs_ha_keepalive.yaml"
         nfs_file = clients[0].remote_file(
             sudo=True,

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_node_replacement.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_node_replacement.py
@@ -82,11 +82,17 @@ def run(ceph_cluster, **kw):
         client1 = clients[0]
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_name = "cephnfs"
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
 
         log.info("validate the services have started on nfs")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_snapshot_access.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_snapshot_access.py
@@ -68,11 +68,17 @@ def run(ceph_cluster, **kw):
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
         log.info("Creating NFS HA cluster with --ingress flag")
 
-        client1.exec_command(
-            sudo=True,
-            cmd=f'ceph nfs cluster create {nfs_name} "2 {nfs_servers[0].node.hostname} '
-            f'{nfs_servers[1].node.hostname} {nfs_servers[2].node.hostname}" '
-            f"--ingress --virtual-ip {virtual_ip}/{subnet}",
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                "2",
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+                nfs_servers[2].node.hostname,
+            ],
+            ha=True,
+            vip=f"{virtual_ip}/{subnet}",
         )
 
         log.info("Validate that the HA services have started")

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
@@ -49,8 +49,10 @@ def run(ceph_cluster, **kw):
         nfs_name = "cephfs-nfs"
         local_fs_path = "/tmp/"
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/test_data_integrity_nfs_cephfs_mounts.py
+++ b/tests/cephfs/cephfs_nfs/test_data_integrity_nfs_cephfs_mounts.py
@@ -69,8 +69,10 @@ def run(ceph_cluster, **kw):
         if not fs_details:
             fs_util.create_fs(client1, default_fs)
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_nfs/zip_unzip_files_nfs.py
+++ b/tests/cephfs/cephfs_nfs/zip_unzip_files_nfs.py
@@ -55,8 +55,10 @@ def run(ceph_cluster, **kw):
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_system/cluster_down_up.py
+++ b/tests/cephfs/cephfs_system/cluster_down_up.py
@@ -95,9 +95,13 @@ def run(ceph_cluster, **kw):
             nfs_server = nfs_servers[0].node.hostname
             # Create ceph nfs cluster
             nfs_client[0].exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-            out, rc = nfs_client[0].exec_command(
-                sudo=True,
-                cmd=f"ceph nfs cluster create {nfs_name} {nfs_servers[0].node.hostname},{nfs_servers[1].node.hostname}",
+            fs_util.create_nfs(
+                nfs_client[0],
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=[
+                    nfs_servers[0].node.hostname,
+                    nfs_servers[1].node.hostname,
+                ],
             )
             # Verify ceph nfs cluster is created
             if wait_for_process(

--- a/tests/cephfs/cephfs_system/mds_cache_trimming_caps_recall.py
+++ b/tests/cephfs/cephfs_system/mds_cache_trimming_caps_recall.py
@@ -61,8 +61,10 @@ def test_setup(fs_util, ceph_cluster, client):
     nfs_server = nfs_servers[0].node.hostname
     nfs_name = "cephfs-nfs"
 
-    client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+    fs_util.create_nfs(
+        client,
+        nfs_cluster_name=nfs_name,
+        nfs_server_name=nfs_server,
     )
     if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
         log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_system/mds_failover_standby_replay_systemic_test.py
+++ b/tests/cephfs/cephfs_system/mds_failover_standby_replay_systemic_test.py
@@ -69,8 +69,10 @@ def test_setup(fs_util, ceph_cluster, client):
     nfs_server = nfs_servers[0].node.hostname
     nfs_name = "cephfs-nfs"
 
-    client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+    fs_util.create_nfs(
+        client,
+        nfs_cluster_name=nfs_name,
+        nfs_server_name=nfs_server,
     )
     if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
         log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_system/mds_nfs_node_failure_ops.py
+++ b/tests/cephfs/cephfs_system/mds_nfs_node_failure_ops.py
@@ -105,9 +105,13 @@ def run(ceph_cluster, **kw):
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
-        client1.exec_command(
-            sudo=True,
-            cmd=f"ceph nfs cluster create {nfs_name} {nfs_servers[0].node.hostname},{nfs_servers[1].node.hostname}",
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=[
+                nfs_servers[0].node.hostname,
+                nfs_servers[1].node.hostname,
+            ],
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")

--- a/tests/cephfs/cephfs_top/cephfs_top_negative_tests.py
+++ b/tests/cephfs/cephfs_top/cephfs_top_negative_tests.py
@@ -59,8 +59,10 @@ def test_setup(fs_util, ceph_cluster, client):
     nfs_server = nfs_servers[0].node.hostname
     nfs_name = "cephfs-nfs"
 
-    client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+    fs_util.create_nfs(
+        client,
+        nfs_cluster_name=nfs_name,
+        nfs_server_name=nfs_server,
     )
     if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
         log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -122,8 +122,10 @@ def nfs_test(nfs_req_params):
     log.info("Create new nfs cluster, new exports and run IO")
 
     new_nfs_name = f"{nfs_name}_new"
-    out, rc = nfs_client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {new_nfs_name} {nfs_server_name_1}"
+    fs_util.create_nfs(
+        nfs_client,
+        nfs_cluster_name=new_nfs_name,
+        nfs_server_name=nfs_server_name_1,
     )
     log.info("Verify ceph nfs cluster is created")
     if wait_for_process(client=nfs_client, process_name=nfs_name, ispresent=True):

--- a/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
+++ b/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
@@ -463,8 +463,10 @@ def run(ceph_cluster, **kw):
             nfs_server_name = nfs_server[0].node.hostname
             # Create ceph nfs cluster
             nfs_client[0].exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-            out, rc = nfs_client[0].exec_command(
-                sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server_name}"
+            fs_util.create_nfs(
+                nfs_client[0],
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=nfs_server_name,
             )
             ceph_config["NFS"].update({nfs_name: {}})
             # Verify ceph nfs cluster is created

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -203,8 +203,10 @@ def run(ceph_cluster, **kw):
             nfs_server = nfs_servers[0].node.hostname
             nfs_name = "cephfs-nfs"
 
-            client1.exec_command(
-                sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+            fs_util.create_nfs(
+                client1,
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=nfs_server,
             )
             if not wait_for_process(
                 client=client1, process_name=nfs_name, ispresent=True

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_rename_scenarios.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_rename_scenarios.py
@@ -1023,8 +1023,10 @@ def run(ceph_cluster, **kw):
         # fs_util.prepare_clients(clients, build)
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
-        client1.exec_command(
-            sudo=True, cmd="ceph nfs cluster create %s %s" % (nfs_name, nfs_server)
+        fs_util.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         install_tools(client1)
         mount_subvolumes(ceph_cluster)

--- a/tests/cephfs/clients/client_caps_update_validation.py
+++ b/tests/cephfs/clients/client_caps_update_validation.py
@@ -58,8 +58,10 @@ def test_setup(fs_util, ceph_cluster, client):
     nfs_server = nfs_servers[0].node.hostname
     nfs_name = "cephfs-nfs"
 
-    client.exec_command(
-        sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+    fs_util.create_nfs(
+        client,
+        nfs_cluster_name=nfs_name,
+        nfs_server_name=nfs_server,
     )
     if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
         log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/clients/file_lock_on_mounts.py
+++ b/tests/cephfs/clients/file_lock_on_mounts.py
@@ -94,8 +94,10 @@ def run(ceph_cluster, **kw):
             nfs_server_name = nfs_server[0].node.hostname
             # Create ceph nfs cluster
             nfs_client[0].exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-            out, rc = nfs_client[0].exec_command(
-                sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server_name}"
+            fs_util.create_nfs(
+                nfs_client[0],
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=nfs_server_name,
             )
             # Verify ceph nfs cluster is created
             if wait_for_process(

--- a/tests/cephfs/clients/fs_basic_bash_cmds.py
+++ b/tests/cephfs/clients/fs_basic_bash_cmds.py
@@ -89,8 +89,10 @@ def run(ceph_cluster, **kw):
             nfs_server_name = nfs_server[0].node.hostname
             # Create ceph nfs cluster
             nfs_client[0].exec_command(sudo=True, cmd="ceph mgr module enable nfs")
-            out, rc = nfs_client[0].exec_command(
-                sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server_name}"
+            fs_util.create_nfs(
+                nfs_client[0],
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=nfs_server_name,
             )
             # Verify ceph nfs cluster is created
             if wait_for_process(

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -104,8 +104,10 @@ class CephFSCommonUtils(FsUtils):
         nfs_server = nfs_servers[0].node.hostname
         out, _ = client.exec_command(sudo=True, cmd="ceph nfs cluster ls")
         if nfs_name not in out:
-            client.exec_command(
-                sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+            self.create_nfs(
+                client,
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=nfs_server,
             )
         if wait_for_process(client=client, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/snapshot_clone/cg_snap_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_test.py
@@ -271,8 +271,10 @@ def run(ceph_cluster, **kw):
                 nfs_server = nfs_servers[0].node.hostname
                 nfs_name = "cephfs-nfs"
                 client1 = clients[0]
-                client1.exec_command(
-                    sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+                fs_util_v1.create_nfs(
+                    client1,
+                    nfs_cluster_name=nfs_name,
+                    nfs_server_name=nfs_server,
                 )
                 if wait_for_process(
                     client=client1, process_name=nfs_name, ispresent=True

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -118,8 +118,10 @@ def run(ceph_cluster, **kw):
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
         client1 = clients[0]
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/snapshot_clone/snapshot_nfs_mount.py
+++ b/tests/cephfs/snapshot_clone/snapshot_nfs_mount.py
@@ -65,8 +65,10 @@ def run(ceph_cluster, **kw):
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
         client1 = clients[0]
-        client1.exec_command(
-            sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
+        fs_util_v1.create_nfs(
+            client1,
+            nfs_cluster_name=nfs_name,
+            nfs_server_name=nfs_server,
         )
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")

--- a/tests/cephfs/snapshot_clone/test_referent_inode_singleFS.py
+++ b/tests/cephfs/snapshot_clone/test_referent_inode_singleFS.py
@@ -597,7 +597,7 @@ def run(ceph_cluster, **kwargs) -> int:
 
         nfs_name = "cephfs-nfs"
         try:
-            cmd_output, cmd_return_code = fs_util.create_nfs(
+            cmd_output = fs_util.create_nfs(
                 client, nfs_name, validate=True, placement=f"1 {nfs_server}"
             )
             log.info(

--- a/tests/cephfs/snapshot_clone/test_snapshot_visibility_multi_fs_nfs_clients.py
+++ b/tests/cephfs/snapshot_clone/test_snapshot_visibility_multi_fs_nfs_clients.py
@@ -31,7 +31,7 @@ def run(ceph_cluster, **kw):
     """
     try:
         global fs_system_utils, snap_util, cephfs_common_utils, fs_io, nfs_name, nfs_server, sv_test_params, clients
-        global nfs_servers
+        global nfs_servers, fs_util
         test_data = kw.get("test_data")
         fs_util = FsUtilsv1(ceph_cluster, test_data=test_data)
         cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
@@ -268,8 +268,10 @@ def setup_test_obj(obj_name, obj_type, **kwargs):
                     sudo=True, cmd="ceph nfs cluster ls;ceph orch ls"
                 )
                 log.info(out)
-                clients[0].exec_command(
-                    sudo=True, cmd=f"ceph nfs cluster create {obj_name} {nfs_server1}"
+                fs_util.create_nfs(
+                    clients[0],
+                    nfs_cluster_name=obj_name,
+                    nfs_server_name=nfs_server1,
                 )
                 if wait_for_process(
                     client=clients[0], process_name=obj_name, ispresent=True


### PR DESCRIPTION
# Description

## Issue: 
Currently RHEL-10.1 needs a manual enable for rpcbind service as a workaround
Ref: https://github.com/red-hat-storage/cephci/pull/5422

## Impact:

- Existing Sanity and Regression Suite for CephFS fails to mount

## Fixes

- Made changes to the harcoded commands to use lib for create on all tests
- Enhance the cephfs lib to adapt to NFS Cli Create
- Add a try block with check_ec flag enabled to handle negative scenarios in cephfs

## Log
https://149.81.216.83/view/Executor/job/tentacle-test-executor/224/pipeline-overview/

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
