### PR TITLE
Decoupling Initiator Module: Separating out IO and Initiator setup

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -286,7 +286,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:negative
+          - nqn: nqn.2016-06.io.spdk:negative
             listener_port: 4420
             node: node10
         operation: CEPH-83575812
@@ -325,7 +325,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575467
+          - nqn: nqn.2016-06.io.spdk:ceph-83575467
             listener_port: 4420
             node: node10
         cleanup:
@@ -365,7 +365,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575813
+          - nqn: nqn.2016-06.io.spdk:ceph-83575813
             listener_port: 4420
             node: node10
         cleanup:
@@ -401,8 +401,10 @@ tests:
               count: 1
               size: 5G
             listener_port: 4420
+            hosts:
+              node: node10
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575455
+          - nqn: nqn.2016-06.io.spdk:ceph-83575455
             listener_port: 4420
             node: node10
         cleanup:

--- a/suites/squid/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
@@ -127,7 +127,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575814
+          - nqn: nqn.2016-06.io.spdk:ceph-83575814
             listener_port: 4420
             node: node10
         cleanup:

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
@@ -76,7 +76,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -113,7 +113,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10
 
@@ -125,7 +125,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -161,7 +161,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10
 
@@ -173,7 +173,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -210,7 +210,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10
 
@@ -222,7 +222,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -258,6 +258,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -115,7 +115,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10
 
@@ -127,7 +127,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -163,7 +163,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10
 
@@ -175,7 +175,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -212,7 +212,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10
 
@@ -224,7 +224,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -260,6 +260,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -115,7 +115,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10
 
@@ -127,7 +127,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -163,7 +163,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10
 
@@ -175,7 +175,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -212,7 +212,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10
 
@@ -224,7 +224,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576118
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -260,6 +260,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576118
+              - nqn: nqn.2016-06.io.spdk:ceph-83576118
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -115,7 +115,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10
 
@@ -127,7 +127,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -163,7 +163,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10
 
@@ -176,7 +176,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -213,7 +213,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10
 
@@ -226,7 +226,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576115
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -262,6 +262,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576115
+              - nqn: nqn.2016-06.io.spdk:ceph-83576115
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1  # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -115,7 +115,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10
 
@@ -127,7 +127,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -163,7 +163,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10
 
@@ -175,7 +175,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1  # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -212,7 +212,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10
 
@@ -224,7 +224,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -260,6 +260,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -115,7 +115,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10
 
@@ -127,7 +127,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -163,7 +163,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10
 
@@ -175,7 +175,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -212,7 +212,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10
 
@@ -224,7 +224,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576117
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -260,6 +260,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576117
+              - nqn: nqn.2016-06.io.spdk:ceph-83576117
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
@@ -76,7 +76,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -113,7 +113,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10
 
@@ -123,7 +123,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -159,7 +159,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10
 
@@ -171,7 +171,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -208,7 +208,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10
 
@@ -220,7 +220,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -256,6 +256,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1  # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -113,7 +113,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10
 
@@ -125,7 +125,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -159,7 +159,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10
 
@@ -171,7 +171,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -206,7 +206,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10
 
@@ -218,7 +218,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -252,6 +252,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -113,7 +113,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10
 
@@ -125,7 +125,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -159,7 +159,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10
 
@@ -171,7 +171,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -206,7 +206,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10
 
@@ -218,7 +218,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576116
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -252,6 +252,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576116
+              - nqn: nqn.2016-06.io.spdk:ceph-83576116
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
@@ -75,7 +75,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576113
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -110,7 +110,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10
 
@@ -120,7 +120,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576113
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -154,7 +154,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10
 
@@ -166,7 +166,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576113
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -201,7 +201,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10
 
@@ -213,7 +213,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576113
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -247,6 +247,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
@@ -78,7 +78,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
@@ -115,7 +115,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10
 
@@ -127,7 +127,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -163,7 +163,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10
 
@@ -175,7 +175,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -212,7 +212,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10
 
@@ -224,7 +224,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576114
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -260,6 +260,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576114
+              - nqn: nqn.2016-06.io.spdk:ceph-83576114
                 listener_port: 4420
                 node: node10

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
@@ -110,7 +110,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10
 
@@ -154,7 +154,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10
 
@@ -166,7 +166,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576113
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1 # number of iterations to find out average
         io_profiles:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
@@ -201,7 +201,7 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10
 
@@ -213,7 +213,7 @@ tests:
       module: test_io_perf.py
       polarion-id: CEPH-83576113
       config:
-        iterations: 1               # number of iterations to find out average
+        iterations: 1  # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
@@ -247,6 +247,6 @@ tests:
                 listener_port: 4420
                 allow_host: "*"
             initiators: # Configure Initiators with all pre-req
-              - subnqn: nqn.2016-06.io.spdk:ceph-83576113
+              - nqn: nqn.2016-06.io.spdk:ceph-83576113
                 listener_port: 4420
                 node: node10

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -63,7 +63,7 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-#  Perform Data Integrity tests
+ # Perform Data Integrity tests
   - test:
       abort-on-fail: false
       config:
@@ -286,7 +286,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:negative
+          - nqn: nqn.2016-06.io.spdk:negative
             listener_port: 4420
             node: node10
         operation: CEPH-83575812
@@ -325,7 +325,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575467
+          - nqn: nqn.2016-06.io.spdk:ceph-83575467
             listener_port: 4420
             node: node10
         cleanup:
@@ -365,7 +365,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575813
+          - nqn: nqn.2016-06.io.spdk:ceph-83575813
             listener_port: 4420
             node: node10
         cleanup:
@@ -401,6 +401,8 @@ tests:
               count: 1
               size: 5G
             listener_port: 4420
+            hosts:
+              node: node10
         initiators: # Configure Initiators with all pre-req
           - nqn: nqn.2016-06.io.spdk:ceph-83575455
             listener_port: 4420

--- a/suites/tentacle/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
+++ b/suites/tentacle/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
@@ -127,7 +127,7 @@ tests:
             listener_port: 4420
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:ceph-83575814
+          - nqn: nqn.2016-06.io.spdk:ceph-83575814
             listener_port: 4420
             node: node10
         cleanup:

--- a/tests/nvmeof/test_io_perf.py
+++ b/tests/nvmeof/test_io_perf.py
@@ -12,8 +12,9 @@ import yaml
 from ceph.ceph import Ceph
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
-from tests.nvmeof.test_ceph_nvmeof_gateway import disconnect_initiator, initiators
+from tests.nvmeof.test_ceph_nvmeof_gateway import disconnect_initiator
 from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.initiator import NVMeInitiator
 from tests.nvmeof.workflows.nvme_service import NVMeService
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.io.fio_profiles import IO_Profiles
@@ -471,7 +472,7 @@ def nvmeof(ceph_cluster, **args):
             }
 
             initiator_cfg = {
-                "subnqn": subsystem["nqn"],
+                "nqn": subsystem["nqn"],
                 "listener_port": subsystem["listener_port"],
                 "node": args["initiator_node"],
             }
@@ -508,15 +509,19 @@ def nvmeof(ceph_cluster, **args):
                     )
                     # apply overrides
                     initiator_cfg["io_args"].update(args.get("io_overrides", {}))
+                    client = get_node_by_id(ceph_cluster, args["initiator_node"])
+                    initiator = NVMeInitiator(client)
+                    initiator.connect_targets(nvmegwcli, args["initiators"][0])
+                    paths = initiator.list_devices()
+                    i = initiator.start_fio(paths=paths, **initiator_cfg["io_args"])
 
-                    i = initiators(ceph_cluster, nvmegwcli, initiator_cfg)
                     parse_fio_output(
                         get_node_by_id(ceph_cluster, args["initiator_node"]), i[0]
                     )
 
                     # disconnect initiator
                     disconnect_initiator(
-                        ceph_cluster, args["initiator_node"], initiator_cfg["subnqn"]
+                        ceph_cluster, args["initiator_node"], initiator_cfg["nqn"]
                     )
 
             except Exception as err:


### PR DESCRIPTION
Pass log:

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XXKAHV/ : test_io_perf.py
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KWKQIR/Perform_restart_of_NVMeOF_gateway_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JVOIVP/Perform_cluster_operations_when_IO_operations_are_in_progress._0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEI90K/Remove-image_ops_on_NVMe_Namespace_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEI90K/Perform_restart_of_NVMeOF_gateway_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEI90K/RBD_operations_shrink_and_expand_on_images_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SLH1GS