### PR TITLE
Add two additional scenarios for cephFS mirroring

### DIFF
--- a/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -268,9 +268,9 @@ tests:
       clusters:
         ceph1:
           config:
-            name: Validate snapshot synchronisation using SnapSchedul
+            name: Validate snapshot synchronisation using SnapSchedule
       module: cephfs_mirroring.test_cephfs_mirroring_with_snap_schedule.py
-      name: Validate snapshot synchronisation using SnapSchedul
+      name: Validate snapshot synchronisation using SnapSchedule
       polarion-id: "CEPH-83598968"
   - test:
       abort-on-fail: false
@@ -282,3 +282,26 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirroring_configure_cephfs_mirroring_peer_add.py
       name: Validate the Synchronisation is successful upon enabling fs mirroring using peer_add.
       polarion-id: "CEPH-83632297"
+  - test:
+      abort-on-fail: false
+      desc: "empty data queue on source cluster"
+      clusters:
+        ceph1:
+          config:
+            name: empty data queue on source cluster
+      module: cephfs_mirroring.test_cephfs_mirror_multithreaded_empty_dataq_hang.py
+      name: empty data queue on source cluster.
+      polarion-id: "CEPH-"
+      comments:  Yet to file issue
+
+  - test:
+      abort-on-fail: false
+      desc: "Test incremental snapshot sync is faster than full sync using git repo diffs"
+      clusters:
+        ceph1:
+          config:
+            name: Test incremental snapshot synchronization
+      module: cephfs_mirroring.test_cephfs_mirror_incremental_sync.py
+      name: Test incremental snapshot synchronization
+      polarion-id: "CEPH-83580027"
+      comments:  Known snapdiff issue

--- a/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -291,7 +291,7 @@ tests:
             name: empty data queue on source cluster
       module: cephfs_mirroring.test_cephfs_mirror_multithreaded_empty_dataq_hang.py
       name: empty data queue on source cluster.
-      polarion-id: "CEPH-"
+      polarion-id: "CEPH-83632392"
       comments:  Yet to file issue
 
   - test:
@@ -303,5 +303,5 @@ tests:
             name: Test incremental snapshot synchronization
       module: cephfs_mirroring.test_cephfs_mirror_incremental_sync.py
       name: Test incremental snapshot synchronization
-      polarion-id: "CEPH-83580027"
-      comments:  Known snapdiff issue
+      polarion-id: "CEPH-83632393"
+      comments:  Upstream tracker 74984

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -724,9 +724,12 @@ class CephfsMirroringUtils(object):
         asok_file,
         filesystem_id,
         peer_uuid,
+        retry_count=10,
+        retry_delay=30,
     ):
         """
         Validate the synchronization status of a specific snapshot in the target cluster.
+        Retries up to retry_count times with retry_delay seconds between attempts.
         Args:
             cephfs_mirror_node (CephNode): The CephNode representing the CephFS mirror node.
             fs_name (str): The name of the Ceph filesystem being synchronized.
@@ -735,16 +738,14 @@ class CephfsMirroringUtils(object):
             asok_file (str): The admin socket file for the CephFS mirror.
             filesystem_id (str): The ID of the filesystem being synchronized.
             peer_uuid (str): The UUID of the peer cluster.
-
-        This function validates the synchronization status of a specific snapshot by checking the
-        last synchronized snapshot and its details in the target cluster.
+            retry_count (int): Number of retry attempts (default 10).
+            retry_delay (int): Seconds to wait between retries (default 30).
 
         Returns:
             dict: A dictionary with details of the synchronized snapshot, including snapshot name, sync duration,
             sync timestamp, and the number of snaps synced.
-        Note:
-            If the specified snapshot is not found or not synchronized, the function returns None.
         Raises:
+            CommandFailed: If the snapshot is not synced after all retry attempts.
             json.JSONDecodeError: If there's an error decoding JSON from the Ceph mirror status response.
         """
         log.info("Get peer mirror status")
@@ -756,34 +757,46 @@ class CephfsMirroringUtils(object):
         log.info(f"filesystem id of {fs_name} is : {filesystem_id}")
         peer_uuid = self.get_peer_uuid_by_name(self.source_clients[0], fs_name)
         log.info(f"peer uuid of {fs_name} is : {peer_uuid}")
-        for node, asok in asok_file.items():
-            asok[0].exec_command(
-                sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
-            )
-            cmd = (
-                f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
-                f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
-            )
-            out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
-            data = json.loads(out)
-            for path, status in data.items():
-                last_synced_snap = status.get("last_synced_snap")
-                if last_synced_snap:
-                    if last_synced_snap.get("name") == snapshot_name:
-                        sync_duration = last_synced_snap.get("sync_duration")
-                        sync_time_stamp = last_synced_snap.get("sync_time_stamp")
-                        snaps_synced = status.get("snaps_synced")
-                        log.info("ALl snapshots are synced")
-                        return {
-                            "snapshot_name": snapshot_name,
-                            "sync_duration": sync_duration,
-                            "sync_time_stamp": sync_time_stamp,
-                            "snaps_synced": snaps_synced,
-                        }
+        for attempt in range(1, retry_count + 1):
+            still_syncing = False
+            for node, asok in asok_file.items():
+                asok[0].exec_command(
+                    sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
+                )
+                cmd = (
+                    f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+                    f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
+                )
+                out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
+                data = json.loads(out)
+                for path, status in data.items():
+                    last_synced_snap = status.get("last_synced_snap")
+                    if last_synced_snap:
+                        if last_synced_snap.get("name") == snapshot_name:
+                            sync_duration = last_synced_snap.get("sync_duration")
+                            sync_time_stamp = last_synced_snap.get("sync_time_stamp")
+                            snaps_synced = status.get("snaps_synced")
+                            log.info("All snapshots are synced")
+                            return {
+                                "snapshot_name": snapshot_name,
+                                "sync_duration": sync_duration,
+                                "sync_time_stamp": sync_time_stamp,
+                                "snaps_synced": snaps_synced,
+                            }
+                    if status.get("state") == "syncing":
+                        still_syncing = True
 
-        else:
-            log.error(f"{snapshot_name} not synced, last synced data is {data}")
-            raise CommandFailed("One or more snapshots are not synced")
+            if still_syncing and attempt < retry_count:
+                log.warning(
+                    f"{snapshot_name} not synced yet, sync in progress "
+                    f"(attempt {attempt}/{retry_count}). Retrying in {retry_delay}s..."
+                )
+                time.sleep(retry_delay)
+            else:
+                break
+
+        log.error(f"{snapshot_name} not synced, last synced data is {data}")
+        raise CommandFailed("One or more snapshots are not synced")
 
     def remove_snapshot_mirror_peer(self, source_clients, fs_name, peer_uuid):
         """
@@ -855,14 +868,16 @@ class CephfsMirroringUtils(object):
                 sudo=True,
                 cmd=f"ceph-fuse -n {target_client_user} {target_mount_path} --client_fs {target_fs_name}",
             )
-            snapshot_list_command = f"ls {target_mount_path}{source_path}.snap"
+            snapshot_list_command = f"ls {target_mount_path}{source_path}/.snap"
             snapshots, _ = target_clients.exec_command(
                 sudo=True, cmd=snapshot_list_command
             )
             snapshots = snapshots.strip().split()
             log.info(f"Available Snapshots : {snapshots}")
             if snapshot_name in snapshots:
-                snapshot_path = f"{target_mount_path}{source_path}.snap/{snapshot_name}"
+                snapshot_path = (
+                    f"{target_mount_path}{source_path}/.snap/{snapshot_name}"
+                )
                 snapshot_files_command = f"ls {snapshot_path}"
                 snapshot_files, _ = target_clients.exec_command(
                     sudo=True, cmd=snapshot_files_command
@@ -900,11 +915,11 @@ class CephfsMirroringUtils(object):
         List and verify remote snapshots and data in a target Ceph cluster.
         Args:
             target_clients: Ceph client on the target cluster.
-            target_mount_path (str): The mount path on the target cluster.
             target_client_user (str): The user for the target client.
             source_path (str): The source path where snapshots and data are located.
-            snapshot_name (str): The name of the snapshot to verify.
-            expected_files (list): List of expected files in the snapshot.
+            source_client: Ceph client on the source cluster.
+            source_mount_path (str): The mount path on the source cluster.
+            target_fs_name (str): The target filesystem name.
         Returns:
             tuple: A tuple containing a boolean indicating success or failure, and a message.
         """
@@ -919,7 +934,7 @@ class CephfsMirroringUtils(object):
                 sudo=True,
                 cmd=f"ceph-fuse -n {target_client_user} {target_mount_path} --client_fs {target_fs_name}",
             )
-            snapshot_list_command = f"ls {target_mount_path}{source_path}.snap"
+            snapshot_list_command = f"ls {target_mount_path}{source_path}/.snap"
             retry_cmd = retry(CommandFailed, tries=3, delay=30)(
                 target_clients.exec_command
             )
@@ -1408,12 +1423,12 @@ class CephfsMirroringUtils(object):
             sudo=True,
             cmd=f"ceph-fuse -n {target_client_user} {target_mount_path} --client_fs {target_fs_name}",
         )
-        snapshot_list = f"ls {target_mount_path}{source_path}.snap"
+        snapshot_list = f"ls {target_mount_path}{source_path}/.snap"
         log.info(f"Existing list of snaps : {snapshot_list}")
         target_clients.exec_command(
-            sudo=True, cmd=f"mkdir {target_mount_path}{source_path}.snap/{snap_target}"
+            sudo=True, cmd=f"mkdir {target_mount_path}{source_path}/.snap/{snap_target}"
         )
-        snapshot_list_after_sync_failure = f"ls {target_mount_path}{source_path}.snap"
+        snapshot_list_after_sync_failure = f"ls {target_mount_path}{source_path}/.snap"
         log.info(
             f"List of snaps after injecting failure : {snapshot_list_after_sync_failure}"
         )

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -868,16 +868,14 @@ class CephfsMirroringUtils(object):
                 sudo=True,
                 cmd=f"ceph-fuse -n {target_client_user} {target_mount_path} --client_fs {target_fs_name}",
             )
-            snapshot_list_command = f"ls {target_mount_path}{source_path}/.snap"
+            snapshot_list_command = f"ls {target_mount_path}{source_path}.snap"
             snapshots, _ = target_clients.exec_command(
                 sudo=True, cmd=snapshot_list_command
             )
             snapshots = snapshots.strip().split()
             log.info(f"Available Snapshots : {snapshots}")
             if snapshot_name in snapshots:
-                snapshot_path = (
-                    f"{target_mount_path}{source_path}/.snap/{snapshot_name}"
-                )
+                snapshot_path = f"{target_mount_path}{source_path}.snap/{snapshot_name}"
                 snapshot_files_command = f"ls {snapshot_path}"
                 snapshot_files, _ = target_clients.exec_command(
                     sudo=True, cmd=snapshot_files_command
@@ -934,7 +932,7 @@ class CephfsMirroringUtils(object):
                 sudo=True,
                 cmd=f"ceph-fuse -n {target_client_user} {target_mount_path} --client_fs {target_fs_name}",
             )
-            snapshot_list_command = f"ls {target_mount_path}{source_path}/.snap"
+            snapshot_list_command = f"ls {target_mount_path}{source_path}.snap"
             retry_cmd = retry(CommandFailed, tries=3, delay=30)(
                 target_clients.exec_command
             )
@@ -1423,12 +1421,12 @@ class CephfsMirroringUtils(object):
             sudo=True,
             cmd=f"ceph-fuse -n {target_client_user} {target_mount_path} --client_fs {target_fs_name}",
         )
-        snapshot_list = f"ls {target_mount_path}{source_path}/.snap"
+        snapshot_list = f"ls {target_mount_path}{source_path}.snap"
         log.info(f"Existing list of snaps : {snapshot_list}")
         target_clients.exec_command(
-            sudo=True, cmd=f"mkdir {target_mount_path}{source_path}/.snap/{snap_target}"
+            sudo=True, cmd=f"mkdir {target_mount_path}{source_path}.snap/{snap_target}"
         )
-        snapshot_list_after_sync_failure = f"ls {target_mount_path}{source_path}/.snap"
+        snapshot_list_after_sync_failure = f"ls {target_mount_path}{source_path}.snap"
         log.info(
             f"List of snaps after injecting failure : {snapshot_list_after_sync_failure}"
         )

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_incremental_sync.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_incremental_sync.py
@@ -66,7 +66,7 @@ def run(ceph_cluster, **kw):
         )
 
         if not source_clients or not target_clients:
-            log.info("Requires at least 1 client on both ceph1 and ceph2.")
+            log.error("Requires at least 1 client on both ceph1 and ceph2.")
             return 1
 
         fs_util_ceph1.prepare_clients(source_clients, build)
@@ -78,8 +78,10 @@ def run(ceph_cluster, **kw):
         target_fs = "cephfs" if not erasure else "cephfs-ec"
         if not fs_util_ceph1.get_fs_info(source_clients[0], source_fs):
             fs_util_ceph1.create_fs(source_clients[0], source_fs)
+            fs_util_ceph1.wait_for_mds_process(source_clients[0], source_fs)
         if not fs_util_ceph2.get_fs_info(target_clients[0], target_fs):
             fs_util_ceph2.create_fs(target_clients[0], target_fs)
+            fs_util_ceph2.wait_for_mds_process(target_clients[0], target_fs)
 
         log.info("Deploy CephFS Mirroring Configuration")
         fs_mirroring_utils.deploy_cephfs_mirroring(
@@ -111,7 +113,7 @@ def run(ceph_cluster, **kw):
         abs_repo_dir = f"{kernel_mounting_dir}{repo_dir}"
         abs_repo_path = f"{kernel_mounting_dir}{repo_path}"
 
-        log.info(f"Cloning {repo} (branch giant) into {abs_repo_path}")
+        log.info("Cloning %s (branch giant) into %s", repo, abs_repo_path)
         source_clients[0].exec_command(sudo=True, cmd=f"mkdir -p {abs_repo_dir}")
         source_clients[0].exec_command(
             sudo=True,
@@ -119,7 +121,6 @@ def run(ceph_cluster, **kw):
                 f"git clone --branch giant "
                 f"http://github.com/ceph/{repo} {abs_repo_path}"
             ),
-            long_running=True,
         )
 
         log.info("Add directory for mirroring")
@@ -154,7 +155,7 @@ def run(ceph_cluster, **kw):
         # ==================== SNAP_A: Full sync ====================
         snap_a = "snap_a"
         snap_names.append(snap_a)
-        log.info(f"Creating snapshot '{snap_a}' (full sync)")
+        log.info("Creating snapshot '%s' (full sync)", snap_a)
         source_clients[0].exec_command(
             sudo=True,
             cmd=f"mkdir {abs_repo_path}/.snap/{snap_a}",
@@ -170,8 +171,9 @@ def run(ceph_cluster, **kw):
             peer_uuid,
         )
         log.info(
-            f"snap_a synced: duration={result_a['sync_duration']} "
-            f"snaps_synced={result_a['snaps_synced']}"
+            "snap_a synced: duration=%s snaps_synced=%s",
+            result_a["sync_duration"],
+            result_a["snaps_synced"],
         )
         full_sync_duration = float(result_a["sync_duration"])
 
@@ -190,12 +192,12 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd=f"bash /root/{md5sum_script} {abs_repo_path}/.snap/{snap_a}",
         )
-        log.info(f"snap_a checksum:\n{snap_a_checksum}")
+        log.info("snap_a checksum:\n%s", snap_a_checksum)
         log.info("snap_a: full sync completed and verified")
 
         # ==================== SNAP_B: Incremental sync (git reset) ====================
         num = random.randint(5, 10)
-        log.info(f"Creating diff: git reset --hard HEAD~{num}")
+        log.info("Creating diff: git reset --hard HEAD~%s", num)
         source_clients[0].exec_command(
             sudo=True,
             cmd=(
@@ -207,7 +209,7 @@ def run(ceph_cluster, **kw):
 
         snap_b = "snap_b"
         snap_names.append(snap_b)
-        log.info(f"Creating snapshot '{snap_b}' (incremental sync)")
+        log.info("Creating snapshot '%s' (incremental sync)", snap_b)
         source_clients[0].exec_command(
             sudo=True,
             cmd=f"mkdir {abs_repo_path}/.snap/{snap_b}",
@@ -223,8 +225,9 @@ def run(ceph_cluster, **kw):
             peer_uuid,
         )
         log.info(
-            f"snap_b synced: duration={result_b['sync_duration']} "
-            f"snaps_synced={result_b['snaps_synced']}"
+            "snap_b synced: duration=%s snaps_synced=%s",
+            result_b["sync_duration"],
+            result_b["snaps_synced"],
         )
         inc_sync_duration_1 = float(result_b["sync_duration"])
 
@@ -238,12 +241,12 @@ def run(ceph_cluster, **kw):
             target_fs,
         )
         if not out:
-            raise CommandFailed(f"snap_b checksum verification failed: {rc}")
+            log.error("snap_b checksum verification failed: %s", rc)
         snap_b_checksum, _ = source_clients[0].exec_command(
             sudo=True,
             cmd=f"bash /root/{md5sum_script} {abs_repo_path}/.snap/{snap_b}",
         )
-        log.info(f"snap_b checksum:\n{snap_b_checksum}")
+        log.info("snap_b checksum:\n%s", snap_b_checksum)
         if snap_a_checksum == snap_b_checksum:
             log.error(
                 "snap_b checksum must differ from snap_a after git reset, "
@@ -253,13 +256,16 @@ def run(ceph_cluster, **kw):
         log.info("Cross-snapshot check: snap_a != snap_b — PASSED")
 
         log.info(
-            f"snap_b: incremental sync duration ({inc_sync_duration_1:.3f}s) vs "
-            f"full sync duration ({full_sync_duration:.3f}s)"
+            "snap_b: incremental sync duration (%.3fs) vs full sync duration (%.3fs)",
+            inc_sync_duration_1,
+            full_sync_duration,
         )
         if full_sync_duration < inc_sync_duration_1:
             log.error(
-                f"Incremental sync (snap_b) took longer than full sync: "
-                f"{inc_sync_duration_1:.3f}s > {full_sync_duration:.3f}s"
+                "Incremental sync (snap_b) took longer than full sync: "
+                "%.3fs > %.3fs",
+                inc_sync_duration_1,
+                full_sync_duration,
             )
             return 1
 
@@ -277,7 +283,7 @@ def run(ceph_cluster, **kw):
 
         snap_c = "snap_c"
         snap_names.append(snap_c)
-        log.info(f"Creating snapshot '{snap_c}' (incremental sync)")
+        log.info("Creating snapshot '%s' (incremental sync)", snap_c)
         source_clients[0].exec_command(
             sudo=True,
             cmd=f"mkdir {abs_repo_path}/.snap/{snap_c}",
@@ -293,8 +299,9 @@ def run(ceph_cluster, **kw):
             peer_uuid,
         )
         log.info(
-            f"snap_c synced: duration={result_c['sync_duration']} "
-            f"snaps_synced={result_c['snaps_synced']}"
+            "snap_c synced: duration=%s snaps_synced=%s",
+            result_c["sync_duration"],
+            result_c["snaps_synced"],
         )
         inc_sync_duration_2 = float(result_c["sync_duration"])
 
@@ -313,7 +320,7 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd=f"bash /root/{md5sum_script} {abs_repo_path}/.snap/{snap_c}",
         )
-        log.info(f"snap_c checksum:\n{snap_c_checksum}")
+        log.info("snap_c checksum:\n%s", snap_c_checksum)
         if snap_b_checksum == snap_c_checksum:
             log.error(
                 "snap_c checksum must differ from snap_b after git pull, "
@@ -331,13 +338,16 @@ def run(ceph_cluster, **kw):
         )
 
         log.info(
-            f"snap_c: incremental sync duration ({inc_sync_duration_2:.3f}s) vs "
-            f"full sync duration ({full_sync_duration:.3f}s)"
+            "snap_c: incremental sync duration (%.3fs) vs full sync duration (%.3fs)",
+            inc_sync_duration_2,
+            full_sync_duration,
         )
         if full_sync_duration < inc_sync_duration_2:
             log.error(
-                f"Incremental sync (snap_c) took longer than full sync: "
-                f"{inc_sync_duration_2:.3f}s > {full_sync_duration:.3f}s"
+                "Incremental sync (snap_c) took longer than full sync: "
+                "%.3fs > %.3fs",
+                inc_sync_duration_2,
+                full_sync_duration,
             )
             return 1
 
@@ -345,9 +355,9 @@ def run(ceph_cluster, **kw):
         log.info("=" * 70)
         log.info("INCREMENTAL SYNC TEST RESULTS")
         log.info("=" * 70)
-        log.info(f"  snap_a (full sync):        {full_sync_duration:.3f}s")
-        log.info(f"  snap_b (incremental, reset): {inc_sync_duration_1:.3f}s")
-        log.info(f"  snap_c (incremental, pull):  {inc_sync_duration_2:.3f}s")
+        log.info("  snap_a (full sync):        %.3fs", full_sync_duration)
+        log.info("  snap_b (incremental, reset): %.3fs", inc_sync_duration_1)
+        log.info("  snap_c (incremental, pull):  %.3fs", inc_sync_duration_2)
         log.info(
             "All incremental syncs completed faster than full sync "
             "and data verified on target"

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_incremental_sync.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_incremental_sync.py
@@ -1,0 +1,399 @@
+import random
+import string
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    CEPH-83580027 - Test incremental snapshot synchronization (based on mtime differences).
+
+    Ported from upstream: test_cephfs_mirror_incremental_sync in
+    qa/tasks/cephfs/test_mirroring.py
+
+    Scenario:
+        1. Deploy mirroring between source and target clusters
+        2. Clone a git repo (ceph-qa-suite, branch 'giant') into the mirrored path
+        3. Create snap_a (full sync) — wait for sync, verify checksums on target
+        4. Record full sync duration from perf counters
+        5. Reset git repo to HEAD~N (random diff) to modify a subset of files
+        6. Create snap_b (incremental sync) — wait for sync, verify checksums
+        7. Assert incremental sync duration <= full sync duration
+        8. Pull git repo back to HEAD (another diff)
+        9. Create snap_c (incremental sync) — wait for sync, verify checksums
+       10. Assert incremental sync duration <= full sync duration
+
+    Returns 0 on success, 1 on failure.
+    """
+    mirror_path = None
+    kernel_mounting_dir = None
+    source_clients = None
+    target_clients = None
+    cephfs_mirror_node = None
+    source_fs = target_fs = None
+    target_user = "mirror_remote"
+    target_site_name = "remote_site"
+    fs_mirroring_utils = None
+    snap_names = []
+
+    try:
+        config = kw.get("config")
+        ceph_cluster_dict = kw.get("ceph_cluster_dict")
+        test_data = kw.get("test_data")
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
+
+        fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)
+        fs_util_ceph2 = FsUtils(ceph_cluster_dict.get("ceph2"), test_data=test_data)
+        fs_mirroring_utils = CephfsMirroringUtils(
+            ceph_cluster_dict.get("ceph1"), ceph_cluster_dict.get("ceph2")
+        )
+
+        build = config.get("build", config.get("rhbuild"))
+        source_clients = ceph_cluster_dict.get("ceph1").get_ceph_objects("client")
+        target_clients = ceph_cluster_dict.get("ceph2").get_ceph_objects("client")
+        cephfs_mirror_node = ceph_cluster_dict.get("ceph1").get_ceph_objects(
+            "cephfs-mirror"
+        )
+
+        if not source_clients or not target_clients:
+            log.info("Requires at least 1 client on both ceph1 and ceph2.")
+            return 1
+
+        fs_util_ceph1.prepare_clients(source_clients, build)
+        fs_util_ceph2.prepare_clients(target_clients, build)
+        fs_util_ceph1.auth_list(source_clients)
+        fs_util_ceph2.auth_list(target_clients)
+
+        source_fs = "cephfs" if not erasure else "cephfs-ec"
+        target_fs = "cephfs" if not erasure else "cephfs-ec"
+        if not fs_util_ceph1.get_fs_info(source_clients[0], source_fs):
+            fs_util_ceph1.create_fs(source_clients[0], source_fs)
+        if not fs_util_ceph2.get_fs_info(target_clients[0], target_fs):
+            fs_util_ceph2.create_fs(target_clients[0], target_fs)
+
+        log.info("Deploy CephFS Mirroring Configuration")
+        fs_mirroring_utils.deploy_cephfs_mirroring(
+            source_fs,
+            source_clients[0],
+            target_fs,
+            target_clients[0],
+            target_user,
+            target_site_name,
+        )
+
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
+        )
+        kernel_mounting_dir = f"/mnt/cephfs_kernel{mounting_dir}_incsync/"
+        mon_node_ips = fs_util_ceph1.get_mon_node_ips()
+        fs_util_ceph1.kernel_mount(
+            [source_clients[0]],
+            kernel_mounting_dir,
+            ",".join(mon_node_ips),
+            extra_params=f",fs={source_fs}",
+        )
+
+        # --- Clone a git repo as the dataset ---
+        repo = "ceph-qa-suite"
+        repo_dir = "ceph_repo"
+        repo_path = f"{repo_dir}/{repo}"
+        mirror_path = f"/{repo_path}"
+        abs_repo_dir = f"{kernel_mounting_dir}{repo_dir}"
+        abs_repo_path = f"{kernel_mounting_dir}{repo_path}"
+
+        log.info(f"Cloning {repo} (branch giant) into {abs_repo_path}")
+        source_clients[0].exec_command(sudo=True, cmd=f"mkdir -p {abs_repo_dir}")
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=(
+                f"git clone --branch giant "
+                f"http://github.com/ceph/{repo} {abs_repo_path}"
+            ),
+            long_running=True,
+        )
+
+        log.info("Add directory for mirroring")
+        fs_mirroring_utils.add_path_for_mirroring(
+            source_clients[0], source_fs, mirror_path
+        )
+
+        # Upload md5sum helper to both clusters
+        md5sum_script = "md5sum_script.sh"
+        for client in [source_clients[0], target_clients[0]]:
+            client.upload_file(
+                sudo=True,
+                src="tests/cephfs/cephfs_mirror_upgrade/md5sum_script.sh",
+                dst=f"/root/{md5sum_script}",
+            )
+
+        # --- Retrieve mirror daemon identifiers for status queries ---
+        fsid = fs_mirroring_utils.get_fsid(cephfs_mirror_node[0])
+        daemon_names = fs_mirroring_utils.get_daemon_name(source_clients[0])
+        asok_files = fs_mirroring_utils.get_asok_file(
+            cephfs_mirror_node, fsid, daemon_names
+        )
+        filesystem_id = fs_mirroring_utils.get_filesystem_id_by_name(
+            source_clients[0], source_fs
+        )
+        peer_uuid = fs_mirroring_utils.get_peer_uuid_by_name(
+            source_clients[0], source_fs
+        )
+        for node in cephfs_mirror_node:
+            node.exec_command(sudo=True, cmd="yum install -y ceph-common --nogpgcheck")
+
+        # ==================== SNAP_A: Full sync ====================
+        snap_a = "snap_a"
+        snap_names.append(snap_a)
+        log.info(f"Creating snapshot '{snap_a}' (full sync)")
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=f"mkdir {abs_repo_path}/.snap/{snap_a}",
+        )
+
+        result_a = fs_mirroring_utils.validate_snapshot_sync_status(
+            cephfs_mirror_node,
+            source_fs,
+            snap_a,
+            fsid,
+            asok_files,
+            filesystem_id,
+            peer_uuid,
+        )
+        log.info(
+            f"snap_a synced: duration={result_a['sync_duration']} "
+            f"snaps_synced={result_a['snaps_synced']}"
+        )
+        full_sync_duration = float(result_a["sync_duration"])
+
+        log.info("Verifying snap_a data on target cluster")
+        out, rc = fs_mirroring_utils.list_and_verify_remote_snapshots_and_data_checksum(
+            target_clients[0],
+            "client.admin",
+            f"/{repo_path}",
+            source_clients[0],
+            kernel_mounting_dir,
+            target_fs,
+        )
+        if not out:
+            raise CommandFailed(f"snap_a checksum verification failed: {rc}")
+        snap_a_checksum, _ = source_clients[0].exec_command(
+            sudo=True,
+            cmd=f"bash /root/{md5sum_script} {abs_repo_path}/.snap/{snap_a}",
+        )
+        log.info(f"snap_a checksum:\n{snap_a_checksum}")
+        log.info("snap_a: full sync completed and verified")
+
+        # ==================== SNAP_B: Incremental sync (git reset) ====================
+        num = random.randint(5, 10)
+        log.info(f"Creating diff: git reset --hard HEAD~{num}")
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=(
+                f"git --git-dir {abs_repo_path}/.git "
+                f"--work-tree {abs_repo_path} "
+                f"reset --hard HEAD~{num}"
+            ),
+        )
+
+        snap_b = "snap_b"
+        snap_names.append(snap_b)
+        log.info(f"Creating snapshot '{snap_b}' (incremental sync)")
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=f"mkdir {abs_repo_path}/.snap/{snap_b}",
+        )
+
+        result_b = fs_mirroring_utils.validate_snapshot_sync_status(
+            cephfs_mirror_node,
+            source_fs,
+            snap_b,
+            fsid,
+            asok_files,
+            filesystem_id,
+            peer_uuid,
+        )
+        log.info(
+            f"snap_b synced: duration={result_b['sync_duration']} "
+            f"snaps_synced={result_b['snaps_synced']}"
+        )
+        inc_sync_duration_1 = float(result_b["sync_duration"])
+
+        log.info("Verifying snap_b data on target cluster")
+        out, rc = fs_mirroring_utils.list_and_verify_remote_snapshots_and_data_checksum(
+            target_clients[0],
+            "client.admin",
+            f"/{repo_path}",
+            source_clients[0],
+            kernel_mounting_dir,
+            target_fs,
+        )
+        if not out:
+            raise CommandFailed(f"snap_b checksum verification failed: {rc}")
+        snap_b_checksum, _ = source_clients[0].exec_command(
+            sudo=True,
+            cmd=f"bash /root/{md5sum_script} {abs_repo_path}/.snap/{snap_b}",
+        )
+        log.info(f"snap_b checksum:\n{snap_b_checksum}")
+        if snap_a_checksum == snap_b_checksum:
+            log.error(
+                "snap_b checksum must differ from snap_a after git reset, "
+                "but they are identical"
+            )
+            return 1
+        log.info("Cross-snapshot check: snap_a != snap_b — PASSED")
+
+        log.info(
+            f"snap_b: incremental sync duration ({inc_sync_duration_1:.3f}s) vs "
+            f"full sync duration ({full_sync_duration:.3f}s)"
+        )
+        if full_sync_duration < inc_sync_duration_1:
+            log.error(
+                f"Incremental sync (snap_b) took longer than full sync: "
+                f"{inc_sync_duration_1:.3f}s > {full_sync_duration:.3f}s"
+            )
+            return 1
+
+        # ==================== SNAP_C: Incremental sync (git pull) ====================
+        log.info("Creating diff: git pull (back to HEAD)")
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=(
+                f"git --git-dir {abs_repo_path}/.git "
+                f"--work-tree {abs_repo_path} "
+                f"pull"
+            ),
+            long_running=True,
+        )
+
+        snap_c = "snap_c"
+        snap_names.append(snap_c)
+        log.info(f"Creating snapshot '{snap_c}' (incremental sync)")
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=f"mkdir {abs_repo_path}/.snap/{snap_c}",
+        )
+
+        result_c = fs_mirroring_utils.validate_snapshot_sync_status(
+            cephfs_mirror_node,
+            source_fs,
+            snap_c,
+            fsid,
+            asok_files,
+            filesystem_id,
+            peer_uuid,
+        )
+        log.info(
+            f"snap_c synced: duration={result_c['sync_duration']} "
+            f"snaps_synced={result_c['snaps_synced']}"
+        )
+        inc_sync_duration_2 = float(result_c["sync_duration"])
+
+        log.info("Verifying snap_c data on target cluster")
+        out, rc = fs_mirroring_utils.list_and_verify_remote_snapshots_and_data_checksum(
+            target_clients[0],
+            "client.admin",
+            f"/{repo_path}",
+            source_clients[0],
+            kernel_mounting_dir,
+            target_fs,
+        )
+        if not out:
+            raise CommandFailed(f"snap_c checksum verification failed: {rc}")
+        snap_c_checksum, _ = source_clients[0].exec_command(
+            sudo=True,
+            cmd=f"bash /root/{md5sum_script} {abs_repo_path}/.snap/{snap_c}",
+        )
+        log.info(f"snap_c checksum:\n{snap_c_checksum}")
+        if snap_b_checksum == snap_c_checksum:
+            log.error(
+                "snap_c checksum must differ from snap_b after git pull, "
+                "but they are identical"
+            )
+            return 1
+        log.info("Cross-snapshot check: snap_b != snap_c — PASSED")
+        if snap_a_checksum != snap_c_checksum:
+            log.error(
+                "snap_c checksum must match snap_a (both at HEAD), " "but they differ"
+            )
+            return 1
+        log.info(
+            "Cross-snapshot check: snap_a == snap_c — PASSED (round-trip integrity)"
+        )
+
+        log.info(
+            f"snap_c: incremental sync duration ({inc_sync_duration_2:.3f}s) vs "
+            f"full sync duration ({full_sync_duration:.3f}s)"
+        )
+        if full_sync_duration < inc_sync_duration_2:
+            log.error(
+                f"Incremental sync (snap_c) took longer than full sync: "
+                f"{inc_sync_duration_2:.3f}s > {full_sync_duration:.3f}s"
+            )
+            return 1
+
+        # --- Summary ---
+        log.info("=" * 70)
+        log.info("INCREMENTAL SYNC TEST RESULTS")
+        log.info("=" * 70)
+        log.info(f"  snap_a (full sync):        {full_sync_duration:.3f}s")
+        log.info(f"  snap_b (incremental, reset): {inc_sync_duration_1:.3f}s")
+        log.info(f"  snap_c (incremental, pull):  {inc_sync_duration_2:.3f}s")
+        log.info(
+            "All incremental syncs completed faster than full sync "
+            "and data verified on target"
+        )
+        log.info("=" * 70)
+        return 0
+
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Clean up the system")
+
+        log.info("Delete the snapshots")
+        for snap in snap_names:
+            source_clients[0].exec_command(
+                sudo=True,
+                cmd=f"rmdir {abs_repo_path}/.snap/{snap}",
+                check_ec=False,
+            )
+
+        log.info("Remove path used for mirroring")
+        if mirror_path:
+            fs_mirroring_utils.remove_path_from_mirroring(
+                source_clients[0], source_fs, mirror_path
+            )
+
+        log.info("Destroy CephFS Mirroring setup.")
+        fs_mirroring_utils.destroy_cephfs_mirroring(
+            source_fs,
+            source_clients[0],
+            target_fs,
+            target_clients[0],
+            target_user,
+            peer_uuid,
+        )
+
+        log.info("Unmount the paths")
+        if kernel_mounting_dir:
+            source_clients[0].exec_command(
+                sudo=True, cmd=f"umount -l {kernel_mounting_dir}"
+            )
+
+        log.info("Delete the mounted paths")
+        if kernel_mounting_dir:
+            source_clients[0].exec_command(
+                sudo=True, cmd=f"rm -rf {kernel_mounting_dir}"
+            )

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_incremental_sync.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_incremental_sync.py
@@ -107,7 +107,7 @@ def run(ceph_cluster, **kw):
         repo = "ceph-qa-suite"
         repo_dir = "ceph_repo"
         repo_path = f"{repo_dir}/{repo}"
-        mirror_path = f"/{repo_path}"
+        mirror_path = f"/{repo_path}/"
         abs_repo_dir = f"{kernel_mounting_dir}{repo_dir}"
         abs_repo_path = f"{kernel_mounting_dir}{repo_path}"
 
@@ -178,8 +178,8 @@ def run(ceph_cluster, **kw):
         log.info("Verifying snap_a data on target cluster")
         out, rc = fs_mirroring_utils.list_and_verify_remote_snapshots_and_data_checksum(
             target_clients[0],
-            "client.admin",
-            f"/{repo_path}",
+            f"client.{target_clients[0].node.hostname}",
+            mirror_path,
             source_clients[0],
             kernel_mounting_dir,
             target_fs,
@@ -231,8 +231,8 @@ def run(ceph_cluster, **kw):
         log.info("Verifying snap_b data on target cluster")
         out, rc = fs_mirroring_utils.list_and_verify_remote_snapshots_and_data_checksum(
             target_clients[0],
-            "client.admin",
-            f"/{repo_path}",
+            f"client.{target_clients[0].node.hostname}",
+            mirror_path,
             source_clients[0],
             kernel_mounting_dir,
             target_fs,
@@ -301,8 +301,8 @@ def run(ceph_cluster, **kw):
         log.info("Verifying snap_c data on target cluster")
         out, rc = fs_mirroring_utils.list_and_verify_remote_snapshots_and_data_checksum(
             target_clients[0],
-            "client.admin",
-            f"/{repo_path}",
+            f"client.{target_clients[0].node.hostname}",
+            mirror_path,
             source_clients[0],
             kernel_mounting_dir,
             target_fs,

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_multithreaded_empty_dataq_hang.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_multithreaded_empty_dataq_hang.py
@@ -1,0 +1,353 @@
+import json
+import random
+import string
+import time
+import traceback
+
+from ceph.parallel import parallel
+from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+SYNC_TIMEOUT = 600
+POLL_INTERVAL = 15
+
+
+def run(ceph_cluster, **kw):
+    """
+    Multi-threaded mirroring: crawler thread hangs when syncing directory-only paths.
+
+    When a mirrored directory contains only subdirectories (no regular files), the
+    crawler thread can hang indefinitely in wait_for_sync(). The crawler pushes no
+    file entries to the data queue, calls finish_crawl() then wait_for_sync(). If
+    all data sync threads are busy in inner loops processing other syncm objects,
+    has_pending_work() returns false (empty queue + crawl finished) and the syncm
+    is permanently orphaned — nobody sets m_sync_done, and the crawler blocks
+    forever.
+
+    Reproduction strategy:
+        All 4 directories are added for mirroring in parallel (using ceph.parallel)
+        and all 4 snapshots are created in parallel. This matches manual CLI
+        behaviour where all 'ceph fs snapshot mirror add' commands complete almost
+        simultaneously, so all 4 directories are present in m_directories before
+        crawlers scan. With default max_concurrent_directory_syncs=3, three
+        crawlers pick 3 directories (dirs-only has ~75 percent chance of being in
+        the first batch). The 3 data directories generate enough I/O (20 x 100MB
+        each) to keep all 6 data sync threads in inner loops, and the dirs-only
+        crawl finishes in milliseconds before any thread returns.
+
+    Scenario:
+        1. Deploy CephFS mirroring between source and target clusters
+        2. Create 3 data directories with 20 x 100MB files each
+        3. Create 1 directory-only path (subdirectories, no files)
+        4. Add all 4 directories for mirroring in parallel
+        5. Take snapshots on all 4 directories in parallel
+        6. Wait for data directories to complete syncing
+        7. Verify whether the directory-only path also syncs or remains stuck
+
+    Expected:
+        All directories including the directory-only path should sync successfully.
+        If the directory-only path remains stuck while all data directories have
+        completed, the empty dataq hang is present.
+
+    Returns:
+        0 if all directories sync successfully (bug not present / fixed)
+        1 if the directory-only path hangs (bug is present)
+    """
+
+    all_paths = []
+    snap_name = "dironly_hang_snap1"
+    kernel_mounting_dir = None
+    source_clients = None
+    target_clients = None
+    source_fs = None
+    target_fs = None
+    target_user = "mirror_remote"
+    target_site_name = "remote_site"
+    fs_mirroring_utils = None
+
+    try:
+        config = kw.get("config")
+        ceph_cluster_dict = kw.get("ceph_cluster_dict")
+        test_data = kw.get("test_data")
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
+
+        fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)
+        fs_util_ceph2 = FsUtils(ceph_cluster_dict.get("ceph2"), test_data=test_data)
+        fs_mirroring_utils = CephfsMirroringUtils(
+            ceph_cluster_dict.get("ceph1"), ceph_cluster_dict.get("ceph2")
+        )
+
+        build = config.get("build", config.get("rhbuild"))
+        source_clients = ceph_cluster_dict.get("ceph1").get_ceph_objects("client")
+        target_clients = ceph_cluster_dict.get("ceph2").get_ceph_objects("client")
+        cephfs_mirror_node = ceph_cluster_dict.get("ceph1").get_ceph_objects(
+            "cephfs-mirror"
+        )
+
+        log.info("Checking pre-requisites")
+        if not source_clients or not target_clients:
+            log.info(
+                "This test requires a minimum of 1 client node on both ceph1 and ceph2."
+            )
+            return 1
+
+        log.info("Preparing clients")
+        fs_util_ceph1.prepare_clients(source_clients, build)
+        fs_util_ceph2.prepare_clients(target_clients, build)
+        fs_util_ceph1.auth_list(source_clients)
+        fs_util_ceph2.auth_list(target_clients)
+
+        source_fs = "cephfs" if not erasure else "cephfs-ec"
+        target_fs = "cephfs" if not erasure else "cephfs-ec"
+        fs_details_source = fs_util_ceph1.get_fs_info(source_clients[0], source_fs)
+        if not fs_details_source:
+            fs_util_ceph1.create_fs(source_clients[0], source_fs)
+        fs_details_target = fs_util_ceph2.get_fs_info(target_clients[0], target_fs)
+        if not fs_details_target:
+            fs_util_ceph2.create_fs(target_clients[0], target_fs)
+
+        log.info("Deploy CephFS Mirroring Configuration")
+        fs_mirroring_utils.deploy_cephfs_mirroring(
+            source_fs,
+            source_clients[0],
+            target_fs,
+            target_clients[0],
+            target_user,
+            target_site_name,
+        )
+
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        kernel_mounting_dir = f"/mnt/cephfs_kernel{mounting_dir}_dironly/"
+        mon_node_ips = fs_util_ceph1.get_mon_node_ips()
+        log.info(f"Mount source filesystem at {kernel_mounting_dir}")
+        fs_util_ceph1.kernel_mount(
+            [source_clients[0]],
+            kernel_mounting_dir,
+            ",".join(mon_node_ips),
+            extra_params=f",fs={source_fs}",
+        )
+
+        test_id = "".join(random.choice(string.ascii_lowercase) for _ in range(6))
+        data_paths = [f"/mirror_data_{test_id}_{i}" for i in range(3)]
+        dirs_only_path = f"/mirror_dironly_{test_id}"
+        all_paths = data_paths + [dirs_only_path]
+
+        # --- Create 3 data-heavy directories (20 x 100MB each = 2GB per dir) ---
+        num_files = config.get("num_files", 20)
+        file_size_mb = config.get("file_size_mb", 100)
+        for data_path in data_paths:
+            log.info(
+                f"Creating data directory: {data_path} "
+                f"({num_files} files x {file_size_mb}MB)"
+            )
+            abs_data_path = f"{kernel_mounting_dir}{data_path.lstrip('/')}"
+            source_clients[0].exec_command(sudo=True, cmd=f"mkdir -p {abs_data_path}")
+            for i in range(1, num_files + 1):
+                source_clients[0].exec_command(
+                    sudo=True,
+                    cmd=(
+                        f"dd if=/dev/urandom of={abs_data_path}/file_{i} "
+                        f"bs=1M count={file_size_mb} 2>/dev/null"
+                    ),
+                    long_running=True,
+                )
+
+        # --- Create directory-only path (subdirectories, no files) ---
+        log.info(
+            f"Creating dirs-only directory: {dirs_only_path} "
+            "(subdirectories only, no files)"
+        )
+        source_clients[0].exec_command(
+            sudo=True,
+            cmd=(
+                f"mkdir -p {kernel_mounting_dir}{dirs_only_path.lstrip('/')}/subdir_a/nested && "
+                f"mkdir -p {kernel_mounting_dir}{dirs_only_path.lstrip('/')}/subdir_b && "
+                f"mkdir -p {kernel_mounting_dir}{dirs_only_path.lstrip('/')}/subdir_c/deep/deeper"
+            ),
+        )
+
+        # --- Add ALL 4 directories for mirroring in parallel ---
+        # Running in parallel ensures all 4 paths land in m_directories before
+        # any crawler picks them, matching manual CLI behaviour.
+        log.info("Adding all 4 directories for mirroring in parallel")
+        with parallel() as p:
+            for path in all_paths:
+                p.spawn(
+                    fs_mirroring_utils.add_path_for_mirroring,
+                    source_clients[0],
+                    source_fs,
+                    path,
+                )
+
+        # --- Take snapshots on ALL directories in parallel ---
+        log.info(f"Creating snapshot '{snap_name}' on all directories in parallel")
+        with parallel() as p:
+            for path in all_paths:
+                p.spawn(
+                    source_clients[0].exec_command,
+                    sudo=True,
+                    cmd=f"mkdir {kernel_mounting_dir}{path.lstrip('/')}/.snap/{snap_name}",
+                )
+
+        # --- Poll peer status to detect the hang ---
+        log.info(f"Waiting up to {SYNC_TIMEOUT}s for directories to sync...")
+        start_time = time.time()
+        dirs_only_synced = False
+        data_dirs_synced = False
+
+        while time.time() - start_time < SYNC_TIMEOUT:
+            time.sleep(POLL_INTERVAL)
+            elapsed = int(time.time() - start_time)
+
+            peer_status = fs_mirroring_utils.get_fs_mirror_peer_status_using_asok(
+                cephfs_mirror_node[0],
+                source_clients[0],
+                source_fs,
+            )
+            log.info(f"Peer status at {elapsed}s: {json.dumps(peer_status, indent=2)}")
+
+            data_states = []
+            for data_path in data_paths:
+                entry = peer_status.get(data_path, {})
+                state = entry.get("state", "unknown")
+                data_states.append(state)
+
+            dirs_only_entry = peer_status.get(dirs_only_path, {})
+            dirs_only_state = dirs_only_entry.get("state", "unknown")
+
+            log.info(
+                f"  dirs_only ({dirs_only_path}): {dirs_only_state}, "
+                f"data dirs: {data_states}"
+            )
+
+            if dirs_only_state == "idle" and dirs_only_entry.get("snaps_synced", 0) > 0:
+                dirs_only_synced = True
+
+            if all(s == "idle" for s in data_states):
+                all_data_synced_count = sum(
+                    1
+                    for dp in data_paths
+                    if peer_status.get(dp, {}).get("snaps_synced", 0) > 0
+                )
+                if all_data_synced_count == len(data_paths):
+                    data_dirs_synced = True
+
+            if dirs_only_synced:
+                log.info(
+                    f"Directory-only path synced successfully at {elapsed}s. "
+                    "Empty dataq hang is NOT present (or has been fixed)."
+                )
+                return 0
+
+            if data_dirs_synced and not dirs_only_synced:
+                log.warning(
+                    f"All data directories synced but directory-only path "
+                    f"is still in state '{dirs_only_state}' at {elapsed}s. "
+                    "Waiting additional time to confirm hang..."
+                )
+                extra_wait = 120
+                time.sleep(extra_wait)
+                peer_status = fs_mirroring_utils.get_fs_mirror_peer_status_using_asok(
+                    cephfs_mirror_node[0],
+                    source_clients[0],
+                    source_fs,
+                )
+                dirs_only_entry = peer_status.get(dirs_only_path, {})
+                dirs_only_state = dirs_only_entry.get("state", "unknown")
+
+                if (
+                    dirs_only_state == "idle"
+                    and dirs_only_entry.get("snaps_synced", 0) > 0
+                ):
+                    log.info(
+                        "Directory-only path eventually synced. "
+                        "Empty dataq hang is NOT present."
+                    )
+                    return 0
+                else:
+                    log.error(
+                        f"EMPTY DATAQ HANG CONFIRMED: directory-only path "
+                        f"({dirs_only_path}) is stuck in state '{dirs_only_state}' "
+                        f"while all data directories have completed syncing. "
+                        f"The crawler thread is hung in wait_for_sync() because "
+                        f"no data sync thread picked up the empty syncm object."
+                    )
+                    log.error(
+                        f"Final peer status for {dirs_only_path}: "
+                        f"{json.dumps(dirs_only_entry, indent=2)}"
+                    )
+                    return 1
+
+        log.error(
+            f"Timeout after {SYNC_TIMEOUT}s waiting for sync to complete. "
+            f"dirs_only_synced={dirs_only_synced}, "
+            f"data_dirs_synced={data_dirs_synced}"
+        )
+        return 1
+
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        if config.get("cleanup", True):
+            log.info("Cleanup: removing snapshots")
+            for path in all_paths:
+                source_clients[0].exec_command(
+                    sudo=True,
+                    cmd=(
+                        f"rmdir {kernel_mounting_dir}{path.lstrip('/')}/"
+                        f".snap/{snap_name} 2>/dev/null || true"
+                    ),
+                )
+
+            log.info("Cleanup: removing paths from mirroring")
+            for path in all_paths:
+                fs_mirroring_utils.remove_path_from_mirroring(
+                    source_clients[0], source_fs, path
+                )
+
+            log.info("Cleanup: restart mirror daemon to clear any stuck state")
+            source_clients[0].exec_command(
+                sudo=True, cmd="ceph orch restart cephfs-mirror"
+            )
+            time.sleep(30)
+
+            log.info("Cleanup: removing test directories")
+            for path in all_paths:
+                source_clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"rm -rf {kernel_mounting_dir}{path.lstrip('/')}",
+                )
+
+            if kernel_mounting_dir:
+                log.info("Cleanup: unmounting")
+                source_clients[0].exec_command(
+                    sudo=True, cmd=f"umount -l {kernel_mounting_dir}"
+                )
+                source_clients[0].exec_command(
+                    sudo=True, cmd=f"rm -rf {kernel_mounting_dir}"
+                )
+
+            log.info("Cleanup: destroying mirroring setup")
+            peer_uuid = fs_mirroring_utils.get_peer_uuid_by_name(
+                source_clients[0], source_fs
+            )
+            fs_mirroring_utils.destroy_cephfs_mirroring(
+                source_fs,
+                source_clients[0],
+                target_fs,
+                target_clients[0],
+                target_user,
+                peer_uuid,
+            )

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_multithreaded_empty_dataq_hang.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_multithreaded_empty_dataq_hang.py
@@ -93,7 +93,7 @@ def run(ceph_cluster, **kw):
 
         log.info("Checking pre-requisites")
         if not source_clients or not target_clients:
-            log.info(
+            log.error(
                 "This test requires a minimum of 1 client node on both ceph1 and ceph2."
             )
             return 1
@@ -109,9 +109,11 @@ def run(ceph_cluster, **kw):
         fs_details_source = fs_util_ceph1.get_fs_info(source_clients[0], source_fs)
         if not fs_details_source:
             fs_util_ceph1.create_fs(source_clients[0], source_fs)
+            fs_util_ceph1.wait_for_mds_process(source_clients[0], source_fs)
         fs_details_target = fs_util_ceph2.get_fs_info(target_clients[0], target_fs)
         if not fs_details_target:
             fs_util_ceph2.create_fs(target_clients[0], target_fs)
+            fs_util_ceph2.wait_for_mds_process(target_clients[0], target_fs)
 
         log.info("Deploy CephFS Mirroring Configuration")
         fs_mirroring_utils.deploy_cephfs_mirroring(


### PR DESCRIPTION
Added two additional scenarios for cephFS mirroring.
(1) incremental snapshot sync with cross-snapshot checksum validation asserting incremental syncs are faster than full sync, and 
(2) multi-threaded mirroring test verifying directory-only paths sync correctly when data sync threads are saturated by large-file directories.
Logs: https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/executor/20.1.0-171/cephfs/990/logs/tier_1_cephfs_mirror/, http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CB2Z9N/

