### PR TITLE
Configure configure_subsystems() function is broken because of PR#5758

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -412,7 +412,7 @@ def test_ceph_83610948(ceph_cluster, config):
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
     # Validate the Health warning states
     @retry(ValueError, tries=6, delay=5)
@@ -677,7 +677,7 @@ def test_ceph_83611306(ceph_cluster, config):
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
     # Validate the Health warning states
     @retry(ValueError, tries=10, delay=60)
@@ -790,7 +790,7 @@ def test_CEPH_83616917(ceph_cluster, config):
     ha.gateways = nvme_service.gateways
 
     # Configure subsystems, --max-namespaces is 10 and we are creating 10 namesapces
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
     # Check for alert
     # NVMeoFSubsystemNamespaceLimit prometheus alert should be firing
@@ -934,7 +934,7 @@ def test_ceph_83616916(ceph_cluster, config):
     ha.gateways = nvme_service.gateways
     nvmegwcli = ha.gateways[0]
 
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
     # Check for alert
     # NVMeoFGatewayOpenSecurity prometheus alert should be firing
@@ -1184,7 +1184,7 @@ def test_ceph_83617545(ceph_cluster, config):
 
     # Configure subsystems
     LOG.info("Configure subsystems")
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
     # Check for alert
     # NVMeoFTooManyNamespaces prometheus alert should be firing
@@ -1258,7 +1258,7 @@ def test_ceph_83617640(ceph_cluster, config):
 
     # Configure subsystems
     LOG.info("Configure subsystems")
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
     # Check for alert
     # NVMeoFVersionMismatch prometheus alert should be in inactive state

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_ns_reservation.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_ns_reservation.py
@@ -295,7 +295,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         nvmegwcli = nvme_service.gateways[0]
 
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+            configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
 
         if config.get("initiators"):
             for i in config["initiators"]:

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -49,7 +49,7 @@ def test_ceph_83595464(ceph_cluster, config, rbd_obj):
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
     ha.run()
 
     # Update the config
@@ -98,7 +98,7 @@ def test_ceph_83595464(ceph_cluster, config, rbd_obj):
                 f"Failed to delete subsystem {sub['nqn']}: {out} with error {err}"
             )
     # Configure gateway entities
-    configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
     config["nvme_service"] = nvme_service
 
 

--- a/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
+++ b/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
@@ -87,8 +87,8 @@ def test_ceph_83608838(ceph_cluster, config):
 
     # Configure subsystems
     LOG.info("Configure subsystems")
-    configure_subsystems(nvme_service)
-    configure_hosts(nvme_service.gateways[0], config)
+    configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
+    configure_hosts(nvme_service.gateways[0], config, ceph_cluster=ceph_cluster)
     listeners = [nvme_service.gateways[0].node.id]
     for cfg in config["subsystems"]:
         if cfg.get("listeners"):
@@ -166,8 +166,8 @@ def test_ceph_83609769(ceph_cluster, config):
 
     # Configure subsystems
     LOG.info("Configure subsystems")
-    configure_subsystems(nvme_service)
-    configure_hosts(nvme_service.gateways[0], config)
+    configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
+    configure_hosts(nvme_service.gateways[0], config, ceph_cluster=ceph_cluster)
     listeners = [nvme_service.gateways[0].node.id]
     for cfg in config["subsystems"]:
         if cfg.get("listeners"):
@@ -399,8 +399,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
             # Configure Subsystem
             if config.get("subsystems"):
-                configure_subsystems(nvme_service)
-                configure_hosts(nvme_service.gateways[0], config)
+                configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
+                configure_hosts(
+                    nvme_service.gateways[0], config, ceph_cluster=ceph_cluster
+                )
                 listeners = [nvme_service.gateways[0].node.id]
                 for cfg in config["subsystems"]:
                     if cfg.get("listeners"):

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -62,7 +62,7 @@ def test_ceph_83575812(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         # Get Image name
         list_args = {}
@@ -109,7 +109,7 @@ def test_ceph_83575467(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         @retry(IOError, tries=5, delay=5)
         def list_subsystems(**sub_args):
@@ -178,7 +178,7 @@ def test_ceph_83575813(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         # Run IOS on nvme namespaces
         initiator.disconnect_all()
@@ -373,7 +373,7 @@ def test_ceph_83576084(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         cmd_args = {
             "transport": "tcp",
@@ -464,7 +464,7 @@ def test_ceph_83576085(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         json_format = {"output-format": "json"}
         _dir = f"/tmp/dir_{generate_unique_id(4)}"
@@ -523,7 +523,7 @@ def test_ceph_83576087(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         json_format = {"output-format": "json"}
         _dir = f"/tmp/dir_{generate_unique_id(4)}"
@@ -590,7 +590,7 @@ def test_ceph_83576093(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         json_format = {"output-format": "json"}
         _dir = f"/tmp/dir_{generate_unique_id(4)}"
@@ -685,7 +685,7 @@ def test_ceph_83575814(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         mon_host = ceph_cluster.get_nodes(role="mon")[0]
         with parallel() as p:
@@ -741,7 +741,7 @@ def test_ceph_83581753(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         list_args = {}
         list_args.setdefault("args", {}).update(
@@ -811,7 +811,7 @@ def test_ceph_83581945(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         list_args = {}
         list_args.setdefault("args", {}).update(
@@ -902,7 +902,7 @@ def test_ceph_83581755(ceph_cluster, rbd, nvme_service, pool, config):
 
         # Configure Subsystem, listeners, host, namespaces
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd)
+            configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
         list_args = {}
         list_args.setdefault("args", {}).update(
@@ -1040,11 +1040,12 @@ def test_ceph_83608266(
 
             # Configure Subsystem, listeners, host, namespaces
             if config.get("subsystems"):
-                configure_subsystems(nvme_service)
+                configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
                 configure_listeners(nvme_service.gateways, nvme_service.config)
                 configure_hosts(
                     nvme_service.gateways[0],
                     nvme_service.config,
+                    ceph_cluster=ceph_cluster,
                 )
 
             for _ in range(2):

--- a/tests/nvmeof/test_ceph_nvmeof_ns_masking.py
+++ b/tests/nvmeof/test_ceph_nvmeof_ns_masking.py
@@ -363,9 +363,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         nvmegwcli = nvme_service.gateways[0]
 
         if config.get("subsystems"):
-            configure_subsystems(nvme_service)
+            configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
             configure_listeners(nvme_service.gateways, nvme_service.config)
-            configure_hosts(nvme_service.gateways[0], nvme_service.config)
+            configure_hosts(
+                nvme_service.gateways[0], nvme_service.config, ceph_cluster=ceph_cluster
+            )
 
         ns_masking = NamespaceMasking(
             ceph_cluster,

--- a/tests/nvmeof/test_ceph_nvmeof_ns_resize.py
+++ b/tests/nvmeof/test_ceph_nvmeof_ns_resize.py
@@ -223,9 +223,9 @@ def test_ceph_83627178(ceph_cluster, config, nvme_service):
 
     # Configure subsystems and listeners
     LOG.info("Configure subsystems, listeners")
-    configure_subsystems(nvme_service)
+    configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
     configure_listeners(nvme_service.gateways, nvme_service.config)
-    configure_hosts(nvmegwcli, nvme_service.config)
+    configure_hosts(nvmegwcli, nvme_service.config, ceph_cluster=ceph_cluster)
 
     # Configure namespaces
     ns_data = configure_ns(config, rbd_pool, rbd_obj, nvmegwcli)

--- a/tests/nvmeof/test_ceph_nvmeof_qos_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_qos_tests.py
@@ -196,7 +196,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             nvmegwcli = nvme_service.gateways[0]
 
         if config.get("subsystems"):
-            configure_gw_entities(nvme_service, rbd_obj=rbd_obj)
+            configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
             configure_qos(ceph_cluster, nvmegwcli, config["subsystems"][0], config)
 
         return 0

--- a/tests/nvmeof/test_ceph_nvmeof_readonly_ns.py
+++ b/tests/nvmeof/test_ceph_nvmeof_readonly_ns.py
@@ -138,9 +138,9 @@ def test_ceph_83624617(ceph_cluster, config, nvme_service):
 
     # Configure subsystems
     LOG.info("Configure subsystems, listeners")
-    configure_subsystems(nvme_service)
+    configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
     configure_listeners(nvme_service.gateways, nvme_service.config)
-    configure_hosts(nvmegwcli, nvme_service.config)
+    configure_hosts(nvmegwcli, nvme_service.config, ceph_cluster=ceph_cluster)
 
     # Configure readonly namespaces
     ns_data = configure_ns(config, rbd_pool, rbd_obj, nvmegwcli, readonly=True)

--- a/tests/nvmeof/test_io_perf.py
+++ b/tests/nvmeof/test_io_perf.py
@@ -486,7 +486,7 @@ def nvmeof(ceph_cluster, **args):
 
             # Configure Subsystem, listeners, host, namespaces
             if args.get("subsystems"):
-                configure_gw_entities(nvme_service, rbd_obj=rbd)
+                configure_gw_entities(nvme_service, rbd_obj=rbd, cluster=ceph_cluster)
 
             try:
                 # Run with profiles and collect results

--- a/tests/nvmeof/test_nvmeof_gwgroup.py
+++ b/tests/nvmeof/test_nvmeof_gwgroup.py
@@ -35,6 +35,7 @@ def run_gateway_group_operations(
                     configure_gw_entities,
                     nvme_service,
                     rbd_obj=rbd_obj,
+                    cluster=ceph_cluster,
                 )
 
         # HA failover and failback

--- a/tests/nvmeof/test_nvmeof_gwgroup_inbandauth.py
+++ b/tests/nvmeof/test_nvmeof_gwgroup_inbandauth.py
@@ -28,7 +28,7 @@ def configure_gw_entities_with_encryption(gwgroup_config, ceph_cluster, nvme_ser
     hosts = gwgroup_config.get("hosts", [])
     initiators = []
     if gwgroup_config.get("subsystems"):
-        initiators.extend(configure_subsystems(nvme_service))
+        initiators.extend(configure_subsystems(nvme_service, ceph_cluster=ceph_cluster))
         # configure_hosts will be called for all subsystems in the loop below
         # to ensure consistent handling
         listeners = [nvme_service.gateways[0].node.id]


### PR DESCRIPTION
configure_subsystems() function is broken because of PR#5758

Commit for reference https://github.com/red-hat-storage/cephci/commit/a1a79fea136476547ac9f005df884f5d460cd45b#diff-1e84b39c7d4def5cd8e73cf78c640daf860bbd58249d14ff4ed19dc930fe4a1fR8-R61

before it was 
`def configure_subsystems(nvme_service):`

After above commit it is was changed to below
`def configure_subsystems(nvme_service, ceph_cluster=None):`

Inside configure_subsystem() below lines of code is introduced because of above commit
```
ceph_version = get_ceph_version_from_cluster(
            ceph_cluster.get_nodes(role="client")[0]
        )
```

When ever ceph_cluster is None then it will fail as below error in all scripts
`ERROR - 'NoneType' object has no attribute 'get_nodes'`

I didn't collected the logs because entire regression suite scripts are changed here and need to re-execute regression suite
