### PR TITLE
[Cephci] Inlcude changes needed for bug bz2324153 and bz2237854

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
@@ -119,6 +119,14 @@ tests:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
         git_clone_configs_repo: true
+  - test: # Bug 2324153
+      name: test STS assume role with web identity with wrong thumbprint
+      desc: test STS assume role with web identity with wrong thumbprint
+      polarion-id: CEPH-83573497
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_wrong_thumbprint.yaml
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token

--- a/suites/tentacle/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_sts_aswi.yaml
@@ -119,6 +119,14 @@ tests:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
         git_clone_configs_repo: true
+  - test: # Bug 2324153
+      name: test STS assume role with web identity with wrong thumbprint
+      desc: test STS assume role with web identity with wrong thumbprint
+      polarion-id: CEPH-83573497
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_wrong_thumbprint.yaml
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token


### PR DESCRIPTION
# Description
depends on: https://github.com/red-hat-storage/ceph-qe-scripts/pull/842
Automating 2 Bug BZ2324153 and BZ2237854

[Bug 2324153](https://bugzilla.redhat.com/show_bug.cgi?id=2324153) - [8.0][rgw][sts] with incorrect thumbprints in the OIDC provider, sts aswi request is successful bypassing thumbprint verification

[Bug 2237854](https://bugzilla.redhat.com/show_bug.cgi?id=2237854) - [rgw][sts]: assume_role_with_web_identity call is failing as validation of signature is failing with invalid padding

log:
testcase log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_sts_aswi_wrong_thumbprint.console.log
different testcase : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_sts_using_boto.console.log
end to end log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-6CZRC9/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
