### PR TITLE
Fix DMFG Upgrade IBM Suites Configuration

### DIFF
--- a/suites/tentacle/upgrades/tier1-upgrade-ibm-7x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-ibm-7x-to-9x.yaml
@@ -28,8 +28,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                rhcs-version: 7.1
+                release: "rc"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/upgrades/tier1-upgrade-ibm-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-ibm-8x-to-9x.yaml
@@ -30,8 +30,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                rhcs-version: 8.1
+                release: "rc"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/upgrades/tier1-upgrade-with-monitoring-stack-ibm-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-with-monitoring-stack-ibm-8x-to-9x.yaml
@@ -30,8 +30,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                rhcs-version: 8.1
+                release: "rc"
                 mon-ip: node1
                 orphan-initial-daemons: true
           - config:

--- a/suites/tentacle/upgrades/tier2-upgrade-ibm-staggered-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier2-upgrade-ibm-staggered-8x-to-9x.yaml
@@ -36,8 +36,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8S-rhel-9.repo"
+                rhcs-version: 8.1
+                release: "rc"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true


### PR DESCRIPTION
`custom_image` and `custom_repo` added in the bootstrap configuration were not used by the bootstrap script, so the default Cephadm image/repo gets selected instead — which leads to failures like:

`Error: Unable to find a match: cephadm-2:20.1.0-112*.el9cp`

These fields replaced with the `rhcs-version` and `release` to pick correct image and repo are during upgrades.

Log:
- https://149.81.216.83/view/Tentacle/job/tentacle-upgrade-ci/33/