### PR TITLE
TFA Fixs for weekly pipeline

### DIFF
--- a/suites/tentacle/cephfs/tier-3_cephfs_bugs.yaml
+++ b/suites/tentacle/cephfs/tier-3_cephfs_bugs.yaml
@@ -161,6 +161,14 @@ tests:
         module: test_client.py
         name: configure client
   - test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup: 1
+        daemon_list: [ 'mds','osd','mgr','mon' ]
+  - test:
       name: Change pg size of cephfs pools
       module: cephfs_bugs.test_cephfs_pool_size_change.py
       polarion-id: CEPH-11260
@@ -300,3 +308,13 @@ tests:
       polarion-id: CEPH-83593402
       desc: volume_ops_parallel_to_clone
       abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check : 1
+        daemon_list : ['mds','osd','mgr','mon']
+
+

--- a/tests/cephfs/cephfs_bugs/clone_no_wait_if_max_concurrent.py
+++ b/tests/cephfs/cephfs_bugs/clone_no_wait_if_max_concurrent.py
@@ -8,6 +8,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.cephfs_volume_management import wait_for_process
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from utility.log import Log
 
 log = Log(__name__)
@@ -147,6 +148,7 @@ def clone_test_io(default_fs, client1, fs_util, sv_list, nfs_params):
                 cmd=f"dd if=/dev/random of={file_path} bs=1M count=1000",
                 timeout=3600,
             )
+            mnt_list.append(mounting_dir)
         return mnt_list
     except Exception as ex:
         log.info(ex)
@@ -356,6 +358,7 @@ def run(ceph_cluster, **kw):
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
+        cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
         log.info("checking Pre-requisites")
@@ -365,6 +368,9 @@ def run(ceph_cluster, **kw):
             )
             return 1
         client1 = clients[0]
+        log.info("Check ceph Health before starting the test")
+        if cephfs_common_utils.wait_for_healthy_ceph(client1):
+            raise Exception("Cluster health is not OK before starting the test")
         log.info("Verify the pre-requisites for Clone_no_wait_if_max_concurrent test")
         if clone_test_prechecks(client1) == 1:
             return 1
@@ -441,6 +447,8 @@ def run(ceph_cluster, **kw):
         return 1
 
     finally:
+        wait_time_secs = 300
+        test_fail = 0
         log.info("Setting back the max concurrent clones to default value 4")
         client1.exec_command(
             sudo=True, cmd="ceph config set mgr mgr/volumes/max_concurrent_clones 4"
@@ -449,8 +457,11 @@ def run(ceph_cluster, **kw):
         clients[0].exec_command(
             sudo=True, cmd="ceph config set mgr mgr/volumes/snapshot_clone_no_wait true"
         )
-        for mnt_path in mnt_list:
-            client1.exec_command(sudo=True, cmd=f"umount {mnt_path}", check_ec=False)
+        if isinstance(mnt_list, list):
+            for mnt_path in mnt_list:
+                client1.exec_command(
+                    sudo=True, cmd=f"umount {mnt_path}", check_ec=False
+                )
         if test_status == 1:
             for clonevolume in rmclone_list:
                 fs_util.remove_subvolume(
@@ -475,4 +486,12 @@ def run(ceph_cluster, **kw):
         fs_util.remove_subvolumegroup(
             client1, default_fs, "subvolgroup_1", validate=True
         )
+        if cephfs_common_utils.wait_for_healthy_ceph(client1, wait_time_secs):
+            test_fail = 1
         fs_util.remove_fs(client1, default_fs)
+        if test_fail == 1:
+            log.error(
+                "Cluster health is not OK even after waiting for %s secs ",
+                wait_time_secs,
+            )
+            return 1

--- a/tests/cephfs/cephfs_bugs/test_clone_delete_with_FS_fail.py
+++ b/tests/cephfs/cephfs_bugs/test_clone_delete_with_FS_fail.py
@@ -1,3 +1,4 @@
+import json
 import random
 import string
 import traceback
@@ -5,6 +6,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utilsV1 import FsUtils
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from utility.log import Log
 from utility.retry import retry
 
@@ -57,6 +59,7 @@ def run(ceph_cluster, **kw):
         build = config.get("build", config.get("rhbuild"))
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
+        cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
         log.info("checking Pre-requisites")
         if len(clients) < 1:
             log.info(
@@ -64,19 +67,29 @@ def run(ceph_cluster, **kw):
             )
             return 1
         log.info("setting 'snapshot_clone_no_wait' to false")
-        clients[0].exec_command(
+        client1 = clients[0]
+        client1.exec_command(
             sudo=True,
             cmd="ceph config set mgr mgr/volumes/snapshot_clone_no_wait false",
         )
+        log.info("Simulate clone create delay")
+        client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mgr mgr/volumes/snapshot_clone_delay 2",
+        )
+        log.info("Check ceph Health before starting the test")
+        if cephfs_common_utils.wait_for_healthy_ceph(client1):
+            log.error("Cluster health is not OK before starting the test")
+            return 1
         default_fs = "cephfs_clone"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
-        client1 = clients[0]
         fs_details = fs_util.get_fs_info(client1, fs_name=default_fs)
         if not fs_details:
             fs_util.create_fs(client1, default_fs)
+        fs_util.wait_for_mds_process(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_clone_cancel_1"}
         ]
@@ -97,7 +110,7 @@ def run(ceph_cluster, **kw):
         kernel_mounting_dir_1 = f"/mnt/cephfs_kernel{mounting_dir}_1/"
         mon_node_ips = fs_util.get_mon_node_ips()
         fs_util.kernel_mount(
-            [clients[0]],
+            [client1],
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
@@ -144,18 +157,31 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
+        wait_time_secs = 300
         log.info("Clean Up in progess")
         log.info("setting 'snapshot_clone_no_wait' to true")
-        clients[0].exec_command(
+        client1.exec_command(
             sudo=True, cmd="ceph config set mgr mgr/volumes/snapshot_clone_no_wait true"
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mgr mgr/volumes/snapshot_clone_delay 0",
         )
         fs_util.remove_snapshot(client1, **snapshot)
         fs_util.remove_subvolume(client1, **subvolume)
+        if cephfs_common_utils.wait_for_healthy_ceph(client1):
+            test_fail = 1
         for subvolumegroup in subvolumegroup_list:
             fs_util.remove_subvolumegroup(client1, **subvolumegroup, force=True)
         client1.exec_command(
             sudo=True, cmd=f"ceph fs volume rm {default_fs} --yes-i-really-mean-it"
         )
+        if test_fail == 1:
+            log.error(
+                "Cluster health is not OK even after waiting for %s secs ",
+                wait_time_secs,
+            )
+            return 1
 
 
 def fail_mds(client, fs_util, default_fs):
@@ -172,29 +198,21 @@ def fail_mds(client, fs_util, default_fs):
     )
 
 
-def get_clone_status(client, cmd):
-    out, rc = client.exec_command(sudo=True, cmd=cmd)
-    log.info(out)
-
-
 def clone_ops(clone_list, fs_util, client1, default_fs, rmclone_list):
     for clone in clone_list:
         fs_util.create_clone(client1, **clone, validate=False)
 
     for clone in clone_list:
-        get_clone_status(
-            client1,
-            cmd=f"ceph fs clone status {default_fs} {clone['target_subvol_name']}",
-        )
-    for clone in clone_list:
-        get_clone_status(
-            client1,
-            cmd=f"ceph fs clone cancel {default_fs} {clone['target_subvol_name']}",
-        )
-        get_clone_status(
-            client1,
-            cmd=f"ceph fs clone status {default_fs} {clone['target_subvol_name']}",
-        )
+        clone_name = clone["target_subvol_name"]
+        out, rc = fs_util.get_clone_status(client1, default_fs, clone_name)
+        status = json.loads(out)
+        state = status.get("status", {}).get("state", "")
+        if state in ("pending", "in-progress"):
+            fs_util.clone_cancel(client1, default_fs, clone_name)
+        else:
+            log.info(f"Skipping cancel for {clone_name} - already in state: {state}")
+        out, rc = fs_util.get_clone_status(client1, default_fs, clone_name)
+        log.info(out)
 
     for clonevolume in rmclone_list:
         fs_util.remove_subvolume(

--- a/tests/cephfs/cephfs_bugs/test_mds_cache_oversized_warning_counter.py
+++ b/tests/cephfs/cephfs_bugs/test_mds_cache_oversized_warning_counter.py
@@ -32,19 +32,18 @@ Steps to Reproduce:
 
 
 def run(ceph_cluster, **kw):
+    mds_health_cache_threshold_def = None
+    mds_cache_memory_limit_def = None
+    fuse_mounting_dir_1 = None
     try:
         tc = "CEPH-83594160"
         log.info(f"Running CephFS tests for ceph tracker - {tc}")
-        # Initialize the utility class for CephFS
         fs_util = FsUtils(ceph_cluster)
         cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
-        # Get the client nodes
         clients = ceph_cluster.get_ceph_objects("client")
         config = kw.get("config")
-        # Authenticate the clients
         fs_util.auth_list(clients)
         build = config.get("build", config.get("rhbuild"))
-        # Prepare the clients
         fs_util.prepare_clients(clients, build)
         client1 = clients[0]
         fs_details = fs_util.get_fs_info(client1, "cephfs")
@@ -52,6 +51,11 @@ def run(ceph_cluster, **kw):
             fs_util.remove_fs(client1, "cephfs")
         fs_util.create_fs(client1, "cephfs")
         fs_util.wait_for_mds_process(client1, "cephfs")
+        cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
+        log.info("Check ceph Health before starting the test")
+        if cephfs_common_utils.wait_for_healthy_ceph(client1):
+            log.error("Cluster health is not OK before starting the test")
+            return 1
         # Generate random string for directory names
         rand = "".join(
             random.choice(string.ascii_lowercase + string.digits) for _ in range(5)
@@ -116,26 +120,24 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
-        # Cleanup
         wait_time_secs = 300
         test_fail = 0
-        # Reset to defaults
-        # set to default mds_health_cache_threshold
-        cmd = f"ceph config set mds mds_health_cache_threshold {mds_health_cache_threshold_def}"
-        client1.exec_command(sudo=True, cmd=cmd)
-        # get default mds_cache_memory_limit
-        cmd = f"ceph config set mds mds_cache_memory_limit {mds_cache_memory_limit_def}"
-        client1.exec_command(sudo=True, cmd=cmd)
+        if mds_health_cache_threshold_def is not None:
+            cmd = f"ceph config set mds mds_health_cache_threshold {mds_health_cache_threshold_def}"
+            client1.exec_command(sudo=True, cmd=cmd)
+        if mds_cache_memory_limit_def is not None:
+            cmd = f"ceph config set mds mds_cache_memory_limit {mds_cache_memory_limit_def}"
+            client1.exec_command(sudo=True, cmd=cmd)
         if cephfs_common_utils.wait_for_healthy_ceph(client1, wait_time_secs):
             test_fail = 1
-
-        fs_util.client_clean_up(
-            "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_1
-        )
-        # remove fs
+        if fuse_mounting_dir_1 is not None:
+            fs_util.client_clean_up(
+                "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_1
+            )
         fs_util.remove_fs(client1, "cephfs")
         if test_fail == 1:
-            raise Exception(
+            log.error(
                 "Cluster health is not OK even after waiting for %s secs ",
                 wait_time_secs,
             )
+            return 1

--- a/tests/cephfs/cephfs_bugs/test_mds_inject_health_dummy.py
+++ b/tests/cephfs/cephfs_bugs/test_mds_inject_health_dummy.py
@@ -46,6 +46,10 @@ def run(ceph_cluster, **kw):
         mds_nodes = ceph_cluster.get_nodes("mds")
         host_list = [node.hostname for node in mds_nodes]
         hosts = " ".join(host_list)
+        log.info("Check ceph Health before starting the test")
+        if cephfs_common_utils.wait_for_healthy_ceph(client1):
+            log.error("Cluster health is not OK before starting the test")
+            return 1
         client1.exec_command(
             sudo=True,
             cmd=f"ceph orch apply mds {fs_name} --placement='2 {hosts}'",
@@ -158,10 +162,11 @@ def run(ceph_cluster, **kw):
         )
         fs_util.remove_fs(client1, fs_name)
         if test_fail == 1:
-            raise Exception(
+            log.error(
                 "Cluster health is not OK even after waiting for %s secs ",
                 wait_time_secs,
             )
+            return 1
 
 
 def get_info(json_output, fs_name):

--- a/tests/cephfs/cephfs_bugs/test_volume_ops_parallel_to_clone.py
+++ b/tests/cephfs/cephfs_bugs/test_volume_ops_parallel_to_clone.py
@@ -656,6 +656,12 @@ def run(ceph_cluster, **kw):
     5. Remove subvolumegroups
     6. Reset max_concurrent_clones to default
     """
+    sv_obj = {}
+    subvol_name = None
+    fuse_mounting_dir = None
+    default_fs = None
+    client1 = None
+    clients = []
     try:
         fs_util = FsUtils(ceph_cluster)
         snap_util = SnapUtils(ceph_cluster)
@@ -805,45 +811,43 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Starting Clean Up")
-        client1 = clients[0] if clients else None
+        test_fail = 0
+        if not client1 and clients:
+            client1 = clients[0]
 
-        if client1:
-            # Note: Clones are cleaned up within run_parallel_volume_ops for each operation
+        if client1 and default_fs:
+            if subvol_name:
+                try:
+                    snap_names = snap_util.list_snapshots(
+                        client1, sv_obj, check_ec=False
+                    )
+                    for snap_name in snap_names:
+                        fs_util.remove_snapshot(
+                            client1,
+                            default_fs,
+                            subvol_name,
+                            snap_name,
+                            validate=False,
+                            group_name=sv_obj.get("group_name", None),
+                            check_ec=False,
+                        )
+                except (json.JSONDecodeError, Exception):
+                    log.error("Could not list/remove snapshots during cleanup")
+                    test_fail = 1
 
-            # Clean up snapshot
-            listsnapshot_cmd = (
-                f"ceph fs subvolume snapshot ls {default_fs} {subvol_name}"
-            )
-            if sv_obj.get("group_name"):
-                listsnapshot_cmd += f" --group_name {sv_obj['group_name']}"
-            out, _ = client1.exec_command(
-                sudo=True, cmd=f"{listsnapshot_cmd} --format json"
-            )
-            snapshot_ls = json.loads(out)
-            for j in snapshot_ls:
-                snap_name = j["name"]
-                fs_util.remove_snapshot(
-                    client1,
-                    default_fs,
-                    subvol_name,
-                    snap_name,
-                    validate=True,
-                    group_name=sv_obj.get("group_name", None),
-                )
-            # Clean up subvolume
+                try:
+                    fs_util.remove_subvolume(
+                        client1,
+                        vol_name=default_fs,
+                        subvol_name=subvol_name,
+                        validate=False,
+                        check_ec=False,
+                    )
+                except Exception:
+                    log.error("Could not remove subvolume during cleanup")
+                    test_fail = 1
 
-            if "subvol_name" in locals():
-                fs_util.remove_subvolume(
-                    client1,
-                    vol_name=default_fs,
-                    subvol_name=subvol_name,
-                    validate=True,
-                    check_ec=False,
-                )
-
-            # Unmount
-
-            if "fuse_mounting_dir" in locals():
+            if fuse_mounting_dir:
                 client1.exec_command(
                     sudo=True,
                     cmd=f"umount {fuse_mounting_dir}",
@@ -854,8 +858,6 @@ def run(ceph_cluster, **kw):
                     sudo=True, cmd=f"rm -rf {fuse_mounting_dir}", check_ec=False
                 )
 
-            # Reset max_concurrent_clones to default (4)
-
             client1.exec_command(
                 sudo=True,
                 cmd="ceph config set mgr mgr/volumes/max_concurrent_clones 4",
@@ -863,7 +865,9 @@ def run(ceph_cluster, **kw):
             )
             log.info("Reset max_concurrent_clones to default value 4")
 
-            # Remove FS volume
             fs_util.remove_fs(client1, default_fs)
             log.info("FS volume removed")
         log.info("Clean Up completed")
+        if test_fail:
+            log.info("Test failed due to errors encountered during cleanup")
+            return 1

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -1139,9 +1139,6 @@ class CephfsMirroringUtils(object):
                 log.warning(
                     "Deprecation warning detected as expected: %s", warning_message
                 )
-            #     if LooseVersion(build) >= LooseVersion("9.0"):
-            # log.info("Add mountpoint to fstab due to BZ 2406981")
-            # add_mnt_pt_fstab(mon_node_ip, setup_params, mount_details)
             elif LooseVersion(build) >= LooseVersion("9.1"):
                 log.warning(
                     "Deprecation warning not found in output. "

--- a/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
+++ b/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
@@ -47,7 +47,7 @@ def run(ceph_cluster, **kw):
         active_mds_cnt = config.get("max_mds", 5)
         log.info("checking Pre-requisites")
         if len(clients) < 2:
-            log.info(
+            log.error(
                 f"This test requires minimum 2 client nodes.This has only {len(clients)} clients"
             )
             return 1
@@ -105,12 +105,20 @@ def run(ceph_cluster, **kw):
         log.info("Adding %s MDS to cluster", mds_cnt)
         out, rc = clients[0].exec_command(sudo=True, cmd=cmd)
         if cephfs_common_utils.wait_for_healthy_ceph(clients[0], 300):
+            log.error(
+                "Cluster health check failed after applying MDS daemons. "
+                "Cluster did not reach HEALTH_OK within 300 seconds."
+            )
             return 1
         clients[0].exec_command(
             sudo=True,
             cmd=f"ceph fs set {default_fs} max_mds {active_mds_cnt}",
         )
         if cephfs_common_utils.wait_for_healthy_ceph(clients[0], 300):
+            log.error(
+                f"Cluster health check failed after setting max_mds to {active_mds_cnt}. "
+                "Cluster did not reach HEALTH_OK within 300 seconds."
+            )
             return 1
         upgrade_config = None
         vol_list = [default_fs, "cephfs-ec"]
@@ -628,6 +636,6 @@ def run(ceph_cluster, **kw):
         return 0
 
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -71,9 +71,15 @@ class CephFSCommonUtils(FsUtils):
                     time.sleep(5)
 
         if ceph_healthy == 0:
-            client.exec_command(
+            out, _ = client.exec_command(
                 sudo=True,
                 cmd="ceph fs status;ceph -s;ceph health detail",
+            )
+            log.error(
+                "Cluster did not reach HEALTH_OK within %d seconds. "
+                "Final cluster state:\n%s",
+                wait_time,
+                out,
             )
             return 1
         return 0

--- a/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
+++ b/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
@@ -38,6 +38,26 @@ class SnapUtils(object):
         self.clients = ceph_cluster.get_ceph_objects("client")
         self.cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
 
+    def list_snapshots(self, client, sv_obj, **kwargs):
+        """
+        Returns all snapshot names for a given subvolume.
+        Args:
+            client: ceph client to run cmd
+            sv_obj: dict with keys vol_name, subvol_name, and optionally group_name
+            **kwargs: check_ec (bool) - passed to exec_command, default True
+        Returns:
+            list of snapshot name strings
+        """
+        cmd = f"ceph fs subvolume snapshot ls {sv_obj['vol_name']} {sv_obj['subvol_name']}"
+        if sv_obj.get("group_name"):
+            cmd += f" --group_name {sv_obj['group_name']}"
+        cmd += " --format json"
+        out, _ = client.exec_command(
+            sudo=True, cmd=cmd, check_ec=kwargs.get("check_ec", True)
+        )
+        snapshot_ls = json.loads(out)
+        return [i["name"] for i in snapshot_ls]
+
     def get_snapshot(self, client, sv_obj):
         """
         This method gets a snapshot for given subvolume test object


### PR DESCRIPTION

1. test_clone_delete_with_FS_fail.py
Issue:
The test was intermittently failing when attempting to cancel a clone operation that had already completed by the time the cancel request was issued.
Fix:
Added a validation step to check whether the clone is still in progress before attempting cancellation. The test now only triggers the cancel operation if the clone state is in-progress, preventing false failures due to timing conditions.

Added cluster health check at the start of the test. Add log information if health is not ok. Other minor fixes to initialise variables so that test does not fail with var not initialised in finally.
Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HSP5N4/
