### PR TITLE
[RBD] Fixed the fio run time key

### DIFF
--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -131,7 +131,7 @@ def krbd_io_handler(**kw):
                     if config.get("io_size"):
                         fio_args.update({"size": config.get("io_size")})
                     else:
-                        fio_args.update({"runtime": config.get("runtime", 30)})
+                        fio_args.update({"run_time": config.get("runtime", 30)})
                     if config.get("get_time_taken"):
                         fio_args.update(
                             {"get_time_taken": config.get("get_time_taken")}


### PR DESCRIPTION
# Description
'run_time' is the actual key expected by https://github.com/red-hat-storage/cephci/blob/2e0e9cfe715a409a6592daf265761e3e84bfee47/utility/utils.py#L2259

The wrong key value used in tests/rbd/krbd_io_handler.py leading to 120 sec runtime of fio jobs. 
All the tests that utilise this module and falling under this certain condition are unnecessarily pumping IO for 120 sec instead of the intended time which most of the times is between 30-60 sec. The total fio run time is even magnified by the number of times the fio job is run in a test . For eg In BVT RBD test fio is run 4 times which means 8 min are just catered to the fio job which is not actually intended.
BVT RBD Run time before fix: 1119.235462 sec
BVT RBD Run time after fix: 338.349697 sec

Old logs: http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/bvt/20.1.0-144/285/logs/Build_Verfification_Test/

New logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FTT22T/

**old log snippet:**
2026-01-23 00:15:20,341 - cephci - utils:2236 - DEBUG - Config Received for fio: {'client_node': <ceph.ceph.CephNode object at 0x7f8fc43cf0a0>, 'device_name': '/dev/rbd0', 'runtime': **30**}
2026-01-23 00:15:20,343 - cephci - ceph:1630 - INFO - Execute fio  --ioengine libaio --filename /dev/rbd0 --runtime **120** --time_based --name [test-1](https://issues.redhat.com//browse/test-1) --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.243.100.150
2026-01-23 00:17:20,988 - cephci - ceph:1660 - INFO - Execution of fio  --ioengine libaio --filename /dev/rbd0 --runtime 120 --time_based --name [test-1](https://issues.redhat.com//browse/test-1) --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.243.100.150 took **120.645013 seconds**

**New log snippet:**
2026-01-28 07:11:58,715 - cephci - utils:2236 - DEBUG - Config Received for fio: {'client_node': <ceph.ceph.CephNode object at 0x7f1d4a96e560>, 'device_name': '/dev/rbd0', 'run_time': **30**}
2026-01-28 07:11:58,719 - cephci - ceph:1630 - INFO - Execute fio  --ioengine libaio --filename /dev/rbd0 --runtime **30** --time_based --name [test-1](https://issues.redhat.com//browse/test-1) --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.0.64.20
2026-01-28 07:12:30,056 - cephci - ceph:1660 - INFO - Execution of fio  --ioengine libaio --filename /dev/rbd0 --runtime 30 --time_based --name [test-1](https://issues.redhat.com//browse/test-1) --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on 10.0.64.20 took **31.33341 seconds**


