### PR TITLE
[Test] Add colocation test to restart services

### DIFF
--- a/suites/tentacle/smb/tier-1-smb-colocation.yaml
+++ b/suites/tentacle/smb/tier-1-smb-colocation.yaml
@@ -164,3 +164,46 @@ tests:
   #             subvolumegroup: smb
   #             subvolume: sv2
   #             path: /
+
+  - test:
+      name: Deploy colocation samba services and restart
+      desc: Deploy colocation samba services and restart
+      module: smb_colocation_operations.py
+      polarion-id: CEPH-83628783
+      config:
+        file_type: yaml
+        file_mount: /tmp
+        spec:
+          - resource_type: ceph.smb.cluster
+            cluster_id: smb1
+            auth_mode: user
+            user_group_settings:
+              - {source_type: resource, ref: ug1}
+            custom_ports:
+              smb: 1111
+              smbmetrics: 2222
+              ctdb: 3333
+            placement:
+              label: smb
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            values:
+              users:
+                - {name: user1, password: passwd}
+              groups: []
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /

--- a/tests/smb/smb_colocation_operations.py
+++ b/tests/smb/smb_colocation_operations.py
@@ -1,0 +1,170 @@
+import json
+
+from smb_operations import (
+    check_ctdb_health,
+    check_rados_clustermeta,
+    deploy_smb_service_declarative,
+    smb_cleanup,
+    smbclient_check_shares,
+)
+
+from ceph.ceph_admin import CephAdmin
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def verify_service(node, service_name):
+    """
+    Check service is up
+    Args:
+        node (str): monitor node object
+        service_name (str): service name
+    return: (bool)
+    """
+    # Check smb service is up
+    timeout, interval = 90, 30
+
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        out = json.loads(
+            CephAdm(node).ceph.orch.ls(service_type="smb", format="json-pretty")
+        )[0]
+        if out["service_type"] == "smb" and out["status"]["running"] > 0:
+            break
+    if w.expired:
+        raise OperationFailedError(f"Service {service_name} is not deployed")
+
+
+def run(ceph_cluster, **kw):
+    """Validate SMB Colocation shares after restarting services
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    # Get config
+    config = kw.get("config")
+
+    # Get cephadm obj
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+
+    # Check mandatory parameter file_type
+    if not config.get("file_type"):
+        raise ConfigError("Mandatory config 'file_type' not provided")
+
+    # Get spec file type
+    file_type = config.get("file_type")
+
+    # Check mandatory parameter spec
+    if not config.get("spec"):
+        raise ConfigError("Mandatory config 'spec' not provided")
+
+    # Get smb spec
+    smb_spec = config.get("spec")
+
+    # Get smb spec file mount path
+    file_mount = config.get("file_mount", "/tmp")
+
+    # Get installer node
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+
+    # Get smb nodes
+    smb_nodes = ceph_cluster.get_nodes("smb")
+
+    # get client node
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    # Get smb subvolume mode
+    smb_subvolume_mode = config.get("smb_subvolume_mode", "0777")
+
+    # Get smb service value from spec file
+    smb_shares = []
+    smb_subvols = []
+    for spec in smb_spec:
+        if spec["resource_type"] == "ceph.smb.cluster":
+            smb_cluster_id = spec["cluster_id"]
+            auth_mode = spec["auth_mode"]
+            if "domain_settings" in spec:
+                domain_realm = spec["domain_settings"]["realm"]
+            else:
+                domain_realm = None
+            if "clustering" in spec:
+                clustering = spec["clustering"]
+            else:
+                clustering = "default"
+            if "public_addrs" in spec:
+                public_addrs = [
+                    public_addrs["address"].split("/")[0]
+                    for public_addrs in spec["public_addrs"]
+                ]
+            else:
+                public_addrs = None
+            if "custom_ports" in spec:
+                smb_port = spec["custom_ports"]["smb"]
+            else:
+                smb_port = "445"
+        elif spec["resource_type"] == "ceph.smb.usersgroups":
+            smb_user_name = spec["values"]["users"][0]["name"]
+            smb_user_password = spec["values"]["users"][0]["password"]
+        elif spec["resource_type"] == "ceph.smb.join.auth":
+            smb_user_name = spec["auth"]["username"]
+            smb_user_password = spec["auth"]["password"]
+        elif spec["resource_type"] == "ceph.smb.share":
+            cephfs_vol = spec["cephfs"]["volume"]
+            smb_subvol_group = spec["cephfs"]["subvolumegroup"]
+            smb_subvols.append(spec["cephfs"]["subvolume"])
+            smb_shares.append(spec["share_id"])
+
+    try:
+        # deploy smb services
+        deploy_smb_service_declarative(
+            installer,
+            cephfs_vol,
+            smb_subvol_group,
+            smb_subvols,
+            smb_cluster_id,
+            smb_subvolume_mode,
+            file_type,
+            smb_spec,
+            file_mount,
+        )
+
+        # Verify ctdb clustering
+        if clustering != "never":
+            # check samba clustermeta in rados
+            if not check_rados_clustermeta(cephadm, smb_cluster_id, smb_nodes):
+                log.error("rados clustermeta for samba not found")
+                return 1
+            # Verify CTDB health
+            if not check_ctdb_health(smb_nodes, smb_cluster_id):
+                log.error("ctdb health error")
+                return 1
+
+        # Check smb share using smbclient
+        smbclient_check_shares(
+            smb_nodes,
+            client,
+            smb_shares,
+            smb_user_name,
+            smb_user_password,
+            auth_mode,
+            domain_realm,
+            smb_port,
+            public_addrs,
+        )
+
+        # Restart services
+        out = CephAdm(installer).ceph.orch.restart(f"smb.{smb_cluster_id}")
+        if "Scheduled" not in out:
+            raise OperationFailedError(f"Fail to restart {smb_cluster_id}")
+
+        # Checking service status
+        verify_service(installer, smb_cluster_id)
+
+    except Exception as e:
+        log.error(f"Failed to deploy samba with auth_mode 'user' : {e}")
+        return 1
+    finally:
+        smb_cleanup(installer, smb_shares, smb_cluster_id)
+    return 0


### PR DESCRIPTION
Add colocation tests to deploy more than two colocation services, and restart the colocation services simultaneously.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
