### PR TITLE
[TFA] Fixed timeout issues observed during IO

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -90,7 +90,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
+            - count: 8
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -99,7 +99,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
+            - count: 8
               size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -207,7 +207,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
+            - count: 8
               size: 5G
             listener_port: 4420
             listeners: [node6, node7]
@@ -216,7 +216,7 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 10
+            - count: 8
               size: 5G
             listener_port: 4420
             listeners: [node6, node7]
@@ -333,7 +333,7 @@ tests:
             serial: 1
             max_ns: 2048
             bdevs:
-            - count: 10
+            - count: 8
               size: 5G                              # auto NS load balancing for namespace addition would be verified here
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
@@ -342,7 +342,7 @@ tests:
             serial: 1
             max_ns: 2048
             bdevs:
-            - count: 10
+            - count: 8
               size: 5G
             listener_port: 4420
             listeners: [node4, node5, node6, node7]

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -378,7 +378,7 @@ tests:
             serial: 1
             bdevs:
             - count: 8
-              size: 8G
+              size: 4G
             listener_port: 4420
             listeners:
               - node6


### PR DESCRIPTION

Fixed timeout issues observed during IO

Issue seen in regression:-
```
2025-12-01 09:32:54,842 - cephci - initiator:396 - INFO - All namespaces are optimized for all initiators for gateway 10.243.55.139
2025-12-01 09:32:54,843 - cephci - ha:1428 - INFO - Waiting for completion of IOs.
2025-12-01 10:31:06,360 - ceph.parallel - parallel:160 - ERROR -
Traceback (most recent call last):
File "/data/jenkins/ceph-builds/IBM/9.0/rhel-10/regression/20.1.0-112/nvmeof/12/cephci/ceph/parallel.py", line 158, in __next__
out = self._futures[self._iter_index].result(timeout=_timeout)
File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 448, in result
raise TimeoutError()
concurrent.futures._base.TimeoutError
Failure logs:- https://149.81.216.83/view/Tentacle/job/tentacle-nvmeof-regression-ci/12/pipeline-overview/log?nodeId=341

```
RCA:-
In the test we have 20gb disks as OSDs and we are creating 8 namespaces with 8GB, so total size is 64GB.
During IO, in 64GB only 56GB is getting filled and after that we are observing slow osd ops because of space issues, because of slow osd ops IO is not progressing and getting timeout issues in executions.

```
[ceph: root@ceph-jp-io-timeout-ith28i-node1-installer /]# ceph osd tree
ID  CLASS  WEIGHT   TYPE NAME                                 STATUS  REWEIGHT  PRI-AFF
-1         0.23383  root default                                                       
-3         0.07794      host ceph-jp-io-timeout-ith28i-node3                           
 0    hdd  0.01949          osd.0                                 up   1.00000  1.00000
 3    hdd  0.01949          osd.3                                 up   1.00000  1.00000
 6    hdd  0.01949          osd.6                                 up   1.00000  1.00000
 9    hdd  0.01949          osd.9                                 up   1.00000  1.00000
-5         0.07794      host ceph-jp-io-timeout-ith28i-node4                           
 2    hdd  0.01949          osd.2                                 up   1.00000  1.00000
 5    hdd  0.01949          osd.5                                 up   1.00000  1.00000
 8    hdd  0.01949          osd.8                                 up   1.00000  1.00000
11    hdd  0.01949          osd.11                                up   1.00000  1.00000
-7         0.07794      host ceph-jp-io-timeout-ith28i-node5                           
 1    hdd  0.01949          osd.1                                 up   1.00000  1.00000
 4    hdd  0.01949          osd.4                                 up   1.00000  1.00000
 7    hdd  0.01949          osd.7                                 up   1.00000  1.00000
10    hdd  0.01949          osd.10                                up   1.00000  1.00000

[ceph: root@ceph-jp-io-timeout-ith28i-node1-installer /]# rbd du -p rbd
NAME         PROVISIONED  USED   
SI7X-image0        8 GiB  7.1 GiB
SI7X-image1        8 GiB  7.0 GiB
SI7X-image2        8 GiB  7.2 GiB
SI7X-image3        8 GiB  7.1 GiB
SI7X-image4        8 GiB  7.1 GiB
SI7X-image5        8 GiB  7.0 GiB
SI7X-image6        8 GiB  7.0 GiB
SI7X-image7        8 GiB  6.9 GiB
<TOTAL>           64 GiB   56 GiB
[ceph: root@ceph-jp-io-timeout-ith28i-node1-installer /]# ceph -s
  cluster:
    id:     1a0832ca-d019-11f0-8681-fa163eb37cdb
    health: HEALTH_ERR
            1 stray daemon(s) not managed by cephadm
            2 gateway(s) are in unavailable state; gateway might be down, try to redeploy.
            1 full osd(s)
            1 nearfull osd(s)
            Degraded data redundancy: 201/43293 objects degraded (0.464%), 2 pgs degraded
            Full OSDs blocking recovery: 2 pgs recovery_toofull
            2 pool(s) full
            1 slow ops, oldest one blocked for 150 sec, mon.ceph-jp-io-timeout-ith28i-node1-installer has slow ops
 
  services:
    mon:    3 daemons, quorum ceph-jp-io-timeout-ith28i-node1-installer,ceph-jp-io-timeout-ith28i-node2,ceph-jp-io-timeout-ith28i-node3 (age 28m) [leader: ceph-jp-io-timeout-ith28i-node1-installer]
    mgr:    ceph-jp-io-timeout-ith28i-node1-installer.hvpaeb(active, since 33m), standbys: ceph-jp-io-timeout-ith28i-node2.gbtwgz
    osd:    12 osds: 12 up (since 23m), 12 in (since 23m)
    nvmeof: 2 gateways active (2 hosts)
 
  data:
    pools:   2 pools, 226 pgs
    objects: 14.43k objects, 56 GiB
    usage:   176 GiB used, 64 GiB / 240 GiB avail
    pgs:     201/43293 objects degraded (0.464%)
             224 active+clean
             2   active+recovery_toofull+degraded
 
  io:
    client:   34 KiB/s rd, 40 op/s rd, 0 op/s wr
```
I have decreased the image size and now IO is working as expected and not seen any timeout issues.

Pass Logs:- 
http://magna002.ceph.redhat.com/cephci-jenkins/io_timeout_issues_3rd_dec_25/
 
