### PR TITLE
fix: use release codename for manifest lookup and add `RELEASE_MAP` for community

### DIFF
--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -20,6 +20,7 @@ class CephTestManifest:
         "https://raw.githubusercontent.com/ibmstorage/qe-ceph-manifest/refs/heads/main/"
     )
     SUPPORTED_PRODUCTS = ["community", "redhat", "ibm"]
+    RELEASE_MAP = {"reef": 7, "squid": 8, "tentacle": 9}
 
     def __init__(
         self,
@@ -69,6 +70,9 @@ class CephTestManifest:
 
     @property
     def release(self) -> str:
+        if self.product == "community":
+            return self.RELEASE_MAP[self._release]
+
         return self._release
 
     @release.setter
@@ -193,11 +197,13 @@ class CephTestManifest:
             }
             }
         """
-        _msg = f"Retreving build details of {self.product} - {self.release}. "
+        # Please ensure to use _release instead of release, since release is a
+        # property and can be overridden.
+        _msg = f"Retreving build details of {self.product} - {self._release}. "
         _msg += f"Looking up {self.build_type} section."
         logger.debug(_msg)
 
-        manifest_file: str = f"{self.release}.yaml"
+        manifest_file: str = f"{self._release}.yaml"
         manifest_url: str = self.URI
 
         if self.product.lower() == "community":

--- a/run.py
+++ b/run.py
@@ -510,7 +510,6 @@ def run(args):
     if upstream_build:
         product = "community"
         release = upstream_build
-        build = "nightly"
 
     # FixMe: We should be using product for differentiation.
     ibm_build = False


### PR DESCRIPTION
Changes consists of -
  1. Add `RELEASE_MAP` in `CephTestManifest` and make the release property return the numeric version for community product so callers get a consistent version format.
  2. Use `_release` (not the release property) when building the manifest file path and in debug logs so the manifest filename remains the codename (e.g. reef.yaml) and lookup does not break.
  3. Remove redundant `build` assignment in `run.py` when `upstream_build` is set.