### PR TITLE
Change the tentacle upgrade released tag

### DIFF
--- a/suites/tentacle/upgrades/tier1-upgrade-rhcs-7x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-rhcs-7x-to-9x.yaml
@@ -29,7 +29,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: "rc"
+                release: "nightly"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/upgrades/tier1-upgrade-rhcs-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-rhcs-8x-to-9x.yaml
@@ -31,7 +31,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: nightly
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/upgrades/tier1-upgrade-with-monitoring-stack-rhcs-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-with-monitoring-stack-rhcs-8x-to-9x.yaml
@@ -31,7 +31,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: nightly
                 mon-ip: node1
                 orphan-initial-daemons: true
           - config:

--- a/suites/tentacle/upgrades/tier2-upgrade-rhcs-staggered-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier2-upgrade-rhcs-staggered-8x-to-9x.yaml
@@ -37,7 +37,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: "rc"
+                release: "nightly"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true


### PR DESCRIPTION
# Description

Currently the upgrade suite deploys `n-1`/`n-2` cluster using the RC tag details. However, the compose repo links are not save for more than 5 builds. In such a case, if more than 5 new builds are available, the RC compose repo link gets overwritten.
To mitigate this, we are using the nightly tag where the latest compose repo links will be available.