### PR TITLE
fix: enable CodeReady Builder (CRB) for Ceph build dependencies

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -217,6 +217,11 @@ class CephAdmin(BootstrapMixin, ShellMixin, RegistryLoginMixin):
                 cmd=f"yum-config-manager --add-repo {public_repo_url}",
                 check_ec=False,
             )
+            node.exec_command(
+                sudo=True,
+                cmd="dnf config-manager --set-enabled crb",
+                check_ec=False,
+            )
 
     def install(self, **kwargs: Dict) -> None:
         """Install the cephadm package in all node(s).


### PR DESCRIPTION
Fix ceph dependency issue for rocky10 build by enabling CodeReady Builder (CRB)