### PR TITLE
Adding a new suite file for N-2 Upgrade test - Ceph 7.1x to Ceph 9

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7.1x-to-8.1x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7.1x-to-8.1x-to-9x-latest.yaml
@@ -1,14 +1,15 @@
 ##############################################################################################
 # Tier-Level: 1
-# Test-Suite: tier1-nfs-ganesha-upgrade-ibm-8x-to-9x-latest.yaml
-# Scenario: Upgrade IBM 8.x(GA) cluster to IBM 9(Latest) with NFS-Ganesha in RHEL9
+# Test-Suite: tier1-nfs-ganesha-upgrade-7.1x-to-8.1x-to-9x-latest.yaml
+# Scenario: Upgrade Ceph 7.1x(GA) cluster Ceph 8.1x(GA) to Ceph 9.x(Latest) with NFS-Ganesha in RHEL9
 #
-# Cluster Configuration: Conf: conf/squid/nfs/1admin-3client-7node.yaml
+# Cluster Configuration: Conf: conf/reef/nfs/1admin-3client-7node.yaml
 #
 # Test Steps:
-# - Deploy IBM 8.x(GA) cluster in RHEL 9
-# - Deploy IBM 8.x client
-# - Upgrade cluster along with NFS-Ganesha IOs parllel
+# - Deploy Ceph 7.1x(GA) cluster in RHEL 9
+# - Deploy Ceph 7.1x client
+# - Upgrade cluster to 8.1x (GA) along with NFS-Ganesha IOs in parallel
+# - Upgrade cluster along with NFS-Ganesha IOs parallel on 9.0 builds
 ################################################################################################
 tests:
   - test:
@@ -18,8 +19,8 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Bootstrap IBM 8.x(GA) cluster and deploy services with label placements.
-      desc: Bootstrap IBM 8.x(GA) cluster and deploy services with label placements.
+      name: Bootstrap Ceph 7.1x (N-2) cluster and deploy services with label placements.
+      desc: Bootstrap Ceph 7.1x (N-2) cluster and deploy services with label placements.
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       config:
@@ -29,8 +30,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                rhcs-version: 7.1
+                release: rc
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
@@ -167,7 +168,7 @@ tests:
         cleanup: false
 
   - test:
-      name: Nfs Verify multiple io and lookups
+      name: Nfs Verify multiple parallel io and lookups
       module: nfs_verify_multiple_parallel_io_and_lookups.py
       desc: Perform look ups while multiple parallel io are in progress
       polarion-id: CEPH-83581304
@@ -178,7 +179,7 @@ tests:
         setup: false
 
   - test:
-      name: nfs multiple operations - pre_upgrade
+      name: Nfsv4 multiple operations - pre_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: nfs multiple operations before upgrade create, delete, write, read, rename
       polarion-id: CEPH-83620035
@@ -191,15 +192,14 @@ tests:
         dd_command_size_in_M: 10
         operation: before_upgrade
 
-
   - test:
-      name: Upgrade along with IOs for nfs
+      name: Upgrade to 8.1x along with IOs for nfs - parallel module
       module: test_parallel.py
-      desc: Upgrade along with IOs for nfs in parallel
+      desc: Upgrade along with IOs for nfs - parallel module
       parallel:
         - test:
-            name: Upgrade cluster to latest IBM 9.x
-            desc: Upgrade cluster to latest IBM 9.x
+            name: Upgrade cluster to latest Ceph 8.1x
+            desc: Upgrade cluster to latest Ceph 8.1x
             module: test_cephadm_upgrade.py
             polarion-id: CEPH-83573791,CEPH-83573790
             config:
@@ -207,7 +207,9 @@ tests:
               service: upgrade
               base_cmd_args:
                 verbose: true
-
+              args:
+                rhcs-version: 8.1
+                release: rc
         - test:
             name: nfs operations during upgrade
             module: test_nfs_io_operations_during_upgrade.py
@@ -224,7 +226,7 @@ tests:
               loop_count: 4
 
   - test:
-      name: nfs multiple operations - post_upgrade
+      name: Nfsv3 multiple operations - post_8.1_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: nfs multiple operations after upgrade create, delete, write, read, rename
       polarion-id: CEPH-83620035
@@ -238,6 +240,65 @@ tests:
         operation: after_upgrade
 
   - test:
+      name: Nfsv4 multiple operations - pre_upgrade
+      module: test_nfs_multiple_operations_for_upgrade.py
+      desc: nfs multiple operations before upgrade create, delete, write, read, rename
+      polarion-id: CEPH-83620035
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        setup: false
+        file_count: 50
+        dd_command_size_in_M: 10
+        operation: before_upgrade
+
+  - test:
+      name: Upgrade along with IOs for nfs - parallel module
+      module: test_parallel.py
+      desc: Upgrade along with IOs for nfs - parallel module
+      parallel:
+        - test:
+            name: Upgrade cluster to latest Ceph 9.0
+            desc: Upgrade cluster to latest Ceph 9.0
+            module: test_cephadm_upgrade.py
+            polarion-id: CEPH-83573791,CEPH-83573790
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+        - test:
+            name: nfs operations during upgrade
+            module: test_nfs_io_operations_during_upgrade.py
+            desc: nfs multiple operations during upgrade create, delete, write, read, rename
+            polarion-id: CEPH-83620035
+            abort-on-fail: false
+            config:
+              nfs_version: 4.2
+              clients: 4
+              setup: false
+              file_count: 25
+              dd_command_size_in_M: 10
+              exports_number: 4
+              loop_count: 4
+
+  - test:
+      name: NFSv4 multiple operations - post_upgrade
+      module: test_nfs_multiple_operations_for_upgrade.py
+      desc: nfs multiple operations after upgrade create, delete, write, read, rename
+      polarion-id: CEPH-83620035
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        setup: false
+        file_count: 50
+        dd_command_size_in_M: 10
+        operation: after_upgrade
+
+
+  - test:
       name: Nfs Verify rm write lookups in parellel from multi clients
       module: nfs_verify_parallel_rm_write_lookup.py
       desc: Perform lookups rm and write at the same time
@@ -248,7 +309,7 @@ tests:
         clients: 4
 
   - test:
-      name: Nfs Verify read write operation permissions
+      name: Nfsv4 Verify read write operation permissions
       module: nfs_verify_read_write_operations.py
       desc: Perform read write without permissions on nfs share
       polarion-id: CEPH-83575941
@@ -259,13 +320,24 @@ tests:
         operation: verify_permission
 
   - test:
+      name: Nfsv3 Verify read write operation permissions
+      module: nfs_verify_read_write_operations.py
+      desc: Perform read write without permissions on nfs share
+      polarion-id: CEPH-83575941
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        operation: verify_permission
+
+  - test:
       name: Nfs verify read and write non existing file
       module: nfs_verify_read_write_operations.py
       desc: Perform read write of no existing file on nfs share
       polarion-id: CEPH-83575927
       abort-on-fail: false
       config:
-        nfs_version: 4.1
+        nfs_version: 3
         clients: 3
         operation: verify_non_existing_file
 

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7.1x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7.1x-to-9x-latest.yaml
@@ -1,14 +1,14 @@
 ##############################################################################################
 # Tier-Level: 1
-# Test-Suite: tier1-nfs-ganesha-upgrade-rhcs-8.1x-to-9x-latest.yaml
-# Scenario: Upgrade RHCS 8.1x(GA) cluster to RHCS 9.x(Latest) with NFS-Ganesha in RHEL9
+# Test-Suite: tier1-nfs-ganesha-upgrade-7x-to-9x-latest.yaml
+# Scenario: Upgrade Ceph 7.1(GA) cluster to Ceph 9(Latest) with NFS-Ganesha in RHEL9
 #
-# Cluster Configuration: Conf: conf/reef/nfs/1admin-3client-7node.yaml
+# Cluster Configuration: Conf: conf/tentacle/nfs/1admin-3client-7node.yaml
 #
 # Test Steps:
-# - Deploy RHCS 8.1x(GA) cluster in RHEL 9
-# - Deploy RHCS 8.1x client
-# - Upgrade cluster along with NFS-Ganesha IOs parllel on 9.0 builds
+# - Deploy Ceph 7.1(GA) cluster in RHEL 9
+# - Deploy Ceph 7.1 client
+# - Upgrade cluster along with NFS-Ganesha IOs parllel
 ################################################################################################
 tests:
   - test:
@@ -18,8 +18,8 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Bootstrap RHCS 8.1x (N-1) cluster and deploy services with label placements.
-      desc: Bootstrap RHCS 8.1x (N-1) cluster and deploy services with label placements.
+      name: Bootstrap Ceph 7.1(GA) cluster and deploy services with label placements.
+      desc: Bootstrap Ceph 7.1(GA) cluster and deploy services with label placements.
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       config:
@@ -29,8 +29,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 8.1
-                release: latest
+                rhcs-version: 7.1
+                release: rc
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
@@ -167,7 +167,7 @@ tests:
         cleanup: false
 
   - test:
-      name: Nfs Verify multiple parallel io and lookups
+      name: Nfs Verify multiple io and lookups
       module: nfs_verify_multiple_parallel_io_and_lookups.py
       desc: Perform look ups while multiple parallel io are in progress
       polarion-id: CEPH-83581304
@@ -178,7 +178,7 @@ tests:
         setup: false
 
   - test:
-      name: nfs multiple operations - pre_upgrade
+      name: Nfsv4 multiple operations - pre_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: nfs multiple operations before upgrade create, delete, write, read, rename
       polarion-id: CEPH-83620035
@@ -192,13 +192,13 @@ tests:
         operation: before_upgrade
 
   - test:
-      name: Upgrade along with IOs for nfs - parallel module
+      name: Upgrade along with IOs for nfs
       module: test_parallel.py
-      desc: Upgrade along with IOs for nfs - parallel module
+      desc: Upgrade along with IOs for nfs in parallel
       parallel:
         - test:
-            name: Upgrade cluster to latest RHCS 8.x
-            desc: Upgrade cluster to latest RHCS 8.x
+            name: Upgrade cluster to latest Ceph 9.x
+            desc: Upgrade cluster to latest Ceph 9.x
             module: test_cephadm_upgrade.py
             polarion-id: CEPH-83573791,CEPH-83573790
             config:
@@ -206,6 +206,7 @@ tests:
               service: upgrade
               base_cmd_args:
                 verbose: true
+
         - test:
             name: nfs operations during upgrade
             module: test_nfs_io_operations_during_upgrade.py
@@ -222,7 +223,7 @@ tests:
               loop_count: 4
 
   - test:
-      name: nfs multiple operations - post_upgrade
+      name: Nfsv4.2 multiple operations - post_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: nfs multiple operations after upgrade create, delete, write, read, rename
       polarion-id: CEPH-83620035
@@ -246,7 +247,7 @@ tests:
         clients: 4
 
   - test:
-      name: Nfs Verify read write operation permissions
+      name: Nfsv4 Verify read write operation permissions
       module: nfs_verify_read_write_operations.py
       desc: Perform read write without permissions on nfs share
       polarion-id: CEPH-83575941
@@ -257,13 +258,24 @@ tests:
         operation: verify_permission
 
   - test:
+      name: Nfsv3 Verify read write operation permissions
+      module: nfs_verify_read_write_operations.py
+      desc: Perform read write without permissions on nfs share
+      polarion-id: CEPH-83575941
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        operation: verify_permission
+
+  - test:
       name: Nfs verify read and write non existing file
       module: nfs_verify_read_write_operations.py
       desc: Perform read write of no existing file on nfs share
       polarion-id: CEPH-83575927
       abort-on-fail: false
       config:
-        nfs_version: 4.1
+        nfs_version: 3
         clients: 3
         operation: verify_non_existing_file
 

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
@@ -1,13 +1,13 @@
 ##############################################################################################
 # Tier-Level: 1
-# Test-Suite: tier1-nfs-ganesha-upgrade-rhcs-8x-to-9x-latest.yaml
-# Scenario: Upgrade RHCS 8.x(GA) cluster to RHCS 9(Latest) with NFS-Ganesha in RHEL9
+# Test-Suite: tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
+# Scenario: Upgrade Ceph 8.x(GA) cluster to Ceph 9(Latest) with NFS-Ganesha in RHEL9
 #
-# Cluster Configuration: Conf: conf/reef/nfs/1admin-3client-7node.yaml
+# Cluster Configuration: Conf: conf/squid/nfs/1admin-3client-7node.yaml
 #
 # Test Steps:
-# - Deploy RHCS 8.x(GA) cluster in RHEL 9
-# - Deploy RHCS 8.x client
+# - Deploy Ceph 8.x(GA) cluster in RHEL 9
+# - Deploy Ceph 8.x client
 # - Upgrade cluster along with NFS-Ganesha IOs parllel
 ################################################################################################
 tests:
@@ -18,8 +18,8 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Bootstrap RHCS 8.0(GA) cluster and deploy services with label placements.
-      desc: Bootstrap RHCS 8.0(GA) cluster and deploy services with label placements.
+      name: Bootstrap Ceph 8.x(GA) cluster and deploy services with label placements.
+      desc: Bootstrap Ceph 8.x(GA) cluster and deploy services with label placements.
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       config:
@@ -167,7 +167,7 @@ tests:
         cleanup: false
 
   - test:
-      name: Nfs Verify multiple parallel io and lookups
+      name: Nfs Verify multiple io and lookups
       module: nfs_verify_multiple_parallel_io_and_lookups.py
       desc: Perform look ups while multiple parallel io are in progress
       polarion-id: CEPH-83581304
@@ -178,7 +178,7 @@ tests:
         setup: false
 
   - test:
-      name: nfs multiple operations - pre_upgrade
+      name: Nfsv4 multiple operations - pre_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: nfs multiple operations before upgrade create, delete, write, read, rename
       polarion-id: CEPH-83620035
@@ -192,13 +192,13 @@ tests:
         operation: before_upgrade
 
   - test:
-      name: Upgrade along with IOs for nfs - parallel module
+      name: Upgrade along with IOs for nfs
       module: test_parallel.py
-      desc: Upgrade along with IOs for nfs - parallel module
+      desc: Upgrade along with IOs for nfs in parallel
       parallel:
         - test:
-            name: Upgrade cluster to latest RHCS 9.x
-            desc: Upgrade cluster to latest RHCS 9.x
+            name: Upgrade cluster to latest Ceph 9.x
+            desc: Upgrade cluster to latest Ceph 9.x
             module: test_cephadm_upgrade.py
             polarion-id: CEPH-83573791,CEPH-83573790
             config:
@@ -206,6 +206,7 @@ tests:
               service: upgrade
               base_cmd_args:
                 verbose: true
+
         - test:
             name: nfs operations during upgrade
             module: test_nfs_io_operations_during_upgrade.py
@@ -220,9 +221,10 @@ tests:
               dd_command_size_in_M: 10
               exports_number: 4
               loop_count: 4
+      abort-on-fail: true
 
   - test:
-      name: nfs multiple operations - post_upgrade
+      name: NFSv4 multiple operations - post_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: nfs multiple operations after upgrade create, delete, write, read, rename
       polarion-id: CEPH-83620035
@@ -246,7 +248,7 @@ tests:
         clients: 4
 
   - test:
-      name: Nfs Verify read write operation permissions
+      name: Nfsv4 Verify read write operation permissions
       module: nfs_verify_read_write_operations.py
       desc: Perform read write without permissions on nfs share
       polarion-id: CEPH-83575941
@@ -257,13 +259,24 @@ tests:
         operation: verify_permission
 
   - test:
+      name: Nfsv3 Verify read write operation permissions
+      module: nfs_verify_read_write_operations.py
+      desc: Perform read write without permissions on nfs share
+      polarion-id: CEPH-83575941
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        operation: verify_permission
+
+  - test:
       name: Nfs verify read and write non existing file
       module: nfs_verify_read_write_operations.py
       desc: Perform read write of no existing file on nfs share
       polarion-id: CEPH-83575927
       abort-on-fail: false
       config:
-        nfs_version: 4.1
+        nfs_version: 3
         clients: 3
         operation: verify_non_existing_file
 


### PR DESCRIPTION
# Description
Adding N-2 Upgrade scenario for Tentacle ie., 7.1 RC to 9.0 Latest
Removed RHCS and IBM tags, so that suites can be run generically
Added NFSv3 Scenarios to al Upgrade suites

- [Successful Logs on RHOS-D](http://magna002.ceph.redhat.com/ceph-qe-logs/aravindranth/logs-9.0_nfs_upg_n_2/)
- [Successful 7.1 to 9.0](http://dhcp46-153.lab.eng.blr.redhat.com/logs/IBM/9.0/rhel-9/executor/20.1.0-121/nfs/350/logs/tier1_nfs_ganesha_upgrade_7_1x_to_9x_latest/)
- [Successful Logs for Double hop 7.1-8.1-9.0](http://dhcp46-153.lab.eng.blr.redhat.com/logs/IBM/9.0/rhel-9/executor/20.1.0-121/nfs/354/logs/tier1_nfs_ganesha_upgrade_7_1x_to_8_1x_to_9x_latest/)
