### PR TITLE
Add custom/mirror repo url support for IBM Cloud/Jenkins

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -955,6 +955,9 @@ class Ceph(object):
             base_url = base_url.rstrip("/")
             if cloud_type == "openstack":
                 repo_to_use = f"{base_url}/compose/{repo}/x86_64/os/"
+            elif cloud_type == "ibmc":
+                if not base_url.endswith(".repo"):
+                    repo_to_use = f"{base_url}/Tools"
             else:
                 # The expecatation in other datacenters is Tools suffix is
                 # added by default. This is done for support of earlier


### PR DESCRIPTION
# Description

IBM Cloud environment is expected to use mirror repo for rpm package installations

Currently `qe-ceph-manifest` recipe file contains mirror rpm repo format without `/Tools` suffix, until this suffix is added, cephci framework should be capable to handle the required repo url amendments for smoother deployment.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>