### PR TITLE
Added mon service for node5 .

### DIFF
--- a/conf/tentacle/rgw/rgw_multisite.yaml
+++ b/conf/tentacle/rgw/rgw_multisite.yaml
@@ -35,6 +35,7 @@ globals:
         disk-size: 15
         no-of-volumes: 3
         role:
+          - mon
           - osd
           - rgw
 
@@ -77,6 +78,7 @@ globals:
         disk-size: 15
         no-of-volumes: 3
         role:
+          - mon
           - osd
           - rgw
 


### PR DESCRIPTION
# Description

On IBM clud the issue of deploying monitoring secrvice node-exporter is failing occasionally which looks like system issue. All other nodes in cluster have running either mon/mgr services but node on which either of this service is not running is failing so added `mon` service to the node.

Log: https://149.81.216.83/job/tentacle-test-executor/610/

