### PR TITLE
tests for byok-sni feature

### DIFF
--- a/suites/tentacle/nfs/tier0-nfs-ganesha-byok.yaml
+++ b/suites/tentacle/nfs/tier0-nfs-ganesha-byok.yaml
@@ -48,202 +48,306 @@
 #              gklm_node_password:  "password"
 #              gklm_hostname:       "hostname"
 # ===============================================================================
-
+---
 tests:
-   - test:
-       abort-on-fail: true
-       desc: Install software pre-requisites for cluster deployment.
-       module: install_prereq.py
-       name: setup pre-requisites
+     - test:
+         abort-on-fail: true
+         desc: Install software pre-requisites for cluster deployment.
+         module: install_prereq.py
+         name: setup pre-requisites
 
-   - test:
-       abort-on-fail: true
-       config:
-         steps:
-           - config:
-               command: bootstrap
-               service: cephadm
-               args:
-                 mon-ip: node1
-           - config:
-               command: add_hosts
-               service: host
-               args:
-                 attach_ip_address: true
-                 labels: apply-all-labels
-           - config:
-               command: apply
-               service: osd
-               args:
-                 all-available-devices: true
-           - config:
-               command: apply
-               service: rgw
-               pos_args:
-                 - rgw.1
-               args:
-                 placement:
-                   label: rgw
-           - config:
-               args:
-                 - "ceph fs volume create cephfs"
-               command: shell
-           - config:
-               args:
-                 placement:
-                   label: mds
-               base_cmd_args:
-                 verbose: true
-               command: apply
-               pos_args:
-                 - cephfs
-               service: mds
-           - config:
-               args:
-                 - "ceph osd pool create rbd"
-               command: shell
-           - config:
-               args:
-                 - "rbd pool init rbd"
-               command: shell
-       desc: bootstrap and deploy services.
-       destroy-cluster: false
-       polarion-id: CEPH-83573713
-       module: test_cephadm.py
-       name: Deploy cluster using cephadm
+     - test:
+         abort-on-fail: true
+         config:
+           steps:
+             - config:
+                 command: bootstrap
+                 service: cephadm
+                 args:
+                   mon-ip: node1
+             - config:
+                 command: add_hosts
+                 service: host
+                 args:
+                   attach_ip_address: true
+                   labels: apply-all-labels
+             - config:
+                 command: apply
+                 service: osd
+                 args:
+                   all-available-devices: true
+             - config:
+                 command: apply
+                 service: rgw
+                 pos_args:
+                   - rgw.1
+                 args:
+                   placement:
+                     label: rgw
+             - config:
+                 args:
+                   - "ceph fs volume create cephfs"
+                 command: shell
+             - config:
+                 args:
+                   placement:
+                     label: mds
+                 base_cmd_args:
+                   verbose: true
+                 command: apply
+                 pos_args:
+                   - cephfs
+                 service: mds
+             - config:
+                 args:
+                   - "ceph osd pool create rbd"
+                 command: shell
+             - config:
+                 args:
+                   - "rbd pool init rbd"
+                 command: shell
+         desc: bootstrap and deploy services.
+         destroy-cluster: false
+         polarion-id: CEPH-83573713
+         module: test_cephadm.py
+         name: Deploy cluster using cephadm
 
-   - test:
-       abort-on-fail: true
-       config:
-         command: add
-         id: client.1
-         node: node4
-         install_packages:
-           - ceph-common
-           - ceph-fuse
-         copy_admin_keyring: true
-       desc: Configure the RGW,RBD client system
-       destroy-cluster: false
-       module: test_client.py
-       name: configure client
+     - test:
+         abort-on-fail: true
+         config:
+           command: add
+           id: client.1
+           node: node4
+           install_packages:
+             - ceph-common
+             - ceph-fuse
+           copy_admin_keyring: true
+         desc: Configure the RGW,RBD client system
+         destroy-cluster: false
+         module: test_client.py
+         name: configure client
 
-   - test:
-       abort-on-fail: true
-       config:
-         command: add
-         id: client.2
-         node: node5
-         install_packages:
-           - ceph-common
-           - ceph-fuse
-         copy_admin_keyring: true
-       desc: Configure the RGW,RBD client system
-       destroy-cluster: false
-       module: test_client.py
-       name: configure client
+     - test:
+         abort-on-fail: true
+         config:
+           command: add
+           id: client.2
+           node: node5
+           install_packages:
+             - ceph-common
+             - ceph-fuse
+           copy_admin_keyring: true
+         desc: Configure the RGW,RBD client system
+         destroy-cluster: false
+         module: test_client.py
+         name: configure client
 
-   - test:
-       abort-on-fail: true
-       config:
-         command: add
-         id: client.3
-         node: node6
-         install_packages:
-           - ceph-common
-           - ceph-fuse
-         copy_admin_keyring: true
-       desc: Configure the RGW,RBD client system
-       destroy-cluster: false
-       module: test_client.py
-       name: configure client
+     - test:
+         abort-on-fail: true
+         config:
+           command: add
+           id: client.3
+           node: node6
+           install_packages:
+             - ceph-common
+             - ceph-fuse
+           copy_admin_keyring: true
+         desc: Configure the RGW,RBD client system
+         destroy-cluster: false
+         module: test_client.py
+         name: configure client
 
-   - test:
-       abort-on-fail: true
-       config:
-         command: add
-         id: client.4
-         node: node7
-         install_packages:
-           - ceph-common
-           - ceph-fuse
-         copy_admin_keyring: true
-       desc: Configure the RGW,RBD client system
-       destroy-cluster: false
-       module: test_client.py
-       name: configure client
+     - test:
+         abort-on-fail: true
+         config:
+           command: add
+           id: client.4
+           node: node7
+           install_packages:
+             - ceph-common
+             - ceph-fuse
+           copy_admin_keyring: true
+         desc: Configure the RGW,RBD client system
+         destroy-cluster: false
+         module: test_client.py
+         name: configure client
 
 
-   - test:
-      name: Test Encryption with the correct keys (single cluster)
-      module: byok.test_byok_single_multi_restart.py
-      desc: BYOK single-cluster with FUSE encryption validation
-      polarion-id: CEPH-83625072
-      comments: might fail due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=2420435
-      config:
-        nfs_version: 4.2
-        total_export_num: 4
-        clients: 1
-        nfs_replication_number: 1           # Single cluster mode
-        nfs_mount: /mnt/nfs_byok
-        nfs_export: /export_byok
-        nfs_instance_name: nfs_byok
+     - test:
+         name: Test Encryption with the correct keys (single cluster)
+         module: byok.test_byok_single_multi_restart.py
+         desc: BYOK single-cluster with FUSE encryption validation
+         polarion-id: CEPH-83625072
+         config:
+            nfs_version: 4.2
+            total_export_num: 4
+            clients: 1
+            nfs_replication_number: 1           # Single cluster mode
+            nfs_mount: /mnt/nfs_byok
+            nfs_export: /export_byok
+            nfs_instance_name: nfs_byok
 
-   - test:
-      name: byok multicluster with io and restart - parallel module
-      module: test_parallel.py
-      desc: byok multicluster + restart - parallel module
-      parallel:
-        - test:
-            name: Test multiple clusters with IO
-            module: byok.test_byok_single_multi_restart.py
-            desc: Test multiple clusters with IO
-            polarion-id: CEPH-83627655
-            config:
-              nfs_version: 4.2
-              total_export_num: 4
-              clients: 1
-              nfs_replication_number: 4           # Multi-cluster mode - number of clusters
-              nfs_mount_common_name: nfs_byok     # Used for multi-cluster cleanup naming
-              nfs_export: /export_byok
-              spec:                              # Multi-cluster NFS deployment spec
-                service_type: nfs
-                service_id: nfs_byok
-                placement:
-                  host_pattern: '*'
-                spec:
-                  port: 62000
-                  monitoring_port: 62500
+     - test:
+         name: byok multicluster with io and restart - parallel module
+         module: test_parallel.py
+         desc: byok multicluster + restart - parallel module
+         parallel:
+           - test:
+               name: Test multiple clusters with IO
+               module: byok.test_byok_single_multi_restart.py
+               desc: Test multiple clusters with IO
+               polarion-id: CEPH-83627655
+               config:
+                 nfs_version: 4.2
+                 total_export_num: 4
+                 clients: 1
+                 nfs_replication_number: 2           # Multi-cluster mode - number of clusters
+                 nfs_mount_common_name: nfs_byok     # Used for multi-cluster cleanup naming
+                 nfs_export: /export_byok
+                 spec:                              # Multi-cluster NFS deployment spec
+                   service_type: nfs
+                   service_id: nfs_byok
+                   placement:
+                     host_pattern: '*'
+                   spec:
+                     port: 62000
+                     monitoring_port: 62500
 
-        - test:
-              name: Restart NFS Ganesha services -byok
-              desc: Restart NFS Ganesha services for given time - byok
-              module: scripts_tools.restart_nfs_ganesha_services.py
-              config:
-                clients: 1
-                restart_interval: 2 #in minutes
-                longevity: true
-                # longevity_duration: 1 # in hours
-                longevity_loop: 3 # 3 iterations/loops
+           - test:
+                 name: Restart NFS Ganesha services -byok
+                 desc: Restart NFS Ganesha services for given time - byok
+                 module: scripts_tools.restart_nfs_ganesha_services.py
+                 config:
+                   clients: 1
+                   restart_interval: 2 #in minutes
+                   longevity: true
+                   # longevity_duration: 1 # in hours
+                   longevity_loop: 3 # 3 iterations/loops
 
-   - test:
-      name: Test SIGHUP-reload after KMIP and nfs update (single cluster)
-      module: byok.test_byok_single_multi_restart.py
-      desc: Confirm nfs receives SIGHUP and reloads after KMIP certs in existing NFS service spec update
-      polarion-id: CEPH-83628800
-      config:
-        nfs_version: 4.2
-        total_export_num: 4
-        clients: 1
-        nfs_replication_number: 1           # Single cluster mode
-        nfs_mount: /mnt/nfs_byok
-        nfs_export: /export_byok
-        nfs_instance_name: nfs_byok
-        check_sighup: true
+     - test:
+         name: Test SIGHUP-reload after KMIP and nfs update (single cluster)
+         module: byok.test_byok_single_multi_restart.py
+         desc: Confirm nfs receives SIGHUP and reloads after KMIP certs in existing NFS service spec update
+         polarion-id: CEPH-83628800
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byok
+           check_sighup: true
 
-   - test:
-      name: Test Encryption with the incorrect key and kmip certs (single cluster)
-      module: byok.test_byok_neg_incorrect_key_cert.py
-      desc: BYOK Negative test Incorrect key kmip certs
-      polarion-id: CEPH-83628801
-      config:
-        nfs_version: 4.2
+     - test:
+         name: Test SNI Default Secure Case
+         module: byok.test_sni_feature.py
+         desc: Default Secure Case,servername and verify_hostname match
+         polarion-id: CEPH-83632231
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byoksni
+           operation: Default Secure Case
+
+     - test:
+         name: Test SNI Mismatch Validation Hostname
+         module: byok.test_sni_feature.py
+         desc: Mismatch Validation Hostname, servername and verify_hostname unmatch
+         polarion-id: CEPH-83632232
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byoksni
+           operation: Mismatch Validation Hostname
+
+     - test:
+         name: Test SNI Disable Validation
+         module: byok.test_sni_feature.py
+         desc: Disable Validation, validate_hostname empty
+         polarion-id: CEPH-83632236
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byoksni
+           operation: Disable Validation
+
+     - test:
+         name: Test No SNI, Validate Other Hostname
+         module: byok.test_sni_feature.py
+         desc: Disable Validation, servername is empty and different hostname
+         polarion-id: CEPH-83632237
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byoksni
+           operation: No SNI - Validate Other Hostname
+
+     - test:
+         name: Test Custom SNI - Validation Hostname
+         module: byok.test_sni_feature.py
+         desc: Disable Validation, servername and verify_hostname with other cert
+         polarion-id: CEPH-83632233
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byoksni
+           operation: Custom SNI - Validation Hostname
+
+     - test:
+         name: Test Different SNI and Validation
+         module: byok.test_sni_feature.py
+         desc: Disable Validation, servername and verify_hostname points other certs
+         polarion-id: CEPH-83632234
+         config:
+           nfs_version: 4.2
+           total_export_num: 4
+           clients: 1
+           nfs_replication_number: 1           # Single cluster mode
+           nfs_mount: /mnt/nfs_byok
+           nfs_export: /export_byok
+           nfs_instance_name: nfs_byoksni
+           operation: Different SNI and Validation
+
+     - test:
+        name: Test No SNI - No Validation
+        module: byok.test_sni_feature.py
+        desc: Disable Validation, servername and verify_hostname empty
+        polarion-id: CEPH-83632235
+        config:
+          nfs_version: 4.2
+          total_export_num: 4
+          clients: 1
+          nfs_replication_number: 1           # Single cluster mode
+          nfs_mount: /mnt/nfs_byok
+          nfs_export: /export_byok
+          nfs_instance_name: nfs_byoksni
+          operation: No SNI - No Validation
+
+     - test:
+         name: Test Encryption with the incorrect key and kmip certs (single cluster)
+         module: byok.test_byok_neg_incorrect_key_cert.py
+         desc: BYOK Negative test Incorrect key kmip certs
+         polarion-id: CEPH-83628801
+         config:
+           nfs_version: 4.2

--- a/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
+++ b/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
@@ -105,10 +105,7 @@ def run(ceph_cluster, **kw):
             "installer": installer,
             "nfs_name": nfs_name,
         }
-        log.info("Verify Cluster is healthy before test")
-        if cephfs_common_utils.wait_for_healthy_ceph(client, 300):
-            log.error("Cluster health is not OK even after waiting for 300secs")
-            return 1
+
         fs_details = cephfs_common_utils.get_fs_info(client, fs_name)
         if not fs_details:
             cephfs_common_utils.create_fs(client, fs_name)
@@ -121,18 +118,13 @@ def run(ceph_cluster, **kw):
             return 1
         log.info("PASS:BYOK Test for Incorrect KMIP cert")
         return 0
+
     except Exception as e:
         log.error(e)
         log.error(traceback.format_exc())
         return 1
     finally:
         log.info("Clean Up in progess")
-        wait_time_secs = 300
-        if cephfs_common_utils.wait_for_healthy_ceph(client_objs[0], wait_time_secs):
-            log.error(
-                "Cluster health is not OK even after waiting for %s secs",
-                wait_time_secs,
-            )
         if incorrect_enctag_cleanup != 1 or incorrect_cert_cleanup != 1:
             clean_up_gklm(
                 gklm_rest_client=byok_setup_params["gklm_rest_client"],
@@ -297,17 +289,19 @@ def byok_test_incorrect_kmip_cert():
             if nfs_log_parser(clients[0], nfs_node, nfs_name, expect_list):
                 log.error("NFS Debug log doesn't contain %s", expect_list)
                 return 1
+    incorrect_cert_cleanup = 1
+    log.info("Cleanup mountdir,export and nfs cluster")
+    cleanup_custom_nfs_cluster_multi_export_client(
+        clients, nfs_mount, nfs_name, nfs_export, 1
+    )
+
     log.info("Cleanup GKLM Client")
     clean_up_gklm(
         gklm_rest_client=byok_setup_params["gklm_rest_client"],
         gkml_client_name=byok_setup_params["gklm_client_name"],
         gklm_cert_alias=byok_setup_params["gklm_cert_alias"],
     )
-    incorrect_cert_cleanup = 1
-    log.info("Cleanup mountdir,export and nfs cluster")
-    cleanup_custom_nfs_cluster_multi_export_client(
-        clients, nfs_mount, nfs_name, nfs_export, 1
-    )
+
     nfs_cleanup = 1
     return 0
 

--- a/tests/nfs/byok/test_sni_feature.py
+++ b/tests/nfs/byok/test_sni_feature.py
@@ -1,0 +1,362 @@
+import time
+import traceback
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from cli.utilities.filesys import MountFailedError, Unmount
+from tests.nfs.byok.byok_tools import (
+    clean_up_gklm,
+    create_nfs_instance_for_byok,
+    get_enctag,
+    load_gklm_config,
+    perform_io_operations_and_validate_fuse,
+    setup_gklm_infrastructure,
+    wait_for_gklm_server_restart,
+)
+from tests.nfs.nfs_operations import cleanup_custom_nfs_cluster_multi_export_client
+from tests.nfs.test_nfs_io_operations_during_upgrade import (
+    create_export_and_mount_for_existing_nfs_cluster,
+)
+from utility.gklm_client.gklm_client import GklmClient
+from utility.log import Log
+from utility.utils import get_cephci_config
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    custom_data = kw.get("test_data", {})
+    cephci_data = get_cephci_config()
+
+    # Cluster nodes and setup
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    nfs_node = nfs_nodes[0]  # Use the first NFS node for certificate operations
+    installer = ceph_cluster.get_nodes(role="installer")
+    clients = ceph_cluster.get_nodes("client")
+
+    # Configuration parameters
+    nfs_mount = config.get("nfs_mount", "/mnt/nfs_byok")
+    nfs_export = config.get("nfs_export", "/export_byok")
+    nfs_name = config.get("nfs_instance_name", "nfs_byok")
+    export_num = config.get("total_export_num", 2)
+    no_clients = int(config.get("clients", 1))
+    fs_name = config.get("fs_name", "cephfs")
+    port = config.get("nfs_port", "2049")
+    subvolume_group = "ganeshagroup"
+    operation = config.get("operation", None)
+
+    # Ensure sufficient clients
+    if no_clients > len(clients):
+        raise ConfigError(
+            f"Test requires {no_clients} clients but only {len(clients)} available"
+        )
+    clients = clients[:no_clients]
+
+    # Load GKLM configuration
+    gklm_params = load_gklm_config(custom_data, config, cephci_data)
+    gklm_ip = gklm_params["gklm_ip"]
+    gklm_user = gklm_params["gklm_user"]
+    gklm_password = gklm_params["gklm_password"]
+    gklm_hostname = gklm_params["gklm_hostname"]
+
+    gkml_client_name = "automation"
+    gklm_cert_alias = "cert2"
+    new_ca_cert_alias = "custom_sni_host"
+    client_export_mount_dict = None
+
+    try:
+        log.info("Step 1: Setting up GKLM infrastructure")
+        setup_gklm_infrastructure(
+            nfs_nodes=nfs_nodes,
+            gklm_ip=gklm_ip,
+            gklm_hostname=gklm_hostname,
+        )
+
+        log.info("Step 2: Initializing GKLM REST client")
+        gklm_rest_client = GklmClient(
+            ip=gklm_ip, user=gklm_user, password=gklm_password, verify=False
+        )
+
+        log.info("Step 3: generating certificates and keys, and CA_cert from GKLM")
+        if gklm_hostname not in [
+            x.get("alias") for x in gklm_rest_client.certificates.list_certificates()
+        ]:
+            log.info(f"Not Found CA cert alias {gklm_cert_alias}, creating ")
+            gklm_rest_client.certificates.create_system_certificate(
+                {
+                    "type": "Self-signed",
+                    "alias": gklm_hostname,
+                    "validity": "3650",
+                    "algorithm": "RSA",
+                    "usageSubtype": "KEYSERVING_TLS",
+                }
+            )
+            gklm_rest_client.server.restart_server()
+            wait_for_gklm_server_restart(
+                gklm_rest_client=gklm_rest_client,
+                timeout=500,
+                check_interval=10,
+                initial_wait=10,
+            )
+        ca_cert = gklm_rest_client.certificates.get_system_certificate(
+            cert_name=gklm_hostname
+        )
+
+        rsa_key, cert, _ = gklm_rest_client.certificates.get_certificates(
+            subject={
+                "common_name": nfs_node.hostname,
+                "ip_address": nfs_node.ip_address,
+            }
+        )
+
+        all_clients = gklm_rest_client.clients.list_clients()
+        if gkml_client_name.upper() not in [x.get("clientName") for x in all_clients]:
+            log.info(f"Not Found client name {gkml_client_name}, creating ")
+            gklm_rest_client.clients.create_client(gkml_client_name)
+
+        gklm_rest_client.login()
+        enctag = get_enctag(
+            gklm_rest_client,
+            gkml_client_name,
+            gklm_cert_alias,
+            gklm_user,
+            cert,
+        )
+
+        log.info("Step 4: Configuring CephFS subvolume group for NFS")
+        Ceph(nfs_node).execute("systemctl start rpcbind", sudo=True)
+        Ceph(clients[0]).fs.sub_volume_group.create(
+            volume=fs_name, group=subvolume_group
+        )
+
+        # Single cluster BYOK flow
+
+        log.info(">>> Running single-cluster BYOK with Fuse validation")
+
+        log.info("Step 5: Deploying NFS Ganesha instance with BYOK - with SNI settings")
+        if operation == "Default Secure Case":
+            log.info(
+                "Using default secure case with matching servername and verify_hostname"
+            )
+            kmip_host_list = {
+                "addr": gklm_hostname,
+                "servername": gklm_hostname,
+                "verify_hostname": gklm_hostname,
+            }
+        elif operation == "Mismatch Validation Hostname":
+            log.info(
+                "Using mismatch validation hostname with unmatching servername and verify_hostname"
+            )
+            kmip_host_list = {
+                "addr": gklm_hostname,
+                "servername": gklm_hostname,
+                "verify_hostname": nfs_node.hostname,
+            }
+        elif operation == "Disable Validation":
+            log.info(
+                "Using disable validation with servername set but verify_hostname unset"
+            )
+            kmip_host_list = {
+                "addr": gklm_hostname,
+                "servername": gklm_hostname,
+                "verify_hostname": "",
+            }
+        elif operation == "No SNI - Validate Other Hostname":
+            log.info(
+                "Using no SNI with empty servername and verify_hostname set to unmatching hostname"
+            )
+            kmip_host_list = {
+                "addr": "",
+                "servername": "",
+                "verify_hostname": nfs_node.hostname,
+            }
+        elif operation in [
+            "Custom SNI - Validation Hostname",
+            "Different SNI and Validation",
+            "No SNI - No Validation",
+        ]:
+
+            log.info("Creating new GKLM certificate for operation " + operation)
+
+            all_ca_certs = gklm_rest_client.certificates.list_certificates()
+            if new_ca_cert_alias in [x.get("alias") for x in all_ca_certs]:
+                gklm_rest_client.certificates.delete_system_certificate(
+                    new_ca_cert_alias
+                )
+                log.info(
+                    f"Deleted existing custom SNI certificate with alias {new_ca_cert_alias} to recreate"
+                )
+                time.sleep(5)
+            log.info(
+                f"Creating new GKLM certificate with alias {new_ca_cert_alias} for custom SNI"
+            )
+            gklm_rest_client.certificates.create_system_certificate(
+                {
+                    "type": "Self-signed",
+                    "alias": new_ca_cert_alias,
+                    "cn": new_ca_cert_alias,
+                    "validity": "3650",
+                    "algorithm": "RSA",
+                    "usageSubtype": "KEYSERVING_TLS",
+                }
+            )
+
+            log.info(
+                f"Created new GKLM certificate with alias {new_ca_cert_alias}, rebooting GKLM service to apply changes"
+            )
+
+            restart_data = gklm_rest_client.server.restart_server()
+            log.info(f"GKLM server restart initiated: {restart_data}")
+            wait_for_gklm_server_restart(
+                gklm_rest_client=gklm_rest_client,
+                timeout=500,
+                check_interval=10,
+                initial_wait=10,
+            )
+
+            ca_cert = gklm_rest_client.certificates.get_system_certificate(
+                cert_name=new_ca_cert_alias
+            )
+            log.info("Using custom SNI with custom servername and verify_hostname")
+            if operation == "Custom SNI - Validation Hostname":
+                kmip_host_list = {
+                    "addr": gklm_hostname,
+                    "servername": new_ca_cert_alias,
+                    "verify_hostname": new_ca_cert_alias,
+                }
+            elif operation == "Different SNI and Validation":
+                kmip_host_list = {
+                    "addr": gklm_hostname,
+                    "servername": new_ca_cert_alias,
+                    "verify_hostname": clients[0].hostname,
+                }
+            elif operation == "No SNI - No Validation":
+                kmip_host_list = {
+                    "addr": gklm_hostname,
+                    "servername": "",
+                    "verify_hostname": "",
+                }
+
+        create_nfs_instance_for_byok(
+            installer=installer,
+            nfs_node=nfs_node,
+            nfs_name=nfs_name,
+            kmip_host_list=kmip_host_list,
+            rsa_key=rsa_key,
+            cert=cert,
+            ca_cert=ca_cert,
+        )
+
+        log.info("Step 6: Creating and mounting NFS exports")
+        client_export_mount_dict = create_export_and_mount_for_existing_nfs_cluster(
+            clients,
+            nfs_export,
+            nfs_mount,
+            export_num,
+            fs_name,
+            nfs_name,
+            fs_name,
+            port,
+            version=config.get("nfs_version", "4.0"),
+            enctag=enctag,
+            nfs_server=nfs_node.hostname,
+        )
+
+        log.info(
+            "Step 7: Performing I/O validation on NFS exports \n"
+            "Step 8: Validate encryption via FUSE mounts as well"
+        )
+        perform_io_operations_and_validate_fuse(
+            client_export_mount_dict,
+            clients,
+            file_count=10,
+            dd_command_size_in_M=5,
+            nfs_name=nfs_name,
+        )
+
+        if operation in [
+            "Mismatch Validation Hostname",
+            "No SNI - Validate Other Hostname",
+            "Different SNI and Validation",
+        ]:
+            log.info(
+                "Test failed: Mount succeeded despite hostname mismatch in GKLM certificate."
+            )
+            return 1
+
+        return 0
+
+    except MountFailedError:
+        if operation in [
+            "Mismatch Validation Hostname",
+            "No SNI - Validate Other Hostname",
+            "Different SNI and Validation",
+        ]:
+            log.info(
+                "Mount failed as expected due to hostname mismatch in GKLM certificate."
+            )
+            return 0
+
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+
+    finally:
+        log.info("Cleanup: GKLM, NFS clusters, and mounts")
+        if operation not in [
+            "Mismatch Validation Hostname",
+            "No SNI - Validate Other Hostname",
+            "Different SNI and Validation",
+        ]:
+            log.info("Cleaning up cluster FUSE mounts")
+            for client in clients:
+                for mount in [
+                    m + "_fuse"
+                    for m in client_export_mount_dict.get(client, {}).get("mount", [])
+                ]:
+                    client.exec_command(
+                        sudo=True, cmd=f"rm -rf {mount}/*", long_running=True
+                    )
+                    if Unmount(client).unmount(mount):
+                        raise OperationFailedError(
+                            f"Failed to unmount FUSE mount {mount} on {client.hostname}"
+                        )
+        log.info("Cleaning up cluster mounts and exports")
+        cleanup_custom_nfs_cluster_multi_export_client(
+            clients, nfs_mount, nfs_name, nfs_export, export_num, nfs_nodes=nfs_nodes
+        )
+
+        if operation in ["Custom SNI - Validation Hostname", "No SNI - No Validation"]:
+            log.info(
+                f"Updating GKLM system certificate to add KEYSERVING_TLS usage subtype for {gklm_hostname}"
+            )
+            gklm_rest_client.certificates.update_system_certificate(
+                alias=gklm_hostname,
+                add_usage_subtype="KEYSERVING_TLS",
+            )
+            log.info(
+                f"Updated GKLM system certificate to add KEYSERVING_TLS usage subtype for old {gklm_hostname}"
+            )
+
+            gklm_rest_client.certificates.delete_system_certificate(new_ca_cert_alias)
+            log.info(
+                f"Deleted custom SNI certificate with alias {new_ca_cert_alias} to cleanup"
+            )
+            restart_data = gklm_rest_client.server.restart_server()
+            log.info(f"GKLM server restart initiated: {restart_data}")
+            wait_for_gklm_server_restart(
+                gklm_rest_client=gklm_rest_client,
+                timeout=500,
+                check_interval=10,
+                initial_wait=10,
+            )
+
+        # Clean GKLM resources
+        clean_up_gklm(
+            gklm_rest_client=gklm_rest_client,
+            gkml_client_name=gkml_client_name,
+            gklm_cert_alias=gklm_cert_alias,
+        )
+        log.info("Cleanup completed for all test resources.")

--- a/tests/nfs/scripts_tools/restart_nfs_ganesha_services.py
+++ b/tests/nfs/scripts_tools/restart_nfs_ganesha_services.py
@@ -63,7 +63,7 @@ def run(ceph_cluster, **kw):
     # Determine the NFS instances to restart
     if instances_to_restart is None:
         nfs_to_restart = []
-        for attempt in range(10):
+        for attempt in range(30):
             nfs_to_restart = Ceph(clients[0]).nfs.cluster.ls()
             if nfs_to_restart:
                 log.info(f"Found NFS instances to restart: {nfs_to_restart}")

--- a/utility/gklm_client/certs.py
+++ b/utility/gklm_client/certs.py
@@ -134,3 +134,105 @@ class GklmCertificate:
         else:
             msg = resp.text or f"HTTP {resp.status_code}"
         raise RuntimeError(f"Export certificate failed ({resp.status_code}): {msg}")
+
+    def create_system_certificate(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Create a system certificate on the GKLM server (POST /system/certificates).
+
+        Args:
+            payload: Dictionary matching the GKLM API for creating a certificate,
+               e.g. {
+                    "type": "Self-signed",
+                    "alias": "my_system_cert_alias",
+                    "cn": "gklm.example.com",
+                    "ou": "Security",
+                    "o": "IBM",
+                    "locality": "Armonk",
+                    "state": "KA",
+                    "country": "IN",
+                    "validity": "3650",
+                    "algorithm": "RSA",
+                    "usageSubtype": "KEYSERVING_TLS"
+                    }
+
+        Returns:
+            Parsed JSON response from the GKLM server on success.
+
+        Raises:
+            RuntimeError: On HTTP error or request failure.
+        """
+        url = "{}/system/certificates".format(self.base_url)
+
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+        headers["Accept-Language"] = "en"
+        headers["Content-Type"] = "application/json"
+
+        resp = requests.post(url, json=payload, headers=headers, verify=self.verify)
+        if resp.status_code in (200, 201):
+            # Return JSON payload
+            try:
+                return resp.json()
+            except ValueError:
+                # No JSON body but success status
+                return {"status": resp.status_code, "text": resp.text}
+
+    def update_system_certificate(
+        self, alias: str, add_usage_subtype: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Update system certificate usage subtype (PUT /system/certificates).
+
+        Args:
+            alias: Certificate alias to update
+            add_usage_subtype: Usage subtype to add to the certificate
+                             (e.g., 'KEYSERVING_TLS')
+
+        Returns:
+            Parsed JSON response from the GKLM server on success.
+
+        Raises:
+            RuntimeError: If the HTTP request fails with an error status
+        """
+        url = "{}/system/certificates".format(self.base_url)
+
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+        headers["Accept-Language"] = "en"
+        headers["Content-Type"] = "application/json"
+
+        payload = {"alias": alias}
+        if add_usage_subtype:
+            payload["addUsageSubtype"] = add_usage_subtype
+        resp = requests.put(url, json=payload, headers=headers, verify=self.verify)
+        if resp.status_code in (200, 201):
+            try:
+                return resp.json()
+            except ValueError:
+                return {"status": resp.status_code, "text": resp.text}
+
+    def delete_system_certificate(self, alias: str) -> Optional[Dict[str, Any]]:
+        """
+        Delete a system certificate by alias.
+        Args:
+            alias: System certificate alias to delete
+                  (e.g., 'my_system_cert_alias')
+        Returns:
+            Response JSON if successful, None otherwise
+        Raises:
+            RuntimeError: If the HTTP request fails with an error status
+        """
+        url = "{}/system/certificates/{}".format(self.base_url, alias)
+
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+        headers["Accept-Language"] = "en"
+
+        resp = requests.delete(url, headers=headers, verify=self.verify)
+        if resp.status_code in (200, 201):
+            # Return JSON payload
+            try:
+                return resp.json()
+            except ValueError:
+                # No JSON body but success status
+                return {"status": resp.status_code, "text": resp.text}

--- a/utility/gklm_client/gklm_client.py
+++ b/utility/gklm_client/gklm_client.py
@@ -2,6 +2,7 @@ from utility.gklm_client.auth import GklmAuth
 from utility.gklm_client.certs import GklmCertificate
 from utility.gklm_client.client_mgmt import GklmClientManagement
 from utility.gklm_client.objects import GklmObjects
+from utility.gklm_client.server_mgmt import GklmServer
 
 
 class GklmClient:
@@ -19,6 +20,7 @@ class GklmClient:
         self.certificates = GklmCertificate(self.auth)
         self.clients = GklmClientManagement(self.auth)
         self.objects = GklmObjects(self.auth)
+        self.server = GklmServer(self.auth)
         self.auth.login()
 
     def login(self):

--- a/utility/gklm_client/server_mgmt.py
+++ b/utility/gklm_client/server_mgmt.py
@@ -1,0 +1,189 @@
+from typing import Any, Dict
+
+import requests
+import urllib3
+
+from utility.gklm_client.auth import GklmAuth
+
+# Suppress the InsecureRequestWarning
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class GklmServer:
+    """GKLM Server Management REST API client."""
+
+    def __init__(self, auth: GklmAuth):
+        """
+        Initialize the GKLM Server client.
+
+        Args:
+            auth: GklmAuth object containing authentication credentials
+        """
+        self.auth = auth
+        self.base_url = auth.base_url
+        self.verify = auth.verify
+
+    def get_license(self) -> Dict[str, Any]:
+        """
+        Get license information from GKLM server.
+
+        Returns:
+            License information as dictionary
+
+        Raises:
+            RuntimeError: If the HTTP request fails with an error status
+        """
+        url = "{}/license".format(self.base_url)
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+
+        try:
+            resp = requests.get(url, headers=headers, verify=self.verify)
+
+            if resp.status_code == 200:
+                return resp.json()
+            else:
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    err = resp.json().get("message", resp.text)
+                else:
+                    err = resp.text or "HTTP {}".format(resp.status_code)
+
+                raise RuntimeError(
+                    "Get license failed ({}): {}".format(resp.status_code, err)
+                )
+
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                "An error occurred while getting license: {}".format(str(e))
+            )
+
+    def get_system_info(self) -> Dict[str, Any]:
+        """
+        Get system information from GKLM server.
+
+        Returns:
+            System information as dictionary
+
+        Raises:
+            RuntimeError: If the HTTP request fails with an error status
+        """
+        url = "{}/systemDetails".format(self.base_url)
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+
+        try:
+            resp = requests.get(url, headers=headers, verify=self.verify)
+
+            if resp.status_code == 200:
+                return resp.json()
+            else:
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    err = resp.json().get("message", resp.text)
+                else:
+                    err = resp.text or "HTTP {}".format(resp.status_code)
+
+                raise RuntimeError(
+                    "Get system info failed ({}): {}".format(resp.status_code, err)
+                )
+
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                "An error occurred while getting system info: {}".format(str(e))
+            )
+
+    def get_system_certificates(self) -> Dict[str, Any]:
+        """
+        Get system certificates from GKLM server.
+
+        Returns:
+            System certificates information as dictionary
+
+        Raises:
+            RuntimeError: If the HTTP request fails with an error status
+        """
+        url = "{}/system/certificates".format(self.base_url)
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+
+        try:
+            resp = requests.get(url, headers=headers, verify=self.verify)
+
+            if resp.status_code == 200:
+                return resp.json()
+            else:
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    err = resp.json().get("message", resp.text)
+                else:
+                    err = resp.text or "HTTP {}".format(resp.status_code)
+
+                raise RuntimeError(
+                    "Get system certificates failed ({}): {}".format(
+                        resp.status_code, err
+                    )
+                )
+
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                "An error occurred while getting system certificates: {}".format(str(e))
+            )
+
+    def restart_server(self) -> Dict[str, Any]:
+        """
+        Restart GKLM server.
+
+        Returns:
+            Response from server restart request
+
+        Raises:
+            RuntimeError: If the HTTP request fails with an error status
+        """
+        url = "{}/ckms/servermanagement/restartServer".format(self.base_url)
+        headers = self.auth._headers()
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
+        try:
+            resp = requests.post(url, headers=headers, verify=self.verify)
+
+            if resp.status_code in (200, 201, 202):
+                try:
+                    return resp.json()
+                except ValueError:
+                    return {
+                        "status": resp.status_code,
+                        "message": "Server restart initiated",
+                    }
+            else:
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    err = resp.json().get("message", resp.text)
+                else:
+                    err = resp.text or "HTTP {}".format(resp.status_code)
+
+                raise RuntimeError(
+                    "Restart server failed ({}): {}".format(resp.status_code, err)
+                )
+
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                "An error occurred while restarting server: {}".format(str(e))
+            )
+
+    def health_check(self) -> bool:
+        """
+        Perform health check on GKLM server.
+
+        Returns:
+            True if server is healthy, False otherwise
+        """
+        url = "{}/health".format(self.base_url)
+        headers = self.auth._headers()
+
+        try:
+            resp = requests.get(url, headers=headers, verify=self.verify)
+            return resp.text
+        except requests.exceptions.RequestException:
+            return False


### PR DESCRIPTION
# Description
Adding BYOK-SNI tests to cephci

1. Default Secure Case  --  servername="a", validate_hostname="a" → SNI=a, cert validated for a Connection succeeds
2.Mismatch Validation Hostname  --  servername="a", validate_hostname="c" → SNI=a, expects cert with c. Pass if cert includes c . Otherwise fail
3. Custom SNI + Validation Hostname  --  servername="b", validate_hostname="b" → SNI=b, cert checked for b. Success if cert matches b.
4. Different SNI and Validation  --  servername="b", validate_hostname="c" → SNI=b, validates for c. Works only if cert includes c.
5. Disable Validation (SNI on)  --  servername="a", validate_hostname="" → SNI=a, no hostname check. Connects but insecure
6. No SNI, Validate Other Hostname  --  servername="", validate_hostname="c" → No SNI, expects c in cert. Should fail
7. SNI + No Validation  --  servername="", validate_hostname="" → No SNI, no cert check. Invalid but works

logs:
http://magna002.ceph.redhat.com/ceph/ceph-qe-logs/hacharya/byok/snis/pr/loggies/