### PR TITLE
Zero append tests for Fast EC pools

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -562,8 +562,7 @@ class RadosOrchestrator:
                 2. ec_profile_name -> name of EC profile if pool being created is an EC pool
                 3. min_size -> min replication size for pool to serve data
                 4. size -> min replication size for pool to write data
-                5. erasure_code_use_overwrites -> allows overrides in an erasure coded pool
-                6. allow_ec_overwrites -> This lets RBD and CephFS store their data in an erasure coded pool
+                5. erasure_code_use_overwrites -> This lets RBD and CephFS store their data in an ecpool
                 7. disable_pg_autoscale -> sets auto-scale mode off on the pool
                 8. crush_rule -> custom crush rule for the pool
                 9. pool_quota -> limit the maximum number of objects or the maximum number of bytes stored
@@ -1566,6 +1565,8 @@ class RadosOrchestrator:
                 15. negative_test -> pass true if performing -ve tests. min_compact_client won't be updated for pool
                 creation when this param is set to true. Required for MSR EC pool tests with min_compact_client
                 16. enable_fast_ec_features -> Pass true if the Fast EC features need to be enabled on the created pool
+                17. stripe_width -> Stripe width to be set on the pool (k * stripe_unit)
+                18. stripe_unit -> Chunk size per data shard (recommended: 16384 for Fast EC pools)
         Returns: True -> pass, False -> fail
         """
         failure_domain = kwargs.get("crush-failure-domain", "osd")
@@ -1590,6 +1591,8 @@ class RadosOrchestrator:
         create_ecpool = kwargs.get("create_ecpool", True)
         negative_test = kwargs.get("negative_test", False)
         yes_i_mean_it = kwargs.get("yes_i_mean_it", False)
+        stripe_width = kwargs.get("stripe_width", None)
+        stripe_unit = kwargs.get("stripe_unit", None)
         profile_name = kwargs.get("profile_name", f"ecp_{pool_name}")
         rule_name = f"rule_{pool_name}"
         enable_fast_ec_features = kwargs.get("enable_fast_ec_features", False)
@@ -1638,6 +1641,10 @@ class RadosOrchestrator:
             cmd = cmd + f" d={d}"
         if force:
             cmd = cmd + " --force"
+        if stripe_width:
+            cmd = cmd + f" stripe_width={stripe_width}"
+        if stripe_unit:
+            cmd = cmd + f" stripe_unit={stripe_unit}"
         if yes_i_mean_it:
             cmd = cmd + " --yes-i-really-mean-it "
 

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
@@ -351,6 +351,15 @@ tests:
         test_fast_ec_optimization_params: true
       desc: Verification of EC enhancements Configs for pool and global level
 
+  - test:
+      name: Fast EC space gain verification
+      module: test_fast_ec_config_params.py
+      polarion-id: CEPH-83620451
+      abort-on-fail: true
+      config:
+        test_fast_ec_space_gain: true
+      desc: Verify space savings with EC optimizations - zeros not appended to objects smaller than stripe width
+
 # 2+2@4 specific scenarios, with Fast EC features enabled:
 #        scenario-1: Test the effects of bulk flag and no IO stoppage
 #        scenario-2: Perform rolling reboot of all the OSDs on a particular host.


### PR DESCRIPTION
        Test: Fast EC Space Gain Verification

        Verifies that EC optimizations prevent zero-padding for objects smaller than
        the stripe_unit, resulting in significant space savings at both pool and shard levels.

        Test Steps:
        1. Disable global EC optimizations flag
        2. Create EC pool WITHOUT optimizations (test_ec_pool_without_optimizations)
        3. Create EC pool WITH optimizations enabled (test_ec_pool_with_optimizations)
        4. Write 100 identical 4KB objects to both pools using 'rados put'
        5. Wait for stats to stabilize and trigger deep-scrub
        6. Compare pool-level space usage (bytes_used from 'ceph df detail')
        7. Verify shard-level sizes using:
           - rados stat: Confirms logical object size (4KB) is same for both pools
           - ceph-objectstore-tool: Confirms actual shard size differs (16KB vs 4KB)

        EC Configuration (k=2, m=2, stripe_unit=16KB):
        - stripe_unit = 16KB (chunk size per data shard)
        - stripe_width = k * stripe_unit = 32KB
        - full stripe = (k + m) * stripe_unit = 64KB

        Expected Results:
        - Without optimizations: 4KB object padded to stripe_unit → shard = 16KB
        - With optimizations: 4KB object stored as-is → shard = 4KB
        - Pool-level space savings: ~80% (4x reduction)
        - Shard-level size ratio: 4x (16KB vs 4KB)

        Failure Conditions:
        - Pool with optimizations doesn't use less bytes than pool without
        - Space savings < 50% threshold
        - rados stat object size != 4096 bytes
        - ceph-objectstore-tool shard size: pool1 <= pool2