### PR TITLE
conf: add Rocky-10.1 inventory for upstream builds

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -269,8 +269,12 @@ class BootstrapMixin:
         else:
             _os_major = manifest_obj.platform.split("-")[-1]
             _ceph_version = manifest_obj.ceph_version
-            # * is to enable any test hotfix provided
-            _rpm_version = f"2:{_ceph_version}*.el{_os_major}cp"
+            if build_type == "upstream" or manifest_obj.product == "community":
+                _rpm_version = f"{_ceph_version}*"
+            else:
+                # * is to enable any test hotfix provided
+                _rpm_version = f"2:{_ceph_version}.el{_os_major}cp"
+
             self.install(**{"rpm_version": _rpm_version})
 
         cmd = "cephadm"

--- a/conf/inventory/rocky-10.1-latest.yaml
+++ b/conf/inventory/rocky-10.1-latest.yaml
@@ -1,0 +1,1 @@
+rocky-10.1-server-x86_64.yaml

--- a/conf/inventory/rocky-10.1-server-x86_64-large.yaml
+++ b/conf/inventory/rocky-10.1-server-x86_64-large.yaml
@@ -1,0 +1,41 @@
+---
+version_id: 10.1
+id: rhel
+instance:
+  create:
+    image-name: teuthology-rocky-10.1-x86_64
+    vm-size: ci.standard.large
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: true
+    disable_root: false
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser:pass123
+      expire: false
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
+      - timedatectl set-timezone Etc/UTC
+      - hostnamectl set-hostname $(hostname -s)
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+      - touch /ceph-qa-ready
+
+    final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rocky-10.1-server-x86_64.yaml
+++ b/conf/inventory/rocky-10.1-server-x86_64.yaml
@@ -1,0 +1,41 @@
+---
+version_id: 10.1
+id: rhel
+instance:
+  create:
+    image-name: teuthology-rocky-10.1-x86_64
+    vm-size: ci.standard.medium
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: true
+    disable_root: false
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser:pass123
+      expire: false
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
+      - timedatectl set-timezone Etc/UTC
+      - hostnamectl set-hostname $(hostname -s)
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+      - touch /ceph-qa-ready
+
+    final_message: "Ready for ceph qa testing"


### PR DESCRIPTION
Changes consists of -
- Add Rocky 10.1 inventory
- Add epel repos for rocky-10
- Update bootstrap steps to use upstream cephadm package rpm