### PR TITLE
Fix yum_repos gpcheck typo to gpgcheck (IBM EU RHEL 9.7 rgw)

### DIFF
--- a/conf/inventory/ibm-eu-rhel-9.7-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.7-rgw.yaml
@@ -25,13 +25,13 @@ instance:
       baseos:
         name: BaseOS
         baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/7/BaseOS/
-        gpcheck: false
+        gpgcheck: false
         enabled: true
 
       crb:
         name: codeready-builder
         baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/7/CRB/
-        gpcheck: false
+        gpgcheck: false
         enabled: true
 
     # write the mirror registry details


### PR DESCRIPTION
cloud-init ignores unknown keys; BaseOS/CRB must use gpgcheck.

Made-with: Cursor
