### PR TITLE
[rgw][alternate-to-magna] add support for cloning configs repo which has necessary rgw files required for execution

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
@@ -113,6 +113,7 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
+        git_clone_configs_repo: true
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token

--- a/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
@@ -118,6 +118,7 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
+        git_clone_configs_repo: true
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token

--- a/suites/tentacle/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_sts_aswi.yaml
@@ -118,6 +118,7 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
+        git_clone_configs_repo: true
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -85,6 +85,7 @@ def run(ceph_cluster, **kw):
     client_ceph_object = ceph_cluster.get_ceph_object("client")
     run_io_verify = config.get("run_io_verify", False)
     extra_pkgs = config.get("extra-pkgs")
+    git_clone_configs_repo = config.get("git_clone_configs_repo", False)
     install_start_kafka_broker = config.get("install_start_kafka")
     configure_kafka_broker_security = config.get("configure_kafka_security")
     install_keystone_ldap = config.get("install_keystone_ldap")
@@ -141,6 +142,9 @@ def run(ceph_cluster, **kw):
     if not out:
         exec_from.exec_command(cmd=f"sudo mkdir {test_folder}")
         utils.clone_the_repo(config, exec_from, test_folder_path)
+    if git_clone_configs_repo:
+        utils.clone_configs_repo(rgw_node, repo_name="rgw_configs")
+        utils.clone_configs_repo(client_node, repo_name="rgw_configs")
 
     install_common = config.get("install_common", True)
     if install_common:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2071,6 +2071,30 @@ def clone_the_repo(config, node, path_to_clone):
     node.exec_command(cmd=f"cd {path_to_clone} ; {git_clone_cmd}")
 
 
+def clone_configs_repo(node, repo_name=None):
+    """clone the repo on to test node.
+
+    Args:
+        node: ceph node
+        repo_name: fetches the git repo details based on this repo_name from .cephci.yaml
+
+    """
+    try:
+        repo_dict = get_cephci_config()["repos"][repo_name]
+    except KeyError:
+        raise Exception(
+            f"Repo details are missing for the key {repo_name} in ~/.cephci.yaml to clone it on the node."
+        )
+    repo_url = repo_dict["git_url"]
+    log.info(f"cloning the repo {repo_url}")
+    path_to_clone = repo_dict["dest"]
+    oauth_token = repo_dict.get("oauth_token")
+    if oauth_token:
+        repo_url = repo_url.replace("https://", f"https://oauth2:{oauth_token}@")
+    git_clone_cmd = f"git clone --depth 1 {repo_url}"
+    node.exec_command(cmd=f"cd {path_to_clone} ; {git_clone_cmd}")
+
+
 def calculate_available_storage(node):
     """
     Calculate maximum storage that is available to be used.


### PR DESCRIPTION
this PR is to add support for cloning ceph-qe-ng/configs repo (that contains necessary files required for rgw tests execution) if a test contains config variable `git_clone_configs_repo: true` 
with this we can move away from magna dependency

pass logs on single site:
with config parameter set: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/cephci_ceph_qe_ng_configs/cephci-run-2YM3Y1/

sample fail log if cephci.yaml is not updated with repo details: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/cephci_ceph_qe_ng_configs/cephci-run-FXXJ3O/

sample pass log without config parameter set: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/cephci_ceph_qe_ng_configs/cephci-run-MEDUFK/






# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
