### PR TITLE
Adds negative scenarios for disable stretch mode

### DIFF
--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
@@ -20,7 +20,7 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-#          registry-json: registry.redhat.io
+          registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
           skip-dashboard: true
@@ -94,7 +94,7 @@ tests:
                     label: osd
                   spec:
                     data_devices:
-                      all: "true"                         # boolean as string
+                      all: "true" # boolean as string
           - config:
               command: shell
               args: # display OSD tree
@@ -150,20 +150,14 @@ tests:
         command: add
         id: client.1
         nodes:
-            # added as a workaround due to ceph-common, ceph-base package
-            # installation issue in tentacle
-            - node7:
-                release: 8
-            - node15:
-                release: 8
-            - node16:
-                release: 8
-            - node17:
-                release: 8
+          - node7
+          - node15
+          - node16
+          - node17
         install_packages:
           - ceph-common
           - ceph-base
-        copy_admin_keyring: true          # Copy admin keyring to node
+        copy_admin_keyring: true # Copy admin keyring to node
         caps: # authorize client capabilities
           mon: "allow *"
           osd: "allow *"
@@ -204,14 +198,14 @@ tests:
         io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
 
-#  - test:
-#      name: rgw sanity tests
-#      module: sanity_rgw.py
-#      config:
-#        script-name: test_multitenant_user_access.py
-#        config-file-name: test_multitenant_access.yaml
-#        timeout: 300
-#      desc: Perform rgw tests
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
 
   - test:
       abort-on-fail: false
@@ -227,7 +221,7 @@ tests:
       polarion-id: CEPH-83574439
       abort-on-fail: false
 
-# Run duration ~ 1 hour 10 minutes
+  # Run duration ~ 1 hour 10 minutes
   - test:
       name: Revert stretch mode scenarios
       module: test_stretch_revert.py
@@ -241,7 +235,7 @@ tests:
           - scenario2
       desc: Performs tests related to reverting from stretch mode
 
-# Run duration ~ 45 minutes
+  # Run duration ~ 45 minutes
   - test:
       name: Revert stretch mode netsplit scenarios
       module: test_stretch_revert.py
@@ -315,14 +309,14 @@ tests:
         regular_cluster_with_mon_location: true
       desc: Netsplit detection and warning regular cluster with crush location
 
-# id 111
-# type replicated
-# step take DC2
-# step chooseleaf firstn 2 type host
-# step emit
-# step take DC1
-# step chooseleaf firstn 2 type host
-# step emit
+  # id 111
+  # type replicated
+  # step take DC2
+  # step chooseleaf firstn 2 type host
+  # step emit
+  # step take DC1
+  # step chooseleaf firstn 2 type host
+  # step emit
   - test:
       name: Verify Max avail
       desc: MAX_AVAIL value
@@ -390,12 +384,12 @@ tests:
           - scenario12
       desc: Performs tests related to reverting from stretch mode
 
-# id 1
-# type replicated
-# step take default
-# step choose firstn 0 type datacenter
-# step chooseleaf firstn 2 type host
-# step emit
+  # id 1
+  # type replicated
+  # step take default
+  # step choose firstn 0 type datacenter
+  # step chooseleaf firstn 2 type host
+  # step emit
   - test:
       name: Deploy stretch Cluster with no affinity
       module: test_stretch_deployment_with_placement.py
@@ -408,7 +402,6 @@ tests:
       comments: Pre-deployment -ve scenarios commented due to bug - 2293147
       desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
-
 
   - test:
       name: Verify Max avail
@@ -466,13 +459,17 @@ tests:
           obj_name: "obj5"
 
   - test:
-      name: Revert stretch mode scenarios
+      name: Revert stretch mode negative scenarios
       module: test_stretch_revert.py
-      polarion-id: CEPH-83620057
-      abort-on-fail: true
+      polarion-id: CEPH-83620059
       config:
         stretch_bucket: datacenter
         tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
         scenarios_to_run:
-          - scenario12
+          - scenario13
+          - scenario14
+          - scenario15
+          - scenario16
+          - scenario17
       desc: Performs tests related to reverting from stretch mode


### PR DESCRIPTION
PR adds negative scenarios to disable stretch mode. 
Polarion test case :- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83620059 

```
12. Negative: Revert stretch mode when cluster is in recovery
13. Negative: Execute disable_stretch_mode when not in stretch mode
14. Negative: Incorrect command usage for disabling stretch mode commands
15. Negative: Disable stretch mode without --yes-i-really-mean-it
16. Negative: Revert stretch mode by passing non-existing crush rule
```

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
