### PR TITLE
Currently we are framing service name from pool and gw group name, so fixed it by getting from ceph orch ls output

### DIFF
--- a/tests/nvmeof/workflows/nvme_service.py
+++ b/tests/nvmeof/workflows/nvme_service.py
@@ -2,6 +2,8 @@
 NVMe Service, Gateway Group, and Gateway classes for NVMeoF workflows.
 """
 
+import json
+
 from looseversion import LooseVersion
 
 from ceph.ceph_admin.orch import Orch
@@ -76,13 +78,7 @@ class NVMeService:
         """Delete the NVMe gateway service."""
         ceph_cluster = self.ceph_cluster
 
-        gw_group = self.group
-        pool = self.nvme_metadata_pool
-        if pool == DEFAULT_NVME_METADATA_POOL:
-            service_name = f"nvmeof{pool}"
-        else:
-            service_name = f"nvmeof.{pool}"
-        service_name = f"{service_name}.{gw_group}" if gw_group else service_name
+        service_name = self.service_name
         cfg = {
             "no_cluster_state": False,
             "config": {
@@ -218,6 +214,14 @@ class NVMeService:
         deploy_config = self._create_spec_deployment_config()
         if deploy_config:
             test_nvmeof.run(self.ceph_cluster, **deploy_config)
+
+        # Once the service is deployed, get the service name and service id and store it
+        ceph = Orch(self.ceph_cluster, **{})
+        cmd = "ceph orch ls nvmeof --format json"
+        out, _ = ceph.shell(args=[cmd])
+        services = json.loads(out)
+        self.service_name = services[0]["service_name"]
+        self.service_id = services[0]["service_id"]
 
     def init_gateways(self):
         """


### PR DESCRIPTION
Currently we are framing service name from pool and gw group name, so fixed it by getting from ceph orch ls output

With current implementation when we have different pools (default pool and custom pool), service name is different and not handling correctly. So to overcome this issue, when we create service and service is up, immediately after service is up, we are executing ceph orch ls nvmeof --format json and storing the service name and service id. While cleanup we are getting this service name and deleting it.

```
026-04-17 08:42:28,540 - cephci - ceph:1677 - INFO - Execute cephadm shell  --mount /tmp:/tmp -- ceph orch apply -i /tmp/tmp3vl8u9ca.yaml on ceph-jp91-s7y8uj-node1-installer [10.0.65.138]
2026-04-17 08:42:36,869 - cephci - ceph:1712 - INFO - Execution of cephadm shell  --mount /tmp:/tmp -- ceph orch apply -i /tmp/tmp3vl8u9ca.yaml took 8.328484 seconds on ceph-jp91-s7y8uj-node1-installer by user root [10.0.65.138]
2026-04-17 08:42:36,870 - cephci - shell:64 - DEBUG - Scheduled nvmeof..nvmeof.gw_group1 update...

2026-04-17 08:42:36,870 - cephci - orch:196 - INFO - apply-spec command response :
Scheduled nvmeof..nvmeof.gw_group1 update...

2026-04-17 08:42:36,871 - cephci - helper:1219 - INFO - Validating spec services
2026-04-17 08:42:57,128 - cephci - ceph:1677 - INFO - Execute cephadm shell -- ceph orch ls --service_name nvmeof..nvmeof.gw_group1 --service_type nvmeof --format json --refresh on ceph-jp91-s7y8uj-node1-installer [10.0.65.138]
2026-04-17 08:42:59,391 - cephci - ceph:1712 - INFO - Execution of cephadm shell -- ceph orch ls --service_name nvmeof..nvmeof.gw_group1 --service_type nvmeof --format json --refresh took 2.262736 seconds on ceph-jp91-s7y8uj-node1-installer by user root [10.0.65.138]
2026-04-17 08:42:59,392 - cephci - ceph:1209 - DEBUG - 
2026-04-17 08:42:59,392 - cephci - ceph:1209 - DEBUG - [{"events": ["2026-04-17T03:12:41.816002Z service:nvmeof..nvmeof.gw_group1 [INFO] \"service was created\""], "placement": {"hosts": ["ceph-jp91-s7y8uj-node6", "ceph-jp91-s7y8uj-node7", "ceph-jp91-s7y8uj-node8", "ceph-jp91-s7y8uj-node9"]}, "service_id": ".nvmeof.gw_group1", "service_name": "nvmeof..nvmeof.gw_group1", "service_type": "nvmeof", "spec": {"abort_discovery_on_errors": true, "abort_on_errors": true, "abort_on_update_error": true, "allowed_consecutive_spdk_ping_failures": 1, "break_update_interval_sec": 25, "certificate_source": "inline", "client_cert": "-----BEGIN CERTIFICATE-----\nMIIFDTCCAvWgAwIBAgIUK4lDtVM2Br8dhAgAMqLA3GjRHzkwDQYJKoZIhvcNAQEL\nBQAwFjEUMBIGA1UEAwwLbnZtZS5jbGllbnQwHhcNMjYwNDE3MDMxMjAyWhcNMzYw\nNDE0MDMxMjAyWjAWMRQwEgYDVQQDDAtudm1lLmNsaWVudDCCAiIwDQYJKoZIhvcN\nAQEBBQADggIPADCCAgoCggIBAL9GlQPCfEuCKgSN8beln2+0+c61pQQuO3Wllg0S\ncv6d53t10wAQUKmGum3AKP932zoDF+RgMR5O+7H8/IUhFknw7muTk4QWZAf5WKI2\nZi3tWTIHLBdaRuDt+5bYcG3z/074ZOl9z8rf/creHIwzI55K8iR9kDidO3xpKLkq\nHu9ew4KFNbMkVXkSYup8beHhfNNNwW3QmNuQVUt05l/BRiMmWvqwjjX73g1fQIgQ\nOkTJGrDThXWlFjUJxjOmlYP9ug3aANB+QMBRi4Jq+6VsGwTH45L4bz9Z5ADQl5nD\nrDi35ov41ZJkNyzaBaxV7bYv5Bz729luidP5KoF1Z8+A453UToRdQbXNdqOKxzir\n+8yiCyA4aYak+EGcAs0b21xYat6eLa+JypUUO2+O3qZXdRmeLkXouewVJVxsrL2h\nRNVqcumsJMzZ4yc1jGcY3qReOoox3vKUfID+wsZ2pbTcgFw0FXrdyOQNcLsRmSmW\nm8dJXJsEBW5WANnaRWEqCY+0MtZninblFpMRweGXPmPf44He8QPWQOGiC/BZK/E9\n4hlgPAEgIDlmnksbX+ipLkdhcgxrd19aZbhgLgbqKzKqNkoFkyEP6zCEGSDkYDtA\n1C9igygawdncztGpnA0xSLv+DLQpFX370EztpePLwmMxe3Px4fg9XRp8SeoYbo0w\nq/O7AgMBAAGjUzBRMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFCM4V4DQzq3u\nLCgwQgQcSFGIDngdMB8GA1UdIwQYMBaAFCM4V4DQzq3uLCgwQgQcSFGIDngdMA0G\nCSqGSIb3DQEBCwUAA4ICAQA1Aciz9rNZWpIf9CxP53RAqPzOiLlgF3WHoNs5Wpuo\nTXQGMlV3hclW+fCXXis7tudTtLnlpEOVIWbZVcKpn/hY04QpzfpZr4YaUE9pe3Ns\nGduylhIJGCfsdfWK6VULd2i8J326W38ERztKQULzA4R9BITwqw75TZAHIRQzf2uL\nlCY4PyDNSxoe2MgQOXMjzVT+QJOTqNsPDBWP/LTmFxyvQ0hMYn8hqwIvR3mxLjda\nSpoHNdl96HM2zEp8FehhWLs7MCz2iaheBs+/44OfkI6j4DUO2Si9muA37C5Z7zS2\nAp9LOyXpT5yIVSN9CowiUOjD51nygeKTZGVK6JH8AmyUp5i1qiZiHOuhcFgKNe
```

Here service name is "nvmeof..nvmeof.gw_group1" but when deleting/removing service name we are not framing correctly. and resulting service didn't cleanup

```
2026-04-17 09:23:08,095 - cephci - test_nvmeof:24 - INFO - Executing Ceph NVMeoF remove service
2026-04-17 09:23:08,346 - cephci - ceph:1677 - INFO - Execute cephadm shell -- ceph orch rm nvmeof.nvmeof.gw_group1 on ceph-jp91-s7y8uj-node1-installer [10.0.65.138]
2026-04-17 09:23:11,417 - cephci - ceph:1712 - INFO - Execution of cephadm shell -- ceph orch rm nvmeof.nvmeof.gw_group1 took 3.069856 seconds on ceph-jp91-s7y8uj-node1-installer by user root [10.0.65.138]
2026-04-17 09:23:11,418 - cephci - shell:64 - DEBUG - Invalid service 'nvmeof.nvmeof.gw_group1'. Use 'ceph orch ls' to list available services.
```

With this fix it will be resolved

Sanity logs:- http://magna002.ceph.redhat.com/cephci-jenkins/e2e_fips_17_april_mtls/
Ha sanity logs:- http://magna002.ceph.redhat.com/cephci-jenkins/hasanity_17_april_26/
spec file deployment logs:- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SDP0LW_17_april_mtls/
