### PR TITLE
[Bluestore compression] Adds osd host restart and data integrity tests

### DIFF
--- a/suites/tentacle/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_bluestore.yaml
@@ -316,6 +316,24 @@ tests:
           scenarios_to_run:
             - scenario-10
 
+  - test:
+        name: Bluestore compression validation post OSD restart
+        module: test_bluestore_comp_enhancements.py
+        desc: Positive workflows for bluestore data compression enhancements
+        polarion-id: CEPH-83620071
+        config:
+          scenarios_to_run:
+            - scenario-11
+
+  - test:
+        name: Bluestore compression data integrity test
+        module: test_bluestore_comp_enhancements.py
+        desc: Positive workflows for bluestore data compression enhancements
+        polarion-id: CEPH-83620071
+        config:
+          scenarios_to_run:
+            - scenario-12
+
  # scenario-8 disables bluestore_write_v2
   - test:
         name: Bluestore disable bluestore_write_v2 and validate


### PR DESCRIPTION
Adds below 2 scenarios for compression.
```
            """
            Test compression validation when primary OSD host is restarted after IO.
            Steps:
            1) Create pool, store primary, secondary and tertiary OSD IDs
            2) Enable compression
            3) Write IO to the pool
            4) Validate primary, secondary, tertiary OSDs are compressed
            5) Restart Primary OSD host
            6) Post restart validate primary OSD is still compressed
            7) Delete pool
            """
```

```
            """
            Test data integrity by writing data, retrieving data, and verifying checksum.
            Steps:
            1) Create pool
            2) Enable compression
            3) Write data to the pool and store md5 checksum using fio
            4) Read data from the pool and verify md5 checksum using fio
                If checksum does not match, exit code of FIO command will be 1
            5) Cleanup pool
            """
```
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
