### PR TITLE
Fix upgrade issue with redhat product being selected and FIO installation

### DIFF
--- a/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
@@ -160,7 +160,6 @@ tests:
           - ceph-common
           - ceph-base
           - ceph-fuse
-          - fio
 #          - ceph-test  # Not packaged downstream, need test changes to install it via upstream repos
         copy_admin_keyring: true
         caps:
@@ -168,6 +167,15 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
+  - test:
+      desc: Install fio
+      module: exec.py
+      name: Install FIO
+      config:
+        sudo: true
+        commands:
+          - "dnf install fio -y"
 
   - test:
       name: Enable logging to file

--- a/tests/rados/test_osd_crashes.py
+++ b/tests/rados/test_osd_crashes.py
@@ -323,9 +323,11 @@ def run(ceph_cluster, **kw):
             log.debug(
                 f"Test workflow completed. Start time: {start_time}, End time: {test_end_time}"
             )
+
             if rados_obj.check_crash_status(
                 start_time=start_time, end_time=test_end_time
             ):
-                log.error("Test failed due to crash at the end of test")
-                return 1
-        return 0
+                log.error("Test passed as expected crash was found")
+                return 0
+        log.error("Test failed as expected crash was not found")
+        return 1

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -129,7 +129,7 @@ def run(ceph_cluster, **kw):
                 "Upgrading the cluster from ceph version %s to %s-%s "
                 % (curr_ver, _rhcs_version, _rhcs_release)
             )
-            product: str = args.get("--product", "redhat")
+            product: str = args.get("--product", config["product"])
             ctm: CephTestManifest = CephTestManifest(
                 product=product,
                 release=_rhcs_version,


### PR DESCRIPTION
## 1) ibm-license installation fails since redhat rrepo was being installed by default
```
"2026-03-18 03:47:04,648 - cephci - ceph:1644 - INFO - Execute ACCEPT_EULA=Y yum install -y ibm-storage-ceph-license --nogpgcheck on 10.243.20.202
2026-03-18 03:47:05,653 - cephci - ceph:1202 - DEBUG - Updating Subscription Management repositories.
2026-03-18 03:47:05,653 - cephci - ceph:1202 - DEBUG - Unable to read consumer identity
2026-03-18 03:47:05,653 - cephci - ceph:1202 - DEBUG - 
2026-03-18 03:47:05,653 - cephci - ceph:1202 - DEBUG - This system is not registered with an entitlement server. You can use ""rhc"" or ""subscription-manager"" to register.
2026-03-18 03:47:05,653 - cephci - ceph:1202 - DEBUG - 
2026-03-18 03:47:05,653 - cephci - ceph:1202 - DEBUG - AppStream                                       175 MB/s |  84 MB     00:00    
2026-03-18 03:47:21,426 - cephci - ceph:1202 - DEBUG - BaseOS                                          179 MB/s | 104 MB     00:00    
2026-03-18 03:47:34,281 - cephci - ceph:1202 - DEBUG - codeready-builder                               127 MB/s |  16 MB     00:00    
2026-03-18 03:47:37,598 - cephci - ceph:1202 - DEBUG - created by dnf config-manager from http://repo. 9.1 MB/s | 231 kB     00:00    
2026-03-18 03:47:38,060 - cephci - ceph:1202 - DEBUG - Last metadata expiration check: 0:00:01 ago on Wed Mar 18 07:47:37 2026.
2026-03-18 03:47:41,116 - cephci - ceph:1202 - DEBUG - No match for argument: ibm-storage-ceph-license
2026-03-18 03:47:41,188 - cephci - ceph:1202 - ERROR - Error: Unable to find a match: ibm-storage-ceph-license
2026-03-18 03:47:41,189 - cephci - ceph:1674 - INFO - Execution of ACCEPT_EULA=Y yum install -y ibm-storage-ceph-license --nogpgcheck on 10.243.20.202 took 36.539991 seconds
2026-03-18 03:47:41,189 - cephci - utils:355 - ERROR - Execution failed for 'ibm-storage-ceph-license' on 'ceph-rados-7-pjfr-4cqbdx-node7'
2026-03-18 03:47:41,189 - cephci - test_upgrade_warn:434 - ERROR - Could not upgrade the cluster. error : Failed to install package '{pkg}'

Installing ibm-storage-ceph-liscense has passed for other nodes, failing for client node"
```

## 2) FIO was being installed with ceph version since changes in common packages
```
"ERROR - Could not upgrade the cluster. error : yum update --nogpgcheck -y 'ceph*' returned Error: 
 Problem: cannot install both libcephfs2-2:20.1.0-162.el9cp.x86_64 from repo.qe.ceph.lab_repos_ceph_testing_ibm_9_rhel9_20.1.0-162_Tools and libcephfs2-2:19.2.1-331.el9cp.x86_64 from @System
  - package ceph-common-2:20.1.0-162.el9cp.x86_64 from repo.qe.ceph.lab_repos_ceph_testing_ibm_9_rhel9_20.1.0-162_Tools requires libcephfs2 = 2:20.1.0-162.el9cp, but none of the providers can be installed
  - package libcephfs-daemon-2:19.2.1-331.el9cp.x86_64 from @System requires libcephfs2 = 2:19.2.1-331.el9cp, but none of the providers can be installed
  - cannot install the best update candidate for package ceph-common-2:19.2.1-331.el9cp.x86_64
  - problem with installed package libcephfs-daemon-2:19.2.1-331.el9cp.x86_64
 and code 1 on 10.243.20.188"
```

## 3) Comments the expected OSD crash in logs for test `issue repro-osd recovery with allocator file corruption`