### PR TITLE
[RADOS] Install FIO on client nodes in required workflows

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -603,11 +603,15 @@ class RadosOrchestrator:
             )
             self.node.shell([enable_app_cmd])
 
+        allow_ec_overwrites = (
+            "true" if kwargs.get("erasure_code_use_overwrites") else "false"
+        )
+
         cmd_map = {
             "min_size": f"ceph osd pool set {pool_name} min_size {kwargs.get('min_size')}",
             "size": f"ceph osd pool set {pool_name} size {kwargs.get('size')}",
             "erasure_code_use_overwrites": f"ceph osd pool set {pool_name} "
-            f"allow_ec_overwrites {str(kwargs.get('erasure_code_use_overwrites')).lower}",
+            f"allow_ec_overwrites {allow_ec_overwrites}",
             "disable_pg_autoscale": f"ceph osd pool set {pool_name} pg_autoscale_mode off",
             "pool_quota": f"ceph osd pool set-quota {pool_name} {kwargs.get('pool_quota')}",
         }

--- a/tests/rados/test_bluestore_comp_enhancements.py
+++ b/tests/rados/test_bluestore_comp_enhancements.py
@@ -75,6 +75,12 @@ def run(ceph_cluster, **kw):
             "\n\n ************ Execution begins for bluestore data compression scenarios ************ \n\n"
         )
 
+        log.info("Install FIO on client nodes")
+        client_nodes = ceph_cluster.get_nodes(role="client")
+        cmd = "yum install fio -y"
+        for node in client_nodes:
+            node.exec_command(cmd=cmd, sudo=True)
+
         if "scenario-1" in scenarios_to_run:
             log.info("STARTED: Scenario 1: Validate default compression values")
             bluestore_compression.validate_default_compression_values()

--- a/tests/rados/test_four_node_ecpool.py
+++ b/tests/rados/test_four_node_ecpool.py
@@ -233,6 +233,12 @@ def run(ceph_cluster, **kw):
         log.info("SETUP PHASE: Filling EC pool with comprehensive data patterns")
         log.info("=" * 70)
 
+        log.info("Install FIO on client nodes")
+        client_nodes = ceph_cluster.get_nodes(role="client")
+        cmd = "yum install fio -y"
+        for node in client_nodes:
+            node.exec_command(cmd=cmd, sudo=True)
+
         # Step 1: Performing rados bench writes on pool
         log.info("Setup Step 1: Running rados bench writes (5000 objects)...")
         if not rados_obj.bench_write(


### PR DESCRIPTION
# Description

1. Replaces type conversion of boolean variable `erasure_code_use_overwrites` with conditional block
Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/regression/20.1.0-130/rados/17/logs/RADOS_Test___5+2_EC_Pools/EC_pool_5+2@8_LC_-_scenarios_1,2,3_0.log
Pass log - http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/regression/20.1.0-130/rados/18/logs/RADOS_Test___5+2_EC_Pools/EC_pool_5+2@8_LC_-_scenarios_1,2,3_0.log

2. Install FIO package on client nodes in test workflows where FIO is being used as a IO tool
Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/regression/20.1.0-130/rados/18/logs/RADOS_Test___5+2_EC_Pools/EC_pool_5+2@8_LC_-_scenarios_1,2,3_0.log

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

