### PR TITLE
Resolved BVT issue in NVMEeOF

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_bvt.py
+++ b/tests/nvmeof/test_ceph_nvmeof_bvt.py
@@ -101,7 +101,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             return 0
 
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+            configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
         if config.get("initiators"):
             with parallel() as p:


### PR DESCRIPTION
We are hitting 2026-04-13 02:44:29,684 - cephci - test_ceph_nvmeof_bvt:112 - ERROR - 'NoneType' object has no attribute 'get_nodes'

To resolve above issue, this check in is required

Logs :- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-39Y4OF_bvt_fix_13_apr_26/
