### PR TITLE
Addition of support of onecloud as a new env for cluster deployment via cephci

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1,12 +1,15 @@
 """This module implements the required foundation data structures for testing."""
 
+import base64
 import codecs
 import datetime
 import json
+import os
 import pickle
 import random
 import re
 import socket
+import subprocess
 from time import sleep, time
 
 import cryptography
@@ -1299,14 +1302,23 @@ class SSHConnectionManager(object):
         password,
         look_for_keys=False,
         private_key_file_path="",
+        private_key_password=None,
         outage_timeout=600,
     ):
         self.ip_address = ip_address
         self.username = username
         self.password = password
         self.look_for_keys = look_for_keys
-        self._private_key_file_path = private_key_file_path
-        self.pkey = self._get_ssh_key(private_key_file_path) if look_for_keys else None
+        self._private_key_file_path = private_key_file_path or ""
+        self._private_key_password = private_key_password
+        # Use pkey only when no explicit path (key_filename used for path+cert)
+        self.pkey = (
+            self._get_ssh_key(private_key_file_path)
+            if look_for_keys
+            and private_key_file_path
+            and not self._private_key_file_path
+            else None
+        )
         self.__client = paramiko.SSHClient()
         self.__client.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy())
         self.__transport = None
@@ -1317,8 +1329,21 @@ class SSHConnectionManager(object):
     def client(self):
         return self.get_client()
 
+    def get_client(self):
+        if not (self.__transport and self.__transport.is_active()):
+            self.__connect()
+            self.__transport = self.__client.get_transport()
+
+        return self.__client
+
     def _get_ssh_key(self, private_key_file_path):
         """Get SSH key based on file type"""
+        passphrase = self._private_key_password
+        if isinstance(passphrase, str) and passphrase:
+            passphrase = passphrase.encode("utf-8")
+        elif not passphrase:
+            passphrase = None
+
         private_key = None
         with open(private_key_file_path, "rb") as key_file:
             key_data = key_file.read()
@@ -1328,7 +1353,7 @@ class SSHConnectionManager(object):
             private_key = (
                 cryptography.hazmat.primitives.serialization.load_ssh_private_key(
                     key_data,
-                    password=None,
+                    password=passphrase,
                     backend=cryptography.hazmat.backends.default_backend(),
                 )
             )
@@ -1337,7 +1362,7 @@ class SSHConnectionManager(object):
             private_key = (
                 cryptography.hazmat.primitives.serialization.load_pem_private_key(
                     key_data,
-                    password=None,
+                    password=passphrase,
                     backend=cryptography.hazmat.backends.default_backend(),
                 )
             )
@@ -1346,48 +1371,125 @@ class SSHConnectionManager(object):
             private_key,
             cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey,
         ):
-            return paramiko.RSAKey.from_private_key_file(private_key_file_path)
+            return paramiko.RSAKey.from_private_key_file(
+                private_key_file_path, password=self._private_key_password
+            )
 
         elif isinstance(
             private_key,
             cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey,
         ):
-            return paramiko.Ed25519Key.from_private_key_file(private_key_file_path)
+            return paramiko.Ed25519Key.from_private_key_file(
+                private_key_file_path, password=self._private_key_password
+            )
+
+        elif isinstance(
+            private_key,
+            cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey,
+        ):
+            return paramiko.ECDSAKey.from_private_key_file(
+                private_key_file_path, password=self._private_key_password
+            )
 
         logger.error("Unsupported ssh key {}".format(private_key_file_path))
         return False
 
-    def get_client(self):
-        if not (self.__transport and self.__transport.is_active()):
-            self.__connect()
-            self.__transport = self.__client.get_transport()
-
-        return self.__client
+    def close(self):
+        """Close the SSH connection."""
+        try:
+            if self.__client:
+                self.__client.close()
+        except Exception:
+            pass
+        self.__transport = None
 
     def __connect(self):
         """Establishes a connection with the remote host using the IP Address."""
         end_time = datetime.datetime.now() + self.outage_timeout
+        last_error = None
         while end_time > datetime.datetime.now():
             try:
-                self.__client.connect(
-                    self.ip_address,
-                    username=self.username,
-                    password=self.password,
-                    look_for_keys=self.look_for_keys,
-                    allow_agent=False,
-                    pkey=self.pkey,
+                auth = (
+                    "key"
+                    if self._private_key_file_path
+                    else ("password" if self.password else "none")
                 )
+                logger.info(
+                    "SSH connect attempt to %s as %s (auth: %s, key_path: %s)",
+                    self.ip_address,
+                    self.username,
+                    auth,
+                    self._private_key_file_path or "(none)",
+                )
+                connect_kw = {
+                    "hostname": self.ip_address,
+                    "username": self.username,
+                    "password": self.password,
+                    "allow_agent": False,
+                    "look_for_keys": (
+                        False if self._private_key_file_path else self.look_for_keys
+                    ),
+                }
+                if self._private_key_file_path:
+                    # key_filename + passphrase (agent removed per user: agent did not work)
+                    connect_kw["key_filename"] = [self._private_key_file_path]
+                    connect_kw["passphrase"] = self._private_key_password
+                else:
+                    connect_kw["pkey"] = self.pkey
+                self.__client.connect(**connect_kw)
+                logger.info("SSH connected to %s as %s", self.ip_address, self.username)
                 self.__outage_start_time = None
                 return
             except Exception as e:
-                logger.warning(f"Error in connecting to {self.ip_address}: \n{e}")
+                last_error = e
+                logger.warning(
+                    "SSH connect failed to %s as %s: %s (auth: key=%s, pwd=%s)",
+                    self.ip_address,
+                    self.username,
+                    e,
+                    bool(self._private_key_file_path),
+                    bool(self.password),
+                )
                 if not self.__outage_start_time:
                     self.__outage_start_time = datetime.datetime.now()
 
                 logger.debug("Retrying connection in 10 seconds")
                 sleep(10)
 
-        raise AssertionError(f"Unable to establish a connection with {self.ip_address}")
+        hint = ""
+        err_str = str(last_error).lower() if last_error else ""
+        if "timed out" in err_str or "errno 60" in err_str:
+            hint = (
+                " (Connection timed out - check VPN, firewall, security group, "
+                "or run from a network that can reach the VM)"
+            )
+        elif (
+            "authentication" in err_str
+            or "publickey" in err_str
+            or "bad authentication type" in err_str
+        ):
+            key_hint = ""
+            if self._private_key_file_path:
+                cert_path = self._private_key_file_path + "-cert.pub"
+                if os.path.isfile(cert_path):
+                    key_hint = (
+                        f" CISO cert at {self._private_key_file_path}: Paramiko does "
+                        f"not support SSH certs; consider using system ssh or another workaround."
+                    )
+                else:
+                    key_hint = (
+                        f" Key: {self._private_key_file_path}. Ensure it matches "
+                        f"the key OneCloud has for user '{self.username}'."
+                    )
+            elif "bad authentication type" in err_str and self.password:
+                key_hint = (
+                    " Hardened images only allow publickey; use private_key_path "
+                    "with step ssh certificate."
+                )
+            hint = f" (SSH auth failed{key_hint})"
+        raise AssertionError(
+            f"Unable to establish a connection with {self.ip_address}{hint}"
+        )
 
     @property
     def transport(self):
@@ -1446,8 +1548,18 @@ class CephNode(object):
         self.username = kw["username"]
         self.password = kw["password"]
         self.root_passwd = kw["root_password"]
+        self.root_username = kw.get("root_username") or "root"
         self.look_for_key = kw["look_for_key"]
-        self.private_key_path = kw["private_key_path"]
+        self.private_key_password = kw.get("private_key_password")
+        _key_path = kw.get("private_key_path") or ""
+        self.private_key_path = (
+            os.path.expanduser(str(_key_path).strip()) if _key_path else ""
+        )
+        _boot_key = kw.get("bootstrap_key_path") or ""
+        self.bootstrap_key_path = (
+            os.path.expanduser(str(_boot_key).strip()) if _boot_key else ""
+        )
+        self.bootstrap_key_password = kw.get("bootstrap_key_password") or ""
         self.root_login = kw["root_login"]
         self.private_ip = kw["private_ip"]
 
@@ -1506,10 +1618,11 @@ class CephNode(object):
 
         self.root_connection = SSHConnectionManager(
             self.ip_address,
-            "root",
+            self.root_username,
             self.root_passwd,
             look_for_keys=self.look_for_key,
             private_key_file_path=self.private_key_path,
+            private_key_password=self.private_key_password,
         )
         self.connection = SSHConnectionManager(
             self.ip_address,
@@ -1517,6 +1630,7 @@ class CephNode(object):
             self.password,
             look_for_keys=self.look_for_key,
             private_key_file_path=self.private_key_path,
+            private_key_password=self.private_key_password,
         )
         self.rssh = self.root_connection.get_client
         self.rssh_transport = self.root_connection.get_transport
@@ -1582,23 +1696,212 @@ class CephNode(object):
             )
         )
 
-        self.rssh().exec_command("dmesg")
-        self.rssh_transport().set_keepalive(15)
-        _, stdout, stderr = self.rssh().exec_command(
-            f"echo '{self.username}:{self.password}' | chpasswd"
+        _is_onecloud_bootstrap = (
+            hasattr(self, "vm_node")
+            and getattr(self.vm_node, "node_type", None) == "onecloud"
+            and getattr(self, "bootstrap_key_path", "")
+            and self.private_key_path
         )
-        logger.info(stdout.readlines())
-        _, stdout, stderr = self.rssh().exec_command(
-            f"echo 'root:{self.root_passwd}' | chpasswd"
-        )
-        logger.info(stdout.readlines())
+
+        if _is_onecloud_bootstrap:
+            pass  # skip initial Paramiko connect; subprocess handles it below
+        else:
+            self.rssh().exec_command("dmesg")
+            self.rssh_transport().set_keepalive(15)
+
+        # OneCloud: bootstrap via system SSH (OpenSSH supports CISO certificates,
+        # Paramiko does not). Inject regular key into root+cephuser, then reconnect
+        # with Paramiko using the regular key.
+        if _is_onecloud_bootstrap:
+            boot_key = self.bootstrap_key_path
+            key_path = self.private_key_path
+            ssh_user = self.root_username
+
+            key_line = None
+            for path in (key_path + ".pub", key_path + "-cert.pub"):
+                if not path or not os.path.isfile(path):
+                    continue
+                try:
+                    with open(path, "r") as f:
+                        key_line = f.read().strip()
+                    if key_line:
+                        logger.info("OneCloud: using %s for authorized_keys", path)
+                        break
+                except Exception as e:
+                    logger.debug("OneCloud: could not read %s: %s", path, e)
+            if not key_line:
+                raise AssertionError(f"OneCloud: need pub key at {key_path}.pub")
+
+            logger.info(
+                "OneCloud: bootstrap via system SSH on %s as %s",
+                self.ip_address,
+                ssh_user,
+            )
+            ssh_base = [
+                "ssh",
+                "-i",
+                boot_key,
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "LogLevel=ERROR",
+                f"{ssh_user}@{self.ip_address}",
+            ]
+            key_b64 = base64.b64encode(key_line.encode()).decode()
+            setup_cmds = [
+                (
+                    "id cephuser >/dev/null 2>&1 || (sudo groupadd -f cephuser && "
+                    "sudo useradd -m -s /bin/bash -g cephuser cephuser)"
+                ),
+                "echo 'cephuser ALL=(ALL) NOPASSWD:ALL' "
+                "| sudo tee /etc/sudoers.d/cephuser",
+                "sudo chmod 440 /etc/sudoers.d/cephuser",
+                "sudo mkdir -p /home/cephuser/.ssh && "
+                "sudo chmod 700 /home/cephuser/.ssh",
+                f"echo '{key_b64}' | base64 -d "
+                "| sudo tee -a /home/cephuser/.ssh/authorized_keys",
+                "sudo chmod 600 /home/cephuser/.ssh/authorized_keys",
+                "sudo chown -R cephuser:cephuser /home/cephuser/.ssh",
+                "sudo mkdir -p /root/.ssh && sudo chmod 700 /root/.ssh",
+                f"echo '{key_b64}' | base64 -d "
+                "| sudo tee -a /root/.ssh/authorized_keys",
+                "sudo chmod 600 /root/.ssh/authorized_keys",
+                "sudo sed -i 's/^.*PermitRootLogin.*/PermitRootLogin prohibit-password/' "
+                "/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf "
+                "2>/dev/null || true",
+                "sudo sed -i 's/^.*PermitRootLogin.*/PermitRootLogin prohibit-password/' "
+                "/etc/ssh/sshd_config 2>/dev/null || true",
+                "sudo systemctl restart sshd 2>/dev/null || "
+                "sudo systemctl restart ssh 2>/dev/null || true",
+                "sudo touch /ceph-qa-ready",
+            ]
+            ssh_env = None
+            askpass_file = None
+            boot_pwd = getattr(self, "bootstrap_key_password", "")
+            if boot_pwd:
+                import tempfile
+
+                askpass_file = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".sh", delete=False
+                )
+                askpass_file.write(f"#!/bin/sh\necho '{boot_pwd}'\n")
+                askpass_file.close()
+                os.chmod(askpass_file.name, 0o700)
+                ssh_env = os.environ.copy()
+                ssh_env["SSH_ASKPASS"] = askpass_file.name
+                ssh_env["SSH_ASKPASS_REQUIRE"] = "force"
+                ssh_env["DISPLAY"] = ":"
+
+            try:
+                for cmd in setup_cmds:
+                    result = subprocess.run(
+                        ssh_base + [cmd],
+                        capture_output=True,
+                        text=True,
+                        timeout=60,
+                        env=ssh_env,
+                    )
+                    logger.info(
+                        "OneCloud setup: cmd=%s exit=%s out=%r err=%r",
+                        cmd[:60],
+                        result.returncode,
+                        result.stdout[:200],
+                        result.stderr[:200],
+                    )
+                    if result.returncode != 0 and "chpasswd" in cmd:
+                        raise AssertionError(
+                            f"OneCloud setup failed on {self.ip_address}: "
+                            f"chpasswd exit={result.returncode} "
+                            f"err={result.stderr[:200]!r}"
+                        )
+            finally:
+                if askpass_file:
+                    try:
+                        os.unlink(askpass_file.name)
+                    except OSError:
+                        pass
+
+            logger.info(
+                "OneCloud: switching to Paramiko (root+cephuser) for %s",
+                self.ip_address,
+            )
+            self.root_connection.close()
+            self.connection.close()
+            self.root_username = "root"
+            self.root_passwd = ""
+            self.username = "cephuser"
+            self.password = ""
+            self.look_for_key = True
+            _key_pw = getattr(self, "private_key_password", None)
+            root_mgr = SSHConnectionManager(
+                self.ip_address,
+                "root",
+                "",
+                look_for_keys=True,
+                private_key_file_path=key_path,
+                private_key_password=_key_pw,
+            )
+            cephuser_mgr = SSHConnectionManager(
+                self.ip_address,
+                "cephuser",
+                "",
+                look_for_keys=True,
+                private_key_file_path=key_path,
+                private_key_password=_key_pw,
+            )
+            self.root_connection = root_mgr
+            self.connection = cephuser_mgr
+            self.rssh = root_mgr.get_client
+            self.rssh_transport = root_mgr.get_transport
+            self.ssh = cephuser_mgr.get_client
+            self.ssh_transport = cephuser_mgr.get_transport
+            for attempt in range(5):
+                try:
+                    self.rssh().exec_command("whoami")
+                    self.ssh().exec_command("whoami")
+                    logger.info(
+                        "OneCloud: root (rssh) + cephuser (ssh) ready for %s",
+                        self.ip_address,
+                    )
+                    break
+                except Exception as e:
+                    if attempt < 4:
+                        logger.warning(
+                            "OneCloud: connect attempt %s failed: %s, retrying in 3s",
+                            attempt + 1,
+                            e,
+                        )
+                        sleep(3)
+                    else:
+                        raise
+
+        sudo_prefix = "sudo " if self.username != "root" else ""
+        if self.password:
+            _, stdout, stderr = self.rssh().exec_command(
+                f"echo '{self.username}:{self.password}' | {sudo_prefix}chpasswd"
+            )
+            logger.info(stdout.readlines())
+        if self.root_passwd:
+            _, stdout, stderr = self.rssh().exec_command(
+                f"echo 'root:{self.root_passwd}' | {sudo_prefix}chpasswd"
+            )
+            logger.info(stdout.readlines())
         # TCP keepalive (applies to both IPv4 and IPv6 on Linux)
-        self.rssh().exec_command("echo 120 > /proc/sys/net/ipv4/tcp_keepalive_time")
-        self.rssh().exec_command("echo 60 > /proc/sys/net/ipv4/tcp_keepalive_intvl")
-        self.rssh().exec_command("echo 20 > /proc/sys/net/ipv4/tcp_keepalive_probes")
+        self.rssh().exec_command(
+            f"echo 120 | {sudo_prefix}tee /proc/sys/net/ipv4/tcp_keepalive_time"
+        )
+        self.rssh().exec_command(
+            f"echo 60 | {sudo_prefix}tee /proc/sys/net/ipv4/tcp_keepalive_intvl"
+        )
+        self.rssh().exec_command(
+            f"echo 20 | {sudo_prefix}tee /proc/sys/net/ipv4/tcp_keepalive_probes"
+        )
         self.exec_command(cmd="ls / ; uptime ; date")
         self.ssh_transport().set_keepalive(15)
-        if self.vm_node.node_type == "baremetal":
+        vm_node = getattr(self, "vm_node", None)
+        if vm_node and getattr(vm_node, "node_type", None) == "baremetal":
             out, err = self.exec_command(cmd="hostname -s")
         else:
             out, err = self.exec_command(cmd="hostname")
@@ -1610,7 +1913,10 @@ class CephNode(object):
             "hostname and shortname set to %s and %s", self.hostname, self.shortname
         )
         self.set_internal_ip()
-        self.exec_command(cmd="echo 'TMOUT=600' >> ~/.bashrc")
+        self.exec_command(
+            cmd="grep -q 'TMOUT' ~/.bashrc || echo '[[ -z \"${TMOUT+x}\" ]] && export TMOUT=600' >> ~/.bashrc",
+            check_ec=False,
+        )
         self.exec_command(cmd="[ -f /etc/redhat-release ]", check_ec=False)
 
         if self.exit_status == 0:
@@ -1857,12 +2163,14 @@ class CephNode(object):
 
     def __setstate__(self, pickle_dict):
         self.__dict__.update(pickle_dict)
+        key_pw = getattr(self, "private_key_password", None)
         self.root_connection = SSHConnectionManager(
             self.ip_address,
             "root",
             self.root_passwd,
             look_for_keys=self.look_for_key,
             private_key_file_path=self.private_key_path,
+            private_key_password=key_pw,
         )
         self.connection = SSHConnectionManager(
             self.ip_address,
@@ -1870,6 +2178,7 @@ class CephNode(object):
             self.password,
             look_for_keys=self.look_for_key,
             private_key_file_path=self.private_key_path,
+            private_key_password=key_pw,
         )
         self.rssh = self.root_connection.get_client
         self.ssh = self.connection.get_client

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -19,6 +19,18 @@ from libcloud.compute.types import Provider
 from cli.utilities.configure import add_centos_epel_repo
 from compute.baremetal import CephBaremetalNode
 from compute.ibm_vpc import CephVMNodeIBM, get_ibm_service
+from compute.onecloud import (
+    CephVMNodeOneCloud,
+    generate_onecloud_node_name,
+    get_onecloud_client,
+    get_vlan_for_site,
+    get_vm_ip,
+    get_vm_name,
+    parse_vm_list_from_response,
+    process_onecloud_custom_config,
+    resolve_image_for_site,
+    resolve_project_for_site,
+)
 from compute.openstack import CephVMNodeV2, NetworkOpFailure, NodeError, VolumeOpFailure
 from utility.log import Log
 from utility.retry import retry
@@ -361,6 +373,337 @@ def setup_vm_node_ibm(node, ceph_nodes, **params):
     except BaseException as be:  # noqa
         log.error(be, exc_info=True)
         raise
+
+
+def create_onecloud_ceph_nodes(
+    cluster_conf,
+    inventory,
+    onecloud_creds,
+    run_id,
+    instances_name=None,
+    custom_config=None,
+    platform=None,
+):
+    """
+    Create OneCloud cluster (group of VMs) via POST /clusters.
+
+    Args:
+        cluster_conf: Configuration of cluster.
+        inventory: Instance configuration file.
+        onecloud_creds: Global config with globals["onecloud-credentials"].
+        run_id: Unique id for the run.
+        instances_name: Optional name prefix.
+        custom_config: CLI options (e.g. onecloud_site=POK).
+        platform: RHEL platform (e.g. rhel-9, rhel-10) for image selection; filters
+            images by OS version when set.
+    """
+    from compute.onecloud import VM_POLL_INTERVAL, VM_POLL_TIMEOUT, VM_READY_STATES
+
+    log.info("Creating OneCloud instances")
+    glbs = onecloud_creds.get("globals") or {}
+    cred = glbs.get("onecloud-credentials")
+    if not cred:
+        raise NodeError("Missing 'onecloud-credentials' in globals")
+
+    api_key = cred.get("api_key")
+    base_url = cred.get("base_url")
+    verify_ssl = cred.get("verify_ssl", False)
+    if not api_key:
+        raise NodeError("Missing 'api_key' in onecloud-credentials")
+    if not base_url:
+        raise NodeError(
+            "Missing 'base_url' in onecloud-credentials. "
+            "Set it in osp-cred or cephci.yaml."
+        )
+
+    platform_conf = process_onecloud_custom_config(custom_config)
+    ceph_cluster = cluster_conf.get("ceph-cluster")
+    if not ceph_cluster:
+        raise NodeError("OneCloud: invalid cluster config - missing ceph-cluster")
+
+    inventory = inventory or {}
+    if ceph_cluster.get("inventory"):
+        inventory_path = os.path.abspath(ceph_cluster.get("inventory"))
+        with open(inventory_path, "r") as fh:
+            inventory = yaml.safe_load(fh) or {}
+
+    inv_create = inventory.get("instance", {}).get("create") or {}
+    # Priority: cred (osp-cred) > inventory > platform (optional conf/onecloud/X.yaml)
+    preferred_project_id = (
+        cred.get("project_id")
+        or inv_create.get("projectID")
+        or inv_create.get("project_id")
+        or platform_conf.get("project_id")
+    )
+    try:
+        preferred_project_id = (
+            int(preferred_project_id) if preferred_project_id is not None else None
+        )
+    except (TypeError, ValueError):
+        preferred_project_id = None
+
+    site = (
+        cred.get("site") or inv_create.get("site") or platform_conf.get("site") or "POK"
+    )
+    group_id = (
+        cred.get("group_id")
+        or inv_create.get("groupID")
+        or platform_conf.get("group_id")
+        or 1
+    )
+    vlan = (
+        cred.get("default_vlan")
+        or inv_create.get("VLAN")
+        or platform_conf.get("vlan")
+        or 2231
+    )
+    preferred_image_id = (
+        cred.get("default_image_id")
+        or inv_create.get("imageID")
+        or inv_create.get("image_id")
+        or platform_conf.get("image_id")
+    )
+    try:
+        preferred_image_id = (
+            int(preferred_image_id) if preferred_image_id is not None else None
+        )
+    except (TypeError, ValueError):
+        preferred_image_id = None
+
+    resources = (
+        cred.get("default_resources")
+        or inv_create.get("resources")
+        or platform_conf.get("resources")
+        or "small"
+    )
+    arch = (
+        cred.get("default_arch") or inv_create.get("arch") or platform_conf.get("arch")
+    )
+    # Default to x86_64 for RHEL platforms when not specified
+    if not arch and platform and str(platform).lower().startswith("rhel"):
+        arch = "x86_64"
+    cluster_name = ceph_cluster.get("name", "ceph")
+    try:
+        _inst_name = instances_name or os.getlogin()
+    except OSError:
+        _inst_name = instances_name or "cephci"
+
+    # Build virtualMachines array from cluster nodes
+    virtual_machines = []
+    node_specs = {}  # vmname -> (node_key, node_dict, role, id, ...)
+
+    for i in range(1, 100):
+        node_key = "node" + str(i)
+        if not ceph_cluster.get(node_key):
+            break
+
+        node_dict = ceph_cluster.get(node_key)
+        role = RolesContainer(node_dict.get("role") or ["pool"])
+        # OneCloud API: VM names must be 1-25 chars, alphanumeric + hyphens only
+        node_name = generate_onecloud_node_name(run_id, node_key, role)
+        virtual_machines.append(
+            {
+                "vmname": node_name,
+                "vmnotes": f"CephCI node {node_key}",
+            }
+        )
+        # OneCloud does not support custom disk provisioning; ignore no-of-volumes/disk-size
+        node_specs[node_name] = {
+            "node_key": node_key,
+            "node_dict": node_dict,
+            "role": role,
+            "id": node_dict.get("id") or node_key,
+            "location": node_dict.get("location"),
+            "root_login": node_dict.get("root-login", True),
+            "no_of_volumes": 0,
+            "disk_size": 0,
+        }
+
+    if not virtual_machines:
+        raise NodeError("OneCloud: no nodes in cluster config")
+
+    client = get_onecloud_client(api_key, base_url, verify_ssl=verify_ssl)
+    vlan = get_vlan_for_site(client, site, vlan)
+    os_hint = inv_create.get("os") or platform_conf.get("os") or "RedHat"
+    # Prefer images matching inventory version_id (e.g. 9.7) when specified
+    version_preference = inventory.get("version_id")
+    if version_preference is not None:
+        version_preference = str(version_preference).strip() or None
+    excluded_images = []
+    resp = None
+    for _ in range(5):  # Max 5 image attempts
+        image_id = resolve_image_for_site(
+            client,
+            site,
+            preferred_image_id,
+            arch=arch,
+            os_hint=os_hint,
+            exclude_image_ids=excluded_images or None,
+            platform_filter=platform,
+            version_preference=version_preference,
+        )
+        project_id = resolve_project_for_site(client, site, preferred_project_id)
+
+        body = {
+            "name": f"{cluster_name}-{_inst_name}-{run_id}"[:64],
+            "virtualMachines": virtual_machines,
+            "imageID": int(image_id),
+            "resources": resources,
+            "projectID": int(project_id),
+            "site": site,
+            "groupID": int(group_id),
+        }
+        # VLAN is optional—when portal uses "Default" network, omitting VLAN may use it
+        if vlan is not None:
+            body["VLAN"] = int(vlan)
+        # OneCloud API only accepts arch for s390x/ppc64le; omit for x86_64 (default)
+        if arch and arch.lower() in ("s390x", "ppc64le"):
+            body["arch"] = arch
+
+        log.info("Deploying OneCloud cluster with %d VMs", len(virtual_machines))
+        resp = client.post("/clusters", json=body)
+        if resp.status_code in (200, 201):
+            break
+        err_text = resp.text.lower()
+        is_image_site_error = (
+            resp.status_code == 400
+            and "image" in err_text
+            and ("not available" in err_text or "given site" in err_text)
+        )
+        if is_image_site_error and image_id not in excluded_images:
+            excluded_images.append(image_id)
+            log.warning(
+                "OneCloud: image_id %s rejected at site %s, trying another image",
+                image_id,
+                site,
+            )
+            continue
+        log.error(
+            "OneCloud deploy failed. Request body: %s. Response: %s",
+            body,
+            resp.text[:1000],
+        )
+        raise NodeError(
+            f"OneCloud deploy failed: {resp.status_code} {resp.text[:500]}. "
+            "Verify image_id, project_id, site, groupID, VLAN in osp-cred or inventory."
+        )
+
+    if resp is None or resp.status_code not in (200, 201):
+        raise NodeError(
+            "OneCloud deploy failed: no image available at site. "
+            "Try a different site or set image_id in osp-cred/inventory."
+        )
+
+    result = resp.json()
+    if isinstance(result, dict):
+        cluster_id = result.get("clusterid") or (result.get("data") or {}).get(
+            "clusterID"
+        )
+    else:
+        cluster_id = result
+    if cluster_id is None:
+        raise NodeError("OneCloud deploy: no clusterid in response")
+
+    # Poll for VMs to be ready (immediate first poll, then sleep between polls)
+    start = time.time()
+    vms_by_name = {}
+    first_poll = True
+    tried_cluster_id_param = False
+    logged_empty_structure = False
+    while time.time() - start < VM_POLL_TIMEOUT:
+        if not first_poll:
+            sleep(VM_POLL_INTERVAL)
+        first_poll = False
+
+        # Try clusterid first; some APIs expect clusterID (camelCase)
+        vm_resp = client.get(f"/vm?clusterid={cluster_id}")
+        if not tried_cluster_id_param:
+            tried_cluster_id_param = True
+            needs_retry = vm_resp.status_code != 200 or not parse_vm_list_from_response(
+                vm_resp.json()
+            )
+            if needs_retry:
+                vm_resp = client.get(f"/vm?clusterID={cluster_id}")
+        if vm_resp.status_code != 200:
+            log.warning("OneCloud: failed to list VMs: %s", vm_resp.status_code)
+            continue
+
+        vm_data = vm_resp.json()
+        vms = parse_vm_list_from_response(vm_data)
+        vms_by_name = {}
+        for v in vms:
+            name = get_vm_name(v)
+            if name:
+                vms_by_name[name] = v
+
+        # Debug: response structure not recognized (log once)
+        if not vms and isinstance(vm_data, dict) and not logged_empty_structure:
+            logged_empty_structure = True
+            log.info(
+                "OneCloud: GET /vm response top-level keys: %s",
+                list(vm_data.keys())[:15],
+            )
+        # Debug: API returned VMs but none had recognizable names
+        if vms and not vms_by_name:
+            sample = vms[0]
+            keys = list(sample.keys()) if isinstance(sample, dict) else []
+            log.warning(
+                "OneCloud: GET /vm returned %d VM(s) but no vmname/vmName found. "
+                "First VM keys: %s",
+                len(vms),
+                keys[:20],
+            )
+        ready_count = sum(
+            1
+            for v in vms_by_name.values()
+            if (v.get("state") or "").lower() in VM_READY_STATES and get_vm_ip(v)
+        )
+        if ready_count >= len(virtual_machines) and len(vms_by_name) >= len(
+            virtual_machines
+        ):
+            break
+        log.info(
+            "OneCloud: waiting for VMs (%d/%d ready, %d/%d found)",
+            ready_count,
+            len(virtual_machines),
+            len(vms_by_name),
+            len(virtual_machines),
+        )
+
+    if time.time() - start >= VM_POLL_TIMEOUT and len(vms_by_name) < len(
+        virtual_machines
+    ):
+        raise NodeError(
+            f"OneCloud: VMs not ready within {VM_POLL_TIMEOUT}s "
+            f"({len(vms_by_name)}/{len(virtual_machines)} found)"
+        )
+
+    ceph_nodes = {}
+    for vmname, spec in node_specs.items():
+        vm_data = vms_by_name.get(vmname)
+        if not vm_data:
+            log.warning("OneCloud: VM %s not found in cluster response", vmname)
+            continue
+
+        vm = CephVMNodeOneCloud(
+            node=vm_data,
+            api_key=api_key,
+            base_url=base_url,
+            verify_ssl=verify_ssl,
+        )
+        vm.role = spec["role"]
+        vm.root_login = spec["root_login"]
+        vm.id = spec["id"]
+        vm.location = spec["location"]
+        ceph_nodes[spec["node_key"]] = vm
+
+    if len(ceph_nodes) != len(node_specs):
+        raise NodeError(
+            f"OneCloud: mismatch - expected {len(node_specs)} nodes, got {len(ceph_nodes)}"
+        )
+
+    log.info("Done creating OneCloud nodes")
+    return ceph_nodes
 
 
 def create_ceph_nodes(

--- a/cephci/provision.py
+++ b/cephci/provision.py
@@ -38,7 +38,7 @@ Utility to provision cluster on cloud
 
     Options:
         -h --help               Help
-        --cloud-type <CLOUD>    Cloud type [openstack|ibmc|baremetal]
+        --cloud-type <CLOUD>    Cloud type [openstack|ibmc|baremetal|onecloud]
         --global-conf <YAML>    Global config file with node details
         --platform <STR>        Node OS Type & Version
         --prefix <STR>          Resource name prefix
@@ -169,6 +169,14 @@ if __name__ == "__main__":
 
     # Read configuration for cloud
     get_configs(config)
+
+    # OneCloud uses run.py with --cloud onecloud, not this provision CLI
+    if cloud == "onecloud":
+        raise ConfigError(
+            "OneCloud is not supported by provision.py. "
+            "Use run.py with --cloud onecloud for cluster creation. "
+            "Credentials must be in ~/osp-cred-ci-2.yaml (globals.onecloud-credentials)."
+        )
 
     # Check for mandatory OSP paramters
     if cloud == "openstack":

--- a/cephci/utils/configs.py
+++ b/cephci/utils/configs.py
@@ -124,6 +124,24 @@ def get_cloud_credentials(cloud):
 
             msg += _authurl
 
+        # Get onecloud configs
+        elif cloud == "onecloud":
+            _dict["api_key"] = _server["api_key"]
+            _dict["base_url"] = _server["base_url"]
+            _dict["site"] = _server.get("site", "POK")
+            _dict["project_id"] = _server.get("project_id")
+            _dict["group_id"] = _server.get("group_id", 1)
+            _dict["default_vlan"] = _server.get("default_vlan", 2231)
+            _dict["default_image_id"] = _server.get("default_image_id")
+            _dict["default_resources"] = _server.get("default_resources", "small")
+            _dict["default_arch"] = _server.get("default_arch", "x86_64")
+            _dict["private_key_path"] = _server.get("private_key_path")
+            _dict["bootstrap_key_path"] = _server.get("bootstrap_key_path")
+            _dict["bootstrap_key_password"] = _server.get("bootstrap_key_password", "")
+            _dict["ssh_user"] = _server.get("ssh_user", "onecloud-user")
+
+            msg += _dict.get("base_url", "onecloud")
+
         # Set common configs
         _dict["username"] = _server.get("username")
         _dict["password"] = _server.get("password")

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -208,7 +208,7 @@ def get_custom_repo_url(base_url, cloud_type="openstack"):
     """Add the given custom repo on every node part of the cluster.
 
     Args:
-        cloud_type (str): cloudtype (openstack|ibmc)
+        cloud_type (str): cloudtype (openstack|ibmc|aws|onecloud)
         base_url (str): base URL of repository
     """
     if base_url.endswith(".repo"):

--- a/compute/onecloud.py
+++ b/compute/onecloud.py
@@ -1,0 +1,1277 @@
+"""OneCloud provider implementation for CephVMNode."""
+
+import ipaddress
+import os
+import re
+import time
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+import yaml
+
+from utility.log import Log
+
+from .exceptions import NodeDeleteFailure, NodeError
+
+LOG = Log(__name__)
+
+VM_READY_STATES = ("on", "running")
+VM_POLL_INTERVAL = 30
+VM_POLL_TIMEOUT = 1800  # 30 minutes
+CLEANUP_VERIFY_INTERVAL = 5
+CLEANUP_VERIFY_TIMEOUT = 900  # 15 minutes max to wait for deletion to complete
+
+# VM name fields the API may return (OpenAPI uses vmname; some implementations use camelCase)
+VM_NAME_KEYS = ("vmname", "vmName", "VMName", "name")
+
+# Map inventory OS names to OneCloud API expected values (GET /vm/images?os=)
+# API accepts: AIX, CentOS, RedHat, SuSE, Ubuntu, Windows
+OS_HINT_TO_API = {
+    "rhel": "RedHat",
+    "centos": "CentOS",
+    "windows": "Windows",
+    "ubuntu": "Ubuntu",
+    "sles": "SuSE",
+    "suse": "SuSE",
+    "aix": "AIX",
+}
+
+
+def parse_vm_list_from_response(vm_data: Any) -> List[Dict]:
+    """
+    Extract VM list from GET /vm or similar response.
+    Handles multiple response shapes: data, data.virtualMachines, virtualMachines, or direct array.
+    """
+    if vm_data is None:
+        return []
+    if isinstance(vm_data, list):
+        return [v for v in vm_data if isinstance(v, dict)]
+    if not isinstance(vm_data, dict):
+        return []
+    # Try common wrapper keys
+    for key in ("data", "virtualMachines", "vms"):
+        val = vm_data.get(key)
+        if isinstance(val, list):
+            return [v for v in val if isinstance(v, dict)]
+        if isinstance(val, dict) and "virtualMachines" in val:
+            lst = val.get("virtualMachines")
+            if isinstance(lst, list):
+                return [v for v in lst if isinstance(v, dict)]
+    return []
+
+
+def get_vm_name(vm: Dict) -> Optional[str]:
+    """Get VM name from various API field names. Returns None if not found."""
+    if not isinstance(vm, dict):
+        return None
+    for key in VM_NAME_KEYS:
+        name = vm.get(key)
+        if name and isinstance(name, str):
+            return name.strip() or None
+    net = vm.get("network")
+    if isinstance(net, dict):
+        for key in ("hostname", "fqdn"):
+            val = net.get(key)
+            if val and isinstance(val, str):
+                return val.split(".")[0].strip() or None
+    return None
+
+
+def get_vm_ip(vm: Dict) -> Optional[str]:
+    """Get VM IP from various API field names. Returns None if not found."""
+    if not isinstance(vm, dict):
+        return None
+    net = vm.get("network") or {}
+    for key in ("ipaddr", "ipAddr", "ip_address", "public_ip", "floating_ip"):
+        val = net.get(key) or vm.get(key)
+        if val and isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def get_onecloud_client(
+    api_key: str,
+    base_url: str,
+    verify_ssl: bool = False,
+):
+    """
+    Return a simple requests-based client for OneCloud API.
+
+    Args:
+        api_key: JWT Bearer token for authentication.
+        base_url: API base URL from credentials (global_credentials / osp-cred).
+        verify_ssl: If False (default), disable SSL verification.
+
+    Returns:
+        Object with get/post/put/delete methods that add auth headers.
+    """
+    if not base_url:
+        raise NodeError(
+            "OneCloud: 'base_url' is required in credentials. "
+            "Set it in osp-cred (onecloud-credentials) or cephci.yaml."
+        )
+    base = base_url.rstrip("/")
+
+    def _request(method: str, path: str, **kwargs) -> requests.Response:
+        url = f"{base}{path}" if path.startswith("/") else f"{base}/{path}"
+        headers = kwargs.pop("headers", {})
+        headers.setdefault("Accept", "application/json")
+        headers.setdefault("Content-Type", "application/json")
+        headers.setdefault("Authorization", f"Bearer {api_key}")
+        kwargs.setdefault("verify", verify_ssl)
+        return requests.request(method, url, headers=headers, timeout=120, **kwargs)
+
+    class Client:
+        def get(self, path: str, **kwargs) -> requests.Response:
+            return _request("GET", path, **kwargs)
+
+        def post(self, path: str, **kwargs) -> requests.Response:
+            return _request("POST", path, **kwargs)
+
+        def put(self, path: str, **kwargs) -> requests.Response:
+            return _request("PUT", path, **kwargs)
+
+        def delete(self, path: str, **kwargs) -> requests.Response:
+            return _request("DELETE", path, **kwargs)
+
+    return Client()
+
+
+def process_onecloud_custom_config(custom_config: Optional[List[str]] = None) -> Dict:
+    """
+    Process custom config for OneCloud target site/project.
+
+    Users can provide overrides via --custom-config onecloud_site=POK, etc.
+
+    Args:
+        custom_config: List of key=value (e.g. onecloud_site=POK).
+
+    Returns:
+        Dict with site, project_id, group_id, vlan, image_id, resources, arch.
+    """
+    repo_dir = Path(__file__).resolve().parent.parent
+    overrides = {}
+
+    if custom_config:
+        overrides = dict(
+            item.split("=", 1)
+            for item in custom_config
+            if "=" in item and item.split("=", 1)[0].startswith("onecloud")
+        )
+
+    # Platform config: use inventory/cred/--custom-config only (no default.yaml).
+    # Optional: --custom-config onecloud_platform=X loads conf/onecloud/X.yaml if it exists.
+    platform_name = overrides.get("onecloud_platform", "default")
+    platform_dict = {}
+    if platform_name != "default":
+        platform_conf = repo_dir.joinpath(f"conf/onecloud/{platform_name}.yaml")
+        if platform_conf.exists():
+            with platform_conf.open() as fh:
+                platform_dict = yaml.safe_load(fh) or {}
+
+    # Override with custom_config (validate int values to avoid crashes)
+    def _parse_int(key: str, override_key: str) -> None:
+        try:
+            platform_dict[key] = int(overrides[override_key])
+        except (ValueError, TypeError):
+            raise NodeError(f"OneCloud: {override_key} must be a valid integer")
+
+    if "onecloud_site" in overrides:
+        platform_dict["site"] = overrides["onecloud_site"]
+    if "onecloud_project_id" in overrides:
+        _parse_int("project_id", "onecloud_project_id")
+    if "onecloud_group_id" in overrides:
+        _parse_int("group_id", "onecloud_group_id")
+    if "onecloud_vlan" in overrides:
+        _parse_int("vlan", "onecloud_vlan")
+    if "onecloud_image_id" in overrides:
+        _parse_int("image_id", "onecloud_image_id")
+    if "onecloud_resources" in overrides:
+        platform_dict["resources"] = overrides["onecloud_resources"]
+
+    return platform_dict
+
+
+def expand_private_key_path(path: Optional[str]) -> str:
+    """Expand ~ in path; return empty string if path is empty or invalid."""
+    if not path or not str(path).strip():
+        return ""
+    return os.path.expanduser(str(path).strip())
+
+
+def generate_onecloud_node_name(
+    run_id: str, node_key: str, role: Any, max_length: int = 25
+) -> str:
+    """
+    Return VM name for OneCloud API (max 25 chars, alphanumeric + hyphens only).
+
+    Args:
+        run_id: Unique run ID (e.g. 20DBDH).
+        node_key: Node key (e.g. node1, node2).
+        role: RolesContainer with node roles (unused, kept for API compatibility).
+        max_length: Max VM name length (OneCloud default 25).
+
+    Returns:
+        Name like ci-20DBDH-node1, ci-20DBDH-node2.
+    """
+    node_num = "".join(c for c in node_key if c.isdigit()) or "0"
+    name = f"ci-{run_id}-node{node_num}"
+    if len(name) > max_length:
+        name = name[:max_length]
+    return name
+
+
+def _parse_images_response(data: Any) -> List[Dict]:
+    """Extract image list from GET /vm/images response."""
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return [i for i in data if isinstance(i, dict)]
+    if not isinstance(data, dict):
+        return []
+    for key in ("data", "images"):
+        val = data.get(key)
+        if isinstance(val, list):
+            return [i for i in val if isinstance(i, dict)]
+        if isinstance(val, dict) and "images" in val:
+            lst = val.get("images")
+            if isinstance(lst, list):
+                return [i for i in lst if isinstance(i, dict)]
+    return []
+
+
+def _image_display_name(img: Dict) -> str:
+    """Return display name / os_release / name for an image dict."""
+    return str(
+        img.get("display_name") or img.get("os_release") or img.get("name") or ""
+    )
+
+
+def _image_id(img: Dict) -> Optional[int]:
+    """Extract image ID from image dict."""
+    v = img.get("imageid") or img.get("id") or img.get("template_id")
+    try:
+        return int(v) if v is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _image_matches_site(img: Dict, site: str) -> bool:
+    """Return True if image is available at the given site."""
+    site_upper = (site or "").strip().upper()
+    if not site_upper:
+        return True
+    for key in ("site", "site_id", "sites", "site_ids", "site_name"):
+        val = img.get(key)
+        if val is None:
+            continue
+        if isinstance(val, str):
+            if val.strip().upper() == site_upper:
+                return True
+        elif isinstance(val, (int, float)):
+            # site_id might be numeric; we can't map without sites API
+            return True  # Assume match if present
+        elif isinstance(val, list):
+            if any(
+                (str(v).strip().upper() == site_upper if isinstance(v, str) else True)
+                for v in val
+            ):
+                return True
+    return False
+
+
+def _image_is_windows(img: Dict) -> bool:
+    """Return True if image appears to be Windows (exclude - RHEL/Ceph requires Linux)."""
+    name = _image_display_name(img).lower()
+    os_type = str(
+        img.get("os") or img.get("os_type") or img.get("operating_system") or ""
+    ).lower()
+    for term in ("windows", "microsoft"):
+        if term in name or term in os_type:
+            return True
+    return False
+
+
+def _image_matches_arch(img: Dict, arch: str) -> bool:
+    """Return True if image matches the requested architecture (e.g. x86_64)."""
+    if not arch:
+        return True
+    arch_lower = arch.strip().lower()
+    img_arch = (
+        str(img.get("arch") or img.get("architecture") or img.get("arch_id") or "")
+    ).lower()
+    if img_arch and arch_lower in img_arch:
+        return True
+    # x86_64 aliases
+    if arch_lower in ("x86_64", "amd64", "x86-64"):
+        return not img_arch or img_arch in ("x86_64", "amd64", "x86-64")
+    return not img_arch or img_arch == arch_lower
+
+
+def _image_matches_platform(img: Dict, platform_filter: str) -> bool:
+    """Return True if image name/os_release matches the platform (e.g. rhel-9, rhel-10)."""
+    if not platform_filter or not isinstance(platform_filter, str):
+        return True
+    pf = platform_filter.strip().lower()
+    if not pf.startswith("rhel-"):
+        return True
+    # Extract major version: rhel-9 -> 9, rhel-10 -> 10
+    m = re.match(r"rhel-(\d+)(?:\.\d+)?", pf)
+    if not m:
+        return True
+    major = m.group(1)
+    # Check version_id if present (e.g. 9.7, 10.1)
+    ver = img.get("version_id") or img.get("version") or img.get("os_version")
+    if ver is not None and str(ver).strip():
+        ver_str = str(ver).strip()
+        if ver_str.startswith(major + ".") or ver_str == major:
+            return True
+    name = _image_display_name(img).lower()
+    # Match rhel-9, rhel-9.7, RHEL 9, 9.7, etc. Avoid rhel-19 matching rhel-9
+    pattern = rf"(?:^|[^0-9])rhel-{major}(?:\D|$)|rhel\s+{major}(?:\D|$)|(?:^|[^0-9]){major}\.\d+"
+    return bool(re.search(pattern, name))
+
+
+def _image_matches_version(img: Dict, version_preference: str) -> bool:
+    """Return True if image version matches the preference (e.g. 9.7, 10.1)."""
+    if not version_preference or not isinstance(version_preference, str):
+        return False
+    vp = str(version_preference).strip()
+    if not vp:
+        return False
+    ver = img.get("version_id") or img.get("version") or img.get("os_version")
+    if ver is not None and str(ver).strip() == vp:
+        return True
+    name = _image_display_name(img).lower()
+    # Match "9.7", "rhel 9.7", "rhel-9.7", etc.
+    return vp in name or f"rhel-{vp}" in name or f"rhel {vp}" in name
+
+
+def resolve_image_for_site(
+    client,
+    site: str,
+    preferred_image_id: Optional[int] = None,
+    arch: Optional[str] = None,
+    os_hint: Optional[str] = None,
+    exclude_image_ids: Optional[List[int]] = None,
+    platform_filter: Optional[str] = None,
+    version_preference: Optional[str] = None,
+) -> int:
+    """
+    Resolve an image ID that is available at the given site.
+
+    Tries GET /vm/images?site=X first; falls back to GET /vm/images and filters
+    by site if images have site info. Uses preferred_image_id if valid at site,
+    otherwise picks the first available image. When platform_filter is set
+    (e.g. rhel-9, rhel-10), only images matching that RHEL version are considered.
+    When version_preference is set (e.g. 9.7 from inventory version_id), images
+    matching that exact version are preferred over others (e.g. 9.7 over 9.4).
+
+    Args:
+        client: OneCloud API client.
+        site: Site code (e.g. TUC, POK).
+        preferred_image_id: User's preferred image; used if available at site.
+        arch: Optional arch filter (x86_64, s390x, ppc64le).
+        os_hint: Optional OS filter (RHEL/RedHat, CentOS, etc.). RHEL maps to RedHat for API.
+        exclude_image_ids: Image IDs to exclude (e.g. after deploy rejected one).
+        platform_filter: RHEL platform to match (e.g. rhel-9, rhel-10).
+        version_preference: Exact version to prefer (e.g. 9.7 from inventory version_id).
+
+    Returns:
+        Resolved image ID (int).
+
+    Raises:
+        NodeError: If no images found for the site.
+    """
+    site_upper = (site or "").strip().upper()
+    params = {}
+    if site_upper:
+        params["site"] = site_upper
+    if arch:
+        params["arch"] = arch
+    if os_hint:
+        # Map RHEL/RedHat variants to API-expected value (RedHat)
+        hint = str(os_hint).strip().lower()
+        api_os = OS_HINT_TO_API.get(hint, str(os_hint).strip())
+        params["os"] = api_os
+
+    # Try site-filtered request first
+    if params:
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        resp = client.get(f"/vm/images?{qs}")
+    else:
+        resp = client.get("/vm/images")
+
+    if resp.status_code != 200:
+        resp = client.get("/vm/images")
+    if resp.status_code != 200:
+        if preferred_image_id is not None:
+            LOG.warning(
+                "OneCloud: GET /vm/images failed (%s), using preferred image_id %s",
+                resp.status_code,
+                preferred_image_id,
+            )
+            return int(preferred_image_id)
+        raise NodeError(
+            f"OneCloud: cannot list images ({resp.status_code}). "
+            "Set image_id in osp-cred or inventory."
+        )
+
+    data = resp.json()
+    images = _parse_images_response(data)
+    if not images:
+        if preferred_image_id is not None:
+            LOG.warning(
+                "OneCloud: no images in response, using preferred image_id %s",
+                preferred_image_id,
+            )
+            return int(preferred_image_id)
+        raise NodeError(
+            "OneCloud: no images available. Set image_id in osp-cred or inventory."
+        )
+
+    # Exclude Windows - RHEL/Ceph requires Linux; platform filter may not catch all
+    for_site = [i for i in images if not _image_is_windows(i)]
+    if len(for_site) < len(images):
+        LOG.info(
+            "OneCloud: excluded %d Windows image(s), %d RHEL/Linux remaining",
+            len(images) - len(for_site),
+            len(for_site),
+        )
+    if not for_site:
+        raise NodeError(
+            f"OneCloud: no non-Windows images at site {site_upper}. "
+            "Ensure RHEL images are available."
+        )
+
+    # Filter by architecture (x86_64, etc.) when specified
+    if arch:
+        for_arch = [i for i in for_site if _image_matches_arch(i, arch)]
+        if for_arch:
+            for_site = for_arch
+            LOG.info(
+                "OneCloud: filtering images by arch %s (%d match)",
+                arch,
+                len(for_site),
+            )
+        else:
+            LOG.warning(
+                "OneCloud: no images match arch %s, using all (API may not provide arch metadata)",
+                arch,
+            )
+
+    # Filter by site if we have site info in images
+    for_site_filtered = [i for i in for_site if _image_matches_site(i, site_upper)]
+    if for_site_filtered:
+        for_site = for_site_filtered
+    # else: keep for_site as-is (no site info in images; API may have pre-filtered)
+
+    # Filter by platform (rhel-9, rhel-10) when --platform is passed
+    if platform_filter:
+        for_platform = [
+            i for i in for_site if _image_matches_platform(i, platform_filter)
+        ]
+        if for_platform:
+            for_site = for_platform
+            LOG.info(
+                "OneCloud: filtering images by platform %s (%d match)",
+                platform_filter,
+                len(for_site),
+            )
+        else:
+            raise NodeError(
+                f"OneCloud: no images match platform {platform_filter!r} at site {site_upper}. "
+                "Verify image metadata (display_name, os_release) or set image_id in osp-cred/inventory."
+            )
+
+    exclude = set(exclude_image_ids or [])
+
+    def _pick_first_valid(imgs: List[Dict]) -> Optional[tuple]:
+        """Return (image_id, img) for first valid image, or None."""
+        for img in imgs:
+            iid = _image_id(img)
+            if iid is not None and iid not in exclude:
+                return (iid, img)
+        return None
+
+    # Prefer user's choice if it's in the available (and platform-filtered) list and not excluded
+    if preferred_image_id is not None and preferred_image_id not in exclude:
+        pid = int(preferred_image_id)
+        for img in for_site:
+            if _image_id(img) == pid:
+                LOG.info(
+                    "OneCloud: using image_id %s (preferred, available at site %s)",
+                    pid,
+                    site_upper or "?",
+                )
+                return pid
+        LOG.info(
+            "OneCloud: image_id %s not available at site %s (or does not match platform); selecting from site images",
+            preferred_image_id,
+            site_upper,
+        )
+
+    # Prefer images matching version_preference (e.g. 9.7 from inventory) when set
+    for_site_before_version = (
+        for_site  # Keep for fallback if all version matches are excluded
+    )
+    if version_preference:
+        matching = [
+            i for i in for_site if _image_matches_version(i, version_preference)
+        ]
+        if matching:
+            for_site = matching
+            LOG.info(
+                "OneCloud: preferring images matching version %s (%d match)",
+                version_preference,
+                len(for_site),
+            )
+
+    # Pick first valid image not in exclude list
+    picked = _pick_first_valid(for_site)
+    if picked is not None:
+        iid, img = picked
+        name = _image_display_name(img)
+        LOG.info(
+            "OneCloud: using image_id %s at site %s (%s)",
+            iid,
+            site_upper or "?",
+            name[:50] if name else "?",
+        )
+        return iid
+
+    # All version-preferred images excluded? Fall back to full platform list
+    if (
+        version_preference
+        and for_site_before_version
+        and for_site != for_site_before_version
+    ):
+        picked = _pick_first_valid(for_site_before_version)
+        if picked is not None:
+            iid, img = picked
+            name = _image_display_name(img)
+            LOG.info(
+                "OneCloud: version %s image(s) excluded; using image_id %s (%s)",
+                version_preference,
+                iid,
+                name[:50] if name else "?",
+            )
+            return iid
+
+    if preferred_image_id is not None and preferred_image_id not in exclude:
+        # Validate preferred is not Windows before using as last resort
+        for img in images:
+            if _image_id(img) == preferred_image_id:
+                if _image_is_windows(img):
+                    raise NodeError(
+                        f"OneCloud: preferred image_id {preferred_image_id} is Windows. "
+                        "Use a RHEL image_id in osp-cred or inventory."
+                    )
+                break
+        return int(preferred_image_id)
+    raise NodeError(
+        f"OneCloud: no valid image for site {site_upper}. "
+        "Set image_id in osp-cred or inventory."
+    )
+
+
+def _parse_projects_response(data: Any) -> List[Dict]:
+    """Extract project list from GET /projects response."""
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return [p for p in data if isinstance(p, dict)]
+    if isinstance(data, dict):
+        val = data.get("data", data)
+        return val if isinstance(val, list) else []
+    return []
+
+
+def _project_matches_site(proj: Dict, site: str) -> bool:
+    """Return True if project is available at the given site."""
+    site_upper = (site or "").strip().upper()
+    if not site_upper:
+        return True
+    for key in ("site", "site_id", "sites", "site_ids"):
+        val = proj.get(key)
+        if val is None:
+            continue
+        if isinstance(val, str):
+            if val.strip().upper() == site_upper:
+                return True
+        elif isinstance(val, list):
+            if any(
+                str(v).strip().upper() == site_upper for v in val if isinstance(v, str)
+            ):
+                return True
+    return True  # If no site info, assume match
+
+
+def resolve_project_for_site(
+    client,
+    site: str,
+    preferred_project_id: Optional[int] = None,
+) -> int:
+    """
+    Resolve a project ID for the given site.
+
+    Tries GET /projects?site=X first; falls back to GET /projects.
+    Uses preferred_project_id if valid, otherwise picks first available project.
+
+    Args:
+        client: OneCloud API client.
+        site: Site code (e.g. TUC, POK).
+        preferred_project_id: User's preferred project; used if available.
+
+    Returns:
+        Resolved project ID (int).
+
+    Raises:
+        NodeError: If no projects found.
+    """
+    site_upper = (site or "").strip().upper()
+    resp = (
+        client.get(f"/projects?site={site_upper}")
+        if site_upper
+        else client.get("/projects")
+    )
+    if resp.status_code != 200:
+        resp = client.get("/projects")
+    if resp.status_code != 200:
+        if preferred_project_id is not None:
+            LOG.warning(
+                "OneCloud: GET /projects failed (%s), using preferred project_id %s",
+                resp.status_code,
+                preferred_project_id,
+            )
+            return int(preferred_project_id)
+        raise NodeError(
+            "OneCloud: cannot list projects. Set project_id in osp-cred or inventory."
+        )
+
+    data = resp.json()
+    projects = _parse_projects_response(data)
+    if not projects:
+        if preferred_project_id is not None:
+            return int(preferred_project_id)
+        raise NodeError(
+            "OneCloud: no projects available. Set project_id in osp-cred or inventory."
+        )
+
+    for_site = [p for p in projects if _project_matches_site(p, site_upper)]
+    if not for_site:
+        for_site = projects
+
+    def _proj_id(p: Dict) -> Optional[int]:
+        v = p.get("projectid") or p.get("id")
+        try:
+            return int(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    if preferred_project_id is not None:
+        pid = int(preferred_project_id)
+        for p in for_site:
+            if _proj_id(p) == pid:
+                return pid
+        LOG.info(
+            "OneCloud: project_id %s not in site list; selecting from available",
+            preferred_project_id,
+        )
+
+    for p in for_site:
+        pid = _proj_id(p)
+        if pid is not None:
+            name = p.get("projectname") or p.get("name") or ""
+            LOG.info(
+                "OneCloud: using project_id %s at site %s (%s)",
+                pid,
+                site_upper or "?",
+                name[:40] if name else "?",
+            )
+            return pid
+
+    if preferred_project_id is not None:
+        return int(preferred_project_id)
+    raise NodeError(
+        "OneCloud: no valid project for site. Set project_id in osp-cred or inventory."
+    )
+
+
+def get_vlan_for_site(
+    client,
+    site: str,
+    preferred_vlan: Optional[int] = None,
+) -> Optional[int]:
+    """
+    Resolve a valid VLAN for the given site using GET /networks.
+
+    If preferred_vlan is valid for the site, returns it. Otherwise picks the first
+    available VLAN for that site. If the API returns no VLAN IDs (e.g. "Default Pool"
+    with vlan: null), returns None to omit VLAN—the API may then use the Default network.
+
+    Args:
+        client: OneCloud API client (from get_onecloud_client).
+        site: Site code (e.g. TUC, POK).
+        preferred_vlan: VLAN from config; used if valid or as fallback.
+
+    Returns:
+        VLAN ID to use for deploy, or None to omit (API may use "Default" network).
+    """
+    fallback = int(preferred_vlan) if preferred_vlan is not None else None
+    site_upper = (site or "").strip().upper()
+    if not site_upper:
+        return fallback
+
+    try:
+        # Try site-specific endpoint first (some APIs support ?site=)
+        resp = client.get(f"/networks?site={site_upper}")
+        if resp.status_code != 200:
+            resp = client.get("/networks")
+        if resp.status_code != 200:
+            LOG.warning(
+                "OneCloud: GET /networks failed (%s), omitting VLAN for site %s (API may use Default)",
+                resp.status_code,
+                site_upper,
+            )
+            return None
+
+        data = resp.json()
+        networks = data.get("data", data) if isinstance(data, dict) else data
+        if isinstance(networks, dict):
+            # Some APIs return {site: [networks]} or {site: {vlans: [...]}}
+            site_networks = networks.get(site_upper) or networks.get(site_upper.lower())
+            if isinstance(site_networks, list):
+                networks = site_networks
+            elif isinstance(site_networks, dict):
+                networks = site_networks.get("networks", site_networks.get("vlans", []))
+            else:
+                networks = []
+        else:
+            networks = networks if isinstance(networks, list) else []
+    except Exception as e:
+        LOG.warning(
+            "OneCloud: could not fetch networks (%s), omitting VLAN for site %s (API may use Default)",
+            e,
+            site_upper,
+        )
+        return None
+
+    SITE_ALIASES = {
+        "TUC": ["TUC", "TUCSON"],
+        "POK": ["POK", "POUGHKEEPSIE"],
+        "AUS": ["AUS"],
+        "RCH": ["RCH"],
+    }
+
+    def _site_from_net(net):
+        s = (
+            net.get("site")
+            or net.get("site_name")
+            or net.get("site_id")
+            or net.get("identifier")
+            or net.get("location")
+        )
+        if isinstance(s, dict):
+            s = s.get("identifier") or s.get("name") or ""
+        s = (str(s or "")).strip().upper()
+        # Normalize full names to site codes
+        for code, aliases in SITE_ALIASES.items():
+            if any(s == a or s.startswith(a) for a in aliases):
+                return code
+        return s
+
+    vlans_for_site = []
+    for n in networks:
+        net_site = _site_from_net(n)
+        net_vlan = n.get("vlan") or n.get("VLAN") or n.get("vlan_id")
+        if net_vlan is not None:
+            try:
+                net_vlan = int(net_vlan)
+            except (TypeError, ValueError):
+                continue
+        else:
+            continue
+        if net_site == site_upper:
+            vlans_for_site.append(net_vlan)
+
+    vlans_for_site = sorted(set(vlans_for_site))
+    if not vlans_for_site:
+        # GET /networks returned no VLAN IDs (e.g. "Default Pool" with vlan: null).
+        # Omit VLAN so API may use "Default" network like the portal does.
+        LOG.info(
+            "OneCloud: no VLAN IDs in GET /networks for site %s, omitting VLAN (API may use Default network)",
+            site_upper,
+        )
+        return None
+
+    if preferred_vlan is not None and int(preferred_vlan) in vlans_for_site:
+        return int(preferred_vlan)
+
+    chosen = vlans_for_site[0]
+    if preferred_vlan is not None and int(preferred_vlan) != chosen:
+        LOG.info(
+            "OneCloud: VLAN %s not available at site %s; using VLAN %s (available: %s)",
+            preferred_vlan,
+            site_upper,
+            chosen,
+            vlans_for_site[:10],
+        )
+    return chosen
+
+
+def cleanup_onecloud_ceph_nodes(
+    onecloud_cred: Dict,
+    pattern: str,
+    custom_config: Optional[List[str]] = None,
+) -> None:
+    """
+    Clean up OneCloud clusters and VMs matching the given pattern.
+
+    GET /clusters, filter by cluster_name containing pattern, then GET /vm?clusterid=X,
+    DELETE /vm/{id} for each VM, and DELETE /clusters/{id} for the cluster (if supported).
+
+    Args:
+        onecloud_cred: Credentials with globals["onecloud-credentials"].
+        pattern: Pattern to match cluster name (e.g. run id or prefix).
+        custom_config: Optional list of key=value for platform overrides.
+    """
+    glbs = onecloud_cred.get("globals") or {}
+    cred = glbs.get("onecloud-credentials")
+    if not cred:
+        raise NodeError("Missing 'onecloud-credentials' in globals")
+
+    # Handle None/empty pattern to avoid TypeError and accidental match-all
+    pattern = (pattern or "").strip()
+    if not pattern:
+        try:
+            pattern = f"-{os.getlogin()}-"
+        except OSError:
+            pattern = "-cephci-"
+
+    api_key = cred.get("api_key")
+    base_url = cred.get("base_url")
+    verify_ssl = cred.get("verify_ssl", False)
+    if not api_key:
+        raise NodeError("Missing 'api_key' in onecloud-credentials")
+    if not base_url:
+        raise NodeError(
+            "Missing 'base_url' in onecloud-credentials. "
+            "Set it in osp-cred or cephci.yaml."
+        )
+
+    client = get_onecloud_client(api_key, base_url, verify_ssl=verify_ssl)
+
+    LOG.info("Listing OneCloud clusters for cleanup (pattern=%s)", pattern)
+    resp = client.get("/clusters")
+    if resp.status_code != 200:
+        LOG.warning("Failed to list clusters: %s %s", resp.status_code, resp.text[:200])
+        return
+
+    data = resp.json()
+    clusters = data.get("data", []) if isinstance(data, dict) else data
+    if not isinstance(clusters, list):
+        clusters = []
+
+    matching = [c for c in clusters if pattern in c.get("cluster_name", "")]
+    if not matching:
+        LOG.info("No clusters matching pattern '%s'", pattern)
+        return
+
+    LOG.info("Cleaning up %d clusters matching pattern", len(matching))
+
+    for cluster in matching:
+        cluster_id = cluster.get("clusterid") or cluster.get("clusterID")
+        cluster_name = cluster.get("cluster_name", "?")
+        if not cluster_id:
+            continue
+
+        # List VMs in cluster
+        vm_resp = client.get(f"/vm?clusterid={cluster_id}")
+        if vm_resp.status_code != 200:
+            LOG.warning(
+                "Failed to list VMs for cluster %s: %s", cluster_id, vm_resp.status_code
+            )
+            continue
+
+        vm_data = vm_resp.json()
+        vms = vm_data.get("data", []) if isinstance(vm_data, dict) else vm_data
+        if not isinstance(vms, list):
+            vms = []
+
+        for vm in vms:
+            vmid = vm.get("vmid") or vm.get("vmID")
+            if vmid is None:
+                continue
+            try:
+                del_resp = client.delete(f"/vm/{vmid}")
+                if del_resp.status_code in (200, 204):
+                    LOG.info("Deleted VM %s (cluster %s)", vmid, cluster_name)
+                else:
+                    LOG.warning(
+                        "Failed to delete VM %s: %s", vmid, del_resp.status_code
+                    )
+            except Exception as e:
+                LOG.warning("Error deleting VM %s: %s", vmid, e)
+
+        # Verify VMs are gone before proceeding (API may be eventually consistent)
+        def _active_vms(vm_list: List[Dict]) -> List[Dict]:
+            """Filter to VMs that appear active (not deleted/terminated)."""
+            terminal = {"deleted", "terminated", "off"}
+            return [
+                v
+                for v in vm_list
+                if (v.get("state") or v.get("status") or "").lower() not in terminal
+            ]
+
+        vm_resp = client.get(f"/vm?clusterid={cluster_id}")
+        if vm_resp.status_code == 200:
+            try:
+                vm_resp_alt = client.get(f"/vm?clusterID={cluster_id}")
+                if vm_resp_alt.status_code == 200:
+                    vm_resp = vm_resp_alt
+            except Exception:
+                pass
+        all_vms = (
+            parse_vm_list_from_response(vm_resp.json())
+            if vm_resp.status_code == 200
+            else []
+        )
+        remaining = _active_vms(all_vms)
+        if remaining:
+            LOG.info(
+                "OneCloud: verifying deletion for cluster %s (%d VM(s) still listed), polling up to %ds",
+                cluster_name,
+                len(remaining),
+                CLEANUP_VERIFY_TIMEOUT,
+            )
+            deadline = time.time() + CLEANUP_VERIFY_TIMEOUT
+            while time.time() < deadline and remaining:
+                time.sleep(CLEANUP_VERIFY_INTERVAL)
+                vm_resp = client.get(f"/vm?clusterid={cluster_id}")
+                if vm_resp.status_code != 200:
+                    vm_resp = client.get(f"/vm?clusterID={cluster_id}")
+                all_vms = (
+                    parse_vm_list_from_response(vm_resp.json())
+                    if vm_resp.status_code == 200
+                    else []
+                )
+                remaining = _active_vms(all_vms)
+                if remaining:
+                    LOG.info(
+                        "OneCloud: cluster %s still has %d VM(s), waiting...",
+                        cluster_name,
+                        len(remaining),
+                    )
+            if remaining:
+                LOG.warning(
+                    "OneCloud: cluster %s still reports %d VM(s) after %ds; create may use stale data",
+                    cluster_name,
+                    len(remaining),
+                    CLEANUP_VERIFY_TIMEOUT,
+                )
+            else:
+                LOG.info("OneCloud: cluster %s verified empty", cluster_name)
+
+        # Delete cluster after VMs (API may support DELETE /clusters/{id})
+        try:
+            cluster_del_resp = client.delete(f"/clusters/{cluster_id}")
+            if cluster_del_resp.status_code in (200, 204):
+                LOG.info("Deleted cluster %s (%s)", cluster_id, cluster_name)
+            elif cluster_del_resp.status_code in (404, 405, 501):
+                LOG.info(
+                    "Cluster delete not supported (API %s), cluster %s may remain",
+                    cluster_del_resp.status_code,
+                    cluster_name,
+                )
+            else:
+                LOG.warning(
+                    "Failed to delete cluster %s: %s %s",
+                    cluster_id,
+                    cluster_del_resp.status_code,
+                    cluster_del_resp.text[:200],
+                )
+        except Exception as e:
+            LOG.warning("Error deleting cluster %s: %s", cluster_id, e)
+
+    if matching:
+        time.sleep(5)  # allow backend to settle before create
+    LOG.info("Done cleaning up OneCloud nodes with pattern %s", pattern)
+
+
+def vm_start(client, vmid: int) -> None:
+    """
+    Start a VM.
+
+    Args:
+        client: OneCloud API client.
+        vmid: VM ID.
+
+    Raises:
+        NodeError: If the API call fails.
+    """
+    for path in (f"/vm/{vmid}/start", f"/vm/{vmid}/power_on"):
+        resp = client.post(path, json={})
+        if resp.status_code in (200, 201, 202, 204):
+            LOG.info("OneCloud: started VM %s", vmid)
+            return
+        if resp.status_code == 404:
+            continue
+        raise NodeError(
+            f"OneCloud: failed to start VM {vmid}: {resp.status_code} {resp.text[:200]}"
+        )
+    raise NodeError(
+        f"OneCloud: VM start not supported (404 for VM {vmid}). "
+        "Verify API supports /vm/{{id}}/start or /vm/{{id}}/power_on."
+    )
+
+
+def vm_stop(client, vmid: int) -> None:
+    """
+    Stop a VM.
+
+    Args:
+        client: OneCloud API client.
+        vmid: VM ID.
+
+    Raises:
+        NodeError: If the API call fails.
+    """
+    for path in (f"/vm/{vmid}/stop", f"/vm/{vmid}/power_off"):
+        resp = client.post(path, json={})
+        if resp.status_code in (200, 201, 202, 204):
+            LOG.info("OneCloud: stopped VM %s", vmid)
+            return
+        if resp.status_code == 404:
+            continue
+        raise NodeError(
+            f"OneCloud: failed to stop VM {vmid}: {resp.status_code} {resp.text[:200]}"
+        )
+    raise NodeError(
+        f"OneCloud: VM stop not supported (404 for VM {vmid}). "
+        "Verify API supports /vm/{{id}}/stop or /vm/{{id}}/power_off."
+    )
+
+
+def vm_restart(client, vmid: int) -> None:
+    """
+    Restart a VM.
+
+    Args:
+        client: OneCloud API client.
+        vmid: VM ID.
+
+    Raises:
+        NodeError: If the API call fails.
+    """
+    for path in (f"/vm/{vmid}/restart", f"/vm/{vmid}/reboot"):
+        resp = client.post(path, json={})
+        if resp.status_code in (200, 201, 202, 204):
+            LOG.info("OneCloud: restarted VM %s", vmid)
+            return
+        if resp.status_code == 404:
+            continue
+        raise NodeError(
+            f"OneCloud: failed to restart VM {vmid}: {resp.status_code} {resp.text[:200]}"
+        )
+    raise NodeError(
+        f"OneCloud: VM restart not supported (404 for VM {vmid}). "
+        "Verify API supports /vm/{{id}}/restart or /vm/{{id}}/reboot."
+    )
+
+
+def _wait_until_vm_state(
+    client,
+    vmid: int,
+    target_state: str,
+    timeout: int = VM_POLL_TIMEOUT,
+) -> None:
+    """Poll VM until it reaches target_state (e.g. 'on', 'off', 'stopped')."""
+    target_lower = target_state.lower()
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = client.get(f"/vm/{vmid}")
+        if resp.status_code != 200:
+            time.sleep(VM_POLL_INTERVAL)
+            continue
+        data = resp.json()
+        vm = data.get("data", data) if isinstance(data, dict) else {}
+        if isinstance(vm, dict):
+            state = (vm.get("state") or vm.get("status") or "").lower()
+            if state == target_lower:
+                return
+        time.sleep(VM_POLL_INTERVAL)
+    raise NodeError(
+        f"OneCloud: VM {vmid} did not reach state {target_state!r} within {timeout}s"
+    )
+
+
+class CephVMNodeOneCloud:
+    """Represents a VM node from OneCloud API."""
+
+    def __init__(
+        self,
+        node: Dict[str, Any],
+        api_key: str,
+        base_url: str,
+        verify_ssl: bool = False,
+    ) -> None:
+        """
+        Initializes the instance using VM data from OneCloud API.
+
+        Args:
+            node: VM dict from GET /vm or GET /vm/{id} (vmid, vmname, network, etc.).
+            api_key: JWT for API calls (e.g. delete).
+            base_url: API base URL from credentials.
+            verify_ssl: If False, disable SSL certificate verification for API calls.
+        """
+        self.node = node
+        self._api_key = api_key
+        self._base_url = base_url
+        self._verify_ssl = verify_ssl
+        self._roles: List = []
+        self._subnet: str = ""
+        self.root_login: bool = True
+        self.osd_scenario: Optional[str] = None
+        self.location: Optional[str] = None
+        self.id: Optional[str] = None
+
+    @property
+    def ip_address(self) -> str:
+        """Return the IP address of the node (public/floating IP for SSH)."""
+        return get_vm_ip(self.node) or ""
+
+    @property
+    def hostname(self) -> str:
+        """Return the hostname of the VM."""
+        net = self.node.get("network") or {}
+        return (
+            net.get("hostname")
+            or net.get("fqdn", "").split(".")[0]
+            or self.node.get("vmname", "")
+        )
+
+    @property
+    def shortname(self) -> str:
+        """Return the short form of the hostname."""
+        return self.hostname.split(".")[0] if self.hostname else ""
+
+    @property
+    def subnet(self) -> str:
+        """Return the subnet CIDR (e.g. 9.114.200.0/24) derived from VM IP."""
+        if self._subnet:
+            return self._subnet
+        ip = self.ip_address
+        if not ip:
+            return ""
+        net = self.node.get("network") or {}
+        netmask = net.get("netmask") or net.get("subnet_mask") or ""
+        try:
+            if netmask:
+                iface = ipaddress.IPv4Interface(f"{ip}/{netmask}")
+            else:
+                iface = ipaddress.IPv4Interface(f"{ip}/24")
+            self._subnet = str(iface.network)
+            return self._subnet
+        except (ValueError, TypeError):
+            return ""
+
+    @property
+    def no_of_volumes(self) -> int:
+        """Return the number of volumes attached to the VM."""
+        res = self.node.get("resources") or {}
+        disk = res.get("disk") or []
+        return len(disk) if isinstance(disk, list) else 0
+
+    @property
+    def volumes(self) -> List:
+        """Return the list of storage volumes (OneCloud does not expose volume details)."""
+        return []
+
+    @property
+    def role(self) -> List:
+        """Return the Ceph roles of the instance."""
+        return self._roles
+
+    @role.setter
+    def role(self, roles: list) -> None:
+        """Set the roles for the VM."""
+        self._roles = deepcopy(roles)
+
+    @property
+    def node_type(self) -> str:
+        """Return the provider type."""
+        return "onecloud"
+
+    @property
+    def vmid(self) -> Optional[int]:
+        """Return the OneCloud VM ID."""
+        return self.node.get("vmid") or self.node.get("vmID")
+
+    def delete(self) -> None:
+        """Delete the VM via OneCloud API."""
+        vmid = self.vmid
+        if vmid is None:
+            raise NodeDeleteFailure("Cannot delete VM: no vmid")
+
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        resp = client.delete(f"/vm/{vmid}")
+        if resp.status_code not in (200, 204):
+            raise NodeDeleteFailure(
+                f"Failed to delete VM {vmid}: {resp.status_code} {resp.text[:200]}"
+            )
+
+    def start(self, wait: bool = True) -> None:
+        """
+        Start this VM.
+
+        Args:
+            wait: If True, poll until VM reaches running state.
+        """
+        vmid = self.vmid
+        if vmid is None:
+            raise NodeError("Cannot start VM: no vmid")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        vm_start(client, vmid)
+        if wait:
+            _wait_until_vm_state(client, vmid, "on")
+
+    def stop(self, wait: bool = False) -> None:
+        """
+        Stop this VM.
+
+        Args:
+            wait: If True, poll until VM reaches stopped state.
+        """
+        vmid = self.vmid
+        if vmid is None:
+            raise NodeError("Cannot stop VM: no vmid")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        vm_stop(client, vmid)
+        if wait:
+            _wait_until_vm_state(client, vmid, "off")
+
+    def restart(self, wait: bool = True) -> None:
+        """
+        Restart this VM.
+
+        Args:
+            wait: If True, poll until VM reaches running state after restart.
+        """
+        vmid = self.vmid
+        if vmid is None:
+            raise NodeError("Cannot restart VM: no vmid")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        vm_restart(client, vmid)
+        if wait:
+            _wait_until_vm_state(client, vmid, "on")

--- a/conf/inventory/onecloud-rhel-10.1-server-x86_64-medium.yaml
+++ b/conf/inventory/onecloud-rhel-10.1-server-x86_64-medium.yaml
@@ -1,0 +1,16 @@
+---
+# RedHat Enterprise Linux 10.1 - MEDIUM profile (4 vCPUs / 16GB / 100GB + 3x50GB)
+# Same image as onecloud-rhel-10.1-server-x86_64.yaml, different profile
+# OneCloud ignores userData; bootstrap is done via subprocess SSH in ceph.py
+version_id: 10.1
+id: rhel
+instance:
+  create:
+    image_id: 22
+    projectID: 21
+    site: POK
+    groupID: 1
+    VLAN: 2231
+    resources: medium
+    arch: x86_64
+    os: RHEL

--- a/conf/inventory/onecloud-rhel-10.1-server-x86_64.yaml
+++ b/conf/inventory/onecloud-rhel-10.1-server-x86_64.yaml
@@ -1,0 +1,16 @@
+---
+# RedHat Enterprise Linux 10.1
+# image_id: Get from OneCloud API (GET /vm/images)
+# OneCloud ignores userData; bootstrap is done via subprocess SSH in ceph.py
+version_id: 10.1
+id: rhel
+instance:
+  create:
+    image_id: 383  # RHEL 10.1 from OneCloud (get from API/portal)
+    projectID: 808  # IBM-Ceph-QE (get from API/portal)
+    site: POK
+    groupID: 1
+    VLAN: 2231
+    resources: small  # Profiles: small | medium | large
+    arch: x86_64
+    os: RHEL

--- a/conf/inventory/onecloud-rhel-9.7-server-x86_64.yaml
+++ b/conf/inventory/onecloud-rhel-9.7-server-x86_64.yaml
@@ -1,0 +1,16 @@
+---
+# RedHat Enterprise Linux 9.7
+# image_id: Get from OneCloud API (GET /vm/images) - replace placeholder
+# OneCloud ignores userData; bootstrap is done via subprocess SSH in ceph.py
+version_id: 9.7
+id: rhel
+instance:
+  create:
+    image_id: 26  # Replace with actual ID from OneCloud portal
+    projectID: 21
+    site: POK
+    groupID: 1
+    VLAN: 2231
+    resources: medium  # Profiles: small | medium | large
+    arch: x86_64
+    os: RHEL

--- a/conf/onecloud/6node-2client-cluster.yaml
+++ b/conf/onecloud/6node-2client-cluster.yaml
@@ -1,0 +1,80 @@
+# OneCloud cluster config - 8 VMs max
+# Use with:
+#   run.py --global-conf conf/onecloud/1admin-8node-cluster.yaml \
+#     --inventory conf/inventory/onecloud-rhel-10.1-server-x86_64.yaml \
+#     --cloud onecloud --suite <suite> --platform rhel-10.1-server-x86_64
+#
+# Credentials: ~/osp-cred-ci-2.yaml (globals.onecloud-credentials). See osp-cred-onecloud-example.yaml.
+# OneCloud does not support custom disks; no-of-volumes/disk-size are ignored (forced to 0).
+# For cephadm: use all-available-devices to deploy OSDs on discovered devices.
+
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+        no-of-volumes: 0
+        disk-size: 0
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - nfs
+          - rgw
+          - node-exporter
+          - alertmanager
+          - crash
+        no-of-volumes: 0
+        disk-size: 0
+      node3:
+        role:
+          - mon
+          - mgr
+          - mds
+          - rgw
+          - node-exporter
+          - crash
+        no-of-volumes: 0
+        disk-size: 0
+      node4:
+        role:
+          - mon
+          - mds
+          - rgw
+          - node-exporter
+          - crash
+        no-of-volumes: 0
+        disk-size: 0
+      node5:
+        role:
+          - mds
+          - rgw
+          - node-exporter
+          - crash
+        no-of-volumes: 0
+        disk-size: 0
+      node6:
+        role:
+          - mds
+          - nfs
+          - rgw
+          - node-exporter
+          - crash
+        no-of-volumes: 0
+        disk-size: 0
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - client

--- a/examples/cephci.yaml
+++ b/examples/cephci.yaml
@@ -60,6 +60,16 @@ credentials:
       auth-url: <fake-authurl>
       ssh_key: <fake-ssh-key-path>
 
+    onecloud:
+      api_key: <JWT_TOKEN>
+      base_url: https://portal.onecloud.wdc.app.cirrus.ibm.com/api/v3
+      site: POK
+      ssh_user: onecloud-user
+      bootstrap_key_path: ~/.ssh/id_ecdsa_ciso
+      bootstrap_key_password: <passphrase>
+      private_key_path: ~/.ssh/id_ed25519_onecloud
+      # verify_ssl: false
+
   vault:
     url: <fake-url>
     agent:

--- a/osp-cred-onecloud-example.yaml
+++ b/osp-cred-onecloud-example.yaml
@@ -1,0 +1,18 @@
+# OneCloud credentials for osp-cred file (e.g. ~/osp-cred-ci-2.yaml)
+# Add under globals.
+#
+# Two SSH keys are required:
+# 1) bootstrap_key_path - CISO cert key for initial SSH via OpenSSH (e.g. id_ecdsa_ciso)
+# 2) private_key_path   - Regular key for Paramiko connections (e.g. id_ed25519_onecloud)
+#    Generate with: ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_onecloud -N ""
+
+globals:
+  onecloud-credentials:
+    api_key: "<JWT_TOKEN>"
+    base_url: "https://portal.onecloud.wdc.app.cirrus.ibm.com/api/v3"
+    site: POK  # AUS, POK, RCH, TUC
+    ssh_user: "onecloud-user"  # Default cloud-init user; customizable in OneCloud portal
+    bootstrap_key_path: "~/.ssh/id_ecdsa_ciso"       # CISO key for initial OpenSSH bootstrap
+    bootstrap_key_password: "<passphrase>"           # Passphrase for CISO key (from step ssh certificate)
+    private_key_path: "~/.ssh/id_ed25519_onecloud"   # Regular key for Paramiko connections
+    # verify_ssl: false  # If corporate CA causes SSL errors

--- a/run.py
+++ b/run.py
@@ -27,6 +27,7 @@ from ceph.utils import (
     create_baremetal_ceph_nodes,
     create_ceph_nodes,
     create_ibmc_ceph_nodes,
+    create_onecloud_ceph_nodes,
 )
 from cephci.cluster_info import collect_ceph_coredumps, get_ceph_var_logs
 from cephci.utils.build_info import CephTestManifest
@@ -36,6 +37,7 @@ from cli.performance.memory_and_cpu_utils import (
     upload_mem_and_cpu_logger_script,
 )
 from compute.aws_ec2 import cleanup_aws_ceph_nodes
+from compute.onecloud import cleanup_onecloud_ceph_nodes, expand_private_key_path
 from utility import sosreport
 from utility.log import Log
 from utility.polarion import post_to_polarion
@@ -62,7 +64,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         (--platform <name>)
         (--suite <FILE>)...
         (--global-conf FILE | --cluster-conf FILE)
-        [--cloud <openstack> | <ibmc> | <aws> | <baremetal>]
+        [--cloud <openstack> | <ibmc> | <aws> | <baremetal> | <onecloud>]
         [--build <name>]
         [--inventory FILE]
         [--osp-cred <file>]
@@ -110,7 +112,7 @@ Options:
   --global-conf <file>              global cloud configuration file
   --cluster-conf <file>             cluster configuration file
   --inventory <file>                hosts inventory file
-  --cloud <cloud_type>              cloud type (openstack|ibmc|aws|baremetal) [default: openstack]
+  --cloud <cloud_type>              cloud type (openstack|ibmc|aws|baremetal|onecloud) [default: openstack]
   --osp-cred <file>                 openstack credentials as separate file
   --rhbuild <1.3.0>                 ceph downstream version
                                     eg: 1.3.0, 2.0, 2.1 etc
@@ -187,6 +189,7 @@ def create_nodes(
     instances_name=None,
     enable_eus=False,
     custom_config=None,
+    platform=None,
 ):
     """Creates the system under test environment.
 
@@ -199,6 +202,7 @@ def create_nodes(
         instances_name  system names
         enable_eus      Extended OS support
         custom_config   list of <key>=<value>
+        platform        RHEL platform (e.g. rhel-9, rhel-10) for OneCloud image selection
 
     Notes:
         use custom_config to specify the environments or configuration to
@@ -224,6 +228,10 @@ def create_nodes(
         cleanup_ibmc_ceph_nodes(osp_cred, instances_name, custom_config=None)
     elif cloud_type == "aws":
         cleanup_aws_ceph_nodes(osp_cred, instances_name, custom_config=None)
+    elif cloud_type == "onecloud":
+        cleanup_onecloud_ceph_nodes(
+            osp_cred, instances_name, custom_config=custom_config
+        )
 
     ceph_cluster_dict = {}
     clients = []
@@ -246,6 +254,16 @@ def create_nodes(
             ceph_vmnodes = create_aws_ceph_nodes(
                 cluster, inventory, osp_cred, run_id, instances_name, custom_config
             )
+        elif cloud_type == "onecloud":
+            ceph_vmnodes = create_onecloud_ceph_nodes(
+                cluster,
+                inventory,
+                osp_cred,
+                run_id,
+                instances_name,
+                custom_config,
+                platform=platform,
+            )
         elif "baremetal" in cloud_type:
             ceph_vmnodes = create_baremetal_ceph_nodes(cluster)
         else:
@@ -257,9 +275,30 @@ def create_nodes(
 
         ceph_nodes = []
         root_password = None
+        # OneCloud creds: globals.onecloud-credentials (osp-cred) or credentials.cloud.onecloud (cephci.yaml)
+        onecloud_cfg = {}
+        if cloud_type == "onecloud":
+            glbs = osp_cred.get("globals") or {}
+            onecloud_cfg = (
+                (glbs.get("onecloud-credentials") if isinstance(glbs, dict) else {})
+                or ((osp_cred.get("credentials") or {}).get("cloud") or {}).get(
+                    "onecloud"
+                )
+                or {}
+            )
+            log.info(
+                "OneCloud auth: private_key_path=%s",
+                onecloud_cfg.get("private_key_path", "(none)"),
+            )
         for node in ceph_vmnodes.values():
             look_for_key = False
             private_key_path = ""
+            private_key_password = None
+            bootstrap_key_path = ""
+            bootstrap_key_password = ""
+            cephuser_password = "cephuser"
+            ssh_username = "cephuser"
+            root_username = None  # None = use default "root"
 
             if cloud_type == "openstack":
                 private_ip = node.get_private_ip()
@@ -284,6 +323,24 @@ def create_nodes(
                 private_ip = node.ip_address
                 look_for_key = True
                 ceph_nodename = node.hostname
+            elif cloud_type == "onecloud":
+                private_ip = node.ip_address
+                ceph_nodename = node.hostname
+                onecloud_ssh_user = onecloud_cfg.get("ssh_user", "onecloud-user")
+                bootstrap_key_path = expand_private_key_path(
+                    onecloud_cfg.get("bootstrap_key_path", "")
+                )
+                bootstrap_key_password = onecloud_cfg.get("bootstrap_key_password", "")
+                ssh_username = onecloud_ssh_user
+                root_username = onecloud_ssh_user
+                root_password = ""
+                look_for_key = True
+                private_key_path = onecloud_cfg.get("private_key_path", "")
+                private_key_password = onecloud_cfg.get("private_key_password")
+
+            private_key_path = (
+                expand_private_key_path(private_key_path) if private_key_path else ""
+            )
 
             if node.role == "win-iscsi-clients":
                 clients.append(
@@ -293,12 +350,26 @@ def create_nodes(
                 # IPv6 attrs only when available (OpenStack dual-stack); other envs have no ipv6_* on node
                 ipv6_address = getattr(node, "ipv6_address", None)
                 ipv6_subnet = getattr(node, "ipv6_subnet", None)
+                pwd = (
+                    (root_password or "passwd")
+                    if ssh_username == "root"
+                    else cephuser_password
+                )
+                root_pwd = (
+                    ""
+                    if (cloud_type == "onecloud" and look_for_key)
+                    else (root_password or "passwd")
+                )
                 ceph = CephNode(
-                    username="cephuser",
-                    password="cephuser",
-                    root_password="passwd" if not root_password else root_password,
+                    username=ssh_username,
+                    password=pwd,
+                    root_password=root_pwd,
+                    root_username=root_username,
                     look_for_key=look_for_key,
                     private_key_path=private_key_path,
+                    private_key_password=private_key_password,
+                    bootstrap_key_path=bootstrap_key_path,
+                    bootstrap_key_password=bootstrap_key_password,
                     root_login=node.root_login,
                     role=node.role,
                     no_of_volumes=node.no_of_volumes,
@@ -331,8 +402,13 @@ def create_nodes(
     # TODO: refactor cluster dict to cluster list
     log.info("Done creating osp instances")
     log.info("Waiting for Floating IPs to be available")
-    log.info("Sleeping 15 Seconds")
-    time.sleep(15)
+    if cloud_type == "onecloud":
+        wait_sec = 75
+        log.info("OneCloud: sleeping %ds for VM readiness", wait_sec)
+        time.sleep(wait_sec)
+    else:
+        log.info("Sleeping 15 Seconds")
+        time.sleep(15)
 
     for cluster_name, cluster in ceph_cluster_dict.items():
         for instance in cluster:
@@ -444,7 +520,14 @@ def run(args):
     inventory_file = args.get("--inventory")
     osp_cred_file = args.get("--osp-cred")
 
+    # OneCloud: default to osp-cred-ci-2.yaml when --osp-cred not provided
+    if cloud_type == "onecloud" and osp_cred_file is None:
+        default_osp_cred = os.path.expanduser("~/osp-cred-ci-2.yaml")
+        if os.path.exists(default_osp_cred):
+            osp_cred_file = default_osp_cred
+
     osp_cred = load_file(osp_cred_file) if osp_cred_file else dict()
+
     cleanup_name = args.get("--cleanup")
 
     # Set log directory and get absolute path
@@ -493,6 +576,10 @@ def run(args):
             cleanup_aws_ceph_nodes(
                 osp_cred, cleanup_name, custom_config=args.get("--custom-config")
             )
+        elif cloud_type == "onecloud":
+            cleanup_onecloud_ceph_nodes(
+                osp_cred, cleanup_name, custom_config=args.get("--custom-config")
+            )
         else:
             log.warning("Unknown cloud type.")
 
@@ -507,11 +594,16 @@ def run(args):
         and cloud_type in ["openstack", "ibmc", "aws"]
     ):
         raise Exception("Require cloud credentials to create cluster.")
+    if not reuse and cloud_type == "onecloud" and not osp_cred:
+        raise Exception(
+            "OneCloud requires credentials. Use --osp-cred <file> or place "
+            "globals.onecloud-credentials in ~/osp-cred-ci-2.yaml."
+        )
 
     if (
         inventory_file is None
         and not reuse
-        and cloud_type in ["openstack", "ibmc", "aws"]
+        and cloud_type in ["openstack", "ibmc", "aws", "onecloud"]
     ):
         raise Exception("Require system configuration information to provision.")
 
@@ -634,10 +726,11 @@ def run(args):
         if osp_image and inventory.get("instance", {}).get("create"):
             inventory.get("instance").get("create").update({"image-name": osp_image})
 
-        image_name = inventory.get("instance", {}).get("create", {}).get("image-name")
+        inv_create = inventory.get("instance", {}).get("create", {})
+        image_name = inv_create.get("image-name") or inv_create.get("image_id")
 
-        if inventory.get("instance", {}).get("create"):
-            distro.append(inventory.get("instance").get("create").get("image-name"))
+        if inv_create and image_name is not None:
+            distro.append(str(image_name).replace(".iso", ""))
 
     for cluster in conf.get("globals"):
         if cluster.get("ceph-cluster").get("inventory"):
@@ -646,10 +739,10 @@ def run(args):
             )
             with open(cluster_inventory_path, "r") as inventory_stream:
                 cluster_inventory = yaml.safe_load(inventory_stream)
-            image_name = (
-                cluster_inventory.get("instance").get("create").get("image-name")
-            )
-            distro.append(image_name.replace(".iso", ""))
+            inv_create = cluster_inventory.get("instance", {}).get("create", {})
+            image_name = inv_create.get("image-name") or inv_create.get("image_id")
+            if image_name is not None:
+                distro.append(str(image_name).replace(".iso", ""))
 
         # Find the Ceph version
         if build not in ["released", "cvp", "upstream", None]:
@@ -674,7 +767,6 @@ def run(args):
     ceph_version = ", ".join(list(set(ceph_version)))
     log.info("Testing Ceph Version: %s" % (ceph_version))
 
-    service = None
     suite_name = "::".join(suite_files)
 
     def fetch_test_details(var) -> dict:
@@ -727,6 +819,7 @@ def run(args):
                 instances_name,
                 enable_eus=enable_eus,
                 custom_config=custom_config,
+                platform=platform,
             )
 
         except Exception as err:
@@ -1090,6 +1183,10 @@ def run(args):
                 cleanup_ibmc_ceph_nodes(osp_cred, instances_name)
             elif cloud_type == "aws":
                 cleanup_aws_ceph_nodes(osp_cred, instances_name)
+            elif cloud_type == "onecloud":
+                cleanup_onecloud_ceph_nodes(
+                    osp_cred, instances_name, custom_config=custom_config
+                )
 
         if test.get("recreate-cluster") is True:
             ceph_cluster_dict, clients = create_nodes(
@@ -1098,9 +1195,9 @@ def run(args):
                 osp_cred,
                 run_id,
                 cloud_type,
-                service,
                 instances_name,
                 enable_eus=enable_eus,
+                platform=platform,
             )
 
         tcs.append(tc)
@@ -1185,7 +1282,12 @@ def run(args):
                 setup_cluster_access(ceph_cluster_dict[cluster], node)
 
             installer = ceph_cluster_dict[cluster].get_nodes(role="installer")[0]
-            sosreport.run(installer.ip_address, "cephuser", "cephuser", run_dir)
+            sosreport.run(
+                installer.ip_address,
+                installer.username,
+                installer.password or "cephuser",
+                run_dir,
+            )
             # This can be Removed as sos report will have this details as well
             get_ceph_var_logs(ceph_cluster_dict[cluster], run_dir)
 

--- a/suites/onecloud/sample_cluster_deploy.yaml
+++ b/suites/onecloud/sample_cluster_deploy.yaml
@@ -1,0 +1,131 @@
+# OneCloud sample cluster deployment suite
+# Use with: run.py --global-conf conf/onecloud/6node-2client-cluster.yaml \
+#   --inventory conf/inventory/onecloud-rhel-10.1-server-x86_64.yaml \
+#   --cloud onecloud --suite suites/onecloud/sample_cluster_deploy.yaml
+#
+# Requires 6 cluster nodes (node1-node6) and at least 1 client (node7).
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node (node7 for 6node-2client-cluster)
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.2                      # client Id (<type>.<Id>)
+        node: node8                       # client node (node8 for 6node-2client-cluster)
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -55,6 +55,7 @@ rpm_packages = {
         "net-tools",
         "lvm2",
         "podman",
+        "rpcbind",
         "net-snmp-utils",
         "net-snmp",
         "kernel-modules-extra",
@@ -177,11 +178,18 @@ def install_prereq(
     ceph.exec_command(cmd=cmd_remove_apache_arrow)
 
     # Max SSH Sessions
-    sshd_configs = [
-        "sed -i '/MaxSessions*/d' /etc/ssh/sshd_config",
-        "echo 'MaxSessions 150' | tee -a /etc/ssh/sshd_config",
-        "systemctl restart sshd",
-    ]
+    if cloud_type == "onecloud":
+        sshd_configs = [
+            "sed -i '/MaxSessions*/d' /etc/ssh/sshd_config",
+            "echo 'MaxSessions 150' | tee -a /etc/ssh/sshd_config",
+            "systemctl restart sshd",
+        ]
+    else:
+        sshd_configs = [
+            "sudo sed -i '/MaxSessions*/d' /etc/ssh/sshd_config",
+            "echo 'MaxSessions 150' | sudo tee -a /etc/ssh/sshd_config",
+            "sudo systemctl restart sshd",
+        ]
     for sshd_cfg in sshd_configs:
         ceph.exec_command(cmd=sshd_cfg, sudo=True)
 
@@ -264,7 +272,7 @@ def install_prereq(
         ceph.exec_command(cmd="sudo yum clean all")
         config_ntp(ceph, cloud_type)
 
-    registry_login(ceph, distro_ver, test_data)
+    registry_login(ceph, distro_ver, test_data, cloud_type=cloud_type)
     update_iptables(ceph)
 
     if fips_mode:
@@ -394,6 +402,7 @@ def enable_rhel_rpms(ceph, distro_ver):
         ceph:       cluster instance
         distro_ver: distro version details
     """
+    sm_cmd = "subscription-manager"
 
     repos = {
         "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
@@ -402,12 +411,12 @@ def enable_rhel_rpms(ceph, distro_ver):
         "10": ["rhel-10-for-x86_64-appstream-rpms", "rhel-10-for-x86_64-baseos-rpms"],
     }
 
-    ceph.exec_command(sudo=True, cmd=f"subscription-manager release --set {distro_ver}")
+    ceph.exec_command(sudo=True, cmd=f"{sm_cmd} release --set {distro_ver}")
 
     for repo in repos.get(distro_ver.split(".")[0]):
         ceph.exec_command(
             sudo=True,
-            cmd="subscription-manager repos --enable={r}".format(r=repo),
+            cmd="{sm_cmd} repos --enable={r}".format(sm_cmd=sm_cmd, r=repo),
             long_running=True,
         )
 
@@ -420,13 +429,14 @@ def enable_rhel_eus_rpms(ceph, distro_ver):
         distro_ver:     distro version - example: 7.7
         ceph:           ceph object
     """
+    sm_cmd = "subscription-manager"
 
     eus_repos = {"7": ["rhel-7-server-eus-rpms", "rhel-7-server-extras-rpms"]}
 
     for repo in eus_repos.get(distro_ver[0]):
         ceph.exec_command(
             sudo=True,
-            cmd="subscription-manager repos --enable={r}".format(r=repo),
+            cmd="{sm_cmd} repos --enable={r}".format(sm_cmd=sm_cmd, r=repo),
             long_running=True,
         )
 
@@ -438,7 +448,7 @@ def enable_rhel_eus_rpms(ceph, distro_ver):
     else:
         raise NotImplementedError("cannot set EUS repos for %s", rhel_major_version)
 
-    cmd = f"subscription-manager release --set={release}"
+    cmd = f"{sm_cmd} release --set={release}"
 
     ceph.exec_command(
         sudo=True,
@@ -449,7 +459,7 @@ def enable_rhel_eus_rpms(ceph, distro_ver):
     ceph.exec_command(sudo=True, cmd="yum clean all", long_running=True)
 
 
-def registry_login(ceph, distro_ver, test_data=None):
+def registry_login(ceph, distro_ver, test_data=None, cloud_type="openstack"):
     """
     Login to the given Container registries provided in the configuration.
 

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -25,6 +25,7 @@ from cryptography.x509.oid import NameOID
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from jinja_markdown import MarkdownExtension
 
+from cli.exceptions import ConfigError
 from utility.log import Log
 
 log = Log(__name__)
@@ -2006,8 +2007,20 @@ def configure_kafka_cluster_with_security(ceph_cluster, cloud_type):
 
 def config_keystone_ldap(rgw_node, cloud_type):
     """Set the keystone config option on the cluster at startup"""
-    keystone_server = get_cephci_config()["keystone"][cloud_type].get("url")
-    ldap_url = get_cephci_config()["ldap"][cloud_type].get("url")
+    cephci_config = get_cephci_config()
+    keystone_cfg = cephci_config.get("keystone", {})
+    ldap_cfg = cephci_config.get("ldap", {})
+    # OneCloud may share keystone/ldap with openstack; fallback if onecloud not configured
+    lookup = cloud_type if cloud_type in keystone_cfg else "openstack"
+    keystone_server = keystone_cfg.get(lookup, keystone_cfg.get("openstack", {})).get(
+        "url"
+    )
+    ldap_url = ldap_cfg.get(lookup, ldap_cfg.get("openstack", {})).get("url")
+    if not keystone_server or not ldap_url:
+        raise ConfigError(
+            f"keystone/ldap config missing for cloud_type '{cloud_type}'. "
+            "Add keystone.{cloud} and ldap.{cloud} to cephci config."
+        )
 
     out = rgw_node.exec_command(sudo=True, cmd="ceph orch ls | grep rgw")
     rgw_name = out[0].split()[0]


### PR DESCRIPTION
## OneCloud Support for CephCI

### What Changed

OneCloud has been added as a new cloud provider (`--cloud onecloud`) for deploying and testing Ceph clusters via CephCI. The changes span 17 files across the codebase:

**New files:**
- `compute/onecloud.py` — OneCloud provider: VM lifecycle (create/delete/start/stop/restart), image resolution, project/VLAN selection, cloud-init userdata builder, cleanup
- `conf/inventory/onecloud-rhel-*.yaml` — Inventory files for RHEL 9.7 and 10.1 (small and medium profiles)
- `conf/onecloud/6node-2client-cluster.yaml` — 6-node + 2-client cluster config
- `osp-cred-onecloud-example.yaml` — Example credentials file
- `suites/onecloud/sample_cluster_deploy.yaml` — Sample suite (bootstrap, cephadm deploy, client setup)

**Modified files:**
- `run.py` — OneCloud entry point: VM creation, SSH auth (onecloud-user → cephuser switch), cleanup, cloud-init wait
- `ceph/ceph.py` — SSH passphrase support, ECDSA keys, OneCloud two-phase connect (onecloud-user bootstrap → root+cephuser), `sudo` prefix for non-root, better SSH error hints
- `ceph/utils.py` — `create_onecloud_ceph_nodes()`: cluster creation via OneCloud API, image/project/VLAN resolution, userData injection
- `tests/misc_env/install_prereq.py` — Removed retry logic for `yum clean all`
- `utility/utils.py`, `cephci/provision.py`, `cephci/utils/configs.py`, `cli/utilities/` — Minor integration updates

---

### How to Run on OneCloud

**1. Set up credentials** (`~/osp-cred-ci-2.yaml`):
```yaml
globals:
  onecloud-credentials:
    api_key: "<JWT bearer token from OneCloud portal>"
    base_url: "https://portal.onecloud.wdc.app.cirrus.ibm.com/api/v3"
    private_key_path: "~/.ssh/id_ed25519"      # SSH key for hardened images
    private_key_password: ""                     # passphrase if key is encrypted
    verify_ssl: false
```

**2. Choose a cluster config** (e.g. `conf/onecloud/6node-2client-cluster.yaml`):
- Nodes must have `no-of-volumes: 0` and `disk-size: 0`
- Avoid `osd` in node roles (use cephadm `all-available-devices` instead)

**3. Choose an inventory** (e.g. `conf/inventory/onecloud-rhel-10.1-server-x86_64.yaml`):
- Contains `image_id`, `projectID`, `site`, `groupID`, `VLAN`, `resources`, `arch`, `os`
- Cloud-init userdata with `cephuser` setup, SSH keys, and passwords

**4. Run:**
```bash
python run.py \
  --osp-cred ~/osp-cred-ci-2.yaml \
  --global-conf conf/onecloud/6node-2client-cluster.yaml \
  --inventory conf/inventory/onecloud-rhel-10.1-server-x86_64.yaml \
  --cloud onecloud \
  --suite suites/onecloud/sample_cluster_deploy.yaml \
  --platform rhel-10.1-server-x86_64 \
  --build <build>
```

**5. Overrides via `--custom-config`** (optional):
```bash
--custom-config onecloud_site=TUC,onecloud_project_id=808,onecloud_vlan=2231
```

---

### OneCloud Limitations

1. **No additional OSD volumes** — OneCloud does not support attaching extra block storage. `no-of-volumes` and `disk-size` are forced to 0. OSDs can only be deployed on pre-existing devices using `ceph orch apply osd --all-available-devices`. Cluster configs must not include `osd` in node roles (causes `RuntimeError` in `CephObjectFactory`).

2. **Single network per cluster** — All VMs share one VLAN. Per-node network selection is not supported. This blocks:
   - Stretch mode tests (require 2 separate subnets/DCs)
   - 3-AZ tests (require 3 subnets)
   - Multi-subnet tests (e.g. `rhosd-1admin-5node-multiple-subnet`)

3. **No floating IPs** — VMs only have private IPs. SSH access requires VPN or a jump host that can reach the OneCloud network. Tests that create/manage floating IPs (e.g. NFS HA with virtual IP) will not work.

4. **No subnet/CIDR exposure** — `CephVMNodeOneCloud.subnet` returns an empty string. Ceph `public_network` and `cluster_network` may not be set correctly by bootstrap unless the network is auto-detected.

5. **Limited VM profiles** — Only `small`, `medium`, and `large` resource profiles. No fine-grained CPU/RAM/disk control. No per-node flavor override.

6. **Single image per cluster** — All VMs in a cluster use the same OS image. Mix-OS tests (e.g. RHEL 9 + RHEL 10 in one cluster) are not supported.

7. **Hardened images** — OneCloud RHEL images use IBM CISO hardening (publickey-only SSH, compliance configs). CephCI handles this via two-phase SSH: connect as `onecloud-user` → setup root+cephuser → switch. This adds ~75 seconds to cluster setup for cloud-init.

8. **VM name length** — OneCloud limits VM names to 25 characters (alphanumeric + hyphens only).



---

Here are the steps for generating the JWT token and SSH key for OneCloud:

## 1. JWT Token (API Key)

The `api_key` in the credentials file is a JWT Bearer token from the OneCloud portal. It is used for all API calls (`Authorization: Bearer <token>`).

### Steps:

1. **Log in to the OneCloud portal** at `https://portal.onecloud.wdc.app.cirrus.ibm.com`
2. **Navigate to your profile/API settings** — look for "API Keys", "Tokens", or "Access Tokens" in your account/profile menu
3. **Generate a new API token** — the portal will issue a JWT. Copy it immediately (it's typically shown only once)
4. **Paste it into your credentials file** (`~/osp-cred-ci-2.yaml`):

```yaml
globals:
  onecloud-credentials:
    api_key: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
```

---

## 2. SSH Key 

OneCloud hardened images (IBM CISO) only allow publickey SSH authentication. CephCI uses two SSH keys: the CISO certificate key (bootstrap_key_path) connects to VMs via system SSH (OpenSSH) for initial setup, then injects the regular key (private_key_path) into root and cephuser authorized_keys. After setup, Paramiko connects using the regular key for all subsequent operations.

CISO key (bootstrap_key_path) — for initial OpenSSH subprocess bootstrap
Regular key (private_key_path) — for Paramiko connections after bootstrap

We would need to follow the steps provided here : https://ibm.box.com/s/jylv7pvb43885iohj3hawpbrpucj69to as a prereq.

```
ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_onecloud -N ""
```
### IBM CISO Step Certificate 

OneCloud environment requires IBM CISO certificates:

## Get a step SSH certificate from your CISO CA
```
step ssh certificate "your-email@ibm.com" ~/.ssh/id_ciso_key
```
This creates:
 ~/.ssh/id_ciso_key         (private key)
 ~/.ssh/id_ciso_key.pub     (public key)
 ~/.ssh/id_ciso_key-cert.pub (signed certificate)
```

Then in your credentials file:
```yaml
globals:
  onecloud-credentials:
    api_key: "<JWT_TOKEN>"
    base_url: "https://portal.onecloud.wdc.app.cirrus.ibm.com/api/v3"
    site: POK  # AUS, POK, RCH, TUC
    ssh_user: "onecloud-user"  # Default cloud-init user; customizable in OneCloud portal
    bootstrap_key_path: "~/.ssh/id_ecdsa_ciso"       # CISO key for initial OpenSSH bootstrap
    bootstrap_key_password: "<passphrase>"           # Passphrase for CISO key (from step ssh certificate)
    private_key_path: "~/.ssh/id_ed25519_onecloud"   # Regular key for Paramiko connections
    # verify_ssl: false  # If corporate CA causes SSL errors
```

CephCI auto-discovers the `.pub` and `-cert.pub` files from the `private_key_path`.


**Test the API token:**
```bash
curl -s -H "Authorization: Bearer <JWT_TOKEN>" \
  -H "Accept: application/json" \
  "https://portal.onecloud.wdc.app.cirrus.ibm.com/api/v3/vm/images?site=POK" | python3 -m json.tool | head -20
```

If that returns image data, your token is valid.

**Final credentials file** (`~/osp-cred-ci-2.yaml`):
```yaml
globals:
  onecloud-credentials:
    api_key: "<JWT_TOKEN>"
    site: POK
    private_key_path: "~/.ssh/id_ed25519_onecloud"
    private_key_password: ""
    verify_ssl: false
```

Pass log for onecloud cluster deployment : http://magna002.ceph.redhat.com/ceph-qe-logs/runlogs/cephci-run-JHLDSQ/ 

Developed via Cursor.