### PR TITLE
NVMEof ALERTS timing issues

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -132,7 +132,7 @@ class PrometheusAlerts:
 
         Note: inetrval is the key here to calculate the alerting window
         """
-        return timeout + interval
+        return timeout + (2 * interval)
 
     def monitor_alert(
         self, alert_name, state="firing", msg="", timeout=60, interval=10


### PR DESCRIPTION
NVMEof ALERTS timing issues
[Validate_NVMeoFMultipleNamespacesOfRBDImage_alert_0.log](https://github.com/user-attachments/files/23816184/Validate_NVMeoFMultipleNamespacesOfRBDImage_alert_0.log)
