### PR TITLE
[TFA-fix] Added Configure the RGW client system to avoid ceph-common failure

### DIFF
--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -100,7 +100,20 @@ tests:
                 - service_type: crash
                   placement:
                     host_pattern: "*"
-
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
   # STS tests
 
   - test:

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -101,7 +101,17 @@ tests:
                 - service_type: crash
                   placement:
                     host_pattern: "*"
-
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
   - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -101,7 +101,17 @@ tests:
                 - service_type: crash
                   placement:
                     host_pattern: "*"
-
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
 
   # STS tests
 

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -101,7 +101,17 @@ tests:
                 - service_type: crash
                   placement:
                     host_pattern: "*"
-
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
   - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -101,7 +101,17 @@ tests:
                 - service_type: crash
                   placement:
                     host_pattern: "*"
-
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
 
   # STS tests
 


### PR DESCRIPTION
Jira: 
https://issues.redhat.com/browse/RHCEPHQE-22606 

Failed log:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-361/rgw/50/tier-2_ssl_rgw_regression_test/

pass log: 
https://ibm.ent.box.com/folder/353849984702 


