### PR TITLE
Fix: Ensure /home/cephuser/ansible directory and log file are created…

### DIFF
--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -350,6 +350,15 @@ def setup_installer_node(
     # Configure cephadm ansible inventory hosts
     configure_cephadm_ansible_inventory(nodes)
 
+    installer.exec_command(
+        sudo=True,
+        cmd=(
+            "mkdir -p /home/cephuser/ansible && "
+            "touch /home/cephuser/ansible/ansible.log && "
+            "chown -R cephuser:cephuser /home/cephuser/ansible"
+        ),
+    )
+
     # Execute cephadm ansible preflight playbook
     exec_cephadm_preflight(installer, build_type, ibm_build, tools_repo)
 


### PR DESCRIPTION
This PR addresses a failure in exec_cephadm_preflight() where the playbook expects the log file at /home/cephuser/ansible/ansible.log, but the directory does not exist during ansible preflight bootstrap.

Log:
https://149.81.216.83/view/Tentacle/job/tentacle-test-executor/332/pipeline-overview/log?nodeId=103

Log Snippet:

```
Running test: Install ceph pre-requisites
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Install_ceph_pre-requisites_0.log
Test <module 'install_prereq' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/misc_env/install_prereq.py'> passed

Running test: Bootstrap cluster with selinux set to Permissive
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Bootstrap_cluster_with_selinux_set_to_Permissive_0.log
Test <module 'test_cephadm_ansible_bootstrap' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_bootstrap.py'> passed

Running test: Add host with labels to cluster using cephadm-ansible wrapper modules
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Add_host_with_labels_to_cluster_using_cephadm-ansible_wrapper_modules_0.log
Test <module 'test_cephadm_ansible_operations' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_operations.py'> passed

Running test: Deploy OSD service to cluster using cephadm-ansible wrapper modules
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Deploy_OSD_service_to_cluster_using_cephadm-ansible_wrapper_modules_0.log
Test <module 'test_cephadm_ansible_operations' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_operations.py'> passed

Running test: Add host with labels to cluster using cephadm-ansible wrapper modules
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Add_host_with_labels_to_cluster_using_cephadm-ansible_wrapper_modules_1.log
Test <module 'test_cephadm_ansible_operations' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_operations.py'> passed

Running test: Deploy OSD service to cluster using cephadm-ansible wrapper modules
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Deploy_OSD_service_to_cluster_using_cephadm-ansible_wrapper_modules_1.log
Test <module 'test_cephadm_ansible_operations' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_operations.py'> passed

Running test: Add host with labels to cluster using cephadm-ansible wrapper modules
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Add_host_with_labels_to_cluster_using_cephadm-ansible_wrapper_modules_2.log
Test <module 'test_cephadm_ansible_operations' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_operations.py'> passed

Running test: Deploy OSD service to cluster using cephadm-ansible wrapper modules
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Deploy_OSD_service_to_cluster_using_cephadm-ansible_wrapper_modules_2.log
Test <module 'test_cephadm_ansible_operations' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_cephadm_ansible_operations.py'> passed

Running test: Check cluster status when nodes are performed with reboot
Test logfile location: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios/Check_cluster_status_when_nodes_are_performed_with_reboot_0.log
Test <module 'test_verify_cluster_health_after_reboot' from '/data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/cephci/tests/cephadm/test_verify_cluster_health_after_reboot.py'> failed

All test logs located here: /data/jenkins/ceph-builds/RH/9.0/rhel-10/executor/20.1.0-118/cephadm/332/logs/tier2_permissive_mode_scenarios

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Install ceph pre-requisites      installation of ceph pre-requisites                            0:04:21.293051                   Pass                             
Bootstrap cluster with selinux   Execute 'playbooks/bootstrap-cluster.yaml' playbook            0:03:59.892310                   Pass                             
Add host with labels to cluste   Execute 'playbooks/add-host-to-cluster.yaml' playbook          0:00:14.445654                   Pass                             
Deploy OSD service to cluster    Execute 'deploy-osd-service.yaml' playbook                     0:00:05.997498                   Pass                             
Add host with labels to cluste   Execute 'add-host-to-cluster.yaml' playbook                    0:00:11.374406                   Pass                             
Deploy OSD service to cluster    Execute 'deploy-osd-service.yaml' playbook                     0:00:06.105999                   Pass                             
Add host with labels to cluste   Execute 'add-host-to-cluster.yaml' playbook                    0:00:11.515558                   Pass                             
Deploy OSD service to cluster    Execute 'deploy-osd-service.yml' playbook                      0:00:06.064823                   Pass                             
Check cluster status when node   Perform reboot and check ceph status                           0:05:37.121981                   Failed            Test fails due to Product Bug - 2295317

```