### PR TITLE
[RADOS] Fix 'allow_ec_overwrites' pool property argument

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -607,7 +607,7 @@ class RadosOrchestrator:
             "min_size": f"ceph osd pool set {pool_name} min_size {kwargs.get('min_size')}",
             "size": f"ceph osd pool set {pool_name} size {kwargs.get('size')}",
             "erasure_code_use_overwrites": f"ceph osd pool set {pool_name} "
-            f"allow_ec_overwrites {kwargs.get('erasure_code_use_overwrites')}",
+            f"allow_ec_overwrites {str(kwargs.get('erasure_code_use_overwrites')).lower}",
             "disable_pg_autoscale": f"ceph osd pool set {pool_name} pg_autoscale_mode off",
             "pool_quota": f"ceph osd pool set-quota {pool_name} {kwargs.get('pool_quota')}",
         }


### PR DESCRIPTION
# Description

Pool property `allow_ec_overwrites` only accepts - true, false, 0, and 1 as inputs

```
2025-12-18 01:34:16,428 - cephci - core_workflows:622 - ERROR - cephadm shell -- ceph osd pool set ec_profile_test allow_ec_overwrites True returned Inferring fsid bbc82bee-dbd9-11f0-82c1-0208c69b770a

Inferring config /var/lib/ceph/bbc82bee-dbd9-11f0-82c1-0208c69b770a/mon.ceph-rados-16-dac9-gu75mr-node1-installer/config

Error EINVAL: expecting value 'true', 'false', '0', or '1'
```
Failure run - https://149.81.216.83/view/Tentacle/job/tentacle-rados-regression-ci/16

Signed-off-by: Harsh Kumar <hakumar@redhat.com>