### PR TITLE
Add new 8x to 9x upgrade nvme suite

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_8x-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_8x-to-9x_upgrade.yaml
@@ -1,0 +1,180 @@
+##############################################################################################
+# Tier-Level: 2
+# Test-Suite: tier-2_nvmeof_8x-to-9x_upgrade.yaml
+# Scenario: Build to build Upgrade,
+#       - Any GAed to next development build
+#       - Currently, 8.x latest cluster to  9.0(Latest dev) Build
+#
+# Cluster Configuration: conf/squid/nvmeof/ceph_nvmeof_ha_cluster_4nodes.yaml
+#
+# Test Steps:
+# - Deploy RHCS/IBM 8.x(latest) cluster in RHEL 9.
+# - Configure NVMeoF gateways and Run IOs in background.
+# - Upgrade cluster from 8.x to 9.0(Latest dev) with NVMe IO in background.
+# - Validate cluster status
+# - Add more namespaces and run IO again.
+# - Perform HA failover and failback.
+################################################################################################
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: >
+        Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap 8.x cluster and deploy services with label placements.
+      desc: Bootstrap 8.x cluster and deploy services with label placements.
+      polarion-id: CEPH-83573777
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                rhcs-version: "8.1"
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client1 and client2
+      desc: Configure the RBD client systems
+      module: test_client.py
+      polarion-id: CEPH-83573758
+      config:
+        command: add
+        rhcs_version: "8.1"
+        id: client.1
+        nodes:
+          - node10
+          - node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Upgrade Cluster to latest 9.x from 8.x CDN ceph version
+      desc: Upgrade cluster to latest version with NVMeoF
+      module: test_ceph_nvmeof_upgrade.py
+      polarion-id: CEPH-83595667
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        gw_group: gw_group1
+        rep_pool_config:
+          pool: rbd
+        install: true  # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems: # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              - count: 8
+                size: 5G
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            hosts:
+              - node10
+        initiators: # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        upgrade:
+          cdn: false
+          release: null
+      destroy-cluster: false
+      abort-on-fail: true
+
+  # 4 GW Single node failure
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        gw_group: gw_group1
+        rep_pool_config:
+          pool: rbd
+        install: true
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems: # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              - count: 8
+                size: 5G
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            hosts:
+              - node11
+        initiators:  # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node11
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node7
+          - tool: systemctl
+            nodes: node9
+      desc: 4GW HA test post upgrade
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW HA test Single failure
+      polarion-id: CEPH-83589016


### PR DESCRIPTION
Pass log for pre requisite, bootstrap: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6DTJVQ/
configure client is failing due to a known build timeouts:
discussion at slack channel: https://ibm-systems-storage.slack.com/archives/C04LZ8AJ3L7/p1765359584544879

The nvme test module will be made compatible with new nvme framework later in the next sprint.
This PR is to add the nvme upgrade yaml and further add the metadata to execute in pipeline.