### PR TITLE
Fix yum_repos gpgcheck typo and Rocky SSH key YAML indent

### DIFF
--- a/conf/inventory/ibm-eu-rhel-9.6.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.6.yaml
@@ -25,13 +25,13 @@ instance:
       baseos:
         name: BaseOS
         baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/6/BaseOS/
-        gpcheck: false
+        gpgcheck: false
         enabled: true
 
       crb:
         name: codeready-builder
         baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/6/CRB/
-        gpcheck: false
+        gpgcheck: false
         enabled: true
 
     # write the mirror registry details

--- a/conf/inventory/ibm-eu-rhel-9.7.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.7.yaml
@@ -25,13 +25,13 @@ instance:
       baseos:
         name: BaseOS
         baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/7/BaseOS/
-        gpcheck: false
+        gpgcheck: false
         enabled: true
 
       crb:
         name: codeready-builder
         baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/7/CRB/
-        gpcheck: false
+        gpgcheck: false
         enabled: true
 
     # write the mirror registry details

--- a/conf/inventory/rocky-10.1-server-x86_64-large.yaml
+++ b/conf/inventory/rocky-10.1-server-x86_64-large.yaml
@@ -21,7 +21,7 @@ instance:
         sudo: ALL=(ALL) NOPASSWD:ALL
         shell: /bin/bash
         ssh-authorized-keys:
-           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
 
     chpasswd:
       list: |

--- a/conf/inventory/rocky-10.1-server-x86_64.yaml
+++ b/conf/inventory/rocky-10.1-server-x86_64.yaml
@@ -21,7 +21,7 @@ instance:
         sudo: ALL=(ALL) NOPASSWD:ALL
         shell: /bin/bash
         ssh-authorized-keys:
-           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
 
     chpasswd:
       list: |


### PR DESCRIPTION
- Replace mistyped gpcheck with gpgcheck for BaseOS/CRB in IBM EU RHEL 9.x inventories (cloud-init ignores unknown keys).
- Normalize ssh-authorized-keys list indent to 10 spaces in Rocky 10.1 inventories to match other server profiles.


Made-with: Cursor
