### PR TITLE
Add '/etc/systemd/system.conf' file check for IBM Cloud VMs

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -1424,6 +1424,13 @@ def enable_coredump(node):
         None
     """
     log.info("Enabling coredump collection on %s" % node.hostname)
+    log.debug("Ensure /etc/systemd/system.conf file exists or create it")
+    _, _, rc, _ = node.exec_command(
+        sudo=True, cmd="test -e /etc/systemd/system.conf", verbose=True
+    )
+    if rc:
+        log.debug("File /etc/systemd/system.conf does not exist, creating..")
+        node.exec_command(sudo=True, cmd="touch /etc/systemd/system.conf")
     sys_cmds = [
         "echo 'fs.suid_dumpable = 2' >> /etc/sysctl.conf",
         "sysctl -p",


### PR DESCRIPTION
# Description

Expected system file `/etc/systemd/system.conf` is not shipped with RHEL OS 9.x but it is part of Openstack VM images, this systemd config file is not found in the images used for deploying IBM Cloud VMs

`The /etc/systemd/system.conf file in Linux holds global configuration settings for the systemd system and service manager. It allows administrators to define default behaviors and parameters that apply to all systemd units (services, targets, mounts, etc.) unless overridden by specific unit files or other configuration directories.`

@obannak Please share the sanity run pass logs

Signed-off-by: Harsh Kumar <hakumar@redhat.com>