### PR TITLE
Fixed check_nfs_daemons_removed_retry() Logic

### DIFF
--- a/suites/tentacle/nfs/tier0-nfs-ganesha-func-sanity.yaml
+++ b/suites/tentacle/nfs/tier0-nfs-ganesha-func-sanity.yaml
@@ -179,7 +179,6 @@ tests:
       module: test_nfs_grpc.py
       desc: Unmount from 1 client and verify client/session IDs are updated
       polarion-id: CEPH-83630616
-      comments: This test may fail on IBM-Cloud. This is not a bug or automation issue. We are currently investigating why This is failing on IBM-Cloud on RH builds only
       abort-on-fail: false
       config:
         operation: verify_id_after_unmount

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -830,7 +830,7 @@ def check_nfs_daemons_removed(client):
     check_nfs_daemons_removed_retry(client)
 
 
-@retry(OperationFailedError, tries=30, delay=10, backoff=1)
+@retry(OperationFailedError, tries=10, delay=10, backoff=1)
 def check_nfs_daemons_removed_retry(client):
     """
     Helper function to check if NFS daemons are removed.
@@ -838,16 +838,18 @@ def check_nfs_daemons_removed_retry(client):
     Returns True if all daemons are removed.
     """
     try:
-        out = client.exec_command(sudo=True, cmd="ceph orch ls | grep nfs")
-        # if there are no nfs daemons, then grep exit code is 1
-        # hence we check if not err, and not if err
-        if out:
-            raise OperationFailedError("NFS daemons are still present")
-    except Exception as e:
-        log.warning(f"Caugt Exception: {e}")
+        out, _ = client.exec_command(sudo=True, cmd="ceph orch ls --service-type=nfs")
+        log.info(out)
+        out = out.strip()
+        if "No services reported" in out:
+            log.info("All NFS daemons have been removed.")
+            return True
+        else:
+            raise OperationFailedError("NFS daemons still present")
 
-    log.info("All NFS daemons have been removed.")
-    return True
+    except Exception as err:
+        log.error(f"Unexpected Error: {err} / Output: {out}")
+        return False
 
 
 def create_nfs_via_file_and_verify(


### PR DESCRIPTION
# Description

The GRPC Failures were due to previous test case not cleaning up the NFS-Cluster.
I have fixed the logic in check_nfs_daemons_removed_retry()

Here are the IBMC logs: 

[http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.1/rhel-10/executor/20.2.1-179/nfs/1224/logs/tier0_nfs_ganesha_func_sanity/](http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.1/rhel-10/executor/20.2.1-179/nfs/1224/logs/tier0_nfs_ganesha_func_sanity/)
