### PR TITLE
Added backoff=1 to avoid test hung for more than 2 days

### DIFF
--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -809,7 +809,7 @@ class CephfsMirroringUtils(object):
         log.error("last synced Snapshot not found or not synced")
         raise CommandFailed("last synced Snapshot not found or not synced")
 
-    @retry(CommandFailed, tries=10, delay=60)
+    @retry(CommandFailed, tries=20, delay=30, backoff=1)
     def validate_snapshot_sync_status(
         self,
         cephfs_mirror_node,
@@ -819,12 +819,10 @@ class CephfsMirroringUtils(object):
         asok_file,
         filesystem_id,
         peer_uuid,
-        retry_count=10,
-        retry_delay=30,
     ):
         """
         Validate the synchronization status of a specific snapshot in the target cluster.
-        Retries up to retry_count times with retry_delay seconds between attempts.
+        Retries up to 10 times with a constant 30s delay between attempts via the @retry decorator.
         Args:
             cephfs_mirror_node (CephNode): The CephNode representing the CephFS mirror node.
             fs_name (str): The name of the Ceph filesystem being synchronized.
@@ -833,8 +831,6 @@ class CephfsMirroringUtils(object):
             asok_file (str): The admin socket file for the CephFS mirror.
             filesystem_id (str): The ID of the filesystem being synchronized.
             peer_uuid (str): The UUID of the peer cluster.
-            retry_count (int): Number of retry attempts (default 10).
-            retry_delay (int): Seconds to wait between retries (default 30).
 
         Returns:
             dict: A dictionary with details of the synchronized snapshot, including snapshot name, sync duration,
@@ -852,45 +848,35 @@ class CephfsMirroringUtils(object):
         log.info(f"filesystem id of {fs_name} is : {filesystem_id}")
         peer_uuid = self.get_peer_uuid_by_name(self.source_clients[0], fs_name)
         log.info(f"peer uuid of {fs_name} is : {peer_uuid}")
-        for attempt in range(1, retry_count + 1):
-            still_syncing = False
-            for node, asok in asok_file.items():
+        for node, asok in asok_file.items():
+            try:
                 asok[0].exec_command(
                     sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
                 )
-                cmd = (
-                    f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
-                    f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
-                )
-                out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
-                data = json.loads(out)
-                for path, status in data.items():
-                    last_synced_snap = status.get("last_synced_snap")
-                    if last_synced_snap:
-                        if last_synced_snap.get("name") == snapshot_name:
-                            sync_duration = last_synced_snap.get("sync_duration")
-                            sync_time_stamp = last_synced_snap.get("sync_time_stamp")
-                            snaps_synced = status.get("snaps_synced")
-                            log.info("All snapshots are synced")
-                            return {
-                                "snapshot_name": snapshot_name,
-                                "sync_duration": sync_duration,
-                                "sync_time_stamp": sync_time_stamp,
-                                "snaps_synced": snaps_synced,
-                            }
-                    if status.get("state") == "syncing":
-                        still_syncing = True
-
-            if still_syncing and attempt < retry_count:
-                log.warning(
-                    f"{snapshot_name} not synced yet, sync in progress "
-                    f"(attempt {attempt}/{retry_count}). Retrying in {retry_delay}s..."
-                )
-                time.sleep(retry_delay)
-            else:
-                break
-
-        log.error(f"{snapshot_name} not synced, last synced data is {data}")
+            except CommandFailed as e:
+                log.warning(f"dnf install ceph-common failed (non-fatal): {e}")
+            cmd = (
+                f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+                f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
+            )
+            out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
+            data = json.loads(out)
+            for path, status in data.items():
+                last_synced_snap = status.get("last_synced_snap")
+                if last_synced_snap:
+                    if last_synced_snap.get("name") == snapshot_name:
+                        sync_duration = last_synced_snap.get("sync_duration")
+                        sync_time_stamp = last_synced_snap.get("sync_time_stamp")
+                        snaps_synced = status.get("snaps_synced")
+                        log.info("All snapshots are synced")
+                        return {
+                            "snapshot_name": snapshot_name,
+                            "sync_duration": sync_duration,
+                            "sync_time_stamp": sync_time_stamp,
+                            "snaps_synced": snaps_synced,
+                        }
+        log.info("snapshot status: %s", status.get("state"))
+        log.error("%s not synced, last synced data is %s", snapshot_name, data)
         raise CommandFailed("One or more snapshots are not synced")
 
     def remove_snapshot_mirror_peer(self, source_clients, fs_name, peer_uuid):
@@ -1327,36 +1313,13 @@ class CephfsMirroringUtils(object):
             if self.disable_mirroring_module(target_client) != 0:
                 raise Exception("Failed to disable mirroring module on Target.")
 
-            log.info(
-                "Waiting for mgr to stabilize and volumes module to be available "
-                "after disabling mirroring modules"
-            )
-            self._ensure_volumes_module(source_client)
-
             log.info("CephFS mirroring setup destroyed successfully.")
 
         except Exception as e:
             log.error(f"Error destroying CephFS mirroring setup: {e}")
 
-    @retry(Exception, tries=10, delay=15)
-    def _ensure_volumes_module(self, client):
-        """
-        Ensure the 'volumes' mgr module is loaded after a mgr restart.
-
-        Disabling mgr modules (like mirroring) triggers a mgr restart, which
-        temporarily unloads all modules including 'volumes'. Subsequent commands
-        such as 'ceph fs subvolume rm' will fail with ENOTSUP until the module
-        is re-loaded. This polls using the same pattern as enable_mirroring_module
-        / disable_mirroring_module until the volumes module is available.
-        """
-        out, _ = client.exec_command(
-            sudo=True, cmd="ceph mgr module ls --format json-pretty"
-        )
-        module_status = json.loads(out)
-        if "volumes" not in module_status.get("enabled_modules", []):
-            raise Exception("volumes mgr module is not yet available")
-        log.info("volumes mgr module is available")
-
+    @retry(Exception, tries=10, delay=15, backoff=1)
+    
     def add_files_and_validate(
         self,
         source_clients,
@@ -2251,3 +2214,49 @@ class CephfsMirroringUtils(object):
         else:
             log.error(f"Path '{absolute_path}' not found in the mirror status.")
             return None
+
+
+@retry(CommandFailed, tries=10, delay=30, backoff=1)
+def wait_for_sync_idle(fs_name, fsid, asok_file, filesystem_id, peer_uuid, paths):
+    """
+    Waits until all given paths reach 'idle' state in the mirror peer status.
+    Retries every 30s for up to ~5 minutes.
+
+    Args:
+        fs_name (str): The CephFS volume name (e.g., cephfs).
+        fsid (str): The unique CephFS cluster FSID.
+        asok_file (dict): Dictionary mapping node name to [client_object, asok_path].
+        filesystem_id (int): The ID for the CephFS filesystem.
+        peer_uuid (str): The UUID of the mirroring peer.
+        paths (list): List of absolute paths to check for idle state.
+
+    Raises:
+        CommandFailed: If any path is not in 'idle' state (triggers retry).
+    """
+    for node, asok in asok_file.items():
+        try:
+            asok[0].exec_command(
+                sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
+            )
+        except Exception as e:
+            log.warning("dnf install ceph-common failed (non-fatal): %s", e)
+    cmd = (
+        f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+        f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
+    )
+    out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
+    data = json.loads(out)
+
+    for path in paths:
+        absolute_path = path.rstrip("/")
+        if absolute_path not in data:
+            raise CommandFailed(f"Path '{absolute_path}' not found in mirror status")
+        state = data[absolute_path].get("state", "unknown")
+        synced = data[absolute_path].get("snaps_synced", 0)
+        log.info("%s state=%s snaps_synced=%s", absolute_path, state, synced)
+        if state != "idle":
+            raise CommandFailed(
+                f"Path '{absolute_path}' still in state '{state}', waiting for idle"
+            )
+
+    log.info("All paths are in idle state")

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -1319,7 +1319,6 @@ class CephfsMirroringUtils(object):
             log.error(f"Error destroying CephFS mirroring setup: {e}")
 
     @retry(Exception, tries=10, delay=15, backoff=1)
-    
     def add_files_and_validate(
         self,
         source_clients,

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirroring_with_snap_schedule.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirroring_with_snap_schedule.py
@@ -4,7 +4,10 @@ import string
 import time
 import traceback
 
-from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
+    CephfsMirroringUtils,
+    wait_for_sync_idle,
+)
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.snapshot_clone.cephfs_snap_utils import SnapUtils
 from utility.log import Log
@@ -44,7 +47,8 @@ def run(ceph_cluster, **kw):
             - 1 on failure if there is any mismatch in snapshot counts or any part of the process fails.
 
     Cleanup:
-        - Removes all created snapshot schedules.
+        - Snapshot schedules are removed in the main flow before sync checks; finally repeats
+          removal with check_ec disabled for early-failure cleanup without aborting teardown.
         - Unmounts and removes the mounted directories and paths.
         - Deletes CephFS mirroring configuration and removes the associated subvolumes and subvolume groups.
         - Removes the CephFS filesystem from both the source and target clusters.
@@ -283,7 +287,15 @@ def run(ceph_cluster, **kw):
             f"list of scheduled snapshots from client mount path : {snap_schedule_list2}"
         )
 
-        log.info("Capture the snapshot created count")
+        log.info("Remove snap schedules so no new snapshots are created")
+        snap_util.remove_snap_schedule(
+            source_clients[0], subvol1_path, fs_name=source_fs
+        )
+        snap_util.remove_snap_schedule(
+            source_clients[0], subvol2_path, fs_name=source_fs
+        )
+
+        log.info("Capture the final snapshot count after schedule removal")
         snap_count1, rc = source_clients[0].exec_command(
             sudo=True, cmd=f'ls -lrt {snap_path1}/.snap/| grep "scheduled" | wc -l'
         )
@@ -317,35 +329,48 @@ def run(ceph_cluster, **kw):
         )
         log.info(f"peer uuid of {source_fs} is : {peer_uuid}")
 
+        wait_for_sync_idle(
+            source_fs,
+            fsid,
+            asok_file,
+            filesystem_id,
+            peer_uuid,
+            [subvol1_path, subvol2_path],
+        )
+
         snaps_synced1 = get_snaps_synced(
             source_fs, fsid, asok_file, filesystem_id, peer_uuid, subvol1_path
         )
         snaps_synced2 = get_snaps_synced(
-            source_fs, fsid, asok_file, filesystem_id, peer_uuid, subvol1_path
+            source_fs, fsid, asok_file, filesystem_id, peer_uuid, subvol2_path
         )
-        if snaps_synced1 is not None and snaps_synced2 is not None:
-            log.info(
-                f"Snaps synced for path '{subvol1_path}' is {snaps_synced1} & '{subvol2_path}' is {snaps_synced2}"
+        log.info(
+            "Snaps synced for '%s' is %s & '%s' is %s",
+            subvol1_path,
+            snaps_synced1,
+            subvol2_path,
+            snaps_synced2,
+        )
+
+        if snap_count1 != snaps_synced1:
+            log.error(
+                "Mismatch for %s: snap_count (%s) != snaps_synced (%s)",
+                subvol1_path,
+                snap_count1,
+                snaps_synced1,
             )
-
-            if snap_count1 != snaps_synced1:
-                log.error(
-                    f"Mismatch for {subvol1_path}: snap_count1 ({snap_count1}) != snaps_synced1 ({snaps_synced1})"
-                )
-                return 1
-
-            if snap_count2 != snaps_synced2:
-                log.error(
-                    f"Mismatch for {subvol2_path}: snap_count2 ({snap_count2}) != snaps_synced2 ({snaps_synced2})"
-                )
-                return 1
-
-            log.info("Snap counts and snaps synced match for both subvolumes.")
-            return 0
-        else:
-            log.error("Failed to capture snaps_synced for one or both subvolumes.")
             return 1
 
+        if snap_count2 != snaps_synced2:
+            log.error(
+                "Mismatch for %s: snap_count (%s) != snaps_synced (%s)",
+                subvol2_path,
+                snap_count2,
+                snaps_synced2,
+            )
+            return 1
+
+        log.info("Snap counts and snaps synced match for both subvolumes.")
         return 0
     except Exception as e:
         log.error(e)
@@ -363,12 +388,11 @@ def run(ceph_cluster, **kw):
                 sudo=True, cmd=f"rmdir {snapshot_path}", check_ec=False
             )
 
-        snap_util.remove_snap_schedule(
-            source_clients[0], subvol1_path, fs_name=source_fs
-        ),
-        snap_util.remove_snap_schedule(
-            source_clients[0], subvol2_path, fs_name=source_fs
-        ),
+        # Best-effort remove (check_ec=False) if the main path did not run; harmless if already removed.
+        for _path in (subvol1_path, subvol2_path):
+            snap_util.remove_snap_schedule(
+                source_clients[0], _path, fs_name=source_fs, check_ec=False
+            )
 
         log.info("Unmount the paths")
         paths_to_unmount = [kernel_mounting_dir_1, fuse_mounting_dir_1]

--- a/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
+++ b/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
@@ -318,8 +318,11 @@ class SnapUtils(object):
         Required:
             client: ceph client to run cmd
             path : a snap-schedule path which needs to be removed, type - str
+        Optional:
+            check_ec: if False, non-zero exit from ceph is ignored (idempotent teardown).
         Returns: None
         """
+        check_ec = kw_args.pop("check_ec", True)
         cmd = f"ceph fs snap-schedule remove {path}"
         if kw_args.get("subvol_name"):
             sv_name = kw_args["subvol_name"]
@@ -328,7 +331,7 @@ class SnapUtils(object):
                 cmd += f" --group {kw_args['group_name']}"
         if kw_args.get("fs_name"):
             cmd += f" --fs {kw_args.get('fs_name')}"
-        client.exec_command(sudo=True, cmd=cmd)
+        client.exec_command(sudo=True, cmd=cmd, check_ec=check_ec)
 
     def validate_snap_schedule(self, client, path, sched_val):
         """


### PR DESCRIPTION
1. Replace manual retry loop in validate_snapshot_sync_status with the @retry decorator to eliminate nested outer/inner retry logic that caused jobs to hang for 2+ days when dnf install failed
2. Add backoff=1 to @retry decorators to enforce constant delay instead of exponential backoff
3. Add wait_for_sync_idle() helper to wait until all mirroring paths reach idle state before asserting sync counts
4. Remove snap schedules before capturing final snapshot counts to prevent race conditions
5. Fix bug where snaps_synced2 was incorrectly checking subvol1_path instead of subvol2_path
6. Make dnf install ceph-common non-fatal by wrapping it in try/except

Logs: http://10.64.24.74/logs/ceph-qe-logs/IBM/9.1/rhel-10/executor/20.2.1-135/cephfs/1163/logs/tier_1_cephfs_mirror/