### PR TITLE
Add NFS test for IBM BVT

### DIFF
--- a/suites/tentacle/smoke/bvt-ibm.yaml
+++ b/suites/tentacle/smoke/bvt-ibm.yaml
@@ -195,3 +195,14 @@ tests:
         smb_user_password: passwd
         smb_shares: [share1, share2]
         path: "/"
+
+  - test:
+      name: Nfs Verify file mv and replace opertaion
+      module: nfs_verify_read_write_operations.py
+      desc: Verify mv is overwrites the content of the existing file with same name
+      polarion-id: CEPH-83575934
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 1
+        operation: mv_file_overwrite


### PR DESCRIPTION
# Description

Adding Back NFS BVT Testcase to IBM BVT suite

NFS test was removed as it was failing on RHEL10.1 as rpc-bind was not started by default ion RHEL10.1
Now as the fix for the service is in, BVT is passing fine

[IBM Cloud BVT  logs](http://dhcp46-153.lab.eng.blr.redhat.com/logs/IBM/9.0/rhel-9/executor/20.1.0-120/smoke/329/logs/bvt_ibm/)
