### PR TITLE
Fix to pass only the test cluster node names

### DIFF
--- a/tests/rbd_mirror/test_9470.py
+++ b/tests/rbd_mirror/test_9470.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 from ceph.utils import hard_reboot
@@ -17,8 +18,10 @@ def test_9470(rbd_mirror, pool_type, **kw):
         imagespec = pool + "/" + image
         osd_cred = config.get("osp_cred")
         state_after_demote = "up+stopped" if mirror1.ceph_version < 3 else "up+unknown"
-
-        hard_reboot(osd_cred, name="ceph-rbd1")
+        node = kw["ceph_nodes"].node_list[0]
+        name = getattr(node, "vmname", None)
+        node_prefix = re.sub(r"-node\d+.*$", "", name)
+        hard_reboot(osd_cred, name=node_prefix)
 
         mirror2.promote(imagespec=imagespec, force=True)
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")


### PR DESCRIPTION
# Description

The old logic checks only 'ceph-rbd1' in the host name and reboots all the hosts in openstack whose name starts with 'ceph-rbd1'. This will result in the reboot of hosts in other clusters as well. This is a significant reason why the tests are failing in the pipelines because the suites run in parallel.

Fixed by changing the prefix to be unique to the cluster under test.

Previous logs where nodes from multiple cluster are shutdown: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/9.0/rhel-9/Regression/20.1.0-18/rbd/7/tier-2_rbd_mirror_failover_recovery/Recovery_of_abrupt_failure_of_primary_cluster_0.log

New log: /ceph/cephci-jenkins/cephci-run-UUDR8N/Recovery_of_abrupt_failure_of_primary_cluster_0.log where only the cluster under test nodes are rebooted:

"025-12-16 05:45:43,463 - cephci - test_9470:88 - INFO - Executing test on replicated pool
2025-12-16 05:45:48,694 - cephci - utils:1021 - INFO - Hard-rebooting ceph-rbd1-cd_reg1-L3CJPN-node5
2025-12-16 05:45:48,854 - cephci - utils:1021 - INFO - Hard-rebooting ceph-rbd1-cd_reg1-L3CJPN-node4
2025-12-16 05:45:48,916 - cephci - utils:1021 - INFO - Hard-rebooting ceph-rbd1-cd_reg1-L3CJPN-node3
2025-12-16 05:45:48,979 - cephci - utils:1021 - INFO - Hard-rebooting ceph-rbd1-cd_reg1-L3CJPN-node2
2025-12-16 05:45:49,041 - cephci - utils:1021 - INFO - Hard-rebooting ceph-rbd1-cd_reg1-L3CJPN-node1-installer
2025-12-16 05:45:49,105 - cephci - ceph:1630 - INFO - Execute rbd mirror image promote --force rep_pool_pZZlooPbzs/rep_image_CwJlqEYgvf --cluster ceph on 10.0.67.45
2025-12-16 05:45:50,112 - cephci - ceph:1660 - INFO - Execution of rbd mirror image promote --force rep_pool_pZZlooPbzs/rep_image_CwJlqEYgvf --cluster ceph on 10.0.67.45 took 1.003948 seconds

"


Will provide the magna web link once the test completes. 