### PR TITLE
Add RHCS 9 CDN tools repo for RHEL 10 in cephadm client test

### DIFF
--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -65,6 +65,7 @@ def add(cls, config: Dict) -> None:
             rhcs_version = _build.get("release")
             _manifest_section = _build.get("tag")
             _node = get_node_by_id(cls.cluster, name)
+            manifest_obj = None
             _rpm_version = None
             if rhcs_version:
                 rhcs_version = str(rhcs_version)
@@ -98,25 +99,6 @@ def add(cls, config: Dict) -> None:
                 r"yum-config-manager --disable \*",
             ]
             cmd = 'subscription-manager repos --list-enabled | grep -i "Repo ID"'
-            # Added downstream test repos for RHEL 8 RHCS 6, Will add live repo once available.
-            cdn_ceph_repo = {
-                "7": {"4": ["rhel-7-server-rhceph-4-tools-rpms"]},
-                "8": {
-                    "4": ["rhceph-4-tools-for-rhel-8-x86_64-rpms"],
-                    "5": ["rhceph-5-tools-for-rhel-8-x86_64-rpms"],
-                    "6": [
-                        "http://download.eng.bos.redhat.com/rhel-8/composes/raw/"
-                        "ceph-6.1-rhel-8/RHCEPH-6.1-RHEL-8-20231004.t.1/compose/Tools/x86_64/os/"
-                    ],
-                },
-                "9": {
-                    "5": ["rhceph-5-tools-for-rhel-9-x86_64-rpms"],
-                    "6": ["rhceph-6-tools-for-rhel-9-x86_64-rpms"],
-                    "7": ["rhceph-7-tools-for-rhel-9-x86_64-rpms"],
-                    "8": ["rhceph-8-tools-for-rhel-9-x86_64-rpms"],
-                    "9": ["rhceph-9-tools-for-rhel-9-x86_64-rpms"],
-                },
-            }
 
             rhel_repos = {
                 "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
@@ -128,10 +110,10 @@ def add(cls, config: Dict) -> None:
                     "rhel-9-for-x86_64-appstream-rpms",
                     "rhel-9-for-x86_64-baseos-rpms",
                 ],
-                "10": {
+                "10": [
                     "rhel-10-for-x86_64-appstream-rpms",
                     "rhel-10-for-x86_64-baseos-rpms",
-                },
+                ],
             }
 
             # Collecting already enabled repos
@@ -144,7 +126,7 @@ def add(cls, config: Dict) -> None:
                     enabled_repos.append(repo)
             log.debug(f"Enabled repos on the system are : {enabled_repos}")
 
-            if rhcs_version != "default" and not _manifest_section:
+            if rhcs_version != "default":
                 try:
                     # Disabling all the repos and enabling the ones we need to install the ceph client
                     for cmd in disable_all:
@@ -158,14 +140,10 @@ def add(cls, config: Dict) -> None:
                 for repos in rhel_repos[rhel_version]:
                     _node.exec_command(sudo=True, cmd=f"{enable_cmd}{repos}")
 
-                for repos in cdn_ceph_repo[rhel_version][rhcs_version]:
-                    # This is workaround for  RHEL8 RHCS 6. Will remove once live repo available
-                    if rhel_version == "8" and rhcs_version == "6":
-                        _node.exec_command(
-                            sudo=True, cmd=f"yum-config-manager --add-repo={repos}"
-                        )
-                    else:
-                        _node.exec_command(sudo=True, cmd=f"{enable_cmd}{repos}")
+                if manifest_obj and manifest_obj.repo_id:
+                    _node.exec_command(
+                        sudo=True, cmd=f"{enable_cmd}{manifest_obj.repo_id}"
+                    )
 
                 # Clearing the release preference set and cleaning all yum repos
                 # Observing selinux package dependency issues for ceph-base


### PR DESCRIPTION
## Summary
Enable subscription-manager CDN setup for ceph client installs on **RHEL 10** when using **Red Hat Ceph Storage 9** by adding `rhceph-9-tools-for-rhel-10-x86_64-rpms` to `cdn_ceph_repo` in `tests/cephadm/test_client.py`.

Test Log: https://149.81.216.83/job/qe-tentacle-released/30/stages/log?nodeId=355