### PR TITLE
Fix get_tools_repo to correctly construct Tools repo paths

### DIFF
--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -9,8 +9,11 @@ from cli.ops.cephadm_ansible import (
     exec_cephadm_preflight,
 )
 from cli.utilities.packages import Package, Repos
+from utility.log import Log
 
 from .configs import get_registry_details
+
+log = Log(__name__)
 
 ETC_HOSTS = "/etc/hosts"
 
@@ -372,13 +375,18 @@ def get_tools_repo(repo, ibm_build=False):
         ibm_build (bool): IBM build tag
     """
     repo = repo.rstrip("/")
+    log.info(f"get_tools_repo(): repo={repo}, ibm_build={ibm_build}")
+
+    if repo.endswith(".repo"):
+        return repo
+
+    if "repo.qe.ceph.lab" in repo:
+        return f"{repo}/Tools"
+
     if ibm_build:
         return f"{repo}/Tools"
 
-    elif repo.endswith("repo"):
-        return repo
-
-    return f"{repo}/Tools"
+    return f"{repo}/compose/Tools/x86_64/os"
 
 
 def add_centos_epel_repo(nodes, platform):


### PR DESCRIPTION
- **Added**: Check for `"repo.qe.ceph.lab"` in repo URL alongside `ibm_build` flag
- **Fixed**: Default return path from `{repo}/Tools` to `{repo}/compose/Tools/x86_64/os`
- **Improved**: Changed `elif` to `if` for the `repo.endswith("repo")` 

Cloud_type openstack and rh build log snippet :

`2025-12-03 17:27:38,202 - cephci - ceph:1623 - INFO - Execute sudo hostnamectl set-hostname $(hostname -s) on 10.0.195.173
2025-12-03 17:27:39,482 - cephci - ceph:1653 - INFO - Execution of sudo hostnamectl set-hostname $(hostname -s) on 10.0.195.173 took 1.279203 seconds
2025-12-03 17:27:40,474 - paramiko.transport.sftp - sftp:169 - INFO - [chan 10] Opened sftp connection (server version 3)
2025-12-03 17:27:41,921 - paramiko.transport.sftp - sftp:169 - INFO - [chan 11] Opened sftp connection (server version 3)
2025-12-03 17:27:42,759 - cephci - ceph:1623 - INFO - Execute [ -f ~/.ssh/config ] && chmod 700 ~/.ssh/config on 10.0.195.173
2025-12-03 17:27:44,023 - cephci - ceph:1653 - INFO - Execution of [ -f ~/.ssh/config ] && chmod 700 ~/.ssh/config on 10.0.195.173 took 1.263463 seconds
2025-12-03 17:27:44,833 - paramiko.transport.sftp - sftp:169 - INFO - [chan 12] Opened sftp connection (server version 3)
2025-12-03 17:27:46,804 - cephci - ceph:1623 - INFO - Execute chmod 600 ~/.ssh/authorized_keys on 10.0.195.173
2025-12-03 17:27:48,221 - cephci - ceph:1653 - INFO - Execution of chmod 600 ~/.ssh/authorized_keys on 10.0.195.173 took 1.417344 seconds
2025-12-03 17:27:48,751 - cephci - ceph:1623 - INFO - Execute chmod 400 ~/.ssh/config on 10.0.195.173
2025-12-03 17:27:50,062 - cephci - ceph:1653 - INFO - Execution of chmod 400 ~/.ssh/config on 10.0.195.173 took 1.310865 seconds
2025-12-03 17:27:50,064 - cephci - build_info:198 - DEBUG - Retreving build details of redhat - 8.1. Looking up released section.
2025-12-03 17:27:50,619 - cephci - ceph:965 - INFO - repo to use is http://download-01.beak-001.prod.iad2.dc.redhat.com/rhel-9/composes/auto/ceph-8.1-rhel-9/RHCEPH-8.1-RHEL-9-20251129.ci.0/compose/Tools/x86_64/os/
2025-12-03 17:27:51,237 - cephci - ceph:967 - INFO - Checking http://download-01.beak-001.prod.iad2.dc.redhat.com/rhel-9/composes/auto/ceph-8.1-rhel-9/RHCEPH-8.1-RHEL-9-20251129.ci.0/compose/Tools/x86_64/os/
2025-12-03 17:27:52,641 - paramiko.transport.sftp - sftp:169 - INFO - [chan 12] Opened sftp connection (server version 3)
2025-12-03 17:27:53,562 - cephci - build_info:198 - DEBUG - Retreving build details of redhat - 8.1. Looking up released section.
2025-12-03 17:27:54,177 - cephci - ceph:1623 - INFO - Execute yum -y install cephadm --nogpgcheck on 10.0.195.173
2025-12-03 17:27:55,485 - cephci - ceph:1195 - DEBUG - Updating Subscription Management repositories.
2025-12-03 17:28:09,537 - cephci - ceph:1195 - DEBUG - 
2025-12-03 17:28:09,537 - cephci - ceph:1195 - DEBUG - This system has release set to 10.1 and it receives updates only for this release.
2025-12-03 17:28:09,537 - cephci - ceph:1195 - DEBUG - 
`

Cloud_type IBMC and RH build log snippet :
https://149.81.216.83/view/Squid/job/squid-test-executor/37/pipeline-overview/log?nodeId=103
`2025-12-03 07:47:36,227 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,235 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,261 - paramiko.transport.sftp - sftp:169 - INFO - [chan 10] Opened sftp connection (server version 3)
2025-12-03 07:47:36,264 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,271 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,297 - paramiko.transport.sftp - sftp:169 - INFO - [chan 8] Opened sftp connection (server version 3)
2025-12-03 07:47:36,300 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,307 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,333 - paramiko.transport.sftp - sftp:169 - INFO - [chan 8] Opened sftp connection (server version 3)
2025-12-03 07:47:36,336 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,343 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,368 - paramiko.transport.sftp - sftp:169 - INFO - [chan 9] Opened sftp connection (server version 3)
2025-12-03 07:47:36,371 - cephci - build_info:198 - DEBUG - Retreving build details of ibm - 8.1. Looking up rc section.
2025-12-03 07:47:36,525 - cephci - build_info:198 - DEBUG - Retreving build details of ibm - 8.1. Looking up rc section.
2025-12-03 07:47:36,566 - cephci - ceph:1623 - INFO - Execute ACCEPT_EULA=Y yum install -y ibm-storage-ceph-license --nogpgcheck on 10.243.55.157`


Cloud_type IBMC and ibm build log snippet :
https://149.81.216.83/view/Squid/job/squid-test-executor/35/pipeline-overview/log?nodeId=179

`2025-12-03 07:47:35,222 - cephci - ceph:1623 - INFO - Execute chmod 400 ~/.ssh/config on 10.243.55.160
2025-12-03 07:47:36,226 - cephci - ceph:1653 - INFO - Execution of chmod 400 ~/.ssh/config on 10.243.55.160 took 1.003945 seconds
2025-12-03 07:47:36,227 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,235 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,261 - paramiko.transport.sftp - sftp:169 - INFO - [chan 10] Opened sftp connection (server version 3)
2025-12-03 07:47:36,264 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,271 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,297 - paramiko.transport.sftp - sftp:169 - INFO - [chan 8] Opened sftp connection (server version 3)
2025-12-03 07:47:36,300 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,307 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,333 - paramiko.transport.sftp - sftp:169 - INFO - [chan 8] Opened sftp connection (server version 3)
2025-12-03 07:47:36,336 - cephci - ceph:965 - INFO - repo to use is http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,343 - cephci - ceph:967 - INFO - Checking http://repo.qe.ceph.lab/repos/ceph/testing/ibm/8/rhel9/19.2.1-292/Tools/
2025-12-03 07:47:36,368 - paramiko.transport.sftp - sftp:169 - INFO - [chan 9] Opened sftp connection (server version 3)
2025-12-03 07:47:36,371 - cephci - build_info:198 - DEBUG - Retreving build details of ibm - 8.1. Looking up rc section.
2025-12-03 07:47:36,525 - cephci - build_info:198 - DEBUG - Retreving build details of ibm - 8.1. Looking up rc section.
2025-12-03 07:47:36,566 - cephci - ceph:1623 - INFO - Execute ACCEPT_EULA=Y yum install -y ibm-storage-ceph-license --nogpgcheck on 10.243.55.157
`