### PR TITLE
removed comment form upgrade testcase in squid sanity upgrade suites 

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -332,7 +332,7 @@ tests:
       module: test_cephadm_upgrade.py
       name: multisite ceph upgrade
       polarion-id: CEPH-83574647
-      comments: Upgrade may fail if nightly and stable build paths are incorrect, identical, or if the nightly build version is lower than the stable build.
+      # Upgrade may fail if nightly and stable build paths are incorrect, identical, or if the nightly build version is lower than the stable build.
       clusters:
         ceph-sec:
           config:

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -131,7 +131,7 @@ tests:
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
       polarion-id: CEPH-83573791
-      comments: Upgrade may fail if nightly and stable build paths are incorrect, identical, or if the nightly build version is lower than the stable build.
+      # Upgrade may fail if nightly and stable build paths are incorrect, identical, or if the nightly build version is lower than the stable build.
       verify_cluster_health: true
       config:
         command: start


### PR DESCRIPTION


the comment is visible even when the upgrade  testcase is passing in squid sanity pipeline runs . so commented out the comment , 