### PR TITLE
[TFA-fix]Adding module and name to the configure client test case in squid and tentacle suites for RGW regression tests.

### DIFF
--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -112,6 +112,9 @@ tests:
         copy_admin_keyring: true
       desc: Configure the RGW client system
       polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -112,6 +112,9 @@ tests:
         copy_admin_keyring: true
       desc: Configure the RGW client system
       polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
 
   # STS tests
 

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -112,6 +112,9 @@ tests:
         copy_admin_keyring: true
       desc: Configure the RGW client system
       polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -112,6 +112,9 @@ tests:
         copy_admin_keyring: true
       desc: Configure the RGW client system
       polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
 
   # STS tests
 


### PR DESCRIPTION


Added name, module  to the configure client test case in squid and tentacle suites for ssl  RGW regression tests which was causing termination  of those suites

JIra: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-23651 

Failed log: 
http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/regression/20.1.0-185/rgw/37/logs/Tier_2_SSL_RGW_regression/

passlog: 
http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.0/rhel-10/executor/20.1.0-185/rgw/1198/logs/tier_2_ssl_rgw_regression_test/ 
