### PR TITLE
Workflow to verify file contents are preserved after unmount-remount with fuse mount

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3452,8 +3452,8 @@ EOF"""
                             log.warning(e)
                 if success_count == len(daemon_status_ls):
                     break
-                log.info("Sleeping for 120 secs")
-                time.sleep(120)
+                log.info("Sleeping for 60 secs")
+                time.sleep(60)
             else:
                 log.error(
                     f"All the daemons part of the service {service} did not restart within "

--- a/suites/tentacle/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-bugfixes.yaml
@@ -118,6 +118,7 @@ tests:
         node: node7                       # client node
         install_packages:
           - ceph-common
+          - ceph-fuse
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -247,22 +248,46 @@ tests:
       polarion-id: CEPH-83616882
       desc: Ensures watchers do not persist after client disconnects or interruptions
 
-  # max run time for this test is 3 mins
+  # max run time for this test is 4 mins
   - test:
-      name: CephFS file flush with replicated pools
+      name: CephFS flush kernel mnt with RE pools
       module: test_bug_fixes.py
       config:
         cephfs_file_flush_issue: true
         pool_type: replicated
+        mount_type: kernel
       polarion-id: CEPH-83632223
       desc: Verify file contents are preserved after unmount-remount with kernel client using replicated pools
 
-  # max run time for this test is 3 mins
+  # max run time for this test is 4 mins
   - test:
-      name: CephFS file flush with EC pools
+      name: CephFS flush kernel mnt with EC pools
       module: test_bug_fixes.py
       config:
         cephfs_file_flush_issue: true
         pool_type: ec
+        mount_type: kernel
       polarion-id: CEPH-83632223
       desc: Verify file contents are preserved after unmount-remount with kernel client using EC pools
+
+  # max run time for this test is 4 mins
+  - test:
+      name: CephFS flush fuse mnt with RE pools
+      module: test_bug_fixes.py
+      config:
+        cephfs_file_flush_issue: true
+        pool_type: replicated
+        mount_type: fuse
+      polarion-id: CEPH-83632223
+      desc: Verify file contents are preserved after unmount-remount with fuse client using replicated pools
+
+  # max run time for this test is 4 mins
+  - test:
+      name: CephFS flush fuse mnt with EC pools
+      module: test_bug_fixes.py
+      config:
+        cephfs_file_flush_issue: true
+        pool_type: ec
+        mount_type: fuse
+      polarion-id: CEPH-83632223
+      desc: Verify file contents are preserved after unmount-remount with fuse client using EC pools


### PR DESCRIPTION
When a file is written to a CephFS subvolume and the container/mount is unmounted and remounted, the file size is correct but the contents are all NUL bytes instead of the written data. Addition of test workflow to verify the behaviour.

With PR : https://github.com/red-hat-storage/cephci/pull/5495, added coverage for Kernel mount

With this PR, adding coverage for fuse mount