### PR TITLE
[BYOK] gklm fix for ibm cloud requirement

### DIFF
--- a/suites/tentacle/nfs/tier0-nfs-ganesha-byok.yaml
+++ b/suites/tentacle/nfs/tier0-nfs-ganesha-byok.yaml
@@ -178,7 +178,7 @@ tests:
       module: byok.test_byok_single_multi_restart.py
       desc: BYOK single-cluster with FUSE encryption validation
       polarion-id: CEPH-83625072
-      abort-on-fail: true
+      comments: might fail due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=2420435
       config:
         nfs_version: 4.2
         total_export_num: 4
@@ -187,14 +187,7 @@ tests:
         nfs_mount: /mnt/nfs_byok
         nfs_export: /export_byok
         nfs_instance_name: nfs_byok
-   - test:
-      name: Test Encryption with the incorrect key and kmip certs (single cluster)
-      module: byok.test_byok_neg_incorrect_key_cert.py
-      desc: BYOK Negative test Incorrect key kmip certs
-      polarion-id: CEPH-83628801
-      abort-on-fail: true
-      config:
-        nfs_version: 4.2
+
    - test:
       name: byok multicluster with io and restart - parallel module
       module: test_parallel.py
@@ -205,7 +198,6 @@ tests:
             module: byok.test_byok_single_multi_restart.py
             desc: Test multiple clusters with IO
             polarion-id: CEPH-83627655
-            abort-on-fail: true
             config:
               nfs_version: 4.2
               total_export_num: 4
@@ -238,7 +230,6 @@ tests:
       module: byok.test_byok_single_multi_restart.py
       desc: Confirm nfs receives SIGHUP and reloads after KMIP certs in existing NFS service spec update
       polarion-id: CEPH-83628800
-      abort-on-fail: true
       config:
         nfs_version: 4.2
         total_export_num: 4
@@ -248,3 +239,11 @@ tests:
         nfs_export: /export_byok
         nfs_instance_name: nfs_byok
         check_sighup: true
+
+   - test:
+      name: Test Encryption with the incorrect key and kmip certs (single cluster)
+      module: byok.test_byok_neg_incorrect_key_cert.py
+      desc: BYOK Negative test Incorrect key kmip certs
+      polarion-id: CEPH-83628801
+      config:
+        nfs_version: 4.2

--- a/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
+++ b/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
@@ -8,7 +8,6 @@ from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
     create_nfs_instance_for_byok,
     get_enctag,
-    get_gklm_ca_certificate,
     load_gklm_config,
     nfs_byok_test_setup,
     setup_gklm_infrastructure,
@@ -323,18 +322,15 @@ def gklm_setup():
     gklm_ip = byok_setup_params["gklm_ip"]
     gklm_user = byok_setup_params["gklm_user"]
     gklm_password = byok_setup_params["gklm_password"]
-    gklm_node_user = byok_setup_params["gklm_node_user"]
-    gklm_node_password = byok_setup_params["gklm_node_password"]
+
     gklm_hostname = byok_setup_params["gklm_hostname"]
     gklm_client_name = byok_setup_params["gklm_client_name"]
     gklm_cert_alias = byok_setup_params["gklm_cert_alias"]
     nfs_nodes = byok_setup_params["nfs_nodes"]
     nfs_node = nfs_nodes[0]
-    exe_node = setup_gklm_infrastructure(
+    setup_gklm_infrastructure(
         nfs_nodes=nfs_nodes,
         gklm_ip=gklm_ip,
-        gklm_node_username=gklm_node_user,
-        gklm_node_password=gklm_node_password,
         gklm_hostname=gklm_hostname,
     )
     gklm_rest_client = GklmClient(
@@ -368,13 +364,8 @@ def gklm_setup():
     # ------------------- Prerequisites and Certificate Export -------------------
     # Ensure SSH access, hostname resolution, and certificate availability
     log.info("Setting up SSH and CA certificate prerequisites on NFS and GKLM nodes")
-    ca_cert = get_gklm_ca_certificate(
-        gklm_ip=gklm_ip,
-        gklm_node_username=gklm_node_user,
-        gklm_node_password=gklm_node_password,
-        gkml_servering_cert_name=gklm_hostname,
-        exe_node=exe_node,
-        gklm_rest_client=gklm_rest_client,
+    ca_cert = gklm_rest_client.certificates.get_system_certificate(
+        cert_name=gklm_hostname
     )
     log.info("CA certificate successfully retrieved \n %s", ca_cert)
     return enctag, rsa_key, cert, ca_cert, gklm_rest_client

--- a/tests/nfs/byok/test_byok_nfs_ha_failover_encryption.py
+++ b/tests/nfs/byok/test_byok_nfs_ha_failover_encryption.py
@@ -10,7 +10,6 @@ from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
     create_in_file_certs,
     get_enctag,
-    get_gklm_ca_certificate,
     load_gklm_config,
     perform_io_operations_and_validate_fuse,
     setup_gklm_infrastructure,
@@ -157,8 +156,6 @@ def run(ceph_cluster, **kw):
     gklm_ip = gklm_params["gklm_ip"]
     gklm_user = gklm_params["gklm_user"]
     gklm_password = gklm_params["gklm_password"]
-    gklm_node_username = gklm_params["gklm_node_username"]
-    gklm_node_password = gklm_params["gklm_node_password"]
     gklm_hostname = gklm_params["gklm_hostname"]
 
     gkml_client_name = "automation"
@@ -167,11 +164,9 @@ def run(ceph_cluster, **kw):
 
     try:
         log.info("Step 1: Setting up GKLM infrastructure")
-        exe_node = setup_gklm_infrastructure(
+        setup_gklm_infrastructure(
             nfs_nodes=nfs_servers,
             gklm_ip=gklm_ip,
-            gklm_node_username=gklm_node_username,
-            gklm_node_password=gklm_node_password,
             gklm_hostname=gklm_hostname,
         )
 
@@ -183,13 +178,8 @@ def run(ceph_cluster, **kw):
         log.info(
             "Step 3: Generating certificates and keys, and CA certificate from GKLM"
         )
-        ca_cert = get_gklm_ca_certificate(
-            gklm_ip=gklm_ip,
-            gklm_node_username=gklm_node_username,
-            gklm_node_password=gklm_node_password,
-            exe_node=exe_node,
-            gklm_rest_client=gklm_rest_client,
-            gkml_servering_cert_name=gklm_hostname,
+        ca_cert = gklm_rest_client.certificates.get_system_certificate(
+            cert_name=gklm_hostname
         )
 
         log.info("Step 4: Creating client certificates and encryption tags")

--- a/tests/nfs/byok/test_byok_single_multi_restart.py
+++ b/tests/nfs/byok/test_byok_single_multi_restart.py
@@ -7,7 +7,6 @@ from tests.nfs.byok.byok_tools import (
     create_multiple_nfs_instance_for_byok,
     create_nfs_instance_for_byok,
     get_enctag,
-    get_gklm_ca_certificate,
     load_gklm_config,
     perform_io_operations_and_validate_fuse,
     setup_gklm_infrastructure,
@@ -204,8 +203,6 @@ def run(ceph_cluster, **kw):
     gklm_ip = gklm_params["gklm_ip"]
     gklm_user = gklm_params["gklm_user"]
     gklm_password = gklm_params["gklm_password"]
-    gklm_node_username = gklm_params["gklm_node_username"]
-    gklm_node_password = gklm_params["gklm_node_password"]
     gklm_hostname = gklm_params["gklm_hostname"]
 
     gkml_client_name = "automation"
@@ -214,11 +211,9 @@ def run(ceph_cluster, **kw):
 
     try:
         log.info("Step 1: Setting up GKLM infrastructure")
-        exe_node = setup_gklm_infrastructure(
+        setup_gklm_infrastructure(
             nfs_nodes=nfs_nodes,
             gklm_ip=gklm_ip,
-            gklm_node_username=gklm_node_username,
-            gklm_node_password=gklm_node_password,
             gklm_hostname=gklm_hostname,
         )
 
@@ -229,13 +224,8 @@ def run(ceph_cluster, **kw):
 
         log.info("Step 3: generating certificates and keys, and CA_cert from GKLM")
 
-        ca_cert = get_gklm_ca_certificate(
-            gklm_ip=gklm_ip,
-            gklm_node_username=gklm_node_username,
-            gklm_node_password=gklm_node_password,
-            exe_node=exe_node,
-            gklm_rest_client=gklm_rest_client,
-            gkml_servering_cert_name=gklm_hostname,
+        ca_cert = gklm_rest_client.certificates.get_system_certificate(
+            cert_name=gklm_hostname
         )
 
         rsa_key, cert, _ = gklm_rest_client.certificates.get_certificates(
@@ -262,6 +252,8 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).fs.sub_volume_group.create(
             volume=fs_name, group=subvolume_group
         )
+
+        Ceph(nfs_node).execute("systemctl start rpcbind", sudo=True)
 
         # Single cluster BYOK flow
         if nfs_replication_number == 1:
@@ -417,6 +409,7 @@ def run(ceph_cluster, **kw):
             dynamic_cleanup_common_names(
                 clients,
                 mounts_common_name=config.get("nfs_mount_common_name", "nfs_byok"),
+                group_name=subvolume_group,
             )
 
         if CephFSCommonUtils(ceph_cluster).wait_for_healthy_ceph(clients[0], 300):

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -955,8 +955,13 @@ def create_multiple_nfs_instance_via_spec_file(
                 "spec": {
                     "port": port,
                     "monitoring_port": monitoring_port,
+                    "kmip_cert": spec["kmip_cert"][0],
+                    "kmip_key": spec["kmip_key"][0],
+                    "kmip_ca_cert": spec["kmip_ca_cert"][0],
+                    "kmip_host_list": spec["kmip_host_list"],
                 },
             }
+
             new_objects.append(new_object)
 
             log.debug(

--- a/tests/nfs/test_nfs_io_operations_during_upgrade.py
+++ b/tests/nfs/test_nfs_io_operations_during_upgrade.py
@@ -1,3 +1,4 @@
+import json
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 
@@ -118,7 +119,15 @@ def create_export_and_mount_for_existing_nfs_cluster(
                             nfs_export=export_name,
                             fs=_fs,
                         )
-                    all_exports = Ceph(clients[0]).nfs.export.ls(nfs_name)
+                    if type(nfs_name) is list:
+                        all_exports = []
+                        for nfs in nfs_name:
+                            exports = json.loads(Ceph(clients[0]).nfs.export.ls(nfs))
+                            all_exports.extend(exports)
+                    else:
+                        all_exports = json.loads(
+                            Ceph(clients[0]).nfs.export.ls(nfs_name)
+                        )
                     if export_name not in all_exports:
                         raise OperationFailedError(
                             f"Export {export_name} not found in the list of exports {all_exports}"


### PR DESCRIPTION
Purpose of this fix:
1 . Removing the root access to GKLM server
2. Getting ca_cert/system cert of the gklm via rest api
3. Removing the sshpass package dependency
4. Making sure that gklm server in IBM cloud env works with present tests with small adjustment
 
logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/byok/byok_fix_ibm/
- above logs will be in failed status due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=2420435, Failure occured in clean up state.
