### PR TITLE
tls tests

### DIFF
--- a/cli/ceph/nfs/export/export.py
+++ b/cli/ceph/nfs/export/export.py
@@ -46,19 +46,37 @@ class Export(Cli):
             log.info("Subvolume group created successfully")
         subvol_name = nfs_export.replace("/", "")
 
-        enctag = kwargs.pop("enctag", None)
-        xprtsec = kwargs.pop("xprtsec", None)
+        enctag = kwargs.get("enctag", None)
+        xprtsec = kwargs.get("xprtsec", None)
+        # NFS-export-only options must not be passed to ``fs subvolume create``; doing so
+        # can break ``subvolume getpath`` (empty path) and yields ``ceph nfs export create
+        # ... --path=`` which makes Ganesha reject mounts (e.g. ENOENT / No such file).
+        subvol_kwargs = {
+            k: v for k, v in kwargs.items() if k not in ("enctag", "xprtsec")
+        }
 
         # Step 2: Create subvolume
         cmd = f"ceph fs subvolume create cephfs {subvol_name} --group_name ganeshagroup --namespace-isolated "
-        cmd = "".join(cmd + build_cmd_from_args(**kwargs))
+        cmd = "".join(cmd + build_cmd_from_args(**subvol_kwargs))
         self.execute(sudo=True, cmd=cmd)
         # Get volume path
         cmd = (
             f"ceph fs subvolume getpath cephfs {subvol_name} --group_name ganeshagroup "
         )
         out = self.execute(sudo=True, cmd=cmd)
-        path = out[0].strip()
+        if isinstance(out, tuple):
+            raw = out[0]
+        else:
+            raw = out
+        if isinstance(raw, bytes):
+            path = raw.decode("utf-8", errors="replace").strip()
+        else:
+            path = (raw or "").strip() if raw is not None else ""
+        if not path:
+            raise RuntimeError(
+                f"ceph fs subvolume getpath returned empty path for {subvol_name!r} "
+                f"(nfs_export={nfs_export!r}); cannot create NFS export."
+            )
 
         # Step 3: Create export
         cmd = f"{self.base_cmd} create {fs_name} {nfs_name} {nfs_export} {fs} --path={path} "

--- a/cli/ceph/nfs/export/export.py
+++ b/cli/ceph/nfs/export/export.py
@@ -46,6 +46,9 @@ class Export(Cli):
             log.info("Subvolume group created successfully")
         subvol_name = nfs_export.replace("/", "")
 
+        enctag = kwargs.pop("enctag", None)
+        xprtsec = kwargs.pop("xprtsec", None)
+
         # Step 2: Create subvolume
         cmd = f"ceph fs subvolume create cephfs {subvol_name} --group_name ganeshagroup --namespace-isolated "
         cmd = "".join(cmd + build_cmd_from_args(**kwargs))
@@ -59,9 +62,11 @@ class Export(Cli):
 
         # Step 3: Create export
         cmd = f"{self.base_cmd} create {fs_name} {nfs_name} {nfs_export} {fs} --path={path} "
-        enctag = kwargs.get("enctag")
+
         if enctag:
             cmd = f"{cmd} --kmip_key_id={enctag}"
+        if xprtsec:
+            cmd += f" --xprtsec {xprtsec}"
         if readonly:
             cmd += " --readonly"
         if squash:

--- a/cli/utilities/filesys.py
+++ b/cli/utilities/filesys.py
@@ -22,7 +22,7 @@ class Mount(Cli):
         if not out.strip():
             self.execute(cmd="dnf install -y nfs-utils", sudo=True, timeout=600)
 
-    def nfs(self, mount, version, port, server, export):
+    def nfs(self, mount, version, port, server, export, **kwargs):
         """
         Perform nfs mount
         Args:

--- a/cli/utilities/filesys.py
+++ b/cli/utilities/filesys.py
@@ -40,7 +40,12 @@ class Mount(Cli):
             self.execute(cmd=f"mkdir {mount}", sudo=True)
 
         # Create the mount point
-        cmd = f"{self.base_cmd} -t nfs -o vers={version},port={port} {server}:{export} {mount}"
+        cmd = f"{self.base_cmd} -t nfs -o vers={version},port={port}"
+        xprtsec = kwargs.get("xprtsec")
+        if xprtsec:
+            cmd += f",xprtsec={xprtsec}"
+        cmd += f" {server}:{export} {mount}"
+
         self.execute(sudo=True, long_running=True, cmd=cmd)
 
         out = self.execute(sudo=True, cmd="mount")

--- a/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
@@ -474,7 +474,7 @@ tests:
 
   - test:
       name: TLS deploy, mount verify, and basic IO
-      module: security.test_tls_fearure.py
+      module: security.test_tls_feature.py
       desc: >
         TLS deploy, orch check, tlshd, TLS mount, log checks, basic IO.
       abort-on-fail: false
@@ -491,7 +491,7 @@ tests:
 
   - test:
       name: TLS export enforcement (plain vs TLS-only exports)
-      module: security.test_tls_fearure.py
+      module: security.test_tls_feature.py
       desc: >
         Plain NFS export then TLS-only export; insecure mount must fail; IO with sudo.
       abort-on-fail: false
@@ -504,7 +504,7 @@ tests:
 
   - test:
       name: TLS logs and openssl handshake probe
-      module: security.test_tls_fearure.py
+      module: security.test_tls_feature.py
       desc: >
         Ganesha log substring check and openssl probes (optional redeploy for TLS 1.2 min).
       abort-on-fail: false

--- a/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
@@ -471,3 +471,47 @@ tests:
       config:
         nfs_version: 3
         test_case: verify_mapping
+
+  - test:
+      name: TLS deploy, mount verify, and basic IO
+      module: security.test_tls_fearure.py
+      desc: >
+        TLS deploy, orch check, tlshd, TLS mount, log checks, basic IO.
+      abort-on-fail: false
+      polarion-id: CEPH-83629167
+      config:
+        nfs_version: 4.2
+        clients: 1
+        nfs_cluster_name: cephfs-nfs-tls
+        operation: tls_deploy_mount_verify
+        tls_log_substrings:
+          - AUTH_TLS
+          - TLS
+        strict_tls_log_check: true
+
+  - test:
+      name: TLS export enforcement (plain vs TLS-only exports)
+      module: security.test_tls_fearure.py
+      desc: >
+        Plain NFS export then TLS-only export; insecure mount must fail; IO with sudo.
+      abort-on-fail: false
+      polarion-id: CEPH-83629168
+      config:
+        nfs_version: 4.2
+        clients: 1
+        nfs_cluster_name: cephfs-nfs-tls
+        operation: tls_export_enforcement
+
+  - test:
+      name: TLS logs and openssl handshake probe
+      module: security.test_tls_fearure.py
+      desc: >
+        Ganesha log substring check and openssl probes (optional redeploy for TLS 1.2 min).
+      abort-on-fail: false
+      polarion-id: CEPH-83629169
+      config:
+        nfs_version: 4.2
+        clients: 1
+        nfs_cluster_name: cephfs-nfs-tls
+        operation: tls_logs_openssl_probe
+        redeploy_cluster_min_tls12: false

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -14,7 +14,7 @@ from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
 from cli.exceptions import OperationFailedError
-from cli.utilities.filesys import FuseMount, Mount, Unmount
+from cli.utilities.filesys import FuseMount, Mount, MountFailedError, Unmount
 from cli.utilities.utils import check_coredump_generated, get_ip_from_node, reboot_node
 from utility.log import Log
 from utility.retry import retry
@@ -862,7 +862,6 @@ def create_nfs_via_file_and_verify(
     Returns:
         str: Path to the temporary YAML file.
     """
-    import os
 
     temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
     remote_path = f"/tmp/{os.path.basename(temp_file.name)}"
@@ -1026,17 +1025,16 @@ def open_mandatory_v3_ports(nfs_node, ports_to_open):
     log.info("Firewall rules reloaded successfully")
 
 
-@retry(OperationFailedError, tries=4, delay=5, backoff=2)
+@retry((OperationFailedError, MountFailedError), tries=8, delay=5, backoff=2)
 def mount_retry(client, mount_name, version, port, nfs_server, export_name, **kwargs):
-    if Mount(client).nfs(
+    Mount(client).nfs(
         mount=mount_name,
         version=version,
         port=port,
         server=nfs_server,
         export=export_name,
         **kwargs,
-    ):
-        raise OperationFailedError("Failed to mount nfs on %s" % {export_name.hostname})
+    )
     return True
 
 
@@ -1410,7 +1408,7 @@ def get_ganesha_info_from_container(installer, nfs_service_name, nfs_host_node):
         return (None, None)
 
 
-def nfs_log_parser(client, nfs_node, nfs_name, expect_list=None):
+def nfs_log_parser(client, nfs_node, nfs_name, expect_list=None, expect_quiet=False):
     """
     This method parses the nfs debug log for given list of strings and returns 0 on Success
     and 1 on failure
@@ -1444,9 +1442,14 @@ def nfs_log_parser(client, nfs_node, nfs_name, expect_list=None):
             if exp_str not in results["expect"]:
                 expect_not_found.append(exp_str)
         if len(expect_not_found):
-            log.error(
-                f"Some of expected strings not found in debug logs for {nfs_daemon_name}:{expect_not_found}"
+            msg = (
+                f"Some of expected strings not found in debug logs for "
+                f"{nfs_daemon_name}:{expect_not_found}"
             )
+            if expect_quiet:
+                log.debug(msg)
+            else:
+                log.error(msg)
             return 1
         return 0
 

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -862,7 +862,10 @@ def create_nfs_via_file_and_verify(
     Returns:
         str: Path to the temporary YAML file.
     """
+    import os
+
     temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
+    remote_path = f"/tmp/{os.path.basename(temp_file.name)}"
 
     # Handle case where installer_node is a list
     if isinstance(installer_node, list):
@@ -1024,13 +1027,14 @@ def open_mandatory_v3_ports(nfs_node, ports_to_open):
 
 
 @retry(OperationFailedError, tries=4, delay=5, backoff=2)
-def mount_retry(client, mount_name, version, port, nfs_server, export_name):
+def mount_retry(client, mount_name, version, port, nfs_server, export_name, **kwargs):
     if Mount(client).nfs(
         mount=mount_name,
         version=version,
         port=port,
         server=nfs_server,
         export=export_name,
+        **kwargs,
     ):
         raise OperationFailedError("Failed to mount nfs on %s" % {export_name.hostname})
     return True

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -1,0 +1,298 @@
+import json
+from time import sleep
+
+from ceph.ceph import CommandFailed
+from cli.ceph.ceph import Ceph
+from cli.exceptions import OperationFailedError
+from cli.utilities.packages import Package
+from tests.nfs.nfs_operations import create_nfs_via_file_and_verify, nfs_log_parser
+from utility.log import Log
+from utility.utils import generate_self_signed_certificate
+
+log = Log(__name__)
+
+# Default client mount points TLS tests may leave mounted (for teardown helpers).
+TLS_TEST_MOUNT_CANDIDATES = [
+    "/mnt/plain_tc2",
+    "/mnt/tls_tc2",
+    "/mnt/tls_tc1_0",
+]
+
+
+def tls_config_get(config, *keys, default=None):
+    """
+    Return the first present value for any of ``keys`` in dict-like ``config``.
+    Used for suite YAML with preferred names plus legacy tc_* aliases.
+    """
+    for k in keys:
+        if k in config and config[k] is not None:
+            return config[k]
+    return default
+
+
+def setup_tls_client(client_node, ca_cert):
+    """Install ktls-utils, drop CA trust for tlshd, and restart tlshd on the client."""
+    log.info("Installing ktls-utils on client node %s", client_node.hostname)
+    Package(client_node).install("ktls-utils")
+
+    log.info("Configuring tlshd on client node %s", client_node.hostname)
+    cert_dir = "/cert/tls"
+    cert_path = f"{cert_dir}/tls_ca_cert.pem"
+    client_node.exec_command(sudo=True, cmd=f"mkdir -p {cert_dir}")
+
+    try:
+        cert_file = client_node.remote_file(
+            sudo=True, file_name=cert_path, file_mode="w"
+        )
+        cert_file.write(ca_cert)
+        cert_file.flush()
+    except AttributeError:
+        cert_file = client_node.remote_file(
+            sudo=True, file_name=cert_path, file_mode="wb"
+        )
+        cert_file.write(ca_cert.encode("utf-8"))
+        cert_file.flush()
+
+    client_node.exec_command(
+        sudo=True,
+        cmd="sed -i '/\\[authenticate.client\\]/d' /etc/tlshd.conf",
+        check_ec=False,
+    )
+    client_node.exec_command(
+        sudo=True, cmd="sed -i '/x509.truststore/d' /etc/tlshd.conf", check_ec=False
+    )
+    tlshd_conf_adds = f"\n[authenticate.client]\nx509.truststore= {cert_path}\n"
+    client_node.exec_command(
+        sudo=True, cmd=f"echo '{tlshd_conf_adds}' >> /etc/tlshd.conf"
+    )
+
+    log.info("Restarting tlshd on %s", client_node.hostname)
+    client_node.exec_command(sudo=True, cmd="systemctl enable --now tlshd")
+    client_node.exec_command(sudo=True, cmd="systemctl restart tlshd")
+
+
+def check_mount_fails(client_node, mount_cmd):
+    """
+    Run a mount command that is expected to fail (e.g. non-TLS mount to TLS-only export).
+
+    Returns True if the command failed as expected, False if it succeeded.
+    """
+    log.info("Attempting intentionally failing mount: %s", mount_cmd)
+    try:
+        client_node.exec_command(sudo=True, cmd=mount_cmd)
+        log.error("Mount succeeded but was expected to fail!")
+        return False
+    except CommandFailed:
+        log.info("Mount failed as expected.")
+        return True
+
+
+def full_tls_stack_cleanup(
+    client_node,
+    nfs_name,
+    mount_candidates=None,
+    fs_name="cephfs",
+    subvolume_group="ganeshagroup",
+):
+    """
+    Umount known TLS/plain mounts, delete all exports, delete NFS cluster,
+    remove CephFS subvolumes in the Ganesha group (admin/sudo).
+
+    Args:
+        client_node: Node with ceph admin.
+        nfs_name: NFS cluster service_id.
+        mount_candidates: Paths to lazy-umount and remove; defaults to TLS_TEST_MOUNT_CANDIDATES.
+        fs_name: CephFS name for subvolume cleanup.
+        subvolume_group: FS subvolume group used by NFS exports.
+    """
+    paths = (
+        mount_candidates if mount_candidates is not None else TLS_TEST_MOUNT_CANDIDATES
+    )
+    for m in paths:
+        client_node.exec_command(sudo=True, cmd=f"umount -l {m}", check_ec=False)
+        client_node.exec_command(sudo=True, cmd=f"rm -rf {m}", check_ec=False)
+
+    try:
+        raw = Ceph(client_node).nfs.export.ls(nfs_name)
+        exports = json.loads(raw) if raw else []
+    except (json.JSONDecodeError, TypeError, Exception) as ex:
+        log.warning("Could not list exports for %s: %s", nfs_name, ex)
+        exports = []
+
+    for export in exports:
+        try:
+            Ceph(client_node).nfs.export.delete(nfs_name, export)
+            log.info("Deleted export %s", export)
+        except Exception as ex:
+            log.warning("Export delete %s: %s", export, ex)
+
+    try:
+        Ceph(client_node).nfs.cluster.delete(nfs_name)
+        log.info("Deleted NFS cluster %s", nfs_name)
+    except Exception as ex:
+        log.warning("NFS cluster delete %s: %s", nfs_name, ex)
+
+    sleep(20)
+
+    try:
+        out = client_node.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume ls {fs_name} --group_name {subvolume_group}",
+        )
+        json_string, _ = out
+        for item in json.loads(json_string):
+            subvol = item["name"]
+            client_node.exec_command(
+                sudo=True,
+                cmd=(
+                    f"ceph fs subvolume rm {fs_name} {subvol} "
+                    f"--group_name {subvolume_group}"
+                ),
+            )
+    except Exception as ex:
+        log.warning("Subvolume cleanup: %s", ex)
+
+    try:
+        client_node.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolumegroup rm {fs_name} {subvolume_group} --force",
+            check_ec=False,
+        )
+    except Exception:
+        pass
+
+
+def verify_ceph_orch_nfs_running(client, nfs_name_substring="nfs"):
+    """
+    Verify at least one NFS orch daemon is reported (e.g. after TLS deploy).
+    Returns (True, stdout) on success.
+    """
+    out, _ = client.exec_command(
+        sudo=True, cmd=f"ceph orch ps | grep {nfs_name_substring}", check_ec=False
+    )
+    if not out or "nfs" not in out.lower():
+        log.error(
+            "No NFS service lines in `ceph orch ps | grep %s`", nfs_name_substring
+        )
+        return False, out or ""
+    log.info("NFS orch ps (filtered):\n%s", out)
+    return True, out
+
+
+def verify_tls_strings_in_nfs_logs(
+    client, nfs_node, nfs_cluster_service_id, expect_list
+):
+    """
+    Wrapper around nfs_operations.nfs_log_parser for TLS-related log assertions.
+
+    Args:
+        client: Any node with ceph admin (typically installer or client).
+        nfs_node: Host where the nfs container runs.
+        nfs_cluster_service_id: Ceph NFS cluster name (service_id), e.g. cephfs-nfs-tls.
+        expect_list: Substrings that must appear in cephadm nfs daemon logs.
+
+    Returns:
+        True if all strings found, False otherwise.
+    """
+    if not expect_list:
+        return True
+    rc = nfs_log_parser(
+        client, nfs_node, nfs_cluster_service_id, expect_list=expect_list
+    )
+    if rc != 0:
+        log.error(
+            "TLS log verification failed for cluster %s; expected substrings: %s",
+            nfs_cluster_service_id,
+            expect_list,
+        )
+        return False
+    return True
+
+
+def probe_tls_handshake_with_openssl(
+    client_node, nfs_host, port=2049, tls_version_flag="-tls1_3"
+):
+    """
+    Optional probe: openssl s_client against NFS port (may not always negotiate like HTTPS).
+
+    Returns (success: bool, output_snippet: str).
+    """
+    cmd = (
+        f"bash -c 'echo | timeout 15 openssl s_client -connect {nfs_host}:{port} "
+        f"{tls_version_flag} 2>&1 | head -40'"
+    )
+    try:
+        out, _ = client_node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        log.info("openssl s_client probe output (truncated):\n%s", out[:2000])
+        ok = bool(
+            out and ("TLSv1.3" in out or "CONNECTED" in out or "SSL-Session" in out)
+        )
+        return ok, out or ""
+    except Exception as ex:
+        log.warning("openssl probe skipped/failed: %s", ex)
+        return False, str(ex)
+
+
+def setup_tls_nfs_cluster(
+    installer_node,
+    nfs_node,
+    nfs_name,
+    tls_min_version="TLSv1.3",
+    tls_ciphers="ALL",
+    tls_ktls=True,
+    tls_debug=True,
+):
+    """
+    Creates an NFS-Ganesha cluster with TLS enabled by generating a self-signed
+    certificate and applying the custom config via Ceph orchestrator spec.
+
+    Args:
+        installer: The installer node.
+        nfs_node: The NFS node where the service will be placed.
+        nfs_name: Name of the NFS cluster.
+        tls_min_version: Minimum TLS version.
+        tls_ciphers: TLS ciphers string.
+        tls_ktls: Boolean flag for ktls.
+        tls_debug: Boolean flag for tls debug.
+    """
+    log.info(f"Generating self-signed certificate for {nfs_node.hostname}")
+    subject = {
+        "common_name": nfs_node.hostname,
+        "ip_address": nfs_node.ip_address,
+    }
+    cert_key, cert, ca_cert = generate_self_signed_certificate(subject)
+
+    # Note: `generate_self_signed_certificate` returns cephqe-signed cert + CA PEM when
+    # `get_cephqe_ca()` can download from root-ca-location; otherwise ca_cert is None.
+    # Orchestrator rejects nfs specs with ssl:true but no ssl_ca_cert (EINVAL: CA required).
+    if not ca_cert:
+        ca_cert = cert
+        log.warning(
+            "No cephqe CA available (offline DNS/network to root-ca-location); "
+            "using self-signed server cert PEM as ssl_ca_cert for NFS orch apply."
+        )
+
+    # Construct the TLS cluster spec
+    nfs_spec = {
+        "service_type": "nfs",
+        "service_id": nfs_name,
+        "placement": {"hosts": [nfs_node.hostname]},
+        "spec": {
+            "certificate_source": "inline",
+            "ssl": True,
+            "ssl_cert": cert.rstrip("\n"),
+            "ssl_key": cert_key.rstrip("\n"),
+            "ssl_ca_cert": ca_cert.rstrip("\n"),
+            "tls_ktls": tls_ktls,
+            "tls_debug": tls_debug,
+            "tls_min_version": tls_min_version,
+            "tls_ciphers": tls_ciphers,
+        },
+    }
+
+    log.info(f"Deploying TLS-enabled NFS cluster {nfs_name} via spec file")
+    if not create_nfs_via_file_and_verify(installer_node, [nfs_spec], timeout=300):
+        raise OperationFailedError(f"Failed to create TLS NFS cluster {nfs_name}")
+
+    log.info(f"Successfully deployed TLS NFS cluster {nfs_name}")
+    return ca_cert or cert

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -1,7 +1,7 @@
 import json
-from time import sleep
 
 from ceph.ceph import CommandFailed
+from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
 from cli.exceptions import OperationFailedError
 from cli.utilities.packages import Package
@@ -17,6 +17,204 @@ TLS_TEST_MOUNT_CANDIDATES = [
     "/mnt/tls_tc2",
     "/mnt/tls_tc1_0",
 ]
+
+
+def _nfs_ls_to_cluster_names(clusters):
+    """Normalize ``ceph nfs cluster ls`` JSON to a list of cluster/service id strings."""
+    if not clusters:
+        return []
+    names = []
+    for c in clusters:
+        if isinstance(c, str):
+            names.append(c)
+        elif isinstance(c, dict):
+            for key in ("name", "service_id", "nfs_cluster"):
+                if c.get(key):
+                    names.append(str(c[key]))
+                    break
+    return names
+
+
+def _nfs_cluster_names(client_node):
+    try:
+        clusters = Ceph(client_node).nfs.cluster.ls()
+    except Exception as ex:
+        log.debug("nfs cluster ls failed: %s", ex)
+        return None
+    return _nfs_ls_to_cluster_names(clusters)
+
+
+def _orch_nfs_daemon_count(client_node, nfs_name):
+    """Return count of cephadm NFS daemons for ``nfs.<nfs_name>``, or -1 if query failed."""
+    try:
+        raw, _ = client_node.exec_command(
+            sudo=True,
+            cmd=f"ceph orch ps --service_name nfs.{nfs_name} --format json",
+            timeout=60,
+            check_ec=False,
+        )
+        if raw is None:
+            text = ""
+        elif isinstance(raw, str):
+            text = raw.strip()
+        else:
+            text = raw.read().decode().strip()
+        if not text:
+            return 0
+        data = json.loads(text)
+        if isinstance(data, list):
+            return len(data)
+        return 0
+    except Exception as ex:
+        log.debug("orch ps nfs.%s: %s", nfs_name, ex)
+        return -1
+
+
+def wait_until_nfs_cluster_teardown(client_node, nfs_name, timeout=300, interval=5):
+    """
+    Wait until the NFS cluster is gone from ``ceph nfs cluster ls`` and no daemons remain
+    in ``ceph orch ps`` for ``nfs.<nfs_name>`` (replaces a fixed sleep after cluster delete).
+    """
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        names = _nfs_cluster_names(client_node)
+        if names is None:
+            continue
+        n_daemons = _orch_nfs_daemon_count(client_node, nfs_name)
+        if nfs_name not in names and n_daemons == 0:
+            log.info(
+                "NFS cluster %r teardown complete (mgr + orch) after ~%s s",
+                nfs_name,
+                w._attempt * w.interval,
+            )
+            return True
+        if nfs_name not in names and n_daemons < 0:
+            log.info(
+                "NFS cluster %r absent from mgr ls; orch ps unavailable after ~%s s",
+                nfs_name,
+                w._attempt * w.interval,
+            )
+            return True
+        log.debug(
+            "Waiting for nfs.%s teardown (in_ls=%s, daemon_count=%s)",
+            nfs_name,
+            nfs_name in names,
+            n_daemons,
+        )
+    log.warning(
+        "Timed out after %ss waiting for NFS cluster %r to drain; continuing cleanup.",
+        timeout,
+        nfs_name,
+    )
+    return False
+
+
+def wait_until_nfs_export_visible(
+    client_node, nfs_name, export_path, timeout=180, interval=3
+):
+    """
+    Poll until ``export_path`` appears in ``ceph nfs export ls <nfs_name>``.
+    """
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        try:
+            raw = Ceph(client_node).nfs.export.ls(nfs_name)
+            if not raw or not isinstance(raw, str):
+                continue
+            try:
+                exports = json.loads(raw)
+            except json.JSONDecodeError:
+                if export_path in raw:
+                    log.info(
+                        "Export %r visible for %r after ~%s s (non-JSON ls)",
+                        export_path,
+                        nfs_name,
+                        w._attempt * w.interval,
+                    )
+                    return True
+                continue
+            if isinstance(exports, list):
+                if export_path in exports:
+                    log.info(
+                        "Export %r listed for %r after ~%s s",
+                        export_path,
+                        nfs_name,
+                        w._attempt * w.interval,
+                    )
+                    return True
+                for e in exports:
+                    if e == export_path or export_path in str(e):
+                        log.info(
+                            "Export %r listed for %r after ~%s s",
+                            export_path,
+                            nfs_name,
+                            w._attempt * w.interval,
+                        )
+                        return True
+        except Exception as ex:
+            log.debug("export ls wait: %s", ex)
+    raise OperationFailedError(
+        f"Timed out after {timeout}s waiting for export {export_path!r} on {nfs_name!r}"
+    )
+
+
+def wait_for_tls_strings_in_nfs_logs(
+    client,
+    nfs_node,
+    nfs_cluster_service_id,
+    expect_list,
+    timeout=120,
+    interval=3,
+):
+    """
+    Poll Ganesha logs until all ``expect_list`` substrings are found (same check as
+    ``verify_tls_strings_in_nfs_logs``), instead of sleeping before a single check.
+    """
+    if not expect_list:
+        return True
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        if verify_tls_strings_in_nfs_logs(
+            client,
+            nfs_node,
+            nfs_cluster_service_id,
+            expect_list,
+            expect_quiet=True,
+        ):
+            log.info(
+                "TLS log substrings matched after ~%s s",
+                w._attempt * w.interval,
+            )
+            return True
+    return False
+
+
+def wait_until_ceph_orch_nfs_ps_ready(
+    client_node, nfs_name_substring, timeout=300, interval=5
+):
+    """
+    Poll ``ceph orch ps | grep <substring>`` until NFS service lines appear (e.g. after redeploy).
+
+    Uses the same success criteria as ``verify_ceph_orch_nfs_running`` without logging an error
+    on every poll.
+    """
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        out, _ = client_node.exec_command(
+            sudo=True,
+            cmd=f"ceph orch ps | grep {nfs_name_substring}",
+            check_ec=False,
+        )
+        if out and "nfs" in out.lower():
+            log.info(
+                "ceph orch ps shows NFS (%r) after ~%s s",
+                nfs_name_substring,
+                w._attempt * w.interval,
+            )
+            log.info("NFS orch ps (filtered):\n%s", out)
+            return True
+    log.warning(
+        "Timed out after %ss waiting for NFS in `ceph orch ps | grep %s`",
+        timeout,
+        nfs_name_substring,
+    )
+    return False
 
 
 def tls_config_get(config, *keys, default=None):
@@ -132,34 +330,19 @@ def full_tls_stack_cleanup(
     except Exception as ex:
         log.warning("NFS cluster delete %s: %s", nfs_name, ex)
 
-    sleep(20)
+    wait_until_nfs_cluster_teardown(client_node, nfs_name)
 
+    ceph_cli = Ceph(client_node)
     try:
-        out = client_node.exec_command(
-            sudo=True,
-            cmd=f"ceph fs subvolume ls {fs_name} --group_name {subvolume_group}",
-        )
-        json_string, _ = out
-        for item in json.loads(json_string):
+        raw = ceph_cli.fs.sub_volume.ls(fs_name, group_name=subvolume_group)
+        items = json.loads(raw) if raw else []
+        for item in items:
             subvol = item["name"]
-            client_node.exec_command(
-                sudo=True,
-                cmd=(
-                    f"ceph fs subvolume rm {fs_name} {subvol} "
-                    f"--group_name {subvolume_group}"
-                ),
-            )
+            ceph_cli.fs.sub_volume.rm(fs_name, subvol, group_name=subvolume_group)
     except Exception as ex:
         log.warning("Subvolume cleanup: %s", ex)
 
-    try:
-        client_node.exec_command(
-            sudo=True,
-            cmd=f"ceph fs subvolumegroup rm {fs_name} {subvolume_group} --force",
-            check_ec=False,
-        )
-    except Exception:
-        pass
+    ceph_cli.fs.sub_volume_group.rm(fs_name, subvolume_group, force=True)
 
 
 def verify_ceph_orch_nfs_running(client, nfs_name_substring="nfs"):
@@ -180,7 +363,7 @@ def verify_ceph_orch_nfs_running(client, nfs_name_substring="nfs"):
 
 
 def verify_tls_strings_in_nfs_logs(
-    client, nfs_node, nfs_cluster_service_id, expect_list
+    client, nfs_node, nfs_cluster_service_id, expect_list, expect_quiet=False
 ):
     """
     Wrapper around nfs_operations.nfs_log_parser for TLS-related log assertions.
@@ -190,6 +373,7 @@ def verify_tls_strings_in_nfs_logs(
         nfs_node: Host where the nfs container runs.
         nfs_cluster_service_id: Ceph NFS cluster name (service_id), e.g. cephfs-nfs-tls.
         expect_list: Substrings that must appear in cephadm nfs daemon logs.
+        expect_quiet: If True, omit summary error log (for polling waiters).
 
     Returns:
         True if all strings found, False otherwise.
@@ -197,14 +381,19 @@ def verify_tls_strings_in_nfs_logs(
     if not expect_list:
         return True
     rc = nfs_log_parser(
-        client, nfs_node, nfs_cluster_service_id, expect_list=expect_list
+        client,
+        nfs_node,
+        nfs_cluster_service_id,
+        expect_list=expect_list,
+        expect_quiet=expect_quiet,
     )
     if rc != 0:
-        log.error(
-            "TLS log verification failed for cluster %s; expected substrings: %s",
-            nfs_cluster_service_id,
-            expect_list,
-        )
+        if not expect_quiet:
+            log.error(
+                "TLS log verification failed for cluster %s; expected substrings: %s",
+                nfs_cluster_service_id,
+                expect_list,
+            )
         return False
     return True
 

--- a/tests/nfs/security/test_tls_fearure.py
+++ b/tests/nfs/security/test_tls_fearure.py
@@ -1,0 +1,354 @@
+import traceback
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import OperationFailedError
+from cli.utilities.filesys import Mount, Unmount
+from tests.nfs.security.security_utils import (
+    check_mount_fails,
+    full_tls_stack_cleanup,
+    probe_tls_handshake_with_openssl,
+    setup_tls_client,
+    setup_tls_nfs_cluster,
+    tls_config_get,
+    verify_ceph_orch_nfs_running,
+    verify_tls_strings_in_nfs_logs,
+)
+from tests.nfs.test_nfs_io_operations_during_upgrade import (
+    create_export_and_mount_for_existing_nfs_cluster,
+)
+from tests.nfs.test_nfs_multiple_operations_for_upgrade import (
+    create_file,
+    delete_file,
+    lookup_in_directory,
+    read_from_file_using_dd_command,
+    rename_file,
+    write_to_file_using_dd_command,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+DEFAULT_NFS_TLS_CLUSTER = "cephfs-nfs-tls"
+
+# Single-operation names and the combined workflow
+OP_TLS_DEPLOY_MOUNT_VERIFY = "tls_deploy_mount_verify"
+OP_TLS_EXPORT_ENFORCEMENT = "tls_export_enforcement"
+OP_TLS_LOGS_OPENSSL_PROBE = "tls_logs_openssl_probe"
+OP_TLS_FULL_WORKFLOW = "tls_full_workflow"
+_TLS_FULL_SEQUENCE = [
+    OP_TLS_DEPLOY_MOUNT_VERIFY,
+    OP_TLS_EXPORT_ENFORCEMENT,
+    OP_TLS_LOGS_OPENSSL_PROBE,
+]
+
+
+def _normalize_operation(name):
+    if name is None:
+        return None
+    return str(name).strip().lower().replace("-", "_")
+
+
+def _operations_to_run(config):
+    """
+    Resolve config.operation into an ordered list of operation ids.
+    Accepts tls_full_workflow / tls_all_in_one for the full sequence.
+    """
+    raw = config.get("operation")
+    if raw is None:
+        raise OperationFailedError(
+            "config.operation is required. Use one of: "
+            f"{OP_TLS_DEPLOY_MOUNT_VERIFY}, {OP_TLS_EXPORT_ENFORCEMENT}, "
+            f"{OP_TLS_LOGS_OPENSSL_PROBE}, {OP_TLS_FULL_WORKFLOW} (or tls_all_in_one)."
+        )
+    op = _normalize_operation(raw)
+    if op in (OP_TLS_FULL_WORKFLOW, "tls_all_in_one", "tls_full"):
+        return list(_TLS_FULL_SEQUENCE)
+    if op in _TLS_FULL_SEQUENCE:
+        return [op]
+    raise OperationFailedError(
+        f"Unknown operation {raw!r}. Expected one of: {', '.join(_TLS_FULL_SEQUENCE)} "
+        f"or {OP_TLS_FULL_WORKFLOW}."
+    )
+
+
+def op_tls_deploy_mount_verify(client_node, nfs_node, config, nfs_name):
+    log.info("=== Operation: tls_deploy_mount_verify ===")
+    fs_name = config.get("fs_name", "cephfs")
+    export_name = tls_config_get(
+        config, "tls_export_path", "tc_01_export", default="/tls_export1"
+    )
+    mount_name = tls_config_get(
+        config, "tls_client_mount", "tc_01_mount", default="/mnt/tls_tc1"
+    )
+    version = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+
+    ok, _ = verify_ceph_orch_nfs_running(client_node, nfs_name)
+    if not ok:
+        raise OperationFailedError("NFS service not reported in ceph orch ps")
+
+    expect_logs = tls_config_get(
+        config,
+        "tls_log_substrings",
+        "tc_01_log_expect",
+        default=["AUTH_TLS", "TLS"],
+    )
+
+    client_export_mount_dict = create_export_and_mount_for_existing_nfs_cluster(
+        clients=[client_node],
+        nfs_export=export_name,
+        nfs_mount=mount_name,
+        export_num=1,
+        fs_name=fs_name,
+        nfs_name=nfs_name,
+        fs=fs_name,
+        port=port,
+        version=version,
+        nfs_server=nfs_node.hostname,
+        xprtsec="tls",
+    )
+    # exports_mounts_perclient uses "{nfs_mount}_{i}" e.g. /mnt/tls_tc1_0
+    mount_path = client_export_mount_dict[client_node]["mount"][0]
+
+    sleep(
+        int(
+            tls_config_get(
+                config,
+                "post_mount_sleep_sec",
+                "tc_01_post_mount_sleep",
+                default=3,
+            )
+        )
+    )
+    if not verify_tls_strings_in_nfs_logs(client_node, nfs_node, nfs_name, expect_logs):
+        if tls_config_get(
+            config, "strict_tls_log_check", "tc_01_strict_logs", default=True
+        ):
+            raise OperationFailedError(
+                f"Expected TLS-related log substrings not found after mount: {expect_logs}"
+            )
+        log.warning("Post-mount TLS log verification failed (non-strict); continuing.")
+
+    lookup_in_directory(client_node, mount_path)
+    log.info("Performing basic IO on TLS mount (sudo) via upgrade-test helpers")
+    dd_mb = 5
+    base = "tc1_file"
+    renamed = "tc1_renamed"
+    create_file(client_node, mount_path, base)
+    write_to_file_using_dd_command(client_node, mount_path, base, dd_mb)
+    read_from_file_using_dd_command(client_node, mount_path, base, dd_mb)
+    rename_file(client_node, mount_path, base, renamed)
+    delete_file(client_node, mount_path, renamed)
+
+    log.info("tls_deploy_mount_verify completed successfully.")
+
+
+def op_tls_export_enforcement(client_node, nfs_node, config, nfs_name):
+    log.info("=== Operation: tls_export_enforcement ===")
+    fs_name = config.get("fs_name", "cephfs")
+    version = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+
+    plain_export = tls_config_get(
+        config, "plain_nfs_export", "tc_02_plain_export", default="/plain_export_tc2"
+    )
+    tls_export = tls_config_get(
+        config, "tls_only_export", "tc_02_tls_export", default="/tls_export_tc2"
+    )
+    plain_mount = tls_config_get(
+        config, "plain_export_mount", "tc_02_plain_mount", default="/mnt/plain_tc2"
+    )
+    tls_mount = tls_config_get(
+        config, "tls_export_mount", "tc_02_tls_mount", default="/mnt/tls_tc2"
+    )
+    # Insecure mount attempt uses vers+port only (no xprtsec); see check_mount_fails below.
+    mount_opts = f"-t nfs -o vers={version},port={port}"
+
+    Ceph(client_node).nfs.export.create(
+        fs_name=fs_name,
+        nfs_name=nfs_name,
+        nfs_export=plain_export,
+        fs=fs_name,
+    )
+    sleep(5)
+
+    client_node.create_dirs(dir_path=plain_mount, sudo=True)
+    # TLS-enabled Ganesha still negotiates TLS on the wire; omitting xprtsec fails with e.g.
+    # "mount.nfs: failed to apply fstab options" (exit 32). "Plain" here means the export
+    # was created without --xprtsec tls (not TLS-mandatory at export policy), not cleartext NFS.
+    Mount(client_node).nfs(
+        mount=plain_mount,
+        version=version,
+        port=port,
+        server=nfs_node.hostname,
+        export=plain_export,
+        xprtsec="tls",
+    )
+    log.info("Plain export mounted with TLS transport (xprtsec=tls); IO with sudo")
+    lookup_in_directory(client_node, plain_mount)
+    create_file(client_node, plain_mount, "plain_ok")
+    # Strict: we know this mount succeeded; fail the step if umount errors.
+    client_node.exec_command(sudo=True, cmd=f"umount {plain_mount}")
+
+    Ceph(client_node).nfs.export.create(
+        fs_name=fs_name,
+        nfs_name=nfs_name,
+        nfs_export=tls_export,
+        fs=fs_name,
+        xprtsec="tls",
+    )
+    sleep(5)
+
+    client_node.create_dirs(dir_path=tls_mount, sudo=True)
+    cmd_insecure = f"mount {mount_opts} {nfs_node.hostname}:{tls_export} {tls_mount}"
+    if not check_mount_fails(client_node, cmd_insecure):
+        raise OperationFailedError(
+            "TLS export allowed insecure mount (expected failure)."
+        )
+
+    if Mount(client_node).nfs(
+        mount=tls_mount,
+        version=version,
+        port=port,
+        server=nfs_node.hostname,
+        export=tls_export,
+        xprtsec="tls",
+    ):
+        raise OperationFailedError("TLS mount with xprtsec=tls failed.")
+    lookup_in_directory(client_node, tls_mount)
+    create_file(client_node, tls_mount, "tls_ok")
+    log.info("TLS export: IO with sudo completed.")
+    # Best-effort teardown: mount_retry is for *mount* only, not umount. If the TLS
+    # mount step failed earlier or cleanup already ran, plain umount can fail; use
+    # Unmount (lazy umount -l, Cli.execute check_ec=False) like other NFS tests.
+    Unmount(client_node).unmount(tls_mount)
+
+    log.info("tls_export_enforcement completed successfully.")
+
+
+def op_tls_logs_openssl_probe(installer_node, client_node, nfs_node, config, nfs_name):
+    log.info("=== Operation: tls_logs_openssl_probe ===")
+
+    expect_logs = tls_config_get(
+        config,
+        "tls_log_substrings",
+        "tc_03_log_expect",
+        "tc_01_log_expect",
+        default=["AUTH_TLS", "TLS"],
+    )
+    verify_tls_strings_in_nfs_logs(client_node, nfs_node, nfs_name, expect_logs)
+
+    host = nfs_node.ip_address or nfs_node.hostname
+    ok_13, out_13 = probe_tls_handshake_with_openssl(
+        client_node,
+        host,
+        port=int(config.get("port", 2049)),
+        tls_version_flag="-tls1_3",
+    )
+    if ok_13:
+        log.info("openssl TLSv1.3 probe reported a positive signal.")
+    else:
+        log.warning(
+            "openssl TLSv1.3 probe inconclusive (NFS is not HTTPS). Snippet: %s",
+            (out_13 or "")[:500],
+        )
+
+    ok_12, _ = probe_tls_handshake_with_openssl(
+        client_node,
+        host,
+        port=int(config.get("port", 2049)),
+        tls_version_flag="-tls1_2",
+    )
+    log.info("openssl TLSv1.2 probe ok=%s (informational)", ok_12)
+
+    if tls_config_get(
+        config, "redeploy_cluster_min_tls12", "tc_03_redeploy_tls12", default=False
+    ):
+        log.info(
+            "redeploy_cluster_min_tls12: redeploying NFS with tls_min_version=TLSv1.2"
+        )
+        setup_tls_nfs_cluster(
+            installer_node=installer_node,
+            nfs_node=nfs_node,
+            nfs_name=nfs_name,
+            tls_min_version="TLSv1.2",
+            tls_ciphers=tls_config_get(
+                config, "nfs_tls12_ciphers", "tc_03_tls_ciphers", default="ALL"
+            ),
+            tls_ktls=config.get("tls_ktls", True),
+            tls_debug=config.get("tls_debug", True),
+        )
+        sleep(30)
+        verify_ceph_orch_nfs_running(client_node, nfs_name)
+
+    log.info("tls_logs_openssl_probe completed.")
+
+
+_OP_DISPATCH = {
+    OP_TLS_DEPLOY_MOUNT_VERIFY: lambda inst, c, n, cfg, name: op_tls_deploy_mount_verify(
+        c, n, cfg, name
+    ),
+    OP_TLS_EXPORT_ENFORCEMENT: lambda inst, c, n, cfg, name: op_tls_export_enforcement(
+        c, n, cfg, name
+    ),
+    OP_TLS_LOGS_OPENSSL_PROBE: lambda inst, c, n, cfg, name: op_tls_logs_openssl_probe(
+        inst, c, n, cfg, name
+    ),
+}
+
+
+def run(ceph_cluster, **kw):
+    """
+    Each invocation is independent: deploy TLS NFS + tlshd, run config.operation, full cleanup.
+
+    config.operation: tls_deploy_mount_verify | tls_export_enforcement |
+        tls_logs_openssl_probe | tls_full_workflow (or tls_all_in_one)
+    """
+    log.info("Starting NFS TLS feature tests (independent mode)")
+    config = kw.get("config", {})
+
+    steps = _operations_to_run(config)
+
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    nfs_nodes = ceph_cluster.get_nodes(role="nfs")
+    clients = ceph_cluster.get_nodes(role="client")
+    no_clients = int(config.get("clients", 1))
+    clients = clients[:no_clients]
+    client_node = clients[0]
+
+    if not nfs_nodes or not clients:
+        raise OperationFailedError("Requires at least one NFS node and one client")
+
+    nfs_node = nfs_nodes[0]
+    nfs_name = config.get("nfs_cluster_name", DEFAULT_NFS_TLS_CLUSTER)
+    fs_name = config.get("fs_name", "cephfs")
+
+    try:
+        ca_cert = setup_tls_nfs_cluster(
+            installer_node=installer,
+            nfs_node=nfs_node,
+            nfs_name=nfs_name,
+            tls_min_version=config.get("tls_min_version", "TLSv1.3"),
+            tls_ciphers=config.get("tls_ciphers", "ALL"),
+            tls_ktls=config.get("tls_ktls", True),
+            tls_debug=config.get("tls_debug", True),
+        )
+        setup_tls_client(client_node, ca_cert)
+
+        for step in steps:
+            _OP_DISPATCH[step](installer, client_node, nfs_node, config, nfs_name)
+
+        log.info("NFS TLS operations %s completed successfully.", steps)
+        return 0
+
+    except Exception as e:
+        log.error("Test failed: %s", e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Full TLS stack cleanup (umount, exports, cluster, subvolumes)")
+        try:
+            full_tls_stack_cleanup(client_node, nfs_name, fs_name=fs_name)
+        except Exception as ex:
+            log.error("Cleanup failed: %s", ex)

--- a/tests/nfs/security/test_tls_feature.py
+++ b/tests/nfs/security/test_tls_feature.py
@@ -1,9 +1,8 @@
 import traceback
-from time import sleep
 
 from cli.ceph.ceph import Ceph
 from cli.exceptions import OperationFailedError
-from cli.utilities.filesys import Mount, Unmount
+from cli.utilities.filesys import Mount, MountFailedError, Unmount
 from tests.nfs.security.security_utils import (
     check_mount_fails,
     full_tls_stack_cleanup,
@@ -13,6 +12,9 @@ from tests.nfs.security.security_utils import (
     tls_config_get,
     verify_ceph_orch_nfs_running,
     verify_tls_strings_in_nfs_logs,
+    wait_for_tls_strings_in_nfs_logs,
+    wait_until_ceph_orch_nfs_ps_ready,
+    wait_until_nfs_export_visible,
 )
 from tests.nfs.test_nfs_io_operations_during_upgrade import (
     create_export_and_mount_for_existing_nfs_cluster,
@@ -111,22 +113,38 @@ def op_tls_deploy_mount_verify(client_node, nfs_node, config, nfs_name):
     # exports_mounts_perclient uses "{nfs_mount}_{i}" e.g. /mnt/tls_tc1_0
     mount_path = client_export_mount_dict[client_node]["mount"][0]
 
-    sleep(
-        int(
-            tls_config_get(
-                config,
-                "post_mount_sleep_sec",
-                "tc_01_post_mount_sleep",
-                default=3,
-            )
+    wait_timeout = int(
+        tls_config_get(
+            config,
+            "post_mount_tls_log_wait_timeout_sec",
+            "tc_01_post_mount_tls_log_wait_timeout_sec",
+            "post_mount_sleep_sec",
+            "tc_01_post_mount_sleep",
+            default=120,
         )
     )
-    if not verify_tls_strings_in_nfs_logs(client_node, nfs_node, nfs_name, expect_logs):
+    wait_interval = int(
+        tls_config_get(
+            config,
+            "post_mount_tls_log_wait_interval_sec",
+            "tc_01_post_mount_tls_log_wait_interval_sec",
+            default=3,
+        )
+    )
+    if not wait_for_tls_strings_in_nfs_logs(
+        client_node,
+        nfs_node,
+        nfs_name,
+        expect_logs,
+        timeout=wait_timeout,
+        interval=wait_interval,
+    ):
         if tls_config_get(
             config, "strict_tls_log_check", "tc_01_strict_logs", default=True
         ):
             raise OperationFailedError(
-                f"Expected TLS-related log substrings not found after mount: {expect_logs}"
+                f"Expected TLS-related log substrings not found within {wait_timeout}s "
+                f"after mount: {expect_logs}"
             )
         log.warning("Post-mount TLS log verification failed (non-strict); continuing.")
 
@@ -171,7 +189,7 @@ def op_tls_export_enforcement(client_node, nfs_node, config, nfs_name):
         nfs_export=plain_export,
         fs=fs_name,
     )
-    sleep(5)
+    wait_until_nfs_export_visible(client_node, nfs_name, plain_export)
 
     client_node.create_dirs(dir_path=plain_mount, sudo=True)
     # TLS-enabled Ganesha still negotiates TLS on the wire; omitting xprtsec fails with e.g.
@@ -198,24 +216,26 @@ def op_tls_export_enforcement(client_node, nfs_node, config, nfs_name):
         fs=fs_name,
         xprtsec="tls",
     )
-    sleep(5)
+    wait_until_nfs_export_visible(client_node, nfs_name, tls_export)
 
     client_node.create_dirs(dir_path=tls_mount, sudo=True)
     cmd_insecure = f"mount {mount_opts} {nfs_node.hostname}:{tls_export} {tls_mount}"
     if not check_mount_fails(client_node, cmd_insecure):
-        raise OperationFailedError(
-            "TLS export allowed insecure mount (expected failure)."
-        )
+        log.error("TLS export allowed insecure mount (expected failure).")
+        raise MountFailedError("TLS export allowed insecure mount (expected failure).")
 
-    if Mount(client_node).nfs(
-        mount=tls_mount,
-        version=version,
-        port=port,
-        server=nfs_node.hostname,
-        export=tls_export,
-        xprtsec="tls",
-    ):
-        raise OperationFailedError("TLS mount with xprtsec=tls failed.")
+    try:
+        Mount(client_node).nfs(
+            mount=tls_mount,
+            version=version,
+            port=port,
+            server=nfs_node.hostname,
+            export=tls_export,
+            xprtsec="tls",
+        )
+    except MountFailedError as err:
+        log.error("TLS mount with xprtsec=tls failed: %s", err)
+        raise
     lookup_in_directory(client_node, tls_mount)
     create_file(client_node, tls_mount, "tls_ok")
     log.info("TLS export: IO with sudo completed.")
@@ -279,8 +299,21 @@ def op_tls_logs_openssl_probe(installer_node, client_node, nfs_node, config, nfs
             tls_ktls=config.get("tls_ktls", True),
             tls_debug=config.get("tls_debug", True),
         )
-        sleep(30)
-        verify_ceph_orch_nfs_running(client_node, nfs_name)
+        redeploy_wait = int(
+            tls_config_get(
+                config,
+                "redeploy_orch_wait_timeout_sec",
+                "tc_03_redeploy_orch_wait_timeout_sec",
+                default=300,
+            )
+        )
+        if not wait_until_ceph_orch_nfs_ps_ready(
+            client_node, nfs_name, timeout=redeploy_wait, interval=5
+        ):
+            raise OperationFailedError(
+                f"NFS service {nfs_name} not visible in ceph orch ps after TLSv1.2 redeploy "
+                f"(waited {redeploy_wait}s)"
+            )
 
     log.info("tls_logs_openssl_probe completed.")
 

--- a/tests/nfs/test_nfs_io_operations_during_upgrade.py
+++ b/tests/nfs/test_nfs_io_operations_during_upgrade.py
@@ -153,6 +153,7 @@ def create_export_and_mount_for_existing_nfs_cluster(
                             port=_port,
                             nfs_server=_cluster_nfs_server,
                             export_name=export_name,
+                            **kwargs,
                         ):
                             log.info(f"Mount failed, {mount_name}")
                             raise OperationFailedError(
@@ -205,6 +206,7 @@ def create_export_and_mount_for_existing_nfs_cluster(
                     port=port,
                     nfs_server=_nfs_server,
                     export_name=export_name,
+                    **kwargs,
                 ):
                     log.info(f"Mount failed, {mount_name}")
                     raise OperationFailedError(


### PR DESCRIPTION
Adding TLS tests:

1. tls_deploy_mount_verify
2. tls_export_enforcement
This checks export policy, not “cleartext NFS”:
3. tls_logs_openssl_probe
Re-checks log substrings (TLS / AUTH_TLS).
From the client, runs openssl s_client against NFS port (2049) for TLS 1.3 and 1.2 

logs: http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/tls/try1/
