### PR TITLE
[TFA] fixing checksum go test issue. failure is because cephadm_root_ca not trusted on the client node

### DIFF
--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -112,6 +112,48 @@ tests:
         copy_admin_keyring: true
       desc: Configure the RGW client system
       polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        commands:
+          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
+          - "sudo yum install -y sshpass"
+          - "sleep 20"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node3}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node4}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node5}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node6}:/etc/pki/ca-trust/source/anchors/"
+      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
+      module: exec.py
+      name: copying cephadm_root_ca_cert
+      polarion-id: CEPH-10362
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: rgw
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on rgw nodes
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on rgw nodes
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: client
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on client nodes
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on client nodes
+
+
   - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -112,6 +112,47 @@ tests:
         copy_admin_keyring: true
       desc: Configure the RGW client system
       polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        commands:
+          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
+          - "sudo yum install -y sshpass"
+          - "sleep 20"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node3}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node4}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node5}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node6}:/etc/pki/ca-trust/source/anchors/"
+      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
+      module: exec.py
+      name: copying cephadm_root_ca_cert
+      polarion-id: CEPH-10362
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: rgw
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on rgw nodes
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on rgw nodes
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: client
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on client nodes
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on client nodes
+
   - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create


### PR DESCRIPTION
this PR is to fix the TFA issue of failing checksum go test. the issue is because we moved from "rgw_ssl_deployment_with ssl_cert" to rgw_ssl_with_generate_cert"
in case of rgw ssl with ssl certificate in the yaml, cephci-ca is used as ca and it will be auto trusted on all the nodes in the cluster
but as we moved to generate_cert method for rgw ssl, we need to manually get cephadm_root_ca and trust it on all the nodes so that requests to rgw ssl daemon will not fail with ssl_verify_failure

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_checksum_go_ssl/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
