### PR TITLE
TFA fixes for 9.1 subvol metrics code

### DIFF
--- a/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics.py
+++ b/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics.py
@@ -105,7 +105,8 @@ def run(ceph_cluster, **kw):
             rw=rw,
             rwmixread=rwmixread,
         )
-
+        # wait for quota changes and io to start
+        time.sleep(10)
         # Collect expected values (quota_bytes and used_bytes) in parallel with metrics collection
         expected_values_snapshots: List[Dict[str, Any]] = []
         expected_values_lock = threading.Lock()

--- a/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
+++ b/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
@@ -47,22 +47,6 @@ def _get_quota_and_used_from_metrics(
     return None
 
 
-def _get_du_bytes(client, mount_dir: str) -> Optional[int]:
-    """Run du -sb on mountpoint and return total size in bytes (first column)."""
-    path = mount_dir.rstrip("/")
-    out, rc = client.exec_command(
-        sudo=True, cmd=f"du -sb {path} 2>/dev/null", check_ec=False
-    )
-    if rc != 0:
-        log.error("du -sb failed: %s", out)
-        return None
-    try:
-        return int(out.strip().split()[0])
-    except (ValueError, IndexError) as e:
-        log.error("Failed to parse du output %r: %s", out, e)
-        return None
-
-
 def _fill_data(
     client, mount_dir: str, size_bytes: int, filename: str = "data.bin"
 ) -> int:
@@ -71,9 +55,10 @@ def _fill_data(
     count_mb = size_bytes // (1024 * 1024)
     path = f"{mount_dir.rstrip('/')}/{filename}"
     cmd = f"dd if=/dev/random of={path} bs=1M count={count_mb} conv=fsync 2>/dev/null"
-    out, rc = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
-    if rc != 0:
-        log.error("dd failed: %s", out)
+    try:
+        client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    except Exception as e:
+        log.error("dd failed: %s", e)
         return 1
     return 0
 
@@ -156,7 +141,8 @@ def run(ceph_cluster, **kw):
         # Apply quota 3G on mount
         log.info("Setting quota on %s: 3G bytes", fuse_mount_dir)
         fs_util.set_quota_attrs(client, "1000", QUOTA_3G, fuse_mount_dir)
-
+        # wait for quota changes
+        time.sleep(10)
         # Step 1: Quota is 3G. Fill 2G and verify quota_bytes and used_bytes in metrics
         log.info(
             "Step 1: Fill 2G data and verify quota_bytes = 3G and used_bytes vs du"
@@ -178,18 +164,21 @@ def run(ceph_cluster, **kw):
                 quota_bytes,
             )
             return 1
-        du_bytes = _get_du_bytes(client, fuse_mount_dir)
-        if du_bytes is None:
+        subvol_info = fs_util.get_subvolume_info(
+            client, vol_name=vol_name, subvol_name=subvol_name
+        )
+        expected_used_bytes = subvol_info.get("bytes_used", 0)
+        if expected_used_bytes is None:
             return 1
-        if used_bytes != du_bytes:
+        if used_bytes != expected_used_bytes:
             log.error(
-                "Step 1: used_bytes mismatch with du -sb: metrics used_bytes=%s, du=%s",
+                "Step 1: used_bytes mismatch with expected_used_bytes used_bytes=%s, expected_used_bytes=%s",
                 used_bytes,
-                du_bytes,
+                expected_used_bytes,
             )
             return 1
         log.info(
-            "Step 1: quota_bytes = %s (3G), used_bytes = %s (matches du -sb)",
+            "Step 1 Passed: quota_bytes = %s (3G), used_bytes = %s",
             quota_bytes,
             used_bytes,
         )
@@ -209,17 +198,20 @@ def run(ceph_cluster, **kw):
         log.info("Step 2: quota_bytes after unlimited = %s", quota_bytes)
         if quota_bytes != 0:
             log.warning("Step 2: Expected 0 for unlimited; got %s", quota_bytes)
-        du_bytes = _get_du_bytes(client, fuse_mount_dir)
-        if du_bytes is None:
+        subvol_info = fs_util.get_subvolume_info(
+            client, vol_name=vol_name, subvol_name=subvol_name
+        )
+        expected_used_bytes = subvol_info.get("bytes_used", 0)
+        if expected_used_bytes is None:
             return 1
-        if used_bytes != du_bytes:
+        if used_bytes != expected_used_bytes:
             log.error(
-                "Step 2: used_bytes mismatch with du -sb: metrics used_bytes=%s, du=%s",
+                "Step 2: used_bytes mismatch with expected_used_bytes used_bytes=%s, expected_used_bytes=%s",
                 used_bytes,
-                du_bytes,
+                expected_used_bytes,
             )
             return 1
-        log.info("Step 2: used_bytes = %s (matches du -sb)", used_bytes)
+        log.info("Step 2 Passed: used_bytes = %s", used_bytes)
 
         # Step 3: Add 2G more data (total 4G), then apply quota 5G via set_quota_attrs
         log.info("Step 3: Add 2G more data and set quota to 5G on mount")
@@ -231,7 +223,7 @@ def run(ceph_cluster, **kw):
 
         # Step 4: Rerun metrics fetch and verify quota_bytes = 5G and used_bytes vs du
         log.info(
-            "Step 4: Verify quota_bytes = 5G and used_bytes vs du -sb in subvolume metrics"
+            "Step 4: Verify quota_bytes = 5G and used_bytes vs expected_used_bytes in subvolume metrics"
         )
         result = _get_quota_and_used_from_metrics(
             helper, client, default_fs, subvol_path, ranks
@@ -247,18 +239,21 @@ def run(ceph_cluster, **kw):
                 quota_bytes,
             )
             return 1
-        du_bytes = _get_du_bytes(client, fuse_mount_dir)
-        if du_bytes is None:
+        subvol_info = fs_util.get_subvolume_info(
+            client, vol_name=vol_name, subvol_name=subvol_name
+        )
+        expected_used_bytes = subvol_info.get("bytes_used", 0)
+        if expected_used_bytes is None:
             return 1
-        if used_bytes != du_bytes:
+        if used_bytes != expected_used_bytes:
             log.error(
-                "Step 4: used_bytes mismatch with du -sb: metrics used_bytes=%s, du=%s",
+                "Step 4: used_bytes mismatch with expected_used_bytes used_bytes=%s, expected_used_bytes=%s",
                 used_bytes,
-                du_bytes,
+                expected_used_bytes,
             )
             return 1
         log.info(
-            "Step 4: quota_bytes = %s (5G), used_bytes = %s (matches du -sb)",
+            "Step 4 Passed: quota_bytes = %s (5G), used_bytes = %s",
             quota_bytes,
             used_bytes,
         )

--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -340,6 +340,9 @@ def snap_sched_test(snap_req_params):
                 )
                 log.info(out)
             file_path = out.strip()
+            retry_exec = retry(CommandFailed, tries=3, delay=20)(
+                snap_client.exec_command
+            )
             cmd = f"dd if={file_path} count=10 bs=1M > read_dd"
             out, rc = retry_exec(sudo=True, cmd=cmd)
 


### PR DESCRIPTION
# Description
Jira: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-23351
https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-23536
Fix:1
Failure description: Metrics was being in 1min window and compared. metrics mismatch existed, have fixed with tuning the io execution start timeline.
Passed Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LUF096/cephfs_subvolume_metrics_-_basic_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-531Z9X/test_subvolume_metrics_functional_0.log

Fix2:
Failure description:In post upgrade snapshot test, there was client node mismatch when dd cmd was run on mountpath selected. Fixed it.
Failed log:http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3RK26U/Validates_NFS_after_upgrade_0.log
Passed log with fix:http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-34X9O2/Validates_NFS_after_upgrade_0.log

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
