### PR TITLE
[RADOS] Allow EC Overwrites for Erasure coded pool by default

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1623,6 +1623,10 @@ class RadosOrchestrator:
         profile_name = kwargs.get("profile_name", f"ecp_{pool_name}")
         rule_name = f"rule_{pool_name}"
         enable_fast_ec_features = kwargs.get("enable_fast_ec_features", False)
+        # enable allow_ec_overwrites by default
+        kwargs["erasure_code_use_overwrites"] = kwargs.get(
+            "erasure_code_use_overwrites", True
+        )
 
         # Creating an erasure coded profile with the options provided
         cmd = (


### PR DESCRIPTION
# Description

Enable allow_ec_overwrites pool property for all Erasure coded pool by default.
This is required for testing workflows that perform any kind of overwrite, append or truncate operations.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>