### PR TITLE
Exclude appstream and baseos repos removal during upgrade workflow

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -660,6 +660,35 @@ def setup_repos(
         inst_file.flush()
 
 
+def remove_repos(
+    ceph_node,
+    exclude_repos=[
+        "hashicorp.repo",
+        "redhat.repo",
+        "appstream.repo",
+        "baseos.repo",
+        "crb.repo",
+    ],
+    repo_dir="/etc/yum.repos.d/",
+):
+    """Method to remove all repos from a desired directory except 'exclude_repos' entries
+    This method can also be used to remove general files from any directory on input node
+    Args:
+        ceph_node: node on which repos should be removed
+        exclude_repos: list of repos that will be excluded and retained
+        repo_dir: repo directory defaulted to '/etc/yum.repos.d/'
+    """
+    rm_repo_cmd = f"find {repo_dir} -type f -delete"
+    if exclude_repos:
+        rm_repo_cmd = (
+            f"find {repo_dir} -type f ! -name "
+            + " ! -name ".join(exclude_repos)
+            + " -delete"
+        )
+    for _cmd in [rm_repo_cmd, "yum clean all"]:
+        ceph_node.exec_command(sudo=True, cmd=_cmd)
+
+
 def check_ceph_healthly(
     ceph_mon, num_osds, num_mons, build, mon_container=None, timeout=300
 ):

--- a/tests/cephadm/test_cephadm_upgrade.py
+++ b/tests/cephadm/test_cephadm_upgrade.py
@@ -5,7 +5,7 @@ Test module that verifies the Upgrade of Ceph Storage via the cephadm CLI.
 
 from ceph.ceph_admin.orch import Orch
 from ceph.rados.rados_bench import RadosBench
-from ceph.utils import is_legacy_container_present
+from ceph.utils import is_legacy_container_present, remove_repos
 from cephci.utils.build_info import CephTestManifest
 from utility.log import Log
 
@@ -100,9 +100,8 @@ def run(ceph_cluster, **kwargs) -> int:
             executor.run(config=config["benchmark"])
 
         # Remove existing repos
-        rm_repo_cmd = "find /etc/yum.repos.d/ -type f ! -name hashicorp.repo ! -name redhat.repo -delete"
         for node in ceph_cluster.get_nodes():
-            node.exec_command(sudo=True, cmd=rm_repo_cmd)
+            remove_repos(ceph_node=node)
 
         # Set repo to newer RPMs
         orch.set_tool_repo()

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -18,7 +18,7 @@ from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.orch import Orch
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.utils import get_cluster_timestamp
-from ceph.utils import get_node_by_id
+from ceph.utils import get_node_by_id, remove_repos
 from cephci.utils.build_info import CephTestManifest
 from tests.rados.monitor_configurations import MonConfigMethods
 from utility.log import Log
@@ -176,12 +176,8 @@ def run(ceph_cluster, **kw):
         cluster_obj = Orch(cluster=ceph_cluster, **config)
 
         # Remove existing repos
-        rm_repo_cmd = (
-            "find /etc/yum.repos.d/ -type f ! -name hashicorp.repo ! -name redhat.repo -delete ;"
-            " yum clean all"
-        )
         for node in ceph_cluster.get_nodes():
-            node.exec_command(sudo=True, cmd=rm_repo_cmd)
+            remove_repos(ceph_node=node)
 
         # Set repo to newer RPMs
         cluster_obj.set_tool_repo()


### PR DESCRIPTION
# Description

As part of upgrade workflow, ceph rpms repos present in `/etc/yum.repos.d/` are removed so that new rpm installation/upgrade is unaffected after new repos are added.
Currently, the repos that are excluded from the removal process are - `hashicorp.repo` and `redhat.repo`

IBM Jenkins pipeline triggers IBM Cloud VM where the appstream and base-os repos are compensated by equivalent mirror repos that are explicitly added in `/etc/yum.repos.d/` contrary to RH Jenkins Openstack deployments where these repos are enabled with `subscription-manager` and therefore remain unaffected by the removal command.

When the automation upgrade workflow reaches package update state, appstream and baseos repos have already been removed from `/etc/yum.repos.d/`, and the below error is encountered:
```yum update --nogpgcheck -y ceph* returned Error: 
 Problem: package ceph-common-2:20.1.0-110.el9cp.x86_64 from repo.qe.ceph.lab_repos_ceph_testing_ibm_9_rhel9_20.1.0-110_Tools requires librbd1 = 2:20.1.0-110.el9cp, but none of the providers can be installed
  - cannot install the best update candidate for package ceph-common-2:18.2.1-361.el9cp.x86_64
  - nothing provides libnbd.so.0()(64bit) needed by librbd1-2:20.1.0-110.el9cp.x86_64 from repo.qe.ceph.lab_repos_ceph_testing_ibm_9_rhel9_20.1.0-110_Tools
  - nothing provides libnbd.so.0(LIBNBD_1.0)(64bit) needed by librbd1-2:20.1.0-110.el9cp.x86_64 from repo.qe.ceph.lab_repos_ceph_testing_ibm_9_rhel9_20.1.0-110_Tools
 and code 1 on 10.245.64.64
```

### Proposed fix
The mirror concerned repo files present in `/etc/yum.repos.d/` should be skipped during removal
Repo removal code has been moved to a common method for better maintenance.

Test run:
https://149.81.216.83/view/Executor/job/tentacle-test-executor/351/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>