### PR TITLE
Convert image digests from @sha256 to tag-style format

### DIFF
--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -216,7 +216,16 @@ class CephTestManifest:
 
         try:
             yml_data: Dict[str, Any] = yaml.safe_load(data.text)
-            return yml_data[self.build_type]
+            build_data = yml_data[self.build_type]
+
+            # Convert image digests from '@sha256:<digest>' format to ':<digest>' format if datacenter is 'eu-de'
+            if self.datacenter == "eu-de":
+                images = build_data.get("images", {})
+                for k, v in images.items():
+                    images[k] = v.replace("@sha256:", ":")
+
+            return build_data
+
         except yaml.YAMLError:
             raise RuntimeError("Unable to process the Ceph QE manifest file")
         except KeyError:


### PR DESCRIPTION
# Description
This change normalizes container image references returned from the QE manifest by converting
@sha256:<digest> to :<digest> format.

This ensures consistency with tag-style image references and avoids failures in workflows that do not support @sha256 digest notation.
Failure log snippet: 
```
2025-12-15 23:07:45,373 - cephci - test_cephadm:188 - ERROR - cephadm --image quay.io/rhceph-ci/rhceph@sha256:54458ca5bcd244e31c4595b8590b9675fdadc6ec061047ebb61f1ca7f82c1b40 bootstrap --registry-url registry.redhat.io --registry-username qa@redhat.com --registry-password MTQj5t3n5K86p3gH --mon-ip 10.243.82.206 --orphan-initial-daemons --skip-monitoring-stack returned Error: Failed command: /usr/bin/podman pull quay.io/rhceph-ci/rhceph@sha256:54458ca5bcd244e31c4595b8590b9675fdadc6ec061047ebb61f1ca7f82c1b40 --authfile=/etc/ceph/podman-auth.json
/var/lib/ceph is missing: no daemon listing available
ERROR: Failed command: /usr/bin/podman pull quay.io/rhceph-ci/rhceph@sha256:54458ca5bcd244e31c4595b8590b9675fdadc6ec061047ebb61f1ca7f82c1b40 --authfile=/etc/ceph/podman-auth.json
 and code 1 on 10.243.82.206
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/RH/9.0/rhel-10/sanity/20.1.0-131/190/cephci/tests/ceph_installer/test_cephadm.py", line 172, in run
    func(cfg)
  File "/data/jenkins/ceph-builds/RH/9.0/rhel-10/sanity/20.1.0-131/190/cephci/ceph/ceph_admin/bootstrap.py", line 348, in bootstrap
    out, err = self.installer.exec_command(
  File "/data/jenkins/ceph-builds/RH/9.0/rhel-10/sanity/20.1.0-131/190/cephci/ceph/ceph.py", line 2357, in exec_command
    return self.node.exec_command(cmd=cmd, **kw)
  File "/data/jenkins/ceph-builds/RH/9.0/rhel-10/sanity/20.1.0-131/190/cephci/ceph/ceph.py", line 1754, in exec_command
    raise CommandFailed(
ceph.ceph.CommandFailed: cephadm --image quay.io/rhceph-ci/rhceph@sha256:54458ca5bcd244e31c4595b8590b9675fdadc6ec061047ebb61f1ca7f82c1b40 bootstrap --registry-url registry.redhat.io --registry-username qa@redhat.com --registry-password MTQj5t3n5K86p3gH --mon-ip 10.243.82.206 --orphan-initial-daemons --skip-monitoring-stack returned Error: Failed command: /usr/bin/podman pull quay.io/rhceph-ci/rhceph@sha256:54458ca5bcd244e31c4595b8590b9675fdadc6ec061047ebb61f1ca7f82c1b40 --authfile=/etc/ceph/podman-auth.json
/var/lib/ceph is missing: no daemon listing available
ERROR: Failed command: /usr/bin/podman pull quay.io/rhceph-ci/rhceph@sha256:54458ca5bcd244e31c4595b8590b9675fdadc6ec061047ebb61f1ca7f82c1b40 --authfile=/etc/ceph/podman-auth.json
 and code 1 on 10.243.82.206
```

Pass Log: https://149.81.216.83/view/Tentacle/job/tentacle-test-executor/436/pipeline-overview/log?nodeId=103
log snippet:
```
2025-12-17 06:45:00,091 - cephci - ceph:1630 - INFO - Execute cephadm --image quay.io/rhceph-ci/rhceph:d73121460bf5c4fe1133facf85ae76982d61eb965e403cef9fd5e991679f85e6 bootstrap --registry-url registry.redhat.io --registry-username qa@redhat.com --registry-password <masked> --mon-ip 10.243.103.222 --orphan-initial-daemons --skip-monitoring-stack on 10.243.103.222
2025-12-17 06:46:41,904 - cephci - ceph:1660 - INFO - Execution of cephadm --image quay.io/rhceph-ci/rhceph:d73121460bf5c4fe1133facf85ae76982d61eb965e403cef9fd5e991679f85e6 bootstrap --registry-url registry.redhat.io --registry-username qa@redhat.com --registry-password <masked> --mon-ip 10.243.103.222 --orphan-initial-daemons --skip-monitoring-stack on 10.243.103.222 took 101.812617 seconds
2025-12-17 06:46:41,905 - cephci - bootstrap:355 - INFO - Bootstrap output : Creating directory /etc/ceph for ceph.conf
Verifying podman|docker is present...
Verifying lvm2 is present...
```