### PR TITLE
TFA - locktest suite for v3

### DIFF
--- a/tests/nfs/nfs_run_nfslocktest_suite.py
+++ b/tests/nfs/nfs_run_nfslocktest_suite.py
@@ -74,8 +74,6 @@ def run(ceph_cluster, **kw):
         )
 
         log.info("=== Install & run nfstest ===")
-        setup_passwordless_ssh(clients[0], clients[1])
-        setup_passwordless_ssh(clients[1], clients[0])
         client = clients[0]  # run suite from client0
         client.exec_command(
             cmd="dnf install -y git python3 python3-devel tcpdump wireshark firewalld",


### PR DESCRIPTION
# Description

nfs_run_nfslocktest_suite.py is failing in sanity
The error is
2025-12-07 23:34:45,995 - cephci - nfs_run_nfslocktest_suite:129 - ERROR - Unexpected failure: list index out of range

It is this line -  https://github.com/red-hat-storage/cephci/blob/0517aa8f028fdccb4c78b0293002338806efeb41/tests/nfs/nfs_run_nfslocktest_suite.py#L77

logfile  : dhcp46-153.lab.eng.blr.redhat.com/logs/IBM/9.0/rhel-10/sanity/20.1.0-120/170/logs/Tier_0_NFS_Ganesha_v3/Running_nfstest_lock_suite_0.log](http://dhcp46-153.lab.eng.blr.redhat.com/logs/IBM/9.0/rhel-10/sanity/20.1.0-120/170/logs/Tier_0_NFS_Ganesha_v3/Running_nfstest_lock_suite_0.log)

==== >>> Removed usage of  "setup_passwordless_ssh" in the test as they are not needed for this test.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
