### PR TITLE
Fix FIO timeout issues in nvmeof NS load balancing tests

### DIFF
--- a/conf/squid/nvmeof/ceph_nvmeof_4-nvmeof-gwgroup_2gw_cluster.yaml
+++ b/conf/squid/nvmeof/ceph_nvmeof_4-nvmeof-gwgroup_2gw_cluster.yaml
@@ -14,26 +14,26 @@ globals:
           - mgr
           - osd
         no-of-volumes: 5
-        disk-size: 30
+        disk-size: 60
       node3:
         role:
           - mon
           - osd
         no-of-volumes: 5
-        disk-size: 30
+        disk-size: 60
       node4:
         role:
           - mds
           - osd
         no-of-volumes: 5
-        disk-size: 30
+        disk-size: 60
       node5:
         role:
           - mds
           - osd
           - rgw
         no-of-volumes: 5
-        disk-size: 30
+        disk-size: 60
       node6:
         id: node6
         role:

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -91,7 +91,7 @@ tests:
             max_ns: 100
             bdevs:
             - count: 8
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -100,7 +100,7 @@ tests:
             max_ns: 100
             bdevs:
             - count: 8
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -142,7 +142,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -150,7 +150,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -158,7 +158,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -166,7 +166,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
             allow_host: "*"
@@ -208,7 +208,7 @@ tests:
             max_ns: 100
             bdevs:
             - count: 8
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7]
             allow_host: "*"
@@ -217,7 +217,7 @@ tests:
             max_ns: 100
             bdevs:
             - count: 8
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7]
             allow_host: "*"
@@ -267,7 +267,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -275,7 +275,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -283,7 +283,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -291,7 +291,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -334,7 +334,7 @@ tests:
             max_ns: 2048
             bdevs:
             - count: 8
-              size: 5G                              # auto NS load balancing for namespace addition would be verified here
+              size: 3G                              # auto NS load balancing for namespace addition would be verified here
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
             allow_host: "*"
@@ -343,7 +343,7 @@ tests:
             max_ns: 2048
             bdevs:
             - count: 8
-              size: 5G
+              size: 3G
             listener_port: 4420
             listeners: [node4, node5, node6, node7]
             allow_host: "*"
@@ -362,11 +362,11 @@ tests:
                 - nqn: nqn.2016-06.io.spdk:cnode1
                   bdevs:
                     - count: 5
-                      size: 5G
+                      size: 3G
                 - nqn: nqn.2016-06.io.spdk:cnode2
                   bdevs:
                     - count: 5
-                      size: 5G
+                      size: 3G
           - ns_del:
               count: 3
               subsystems:


### PR DESCRIPTION
Fix failures at https://149.81.216.83/job/tentacle-nvmeof-regression-ci/13/pipeline-overview/log?nodeId=341

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LD1NLP/NVMeoF_4GW_1GWgroup_namespaces_load_balancing_0.log


```
DEBUG - ['/dev/nvme1n1', '/dev/nvme1n2', '/dev/nvme9n1', '/dev/nvme9n2', '/dev/nvme13n1', '/dev/nvme13n2', '/dev/nvme5n1', '/dev/nvme5n2']
2025-12-05 04:15:04,270 - cephci - initiator:155 - INFO - Paths found are ['/dev/nvme1n1', '/dev/nvme1n2', '/dev/nvme9n1', '/dev/nvme9n2', '/dev/nvme13n1', '/dev/nvme13n2', '/dev/nvme5n1', '/dev/nvme5n2']
2025-12-05 04:15:04,272 - cephci - ceph:1630 - INFO - Execute blkdiscard /dev/nvme1n1 on 10.0.66.64
2025-12-05 04:15:05,276 - cephci - ceph:1660 - INFO - Execution of blkdiscard /dev/nvme1n1 on 10.0.66.64 took 1.003608 seconds
2025-12-05 04:15:05,277 - cephci - utils:2212 - DEBUG - Config Received for fio: {'size': '20%', 'device_name': '/dev/nvme1n1', 'client_node': <ceph.ceph.CephNode object at 0x7f7a983d4ee0>, 'long_running': True, 'cmd_timeout': 'notimeout', 'verbose': True}
2025-12-05 04:15:05,279 - cephci - ceph:1630 - INFO - Execute blkdiscard /dev/nvme1n2 on 10.0.66.64
2025-12-05 04:15:05,280 - cephci - ceph:1630 - INFO - Execute fio  --ioengine libaio --filename /dev/nvme1n1 --size 20% --name test-1 --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.0.66.64
2025-12-05 04:15:06,285 - cephci - ceph:1660 - INFO - Execution of blkdiscard /dev/nvme1n2 on 10.0.66.64 took 1.003791 seconds
2025-12-05 04:15:06,286 - cephci - utils:2212 - DEBUG - Config Received for fio: {'size': '20%', 'device_name': '/dev/nvme1n2', 'client_node': <ceph.ceph.CephNode object at 0x7f7a983d4ee0>, 'long_running': True, 'cmd_timeout': 'notimeout', 'verbose': True}
2025-12-05 04:15:06,287 - cephci - ceph:1202 - DEBUG - test-1: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=8
2025-12-05 04:15:06,288 - cephci - ceph:1630 - INFO - Execute blkdiscard /dev/nvme9n1 on 10.0.66.64
2025-12-05 04:15:06,289 - cephci - ceph:1630 - INFO - Execute fio  --ioengine libaio --filename /dev/nvme1n2 --size 20% --name test-1 --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.0.66.64
2025-12-05 04:15:06,289 - cephci - ceph:1202 - DEBUG - fio-3.35
2025-12-05 04:15:06,290 - cephci - ceph:1202 - DEBUG - Starting 1 process
2025-12-05 04:15:07,293 - cephci - ceph:1660 - INFO - Execution of blkdiscard /dev/nvme9n1 on 10.0.66.64 took 1.002768 seconds
2025-12-05 04:15:07,294 - cephci - utils:2212 - DEBUG - Config Received for fio: {'size': '20%', 'device_name': '/dev/nvme9n1', 'client_node': <ceph.ceph.CephNode object at 0x7f7a983d4ee0>, 'long_running': True, 'cmd_timeout': 'notimeout', 'verbose': True}
2025-12-05 04:15:07,295 - cephci - ceph:1202 - DEBUG - test-1: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=8

```