### PR TITLE
The fix provided to fix the logic of the test_MTTR_value,test_MTBF_value and test_score_value method

### DIFF
--- a/suites/tentacle/rados/tier-2_rados_test-new-features.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-new-features.yaml
@@ -299,6 +299,30 @@ tests:
         case_to_run:
           - case10
   - test:
+      name: Track availability- Inconsistent object check
+      desc: Verification of track availability tests on inconsistent object pool
+      module: test_track_availibility_status.py
+      polarion-id: CEPH-83620501
+      config:
+        replicated_pool:
+          create: true
+          pool_name: track_data_pool
+          pg_num_max: 1
+        case_to_run:
+          - case11
+  - test:
+      name: Track availability- Generating inactive PG
+      desc: Verification of track availability tests by generating inactive PG
+      module: test_track_availibility_status.py
+      polarion-id: CEPH-83620501
+      config:
+        replicated_pool:
+          create: true
+          pool_name: track_data_pool
+          pg_num_max: 1
+        case_to_run:
+          - case12
+  - test:
       name: Track availability- Reboot OSD node check
       desc: Verification of track availability tests by rebooting the osd node
       module: test_track_availibility_status.py
@@ -309,5 +333,5 @@ tests:
           pool_name: track_data_pool
           pg_num_max: 1
         case_to_run:
-          - case11
+          - case13
 


### PR DESCRIPTION
# Description

As discussed, I have fixed the TFA issue that occurred in the test_track_availibility_status.py script.

Additionally, I identified a major issue in the methods test_MTBF_value, test_MTTR_value, and test_score_value. When the get_pool_availability_status command fails, the methods were returning 1, and the calling scripts were validating the result using a boolean check, which always evaluates to True. As a result, the tests were passing even when the enable_availability_tracking parameter was set to False (the default value).
I have implemented the necessary fix, and I will raise a separate PR for this change.

```
if not test_MTTR_value(client, pool_name):
         log.error("Case 1: Verification of the MTTR failed ")
         return 1   
```

```
def test_MTTR_value(client, pool_name):
    ..........
    ......................
    if not success:
        log.error("Failed to retrieve the pool available data")
        return 1
```



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
