### PR TITLE
Addition of RDMA support for Thrash tests

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -18,6 +18,7 @@ import random
 import re
 import time
 from collections import namedtuple
+from typing import Optional
 
 from ceph.ceph import CommandFailed, SocketTimeoutException, TimeoutException
 from ceph.ceph_admin import CephAdmin
@@ -28,6 +29,8 @@ from utility import utils
 from utility.log import Log
 
 log = Log(__name__)
+
+NFS_RDMA_DEFAULT_BASE_PORT = 20049
 
 
 class RadosOrchestrator:
@@ -5551,16 +5554,23 @@ EOF"""
 
     def get_host_label(self, host_name):
         """
-        Method is used to get the labels list of the host
+        Return the ceph orch labels for ``host_name`` (inventory hostname).
+
         Args:
-            host_name: Host name
+            host_name: Host name as in ``ceph orch host ls``
 
-        Returns: List of labels of the host
+        Returns:
+            List of label strings (may be empty).
         """
-
         cmd_get_labels = f"ceph orch host ls --host_pattern {host_name}"
         host_output = self.run_ceph_command(cmd=cmd_get_labels)
-        return host_output[0]["labels"]
+        if not host_output or not isinstance(host_output, list) or len(host_output) < 1:
+            log.warning("get_host_label: no orch host data for %s", host_name)
+            return []
+        labels = host_output[0].get("labels")
+        if not labels:
+            return []
+        return list(labels)
 
     def remove_host_label(self, host_name, label):
         """
@@ -7118,6 +7128,10 @@ EOF"""
         nfs_fs_name: str = "nfs-cephfs",
         pool_type: str = "erasure",
         enable_fast_ec_config_params: bool = False,
+        enable_rdma: bool = False,
+        rdma_port: Optional[int] = None,
+        enable_nfsv3: bool = False,
+        nfs_placement_label: Optional[str] = None,
     ) -> dict:
         """
         Create NFS clusters with a dedicated CephFS filesystem and exports.
@@ -7130,13 +7144,30 @@ EOF"""
             nfs_fs_name: CephFS filesystem name for NFS (default: "nfs-cephfs")
             pool_type: Pool type for CephFS - "erasure" or "replicated"
             enable_fast_ec_config_params: Whether to enable fast EC config params
+            enable_rdma: Pass --enable-rdma to ceph nfs cluster create
+            rdma_port: Optional base RDMA port; per-cluster port is
+                rdma_port + cluster_index (same pattern as NFS TCP 2049+i).
+                If omitted when enable_rdma is True, uses ``NFS_RDMA_DEFAULT_BASE_PORT``
+                (20049), i.e. 20049, 20050, … for multi-cluster.
+            enable_nfsv3: Pass --enable-nfsv3 to ceph nfs cluster create
+            nfs_placement_label: If set, prefer orch hosts whose ``labels`` include
+                this string. If no orch host has the label, fall back to all orch hosts.
+                If unset, use all orch hosts.
 
         Returns:
             Dict with nfs_config containing clusters, exports, fs_name, and pool info
         """
+        rdma_base = (
+            (rdma_port if rdma_port is not None else NFS_RDMA_DEFAULT_BASE_PORT)
+            if enable_rdma
+            else None
+        )
+
         log.info(
             f"Creating NFS setup: {num_clusters} clusters, "
             f"{exports_per_cluster} exports each"
+            f"{', RDMA enabled' if enable_rdma else ''}"
+            f"{', NFSv3 enabled on cluster' if enable_nfsv3 else ''}"
         )
 
         # Step 1: Create CephFS filesystem for NFS
@@ -7148,9 +7179,48 @@ EOF"""
             enable_fast_ec_config_params=enable_fast_ec_config_params,
         )
 
-        # Get OSD hosts for NFS placement
-        available_hosts = self.get_osd_hosts()
-        log.info(f"Available OSD hosts for NFS placement: {available_hosts}")
+        lbl = nfs_placement_label
+        raw = self.run_ceph_command(cmd="ceph orch host ls")
+        if isinstance(raw, dict):
+            rows = raw.get("hosts", [])
+        elif isinstance(raw, list):
+            rows = raw
+        else:
+            rows = []
+            if raw:
+                log.warning(
+                    "create_nfs_clusters_and_exports: unexpected orch host ls output type %s",
+                    type(raw).__name__,
+                )
+
+        orch_hosts = list(
+            dict.fromkeys(
+                e["hostname"] for e in rows if isinstance(e, dict) and e.get("hostname")
+            )
+        )
+        if lbl:
+            labeled_hosts = list(
+                dict.fromkeys(
+                    e["hostname"]
+                    for e in rows
+                    if e.get("hostname") and lbl in (e.get("labels") or [])
+                )
+            )
+            available_hosts = labeled_hosts or orch_hosts
+            if not labeled_hosts:
+                log.warning(
+                    "create_nfs_clusters_and_exports: no orch host with label %r; "
+                    "using all orch hosts",
+                    lbl,
+                )
+        else:
+            available_hosts = orch_hosts
+
+        if not available_hosts:
+            raise ValueError(
+                "create_nfs_clusters_and_exports: no hosts available for NFS placement"
+            )
+        log.info("NFS cluster placement hosts: %s", available_hosts)
 
         # Step 2: Create NFS clusters with unique ports starting from 2049
         clusters = []
@@ -7164,15 +7234,29 @@ EOF"""
             selected_host = available_hosts[host_idx]
             placement_str = f'"{placement} {selected_host}"'
 
+            cluster_rdma_port = (rdma_base + i) if enable_rdma else None
             log.info(
                 f"Creating NFS cluster: {cluster_id} on port {port}, host {selected_host}"
+                + (
+                    f", rdma_port {cluster_rdma_port}"
+                    if cluster_rdma_port is not None
+                    else ""
+                )
             )
 
             cmd = f"ceph nfs cluster create {cluster_id} {placement_str} --port={port}"
+            if enable_nfsv3:
+                cmd += " --enable-nfsv3"
+            if enable_rdma:
+                cmd += f" --enable-rdma --rdma_port {cluster_rdma_port}"
             self.client.exec_command(cmd=cmd, sudo=True)
-            clusters.append(
-                {"cluster_id": cluster_id, "port": port, "host": selected_host}
-            )
+            cluster_entry = {
+                "cluster_id": cluster_id,
+                "port": port,
+                "host": selected_host,
+                "rdma_port": cluster_rdma_port,
+            }
+            clusters.append(cluster_entry)
             time.sleep(5)  # Allow cluster to initialize
 
         log.info(f"Created {len(clusters)} NFS clusters")
@@ -7225,6 +7309,8 @@ EOF"""
             "clusters": clusters,
             "exports": exports,
             "pools": created_pools,
+            "enable_rdma": enable_rdma,
+            "enable_nfsv3": enable_nfsv3,
         }
 
     def cleanup_nfs_clusters(self, nfs_config: dict) -> None:

--- a/suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml
@@ -392,3 +392,51 @@ tests:
         pool_name: bug-2423971-long
         cleanup_pool: true
         fail_on_crash: false
+
+# RDMA thrash test, to to run on specific hardware
+#  - test:
+#      name: Fast EC OSD thrashing with compression
+#      desc: Aggressive OSD thrashing with compression & Fast EC enabled
+#      module: test_osd_thrashing.py
+#      polarion-id: CEPH-83632230
+#      config:
+#        pool_configs:
+#          - pool_type: erasure
+#            sample_pool_id: sample-pool-7
+#          - pool_type: erasure
+#            sample_pool_id: sample-pool-9
+#          - pool_type: replicated
+#            sample_pool_id: sample-pool-2
+#        iterations: 120
+#        duration: 600
+#        aggressive: true
+#        enable_crush_thrashing: true
+#        enable_pg_thrashing: true
+#        enable_rgw_thrashing: false
+#        compression: false
+#        cleanup_pools: true
+#        enable_debug_logs: false
+#        inject_errors: false
+#        # Workload controls (all default to true)
+#        enable_fio_cephfs: true
+#        enable_fio_rbd: false
+#        enable_cephfs_snapshots: true
+#        enable_rbd_snapshots: false
+#        enable_ec_snapshots: false
+#        enable_osd_thrashing: true
+#        enable_mon_thrashing: false
+#        enable_election_strategy_thrash: false
+#        enable_mgr_thrashing: false
+#        enable_mds_thrashing: true
+#        enable_nfs_thrashing: true
+#        nfs_num_clusters: 1
+#        nfs_exports_per_cluster: 4
+#        nfs_placement: 1
+#        # NFS-over-RDMA: requires RDMA-capable clients and MDS/NFS hosts
+#        enable_nfs_rdma: true
+#        nfs_rdma_port: 13456
+#        enable_nfsv3: true
+#        # Prefer NFS daemon placement on orch hosts labeled nfs-rdma
+#        nfs_placement_label: nfs-rdma
+#        enable_cephfs_subvolume_thrashing: true
+

--- a/tests/rados/test_osd_thrashing.py
+++ b/tests/rados/test_osd_thrashing.py
@@ -80,8 +80,18 @@ CONFIGURATION OPTIONS:
 - enable_mgr_thrashing: Enable MGR thrashing - failover/restart/random fail (default: False)
 - enable_mds_thrashing: Enable MDS thrashing - failover/restart/random fail (default: False)
 - enable_nfs_thrashing: Enable NFS cluster/export setup for thrashing (default: False)
+- nfs_num_clusters: Number of ``ceph nfs cluster create`` instances (default: 3)
+- nfs_exports_per_cluster: Exports per cluster (default: 4)
+- nfs_placement: Placement daemon count argument to cluster create (default: 1)
 - enable_cephfs_subvolume_thrashing: Enable CephFS subvolume thrashing (default: False)
 - enable_election_strategy_thrash: Enable election strategy changes during MON thrash (default: False)
+- enable_nfs_rdma: Create NFS clusters with ceph nfs cluster create --enable-rdma
+  (default: False). Optional nfs_rdma_port overrides default RDMA base 20049.
+- nfs_rdma_port: Base RDMA port for ``--rdma_port`` (per-cluster: base + index).
+  If unset, ``NFS_RDMA_DEFAULT_BASE_PORT`` (20049) in core_workflows is used.
+- enable_nfsv3: Pass --enable-nfsv3 to ceph nfs cluster create (default: False)
+- nfs_placement_label: Prefer orch hosts with this **ceph orch host label**. If no host
+  has the label, fallback uses all orch hosts.
 
 """
 
@@ -96,7 +106,7 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from ceph.ceph_admin import CephAdmin
-from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.core_workflows import NFS_RDMA_DEFAULT_BASE_PORT, RadosOrchestrator
 from ceph.rados.mgr_workflows import MgrWorkflows
 from ceph.rados.monitor_workflows import MonitorWorkflows
 from ceph.rados.pool_workflows import PoolFunctions
@@ -151,9 +161,17 @@ def run(ceph_cluster, **kw):
         enable_mgr_thrashing (bool): Enable MGR thrashing - failover/restart/random fail (default: False)
         enable_mds_thrashing (bool): Enable MDS thrashing - failover/restart/random fail (default: False)
         enable_nfs_thrashing (bool): Enable NFS cluster/export setup for thrashing (default: False)
+        nfs_num_clusters (int): How many NFS clusters to create (default: 3)
+        nfs_exports_per_cluster (int): Exports per cluster (default: 4)
+        nfs_placement (int): ``ceph nfs cluster create`` placement count (default: 1)
         enable_cephfs_subvolume_thrashing (bool): Enable CephFS subvolume thrashing (default: False)
         enable_election_strategy_thrash (bool): Enable election strategy changes (default: False)
         enable_fast_ec_config_params (bool): Enable fast EC config params (default: True)
+        enable_nfs_rdma (bool): Use --enable-rdma on ceph nfs cluster create (default: False)
+        nfs_rdma_port (int|None): Optional base --rdma_port; if unset, 20049 + index
+        enable_nfsv3 (bool): Pass --enable-nfsv3 to ceph nfs cluster create (default: False)
+        nfs_placement_label (str|None): Prefer orch hosts with this label; if no
+            matches, use all orch hosts (default: None).
 
     Returns:
         0: Test passed - No crashes detected, cluster remained stable
@@ -194,6 +212,14 @@ def run(ceph_cluster, **kw):
     enable_mgr_thrashing = config.get("enable_mgr_thrashing", False)
     enable_mds_thrashing = config.get("enable_mds_thrashing", False)
     enable_nfs_thrashing = config.get("enable_nfs_thrashing", False)
+    enable_nfs_rdma = config.get("enable_nfs_rdma", False)
+    nfs_rdma_port_raw = config.get("nfs_rdma_port")
+    nfs_rdma_port = int(nfs_rdma_port_raw) if nfs_rdma_port_raw is not None else None
+    enable_nfsv3 = config.get("enable_nfsv3", False)
+    nfs_placement_label = config.get("nfs_placement_label") or None
+    nfs_num_clusters = config.get("nfs_num_clusters", 3)
+    nfs_exports_per_cluster = config.get("nfs_exports_per_cluster", 4)
+    nfs_placement = config.get("nfs_placement", 1)
     enable_cephfs_subvolume_thrashing = config.get(
         "enable_cephfs_subvolume_thrashing", False
     )
@@ -243,6 +269,13 @@ def run(ceph_cluster, **kw):
         additional_pools.append("RBD (2 pools)")
     additional_pools_str = " + ".join(additional_pools) if additional_pools else "None"
 
+    rdma_suffix = ""
+    if enable_nfs_rdma:
+        if nfs_rdma_port is not None:
+            rdma_suffix = f" (rdma_port base={nfs_rdma_port})"
+        else:
+            rdma_suffix = f" (rdma default base {NFS_RDMA_DEFAULT_BASE_PORT})"
+
     test_params = (
         f"\n{'=' * 60}\n"
         f"OSD THRASHING TEST WITH CONCURRENT I/O\n"
@@ -271,6 +304,15 @@ def run(ceph_cluster, **kw):
         f"  MGR thrashing: {enable_mgr_thrashing}\n"
         f"  MDS thrashing: {enable_mds_thrashing}\n"
         f"  NFS thrashing: {enable_nfs_thrashing}\n"
+        + (
+            f"  NFS clusters / exports per cluster / placement count: "
+            f"{nfs_num_clusters} / {nfs_exports_per_cluster} / {nfs_placement}\n"
+            if enable_nfs_thrashing
+            else ""
+        )
+        + f"  NFS RDMA (cluster + mounts): {enable_nfs_rdma}{rdma_suffix}\n"
+        f"  NFS cluster NFSv3 enabled: {enable_nfsv3}\n"
+        f"  NFS placement orch label: {nfs_placement_label or '(none)'}\n"
         f"  CephFS subvolume thrashing: {enable_cephfs_subvolume_thrashing}\n"
         f"  Election strategy thrash: {enable_election_strategy_thrash}\n"
         f"  Fast EC config params: {enable_fast_ec_config_params}\n"
@@ -356,11 +398,15 @@ def run(ceph_cluster, **kw):
                 nfs_future = pool_executor.submit(
                     rados_obj.create_nfs_clusters_and_exports,
                     client_node,
-                    num_clusters=config.get("nfs_num_clusters", 3),
-                    exports_per_cluster=config.get("nfs_exports_per_cluster", 4),
-                    placement=config.get("nfs_placement", 1),
+                    num_clusters=nfs_num_clusters,
+                    exports_per_cluster=nfs_exports_per_cluster,
+                    placement=nfs_placement,
                     pool_type="erasure",
                     enable_fast_ec_config_params=enable_fast_ec_config_params,
+                    enable_rdma=enable_nfs_rdma,
+                    rdma_port=nfs_rdma_port,
+                    enable_nfsv3=enable_nfsv3,
+                    nfs_placement_label=nfs_placement_label,
                 )
 
             # Collect results
@@ -425,43 +471,49 @@ def run(ceph_cluster, **kw):
                             f"{len(nfs_config.get('exports', []))} exports"
                         )
 
-                        # NFSv3 prerequisites: ensure rpcbind and rpc.statd are running
-                        # Without these services, NFS-Ganesha cannot register NFSv3 and
-                        # emits "Cannot register NFS V3 on TCP" error.
+                        # Per NFS host: always drop host firewall (TCP + RDMA). When the
+                        # cluster has v3 enabled, also install/start rpcbind and statd.
                         all_nodes = ceph_cluster.get_nodes()
                         configured_hosts = set()
+                        v3_extra = (
+                            "yum install -y rpcbind nfs-utils 2>/dev/null || true; "
+                            "systemctl enable rpcbind rpc-statd 2>/dev/null || true; "
+                            "systemctl start rpcbind rpc-statd 2>/dev/null || true; "
+                            "systemctl list-units --type=service --no-legend | "
+                            "grep '@nfs\\.' | awk '{print $1}' | "
+                            "xargs -r systemctl restart 2>/dev/null || true"
+                        )
                         for cluster_info in nfs_config.get("clusters", []):
                             hostname = cluster_info.get("host")
                             if not hostname or hostname in configured_hosts:
                                 continue
                             configured_hosts.add(hostname)
-                            # Find node object for this NFS server
                             host_node = next(
-                                (n for n in all_nodes if n.hostname == hostname), None
+                                (n for n in all_nodes if n.hostname == hostname),
+                                None,
                             )
                             if not host_node:
                                 log.warning(f"  {hostname}: Node not found, skipping")
                                 continue
                             try:
-                                # Batch: disable firewall, install/start services
-                                # Note: cephadm NFS service is ceph-*@nfs.*.service
+                                fw = (
+                                    "systemctl stop firewalld 2>/dev/null || true; "
+                                    "systemctl disable firewalld 2>/dev/null || true"
+                                )
+                                if nfs_config.get("enable_nfsv3"):
+                                    cmd = fw + "; " + v3_extra
+                                    log_note = "firewall disabled + NFSv3 prerequisites"
+                                else:
+                                    cmd = fw
+                                    log_note = "firewall disabled for NFS/RDMA"
                                 host_node.exec_command(
-                                    cmd="systemctl stop firewalld 2>/dev/null || true; "
-                                    "systemctl disable firewalld 2>/dev/null || true; "
-                                    "yum install -y rpcbind nfs-utils 2>/dev/null || true; "
-                                    "systemctl enable rpcbind rpc-statd 2>/dev/null || true; "
-                                    "systemctl start rpcbind rpc-statd 2>/dev/null || true; "
-                                    "systemctl list-units --type=service --no-legend | "
-                                    "grep '@nfs\\.' | awk '{print $1}' | "
-                                    "xargs -r systemctl restart 2>/dev/null || true",
+                                    cmd=cmd,
                                     sudo=True,
                                     timeout=180,
                                     check_ec=False,
                                 )
                                 nfs_firewall_disabled_nodes.append(host_node)
-                                log.info(
-                                    f"  {hostname}: NFSv3 prerequisites configured"
-                                )
+                                log.info(f"  {hostname}: {log_note}")
                             except Exception as e:
                                 log.warning(f"  {hostname}: Failed - {e}")
 
@@ -560,14 +612,35 @@ def run(ceph_cluster, **kw):
         if nfs_config:
             log.info("NFS Setup:")
             log.info("  Filesystem      : %s", nfs_config.get("fs_name", "N/A"))
-            log.info("  Clusters        : %d", len(nfs_config.get("clusters", [])))
-            for cluster in nfs_config.get("clusters", []):
+            log.info(
+                "  RDMA mounts     : %s",
+                (
+                    "yes (client uses rdma,port= per cluster)"
+                    if nfs_config.get("enable_rdma")
+                    else "no (TCP port= only)"
+                ),
+            )
+            if nfs_config.get("enable_rdma"):
                 log.info(
-                    "    - %s (port: %d, host: %s)",
-                    cluster["cluster_id"],
-                    cluster["port"],
-                    cluster.get("host", "N/A"),
+                    "  NFSv3 on cluster: %s", nfs_config.get("enable_nfsv3", False)
                 )
+            for cluster in nfs_config.get("clusters", []):
+                rp = cluster.get("rdma_port")
+                if nfs_config.get("enable_rdma") and rp is not None:
+                    log.info(
+                        "    - %s (NFS TCP port: %d, RDMA port: %d, host: %s)",
+                        cluster["cluster_id"],
+                        cluster["port"],
+                        rp,
+                        cluster.get("host", "N/A"),
+                    )
+                else:
+                    log.info(
+                        "    - %s (port: %d, host: %s)",
+                        cluster["cluster_id"],
+                        cluster["port"],
+                        cluster.get("host", "N/A"),
+                    )
             exports = nfs_config.get("exports", [])
             log.info("  Exports         : %d", len(exports))
             for export in exports:
@@ -1010,6 +1083,12 @@ def run(ceph_cluster, **kw):
                 "rgw_s3_thrashing": None,
                 "mon_thrashing": None,
                 "mgr_thrashing": None,
+                "mds_thrashing": None,
+                "nfs_fio_thrashing": None,
+                "nfs_locking": None,
+                "nfs_rootsquash": None,
+                "nfs_fsops_extended": None,
+                "cephfs_subvolume_thrashing": None,
             }
             # Map futures to workflow names based on their index
             workflow_order = []
@@ -3924,7 +4003,8 @@ def thrash_nfs_fio(
     Thrash NFS exports with mount -> FIO -> unmount cycles.
 
     Continuously cycles through:
-    1. Mount all NFS exports (cycling through NFSv3, NFSv4.1, NFSv4.2)
+    1. Mount all NFS exports (cycling NFSv4.0/4.1/4.2, and NFSv3 only if the
+       cluster was created with enable_nfsv3)
     2. Run NFS export info/ls commands on 2 random exports
     3. Run FIO workloads on all mounted exports (cycling through I/O patterns)
     4. Unmount all exports
@@ -3939,11 +4019,21 @@ def thrash_nfs_fio(
     Returns:
         Total number of completed mount-FIO-unmount cycles across all workers
     """
-    nfs_versions = (
-        ("3", "nfsvers=3,nolock"),
+    nfs_versions_v4 = (
+        ("4.0", "nfsvers=4.0"),
         ("4.1", "nfsvers=4.1"),
         ("4.2", "nfsvers=4.2"),
     )
+    if nfs_config.get("enable_nfsv3"):
+        nfs_versions = (("3", "nfsvers=3,nolock"),) + nfs_versions_v4
+        log.info(
+            "NFS FIO thrashing includes NFSv3 (cluster was created with --enable-nfsv3)"
+        )
+    else:
+        nfs_versions = nfs_versions_v4
+        log.info(
+            "NFS FIO thrashing skips NFSv3 (cluster was created without --enable-nfsv3)"
+        )
 
     log.info("Starting NFS FIO thrashing (5 parallel workers)")
 
@@ -3992,6 +4082,7 @@ def thrash_nfs_fio(
                         nfs_version=assigned_nfs_version,
                         duration=duration,
                         stop_flag=stop_flag,
+                        nfs_config=nfs_config,
                     )
                 )
 
@@ -4024,7 +4115,8 @@ def _nfs_worker_thread(
     nfs_version: tuple,
     duration: int,
     stop_flag: Dict,
-) -> int:
+    nfs_config: Dict[str, Any],
+) -> Dict[str, int]:
     """
     Worker thread for NFS FIO thrashing.
 
@@ -4036,10 +4128,11 @@ def _nfs_worker_thread(
         worker_id: Unique worker identifier
         export_group: List of (idx, export_dict) tuples assigned to this worker
         cluster_host_map: Cluster ID to host mapping
-        cluster_port_map: Cluster ID to port mapping
+        cluster_port_map: Cluster ID to TCP NFS port mapping (informational)
         nfs_version: Tuple of (version_str, mount_options) e.g. ("4.1", "nfsvers=4.1")
         duration: Total duration in seconds
         stop_flag: Stop signal dict
+        nfs_config: Full NFS setup dict (enable_rdma, clusters with rdma_port, etc.)
 
     Returns:
         Dict with cycles completed and failures encountered by this worker
@@ -4099,8 +4192,11 @@ def _nfs_worker_thread(
                 mount_point = exp["mount_point"]
                 try:
                     client_node.exec_command(cmd=f"mkdir -p {mount_point}", sudo=True)
+                    mount_opts = _nfs_client_mount_option_string(
+                        nfs_config, exp["cluster_id"], nfs_options
+                    )
                     mount_cmd = (
-                        f"mount -t nfs -o {nfs_options},port={exp['port']} "
+                        f"mount -t nfs -o {mount_opts} "
                         f"{exp['host']}:{exp['pseudo_path']} {mount_point}"
                     )
                     client_node.exec_command(cmd=mount_cmd, sudo=True, timeout=60)
@@ -4212,9 +4308,12 @@ FSOPS_WORKER
 
                     # Unmount and remount to verify persistence
                     mount_point = exp["mount_point"]
+                    remount_opts = _nfs_client_mount_option_string(
+                        nfs_config, exp["cluster_id"], nfs_options
+                    )
                     client_node.exec_command(
                         cmd=f"umount -lf {mount_point} && sleep 1 && "
-                        f"mount -t nfs -o {nfs_options},port={exp['port']} "
+                        f"mount -t nfs -o {remount_opts} "
                         f"{exp['host']}:{exp['pseudo_path']} {mount_point}",
                         sudo=True,
                         timeout=60,
@@ -4271,6 +4370,34 @@ FSOPS_WORKER
     return {"cycles": cycle_count, "failures": failures}
 
 
+def _nfs_client_mount_option_string(
+    nfs_config: Dict[str, Any],
+    cluster_id: str,
+    nfs_options_base: str,
+) -> str:
+    """
+    Build mount -o string for NFS client: nfsvers/... plus port= and optional rdma.
+
+    When nfs_config['enable_rdma'] is True, uses per-cluster rdma_port from
+    create_nfs_clusters_and_exports and appends the rdma mount option.
+    """
+    clusters = nfs_config.get("clusters", [])
+    port = None
+    for c in clusters:
+        if c["cluster_id"] == cluster_id:
+            if nfs_config.get("enable_rdma") and c.get("rdma_port") is not None:
+                port = c["rdma_port"]
+                return f"{nfs_options_base},rdma,port={port}"
+            port = c.get("port")
+            break
+    if port is None:
+        log.warning(
+            "_nfs_client_mount_option_string: no port for cluster_id=%s", cluster_id
+        )
+        return nfs_options_base
+    return f"{nfs_options_base},port={port}"
+
+
 def _pick_nfs_endpoint(nfs_config: Dict[str, Any], index: int = 0):
     """Helper to pick NFS export endpoint by index with cached lookups."""
     exports = nfs_config.get("exports", [])
@@ -4285,7 +4412,15 @@ def _pick_nfs_endpoint(nfs_config: Dict[str, Any], index: int = 0):
 
     exp = exports[index % len(exports)]
     host = nfs_config["_cluster_host_map"].get(exp["cluster_id"])
-    port = nfs_config["_cluster_port_map"].get(exp["cluster_id"])
+    cid = exp["cluster_id"]
+    if nfs_config.get("enable_rdma"):
+        if "_cluster_rdma_port_map" not in nfs_config:
+            nfs_config["_cluster_rdma_port_map"] = {
+                c["cluster_id"]: c.get("rdma_port") for c in clusters
+            }
+        port = nfs_config["_cluster_rdma_port_map"].get(cid)
+    else:
+        port = nfs_config["_cluster_port_map"].get(cid)
     return exp, host, port
 
 
@@ -4319,9 +4454,11 @@ def _nfs_mount_context(
     unique_suffix = uuid.uuid4().hex[:8]
     mount_point = f"{mount_base}-{unique_suffix}"
 
+    mount_opts = _nfs_client_mount_option_string(
+        nfs_config, exp["cluster_id"], f"nfsvers={nfs_ver}"
+    )
     mount_cmd = (
-        f"mount -t nfs -o nfsvers={nfs_ver},port={port} "
-        f"{host}:{exp['pseudo_path']} {mount_point}"
+        f"mount -t nfs -o {mount_opts} " f"{host}:{exp['pseudo_path']} {mount_point}"
     )
     try:
         client_node.exec_command(cmd=f"mkdir -p {mount_point}", sudo=True)


### PR DESCRIPTION
- Simplified NFS host selection to use ceph orch host ls as source of truth:
- if nfs_placement_label is set, use matching orch-labeled hosts;
- if no label match, fall back to all orch hosts.
- Hardened orch host parsing to safely handle both list and dict JSON shapes and avoid type-related failures.
- Updated docs/comments in core_workflows.py and test_osd_thrashing.py so they match the new orch-first placement behavior.
- Expanded workflow_results initialization in test_osd_thrashing.py to include NFS/MDS/subvolume workflows for complete iteration summary keys.

log : http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-MJOA5Y/ 