### PR TITLE
Modify loop to reduce the execution time from 17hours to ~minutes

### DIFF
--- a/tests/cephfs/cephfs_bugs/test_create_unlink_ops_concorrently.py
+++ b/tests/cephfs/cephfs_bugs/test_create_unlink_ops_concorrently.py
@@ -145,19 +145,17 @@ def run(ceph_cluster, **kw):
 
         log.info("Run create and unlink ops.")
         for j in range(10):
-            for i in range(1024):
-                filename = f"file-{i}"
-                for directory in [
-                    kernel_mounting_dir_1,
-                    fuse_mounting_dir_1,
-                    nfs_mountung_dir_1,
-                ]:
-                    clients[0].exec_command(
-                        sudo=True, cmd=f"touch {directory}{filename}"
-                    )
-                    clients[0].exec_command(
-                        sudo=True, cmd=f"rm -rf {directory}{filename}"
-                    )
+            for directory in [
+                kernel_mounting_dir_1,
+                fuse_mounting_dir_1,
+                nfs_mountung_dir_1,
+            ]:
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"for i in $(seq 0 1023); do "
+                    f"touch {directory}file-$i && rm -rf {directory}file-$i; done",
+                    timeout=600,
+                )
         log.info(
             "Check for the Ceph Health to see if there are any crash and Health Errors."
         )

--- a/tests/cephfs/cephfs_scale/max_smallfile_snap.py
+++ b/tests/cephfs/cephfs_scale/max_smallfile_snap.py
@@ -135,12 +135,8 @@ def run(ceph_cluster, **kw):
             try:
                 clients[0].exec_command(
                     sudo=True,
-                    cmd=f"mkdir -p {kernel_mounting_dir_1}/{snapshot['snap_name']}",
-                )
-
-                clients[0].exec_command(
-                    sudo=True,
-                    cmd=f"dd if=/dev/zero of={kernel_mounting_dir_1}/{snapshot['snap_name']}/file.txt "
+                    cmd=f"mkdir -p {kernel_mounting_dir_1}/{snapshot['snap_name']} && "
+                    f"dd if=/dev/zero of={kernel_mounting_dir_1}/{snapshot['snap_name']}/file.txt "
                     f"bs=1M count={count_size}",
                     long_running=True,
                 )


### PR DESCRIPTION
# Description

This loop is extremely slow due to the number of individual SSH commands. Here's the math:

Outer loop: 10 iterations
Middle loop: 1024 iterations
Inner loop: 3 directories
Per directory: 2 commands (touch + rm -rf)
Total remote SSH commands = 10 × 1024 × 3 × 2 = 61,440

Each exec_command is a separate SSH round-trip, which from the logs consistently takes ~1 second each. So:

61,440 × ~1s = ~61,440s = ~1,024 minutes = ~17 hours

The test ran for 17h 16m.

Each touch and rm is a separate SSH call. 

The change would reduce runtime from 
(61,440 SSH calls down to 30 (10 × 3), bringing the runtime ) ~17 hours to a few minutes.

Logs with 17 hours: http://magna002.ceph.redhat.com/ceph/ceph-qe-logs/kdhaduk/9.0z2/weekly/ibmc/Test_Cephfs_Bugs/
Logs with 7 min: https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-102/cephfs/1030/logs/tier_3_cephfs_bugs/