### PR TITLE
[RBD] Updated RBD sanity suite

### DIFF
--- a/suites/quincy/rbd/tier-1_rbd.yaml
+++ b/suites/quincy/rbd/tier-1_rbd.yaml
@@ -1,84 +1,58 @@
 # Tier1: RBD build evaluation
 #
 # This test suite evaluates the build to determine the execution of identified
-# regression test suites.
-# This suite requires node2 to be a client node with mons, mgrs and osds
+# RBD regression tests.
+# This suite requires node4 to be a client node with mons, mgrs and osds
 # Example config - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+
 ---
 tests:
-  -
-    test:
+  - test:
       abort-on-fail: true
       module: install_prereq.py
       name: "install ceph pre-requisites"
-  -
-    test:
-      name: Cephadm Bootstrap with custom user option
-      desc: cephadm cluster bootstrap with ssh-user(cephuser) option
-      module: test_bootstrap.py
-      polarion-id: CEPH-83573724
-      config:
-        command: bootstrap
-        base_cmd_args:
-          verbose: true
-        args:
-          ssh-user: cephuser
-          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide with ssh-user
-          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
-          registry-json: registry.redhat.io
-          custom_image: true
-          mon-ip: node1
-      destroy-cluster: false
-      abort-on-fail: true
-  -
-    test:
+
+  - test:
       abort-on-fail: true
       config:
+        verify_cluster_health: true
         steps:
-          -
-            config:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
-              command: add_hosts
-              service: host
-          -
-            config:
+          - config:
+              command: apply
+              service: mgr
               args:
                 placement:
                   label: mgr
+          - config:
               command: apply
-              service: mgr
-          -
-            config:
+              service: mon
               args:
                 placement:
                   label: mon
-              command: apply
-              service: mon
-          -
-            config:
-              args:
-                all-available-devices: true
+          - config:
               command: apply
               service: osd
-          -
-            config:
               args:
-                - "ceph osd pool create rbd"
-              command: shell
-          -
-            config:
-              args:
-                - "rbd pool init rbd"
-              command: shell
-        verify_cluster_health: true
-      desc: "RHCS cluster deployment using cephadm"
-      destroy-clster: false
+                all-available-devices: true
+      desc: Ceph cluster deployment using cephadm
+      destroy-cluster: false
       module: test_cephadm.py
-      name: "deploy cluster"
-  -
-    test:
+      name: deploy cluster
+
+  - test:
       abort-on-fail: true
       config:
         command: add
@@ -89,14 +63,24 @@ tests:
           - rbd-nbd
           - jq
           - fio
+          - git
         node: node4
       desc: "Configure the client system"
       destroy-cluster: false
       module: test_client.py
       name: "configure client"
       polarion-id: CEPH-83573758
-  -
-    test:
+
+  - test:
+      desc: Remove any epel packages
+      module: exec.py
+      name: Remove epel packages
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+
+  - test:
       config:
         script: rbd_groups.sh
         script_path: qa/workunits/rbd
@@ -104,8 +88,8 @@ tests:
       module: test_rbd.py
       name: 1_rbd_cli_groups
       polarion-id: CEPH-83574239
-  -
-    test:
+
+  - test:
       config:
         script: import_export.sh
         script_path: qa/workunits/rbd
@@ -113,6 +97,7 @@ tests:
       module: test_rbd.py
       name: 2_rbd_cli_import_export
       polarion-id: CEPH-83574240
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -121,6 +106,7 @@ tests:
       module: test_rbd.py
       name: 5_librbd_python
       polarion-id: CEPH-83574524
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -129,6 +115,7 @@ tests:
       module: test_rbd.py
       name: 6_rbd_permissions
       polarion-id: CEPH-83574525
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -137,6 +124,7 @@ tests:
       module: test_rbd.py
       name: 7_rbd_read_flags
       polarion-id: CEPH-83574526
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -145,6 +133,7 @@ tests:
       module: test_rbd.py
       name: 9_journal
       polarion-id: CEPH-83574527
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -153,6 +142,7 @@ tests:
       module: test_rbd.py
       name: 10_rbd_kernel
       polarion-id: CEPH-83574528
+
   - test:
       config:
         script_path: qa/workunits/rbd

--- a/suites/reef/rbd/tier-1_rbd.yaml
+++ b/suites/reef/rbd/tier-1_rbd.yaml
@@ -1,84 +1,58 @@
 # Tier1: RBD build evaluation
 #
 # This test suite evaluates the build to determine the execution of identified
-# regression test suites.
-# This suite requires node2 to be a client node with mons, mgrs and osds
+# RBD regression tests.
+# This suite requires node4 to be a client node with mons, mgrs and osds
 # Example config - conf/reef/rbd/4-node-cluster-with-1-client.yaml
+
 ---
 tests:
-  -
-    test:
+  - test:
       abort-on-fail: true
       module: install_prereq.py
       name: "install ceph pre-requisites"
-  -
-    test:
-      name: Cephadm Bootstrap with custom user option
-      desc: cephadm cluster bootstrap with ssh-user(cephuser) option
-      module: test_bootstrap.py
-      polarion-id: CEPH-83573724
-      config:
-        command: bootstrap
-        base_cmd_args:
-          verbose: true
-        args:
-          ssh-user: cephuser
-          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide with ssh-user
-          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
-          registry-json: registry.redhat.io
-          custom_image: true
-          mon-ip: node1
-      destroy-cluster: false
-      abort-on-fail: true
-  -
-    test:
+
+  - test:
       abort-on-fail: true
       config:
+        verify_cluster_health: true
         steps:
-          -
-            config:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
-              command: add_hosts
-              service: host
-          -
-            config:
+          - config:
+              command: apply
+              service: mgr
               args:
                 placement:
                   label: mgr
+          - config:
               command: apply
-              service: mgr
-          -
-            config:
+              service: mon
               args:
                 placement:
                   label: mon
-              command: apply
-              service: mon
-          -
-            config:
-              args:
-                all-available-devices: true
+          - config:
               command: apply
               service: osd
-          -
-            config:
               args:
-                - "ceph osd pool create rbd"
-              command: shell
-          -
-            config:
-              args:
-                - "rbd pool init rbd"
-              command: shell
-        verify_cluster_health: true
-      desc: "RHCS cluster deployment using cephadm"
-      destroy-clster: false
+                all-available-devices: true
+      desc: Ceph cluster deployment using cephadm
+      destroy-cluster: false
       module: test_cephadm.py
-      name: "deploy cluster"
-  -
-    test:
+      name: deploy cluster
+
+  - test:
       abort-on-fail: true
       config:
         command: add
@@ -106,8 +80,7 @@ tests:
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
 
-  -
-    test:
+  - test:
       config:
         script: rbd_groups.sh
         script_path: qa/workunits/rbd
@@ -115,8 +88,8 @@ tests:
       module: test_rbd.py
       name: 1_rbd_cli_groups
       polarion-id: CEPH-83574239
-  -
-    test:
+
+  - test:
       config:
         script: import_export.sh
         script_path: qa/workunits/rbd
@@ -124,6 +97,7 @@ tests:
       module: test_rbd.py
       name: 2_rbd_cli_import_export
       polarion-id: CEPH-83574240
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -132,6 +106,7 @@ tests:
       module: test_rbd.py
       name: 5_librbd_python
       polarion-id: CEPH-83574524
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -140,6 +115,7 @@ tests:
       module: test_rbd.py
       name: 6_rbd_permissions
       polarion-id: CEPH-83574525
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -148,6 +124,7 @@ tests:
       module: test_rbd.py
       name: 7_rbd_read_flags
       polarion-id: CEPH-83574526
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -156,6 +133,7 @@ tests:
       module: test_rbd.py
       name: 9_journal
       polarion-id: CEPH-83574527
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -164,6 +142,7 @@ tests:
       module: test_rbd.py
       name: 10_rbd_kernel
       polarion-id: CEPH-83574528
+
   - test:
       config:
         script_path: qa/workunits/rbd

--- a/suites/squid/rbd/tier-1_rbd.yaml
+++ b/suites/squid/rbd/tier-1_rbd.yaml
@@ -1,84 +1,58 @@
 # Tier1: RBD build evaluation
 #
 # This test suite evaluates the build to determine the execution of identified
-# regression test suites.
-# This suite requires node2 to be a client node with mons, mgrs and osds
+# RBD regression tests.
+# This suite requires node4 to be a client node with mons, mgrs and osds
 # Example config - conf/squid/rbd/4-node-cluster-with-1-client.yaml
+
 ---
 tests:
-  -
-    test:
+  - test:
       abort-on-fail: true
       module: install_prereq.py
       name: "install ceph pre-requisites"
-  -
-    test:
-      name: Cephadm Bootstrap with custom user option
-      desc: cephadm cluster bootstrap with ssh-user(cephuser) option
-      module: test_bootstrap.py
-      polarion-id: CEPH-83573724
-      config:
-        command: bootstrap
-        base_cmd_args:
-          verbose: true
-        args:
-          ssh-user: cephuser
-          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide with ssh-user
-          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
-          registry-json: registry.redhat.io
-          custom_image: true
-          mon-ip: node1
-      destroy-cluster: false
-      abort-on-fail: true
-  -
-    test:
+
+  - test:
       abort-on-fail: true
       config:
+        verify_cluster_health: true
         steps:
-          -
-            config:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
-              command: add_hosts
-              service: host
-          -
-            config:
+          - config:
+              command: apply
+              service: mgr
               args:
                 placement:
                   label: mgr
+          - config:
               command: apply
-              service: mgr
-          -
-            config:
+              service: mon
               args:
                 placement:
                   label: mon
-              command: apply
-              service: mon
-          -
-            config:
-              args:
-                all-available-devices: true
+          - config:
               command: apply
               service: osd
-          -
-            config:
               args:
-                - "ceph osd pool create rbd"
-              command: shell
-          -
-            config:
-              args:
-                - "rbd pool init rbd"
-              command: shell
-        verify_cluster_health: true
-      desc: "RHCS cluster deployment using cephadm"
-      destroy-clster: false
+                all-available-devices: true
+      desc: Ceph cluster deployment using cephadm
+      destroy-cluster: false
       module: test_cephadm.py
-      name: "deploy cluster"
-  -
-    test:
+      name: deploy cluster
+
+  - test:
       abort-on-fail: true
       config:
         command: add
@@ -106,8 +80,7 @@ tests:
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
 
-  -
-    test:
+  - test:
       config:
         script: rbd_groups.sh
         script_path: qa/workunits/rbd
@@ -115,8 +88,8 @@ tests:
       module: test_rbd.py
       name: 1_rbd_cli_groups
       polarion-id: CEPH-83574239
-  -
-    test:
+
+  - test:
       config:
         script: import_export.sh
         script_path: qa/workunits/rbd
@@ -133,6 +106,7 @@ tests:
       module: test_rbd.py
       name: 5_librbd_python
       polarion-id: CEPH-83574524
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -141,6 +115,7 @@ tests:
       module: test_rbd.py
       name: 6_rbd_permissions
       polarion-id: CEPH-83574525
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -149,6 +124,7 @@ tests:
       module: test_rbd.py
       name: 7_rbd_read_flags
       polarion-id: CEPH-83574526
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -157,6 +133,7 @@ tests:
       module: test_rbd.py
       name: 9_journal
       polarion-id: CEPH-83574527
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -165,6 +142,7 @@ tests:
       module: test_rbd.py
       name: 10_rbd_kernel
       polarion-id: CEPH-83574528
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -199,6 +177,6 @@ tests:
       name: RBD image creation in the namespace
       polarion-id: CEPH-83582476
       config:
-        rep-pool-only: True
+        rep-pool-only: true
         rep_pool_config:
           rbd: {}

--- a/suites/tentacle/rbd/tier-1_rbd.yaml
+++ b/suites/tentacle/rbd/tier-1_rbd.yaml
@@ -1,96 +1,69 @@
 # Tier1: RBD build evaluation
 #
 # This test suite evaluates the build to determine the execution of identified
-# regression test suites.
-# This suite requires node2 to be a client node with mons, mgrs and osds
+# RBD regression tests.
+# This suite requires node4 to be a client node with mons, mgrs and osds
 # Example config - conf/tentacle/rbd/4-node-cluster-with-1-client.yaml
+
 ---
 tests:
-  -
-    test:
+  - test:
       abort-on-fail: true
       module: install_prereq.py
       name: "install ceph pre-requisites"
-  -
-    test:
-      name: Cephadm Bootstrap with custom user option
-      desc: cephadm cluster bootstrap with ssh-user(cephuser) option
-      module: test_bootstrap.py
-      polarion-id: CEPH-83573724
-      comments: IBMCEPH-13576
-      config:
-        command: bootstrap
-        base_cmd_args:
-          verbose: true
-        args:
-          ssh-user: cephuser
-          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide with ssh-user
-          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
-          registry-json: registry.redhat.io
-          custom_image: true
-          mon-ip: node1
-      destroy-cluster: false
-      abort-on-fail: true
-  -
-    test:
+
+  - test:
       abort-on-fail: true
       config:
+        verify_cluster_health: true
         steps:
-          -
-            config:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
-              command: add_hosts
-              service: host
-          -
-            config:
+          - config:
+              command: apply
+              service: mgr
               args:
                 placement:
                   label: mgr
+          - config:
               command: apply
-              service: mgr
-          -
-            config:
+              service: mon
               args:
                 placement:
                   label: mon
-              command: apply
-              service: mon
-          -
-            config:
-              args:
-                all-available-devices: true
+          - config:
               command: apply
               service: osd
-          -
-            config:
               args:
-                - "ceph osd pool create rbd"
-              command: shell
-          -
-            config:
-              args:
-                - "rbd pool init rbd"
-              command: shell
-        verify_cluster_health: true
-      desc: "RHCS cluster deployment using cephadm"
-      destroy-clster: false
+                all-available-devices: true
+      desc: Ceph cluster deployment using cephadm
+      destroy-cluster: false
       module: test_cephadm.py
-      name: "deploy cluster"
-  -
-    test:
+      name: deploy cluster
+
+  - test:
       abort-on-fail: true
       config:
         command: add
         copy_admin_keyring: true
         id: client.1
         install_packages:
-          - git
           - ceph-common
           - rbd-nbd
           - jq
           - fio
+          - git
         node: node4
       desc: "Configure the client system"
       destroy-cluster: false
@@ -107,8 +80,7 @@ tests:
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
 
-  -
-    test:
+  - test:
       config:
         script: rbd_groups.sh
         script_path: qa/workunits/rbd
@@ -117,8 +89,8 @@ tests:
       module: test_rbd.py
       name: 1_rbd_cli_groups
       polarion-id: CEPH-83574239
-  -
-    test:
+
+  - test:
       config:
         script: import_export.sh
         script_path: qa/workunits/rbd
@@ -137,6 +109,7 @@ tests:
       module: test_rbd.py
       name: 5_librbd_python
       polarion-id: CEPH-83574524
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -146,6 +119,7 @@ tests:
       module: test_rbd.py
       name: 6_rbd_permissions
       polarion-id: CEPH-83574525
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -155,6 +129,7 @@ tests:
       module: test_rbd.py
       name: 7_rbd_read_flags
       polarion-id: CEPH-83574526
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -164,6 +139,7 @@ tests:
       module: test_rbd.py
       name: 9_journal
       polarion-id: CEPH-83574527
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -173,6 +149,7 @@ tests:
       module: test_rbd.py
       name: 10_rbd_kernel
       polarion-id: CEPH-83574528
+
   - test:
       config:
         script_path: qa/workunits/rbd
@@ -208,6 +185,6 @@ tests:
       name: RBD image creation in the namespace
       polarion-id: CEPH-83582476
       config:
-        rep-pool-only: True
+        rep-pool-only: true
         rep_pool_config:
           rbd: {}

--- a/tests/rbd_mirror/test_rbd_group_mirror_consistency.py
+++ b/tests/rbd_mirror/test_rbd_group_mirror_consistency.py
@@ -363,7 +363,7 @@ def test_mirror_group_consistency(
                         "num_jobs": io_large_cfg.get("num_jobs", "1"),
                         "iodepth": io_large_cfg.get("iodepth", "16"),
                         "io_type": io_large_cfg.get("io-type", "write"),
-                        "cmd_timeout": 2400,
+                        "cmd_timeout": 3600,
                     }
                     run_fio(**io_args)
 
@@ -427,7 +427,7 @@ def test_mirror_group_consistency(
                     )
                     log.info("Force killed rbd-mirror daemon before force promote")
 
-                time.sleep(10)
+                time.sleep(30)
                 md5sum_third_sync_site_b = []
                 for image in image_spec_all[0:2]:
                     md5sum_third_sync_site_b.append(
@@ -447,7 +447,7 @@ def test_mirror_group_consistency(
                     md5sum_second_write_site_a[0:2],
                 )
 
-                time.sleep(5)
+                time.sleep(120)
                 out, err = rbd_secondary.mirror.group.promote(
                     **{"group-spec": group_spec, "force": True}
                 )


### PR DESCRIPTION
# Description
Updated RBD sanity suite as per the recent changes in cephadm bootstrap parameters.
Test result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CZ35X0/
updated the branch and retested again on the failed test above
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VCDSXA/


Also addressed one TFA fix on `tier-2_rbd_group_mirror_failover.yaml`
By increasing the command timeout for 9G IO file size test passed
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VFYMJE/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
