### PR TITLE
Single site single zone upgrade suite from 7.x GA to 9.x

### DIFF
--- a/suites/squid/rgw/test_ss_upgrade_7_1_GA_to_8.x_latest.yaml
+++ b/suites/squid/rgw/test_ss_upgrade_7_1_GA_to_8.x_latest.yaml
@@ -1,0 +1,182 @@
+#Objective: Testing single site upgrade from RHCS 7.1 ga to 8.x latest build
+#platform : RHEL-9
+#conf: conf/squid/rgw/tier-0_rgw.yaml
+
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                rhcs-version: 7.1
+                release: released
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - shared.pri
+              args:
+                placement:
+                  label: rgw
+                  nodes:
+                    - node3
+                    - node4
+                    - node5
+      desc: bootstrap and deployment services with label placements.
+      polarion-id: CEPH-83573777
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Deploy RHCS cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "sleep 120"
+          - "radosgw-admin realm create --rgw-realm india --default"
+          - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+          - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+          - "radosgw-admin period update --rgw-realm india --commit"
+          - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+          - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+          - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+          - "ceph orch restart {service_name:shared.pri}"
+      desc: Setting single zone environment
+      module: exec.py
+      name: Setting single zone environment
+      polarion-id: CEPH-10362
+
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  # configuring HAproxy on the client node 'node4' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node3:80
+              - node4:80
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "radosgw-admin period get"
+      desc: Get period Pre upgrade
+      module: exec.py
+      name: Get period Pre upgrade
+      polarion-id: CEPH-10362
+
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification pre upgrade
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
+
+  - test:
+      name: Upgrade cluster to latest ceph version
+      desc: Upgrade cluster to latest version
+      module: test_cephadm_upgrade.py
+      polarion-id: CEPH-83573791
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      desc: Retrieve the versions of the cluster
+      module: exec.py
+      name: post upgrade gather version
+      polarion-id: CEPH-83575200
+      config:
+        cephadm: true
+        commands:
+          - "ceph versions"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "radosgw-admin period get"
+      desc: Get period post upgrade
+      module: exec.py
+      name: Get period post upgrade
+      polarion-id: CEPH-10362
+
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification post upgrade
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true

--- a/suites/tentacle/rgw/test_ss_upgrade_7_1_GA_to_9.x_latest.yaml
+++ b/suites/tentacle/rgw/test_ss_upgrade_7_1_GA_to_9.x_latest.yaml
@@ -1,0 +1,182 @@
+#Objective: Testing single site single zone upgrade from RHCS 7.1 ga to 9.x latest build
+#platform : RHEL-9
+#conf: conf/tentacle/rgw/tier-0_rgw.yaml
+
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                rhcs-version: 7.1
+                release: released
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - shared.pri
+              args:
+                placement:
+                  label: rgw
+                  nodes:
+                    - node3
+                    - node4
+                    - node5
+      desc: bootstrap and deployment services with label placements.
+      polarion-id: CEPH-83573777
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Deploy RHCS cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "sleep 120"
+          - "radosgw-admin realm create --rgw-realm india --default"
+          - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+          - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+          - "radosgw-admin period update --rgw-realm india --commit"
+          - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+          - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+          - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+          - "ceph orch restart {service_name:shared.pri}"
+      desc: Setting single zone environment
+      module: exec.py
+      name: Setting single zone environment
+      polarion-id: CEPH-10362
+
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  # configuring HAproxy on the client node 'node4' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node3:80
+              - node4:80
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "radosgw-admin period get"
+      desc: Get period pre upgrade
+      module: exec.py
+      name: Get period pre upgrade
+      polarion-id: CEPH-10362
+
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification pre upgrade
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
+
+  - test:
+      name: Upgrade cluster to latest ceph version
+      desc: Upgrade cluster to latest version
+      module: test_cephadm_upgrade.py
+      polarion-id: CEPH-83573791
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      desc: Retrieve the versions of the cluster
+      module: exec.py
+      name: post upgrade gather version
+      polarion-id: CEPH-83575200
+      config:
+        cephadm: true
+        commands:
+          - "ceph versions"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "radosgw-admin period get"
+      desc: Get period post upgrade
+      module: exec.py
+      name: Get period post upgrade
+      polarion-id: CEPH-10362
+
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification post upgrade
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true


### PR DESCRIPTION
# Description

Single site single zone upgrade suite from 7.x GA to 9.x
and 
Single site single zone upgrade suite from 7.x GA to 8.x

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-OYN1BK/
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-R9WHLE/Mbuckets_with_Nobjects_with_etag_verification_post_upgrade_0.log
(with reusing above cluster)

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-2DEB4R/

ss single zone 7.1 released to 8.1 latest: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-IQ17WX/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
