### PR TITLE
Fixed the regression failures seen in 9.1 runs due to auto listeners feature and in cleanup function

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -30,8 +30,6 @@ from utility.utils import generate_unique_id
 
 LOG = Log(__name__)
 
-rbd_obj = None
-nvme_service = None
 cleanup = False
 
 
@@ -213,7 +211,7 @@ def test_ceph_83611097(ceph_cluster, config):
     nvme_service.init_gateways()
 
     # Initialize High Availability
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -307,88 +305,92 @@ def test_ceph_83610950(ceph_cluster, config):
         ceph_cluster: Ceph cluster object
         config: test case config
     """
-    rbd_pool = config["rbd_pool"]
-    rbd_obj = config["rbd_obj"]
-    time_to_fire = config.get("time_to_fire", 60)
-    interval = config.get("interval", 50)
-    alert = "NVMeoFMultipleNamespacesOfRBDImage"
-    msg = "RBD image {image} cannot be reused for multiple NVMeoF namespace"
-    svcs = []
-    services = []
+    try:
+        rbd_pool = config["rbd_pool"]
+        rbd_obj = config["rbd_obj"]
+        time_to_fire = config.get("time_to_fire", 60)
+        interval = config.get("interval", 50)
+        alert = "NVMeoFMultipleNamespacesOfRBDImage"
+        msg = "RBD image {image} cannot be reused for multiple NVMeoF namespace"
+        svcs = []
+        services = []
 
-    # Deploy Services
-    for svc in config["gw_groups"]:
-        svc.update({"rbd_pool": rbd_pool})
-        service = NVMeService(svc, ceph_cluster)
-        service.deploy()
-        service.init_gateways()
-        services.append(service)
-        svc.update({"nvme_service": service})
-        ha = HighAvailability(ceph_cluster, svc["gw_nodes"], **svc)
-        ha.gateways = service.gateways
-        svcs.append(ha)
+        # Deploy Services
+        for svc in config["gw_groups"]:
+            svc.update({"rbd_pool": rbd_pool})
+            service = NVMeService(svc, ceph_cluster)
+            service.deploy()
+            service.init_gateways()
+            services.append(service)
+            svc.update({"nvme_service": service})
+            ha = HighAvailability(ceph_cluster, svc["gw_nodes"], **svc)
+            ha.gateways = service.gateways
+            svcs.append(ha)
 
-    # Create RBD image and multiple NS with that image.
-    ha1, ha2 = svcs
-    nvmegwcl1 = ha1.gateways[0]
-    sub1_args = {"subsystem": f"nqn.2016-06.io.spdk:cnode{generate_unique_id(4)}"}
-    nvmegwcl1.subsystem.add(**{"args": {**sub1_args, **{"no-group-append": True}}})
+        # Create RBD image and multiple NS with that image.
+        ha1, ha2 = svcs
+        nvmegwcl1 = ha1.gateways[0]
+        sub1_args = {"subsystem": f"nqn.2016-06.io.spdk:cnode{generate_unique_id(4)}"}
+        nvmegwcl1.subsystem.add(**{"args": {**sub1_args, **{"no-group-append": True}}})
 
-    nvmegwcl2 = ha2.gateways[0]
-    sub2_args = {"subsystem": f"nqn.2016-06.io.spdk:cnode{generate_unique_id(4)}"}
-    nvmegwcl2.subsystem.add(**{"args": {**sub2_args, **{"no-group-append": True}}})
+        nvmegwcl2 = ha2.gateways[0]
+        sub2_args = {"subsystem": f"nqn.2016-06.io.spdk:cnode{generate_unique_id(4)}"}
+        nvmegwcl2.subsystem.add(**{"args": {**sub2_args, **{"no-group-append": True}}})
 
-    image = f"image-{generate_unique_id(4)}"
-    rbd_obj.create_image(rbd_pool, image, "10G")
+        image = f"image-{generate_unique_id(4)}"
+        rbd_obj.create_image(rbd_pool, image, "10G")
 
-    # Removing nsid because we have https://tracker.ceph.com/issues/72681
-    # img_args = {"rbd-pool": _rbd_pool, "rbd-image": image, "nsid": 1}
-    img_args = {"rbd-pool": rbd_pool, "rbd-image": image, "force": ""}
-    nvmegwcl1.namespace.add(**{"args": {**sub1_args, **img_args}})
-    nvmegwcl2.namespace.add(**{"args": {**sub2_args, **img_args}})
-    events = PrometheusAlerts(ha1.orch)
+        # Removing nsid because we have https://tracker.ceph.com/issues/72681
+        # img_args = {"rbd-pool": _rbd_pool, "rbd-image": image, "nsid": 1}
+        img_args = {"rbd-pool": rbd_pool, "rbd-image": image, "force": ""}
+        nvmegwcl1.namespace.add(**{"args": {**sub1_args, **img_args}})
+        nvmegwcl2.namespace.add(**{"args": {**sub2_args, **img_args}})
+        events = PrometheusAlerts(ha1.orch)
 
-    # Two namespaces created for single RBD image,
-    # NVMeoFMultipleNamespacesOfRBDImage prometheus alert should be firing
-    LOG.info(
-        f"{alert} should be FIRING Since multiple namespaces are created for Single RBD image."
-    )
-    events.monitor_alert(
-        alert, timeout=time_to_fire, interval=interval, msg=msg.format(image=image)
-    )
-    nvmegwcl2.namespace.delete(**{"args": {**sub2_args, **{"nsid": 1}}})
+        # Two namespaces created for single RBD image,
+        # NVMeoFMultipleNamespacesOfRBDImage prometheus alert should be firing
+        LOG.info(
+            f"{alert} should be FIRING Since multiple namespaces are created for Single RBD image."
+        )
+        events.monitor_alert(
+            alert, timeout=time_to_fire, interval=interval, msg=msg.format(image=image)
+        )
+        nvmegwcl2.namespace.delete(**{"args": {**sub2_args, **{"nsid": 1}}})
 
-    # Alert should be inactive
-    LOG.info(f"{alert} should be INACTIVE.")
-    events.monitor_alert(
-        alert, timeout=time_to_fire, interval=interval, state="inactive"
-    )
+        # Alert should be inactive
+        LOG.info(f"{alert} should be INACTIVE.")
+        events.monitor_alert(
+            alert, timeout=time_to_fire, interval=interval, state="inactive"
+        )
 
-    sub2_args = {"subsystem": f"nqn.2016-06.io.spdk:cnode{generate_unique_id(4)}"}
-    nvmegwcl2.subsystem.add(**{"args": {**sub2_args, **{"no-group-append": True}}})
-    nvmegwcl2.namespace.add(**{"args": {**sub2_args, **img_args}})
+        sub2_args = {"subsystem": f"nqn.2016-06.io.spdk:cnode{generate_unique_id(4)}"}
+        nvmegwcl2.subsystem.add(**{"args": {**sub2_args, **{"no-group-append": True}}})
+        nvmegwcl2.namespace.add(**{"args": {**sub2_args, **img_args}})
 
-    # Alert should be active again, since image is used in new subsystem
-    LOG.info(
-        f"{alert} should be FIRING Since multiple namespaces are created for Single RBD image."
-    )
-    events.monitor_alert(
-        alert, timeout=time_to_fire, interval=interval, msg=msg.format(image=image)
-    )
-    nvmegwcl1.namespace.delete(**{"args": {**sub1_args, **{"nsid": 1}}})
+        # Alert should be active again, since image is used in new subsystem
+        LOG.info(
+            f"{alert} should be FIRING Since multiple namespaces are created for Single RBD image."
+        )
+        events.monitor_alert(
+            alert, timeout=time_to_fire, interval=interval, msg=msg.format(image=image)
+        )
+        nvmegwcl1.namespace.delete(**{"args": {**sub1_args, **{"nsid": 1}}})
 
-    # Namespace removed , alert should be inactive
-    LOG.info(f"{alert} should be INACTIVE.")
-    events.monitor_alert(
-        alert, timeout=time_to_fire, interval=interval, state="inactive"
-    )
-    if config.get("cleanup"):
-        LOG.info("Cleaning up NVMeoF services and RBD pool for CEPH-83610950.")
-        for service in services:
-            service.delete_nvme_service()
-            rbd_obj.clean_up(pools=[rbd_pool])
-    global cleanup
-    cleanup = True
+        # Namespace removed , alert should be inactive
+        LOG.info(f"{alert} should be INACTIVE.")
+        events.monitor_alert(
+            alert, timeout=time_to_fire, interval=interval, state="inactive"
+        )
+    except Exception as err:
+        LOG.error(err)
+    finally:
+        if config.get("cleanup"):
+            LOG.info("Cleaning up NVMeoF services and RBD pool for CEPH-83610950.")
+            for service in services:
+                service.delete_nvme_service()
+                rbd_obj.clean_up(pools=[rbd_pool])
+            global cleanup
+            cleanup = False
 
     LOG.info(f"CEPH-83610950 - {alert} alert validated successfully.")
 
@@ -408,7 +410,7 @@ def test_ceph_83610948(ceph_cluster, config):
     nvme_service.deploy()
     nvme_service.init_gateways()
 
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -501,7 +503,7 @@ def test_ceph_83611098(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -595,7 +597,7 @@ def test_ceph_83611099(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -673,7 +675,7 @@ def test_ceph_83611306(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -785,7 +787,7 @@ def test_CEPH_83616917(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -857,7 +859,7 @@ def test_ceph_83617544(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
 
     # Check for alert
@@ -929,7 +931,7 @@ def test_ceph_83616916(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
     nvmegwcli = ha.gateways[0]
@@ -1100,7 +1102,7 @@ def test_ceph_83617622(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -1178,7 +1180,7 @@ def test_ceph_83617545(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     nvmegwcl1 = nvme_service.gateways[0]
 
@@ -1252,7 +1254,7 @@ def test_ceph_83617640(ceph_cluster, config):
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
-    config.update({"nvme_service": nvme_service})
+    config["nvme_service"] = nvme_service
     ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
     ha.gateways = nvme_service.gateways
 
@@ -1342,7 +1344,9 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     Returns:
         int - 0 when the execution is successful else 1 (for failure).
     """
-    global rbd_obj, nvme_service, cleanup
+    global cleanup
+    nvme_service = None
+    rbd_obj = None
     config = kwargs["config"]
     kwargs["config"].update(
         {
@@ -1368,6 +1372,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         LOG.error(err)
     finally:
         if config.get("cleanup") and not cleanup:
-            teardown(nvme_service, rbd_obj)
+            service_to_clean = nvme_service or config.get("nvme_service")
+            if service_to_clean is not None:
+                try:
+                    teardown(service_to_clean, rbd_obj)
+                except Exception as teardown_err:
+                    LOG.error(f"Teardown in run() finally failed: {teardown_err}")
 
     return 1

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -43,6 +43,7 @@ def test_ceph_83595464(ceph_cluster, config, rbd_obj):
     nvme_service = NVMeService(config, ceph_cluster)
     LOG.info("Deploy NVMe service")
     nvme_service.deploy()
+    config["nvme_service"] = nvme_service
     LOG.info("Initialize gateways")
     nvme_service.init_gateways()
     config.update({"nvme_service": nvme_service})
@@ -57,11 +58,13 @@ def test_ceph_83595464(ceph_cluster, config, rbd_obj):
     service_name = get_nvme_service_name(rbd_pool, config.get("gw_group", None))
 
     # Deploy/Reconfigure the service without mTLS
-    # Remove nvme_service from config
-    config.pop("nvme_service")
     LOG.info("Deploy NVMe service without mTLS")
     nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
+    # Remove nvme_service from config
+    config.pop("nvme_service")
+    # Keep config in sync so run() finally can teardown if anything below fails
+    config["nvme_service"] = nvme_service
 
     LOG.info("Redeploy nvmeof service without mTLS")
 
@@ -200,7 +203,15 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     except Exception as err:
         LOG.error(err)
     finally:
-        if config.get("cleanup") and nvme_service is not None:
-            teardown(nvme_service, rbd_obj)
+        # test_case path often only updates config["nvme_service"]; local nvme_service
+        # stays None if the test raises before return, so read from config as fallback.
+        service_to_clean = nvme_service or config.get(
+            "nvme_service",
+        )
+        if config.get("cleanup") and service_to_clean is not None:
+            try:
+                teardown(service_to_clean, rbd_obj)
+            except Exception as teardown_err:
+                LOG.error(f"Teardown in finally failed: {teardown_err}")
 
     return 1

--- a/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
+++ b/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
@@ -9,6 +9,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 
+from looseversion import LooseVersion
+
 from ceph.ceph import Ceph
 from ceph.ceph_admin.orch import Orch
 from ceph.parallel import parallel
@@ -37,7 +39,10 @@ from tests.nvmeof.workflows.nvme_utils import (
 )
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
-from utility.utils import generate_unique_id
+from utility.utils import (
+    generate_unique_id,
+    get_ceph_version_from_cluster,
+)
 
 LOG = Log(__name__)
 
@@ -94,7 +99,9 @@ def test_ceph_83608838(ceph_cluster, config):
         if cfg.get("listeners"):
             listeners.extend(cfg["listeners"])
     listeners = list(set(listeners))
-    configure_listeners(nvme_service.gateways, config, listeners=listeners)
+    ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+    if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+        configure_listeners(nvme_service.gateways, config, listeners=listeners)
     lb_groups = fetch_lb_groups(nvme_service, listeners)
     opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": lb_groups}
     configure_namespaces(nvme_service.gateways[0], config, opt_args)
@@ -173,7 +180,9 @@ def test_ceph_83609769(ceph_cluster, config):
         if cfg.get("listeners"):
             listeners.extend(cfg["listeners"])
     listeners = list(set(listeners))
-    configure_listeners(nvme_service.gateways, config, listeners=listeners)
+    ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+    if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+        configure_listeners(nvme_service.gateways, config, listeners=listeners)
     opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": "sequential"}
     LOG.info("Configure namespaces")
     configure_namespaces(nvme_service.gateways[0], config, opt_args)
@@ -408,7 +417,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                     if cfg.get("listeners"):
                         listeners.extend(cfg["listeners"])
                 listeners = list(set(listeners))
-                configure_listeners(nvme_service.gateways, config, listeners=listeners)
+                ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+                if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+                    configure_listeners(
+                        nvme_service.gateways, config, listeners=listeners
+                    )
                 lb_groups = fetch_lb_groups(nvme_service, listeners)
                 opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": lb_groups}
                 LOG.info("Configure namespaces")
@@ -547,11 +560,15 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
                             # Add listeners and namespaces to newly added GWs
                             LOG.info(f"Adding listeners for {scaleup_nodes}")
-                            configure_listeners(
-                                nvme_service.gateways,
-                                nvme_service.config,
-                                listeners=scaleup_nodes,
+                            ceph_version = get_ceph_version_from_cluster(
+                                nvme_service.clients[0]
                             )
+                            if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+                                configure_listeners(
+                                    nvme_service.gateways,
+                                    nvme_service.config,
+                                    listeners=scaleup_nodes,
+                                )
 
                             lb_groups = fetch_lb_groups(nvme_service, scaleup_nodes)
 

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -1041,7 +1041,9 @@ def test_ceph_83608266(
             # Configure Subsystem, listeners, host, namespaces
             if config.get("subsystems"):
                 configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
-                configure_listeners(nvme_service.gateways, nvme_service.config)
+                ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+                if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+                    configure_listeners(nvme_service.gateways, nvme_service.config)
                 configure_hosts(
                     nvme_service.gateways[0],
                     nvme_service.config,

--- a/tests/nvmeof/test_ceph_nvmeof_ns_masking.py
+++ b/tests/nvmeof/test_ceph_nvmeof_ns_masking.py
@@ -1,6 +1,8 @@
 import json
 from copy import deepcopy
 
+from looseversion import LooseVersion
+
 from ceph.ceph import Ceph
 from ceph.ceph_admin.orch import Orch
 from ceph.nvmeof.initiators.linux import Initiator
@@ -16,7 +18,7 @@ from tests.nvmeof.workflows.nvme_service import NVMeService
 from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
-from utility.utils import generate_unique_id
+from utility.utils import generate_unique_id, get_ceph_version_from_cluster
 
 LOG = Log(__name__)
 
@@ -364,7 +366,9 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
         if config.get("subsystems"):
             configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
-            configure_listeners(nvme_service.gateways, nvme_service.config)
+            ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+            if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+                configure_listeners(nvme_service.gateways, nvme_service.config)
             configure_hosts(
                 nvme_service.gateways[0], nvme_service.config, ceph_cluster=ceph_cluster
             )

--- a/tests/nvmeof/test_ceph_nvmeof_ns_resize.py
+++ b/tests/nvmeof/test_ceph_nvmeof_ns_resize.py
@@ -4,6 +4,8 @@ Test E2E nvmeof namespace resize
 
 import json
 
+from looseversion import LooseVersion
+
 from ceph.ceph import Ceph
 from ceph.ceph_admin.orch import Orch
 from tests.nvmeof.workflows.gateway_entities import (
@@ -17,7 +19,7 @@ from tests.nvmeof.workflows.nvme_service import NVMeService
 from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
 from tests.rbd.rbd_utils import initial_rbd_config, verify_image_size
 from utility.log import Log
-from utility.utils import generate_unique_id
+from utility.utils import generate_unique_id, get_ceph_version_from_cluster
 
 LOG = Log(__name__)
 
@@ -224,7 +226,9 @@ def test_ceph_83627178(ceph_cluster, config, nvme_service):
     # Configure subsystems and listeners
     LOG.info("Configure subsystems, listeners")
     configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
-    configure_listeners(nvme_service.gateways, nvme_service.config)
+    ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+    if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+        configure_listeners(nvme_service.gateways, nvme_service.config)
     configure_hosts(nvmegwcli, nvme_service.config, ceph_cluster=ceph_cluster)
 
     # Configure namespaces

--- a/tests/nvmeof/test_ceph_nvmeof_readonly_ns.py
+++ b/tests/nvmeof/test_ceph_nvmeof_readonly_ns.py
@@ -4,6 +4,8 @@ Test E2E nvmeof readonly namespaces
 
 import json
 
+from looseversion import LooseVersion
+
 from ceph.ceph import Ceph
 from tests.nvmeof.workflows.gateway_entities import (
     configure_hosts,
@@ -20,7 +22,7 @@ from tests.nvmeof.workflows.nvme_service import NVMeService
 from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
-from utility.utils import generate_unique_id
+from utility.utils import generate_unique_id, get_ceph_version_from_cluster
 
 LOG = Log(__name__)
 
@@ -139,7 +141,9 @@ def test_ceph_83624617(ceph_cluster, config, nvme_service):
     # Configure subsystems
     LOG.info("Configure subsystems, listeners")
     configure_subsystems(nvme_service, ceph_cluster=ceph_cluster)
-    configure_listeners(nvme_service.gateways, nvme_service.config)
+    ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+    if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+        configure_listeners(nvme_service.gateways, nvme_service.config)
     configure_hosts(nvmegwcli, nvme_service.config, ceph_cluster=ceph_cluster)
 
     # Configure readonly namespaces

--- a/tests/nvmeof/test_nvmeof_gwgroup.py
+++ b/tests/nvmeof/test_nvmeof_gwgroup.py
@@ -72,6 +72,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                         nvme_service = NVMeService(gwgroup_config, ceph_cluster)
                         LOG.info("Deploy NVMe service")
                         nvme_service.deploy()
+                        cleanup_dict.update({nvme_service: rbd_obj})
                         LOG.info("Initialize gateways")
                         nvme_service.init_gateways()
                     p.spawn(
@@ -82,7 +83,6 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                         rbd_obj,
                         nvme_service,
                     )
-                    cleanup_dict.update({nvme_service: rbd_obj})
         else:
             for gwgroup_config in config["gw_groups"]:
                 clean_up = ["subsystems", "initiators", "pool", "gateway"]
@@ -96,12 +96,12 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                     nvme_service = NVMeService(gwgroup_config, ceph_cluster)
                     LOG.info("Deploy NVMe service")
                     nvme_service.deploy()
+                    cleanup_dict.update({nvme_service: rbd_obj})
                     LOG.info("Initialize gateways")
                     nvme_service.init_gateways()
                 run_gateway_group_operations(
                     ceph_cluster, gwgroup_config, config, rbd_obj, nvme_service
                 )
-                cleanup_dict.update({nvme_service: rbd_obj})
 
         return 0
 

--- a/tests/nvmeof/test_nvmeof_gwgroup_inbandauth.py
+++ b/tests/nvmeof/test_nvmeof_gwgroup_inbandauth.py
@@ -1,3 +1,5 @@
+from looseversion import LooseVersion
+
 from ceph.ceph import Ceph
 from ceph.utils import get_node_by_id
 from tests.nvmeof.workflows.gateway_entities import (
@@ -17,6 +19,7 @@ from tests.nvmeof.workflows.nvme_utils import (
 )
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster
 
 LOG = Log(__name__)
 
@@ -39,7 +42,11 @@ def configure_gw_entities_with_encryption(gwgroup_config, ceph_cluster, nvme_ser
                 hosts.extend(cfg["hosts"])
         listeners = list(set(listeners))
         hosts = list({tuple(sorted(h.items())): h for h in hosts}.values())
-        configure_listeners(nvme_service.gateways, gwgroup_config, listeners=listeners)
+        ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+        if LooseVersion(ceph_version) <= LooseVersion("20.2.1"):
+            configure_listeners(
+                nvme_service.gateways, gwgroup_config, listeners=listeners
+            )
         lb_groups = fetch_lb_groups(nvme_service.gateways, listeners)
         opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": lb_groups}
         configure_namespaces(nvme_service.gateways[0], gwgroup_config, opt_args)


### PR DESCRIPTION
Fixed the regression failures seen in 9.1 runs due to auto listeners feature and in cleanup function

Analyzed the failures in http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/regression/20.2.1-173/nvmeof/33/logs/

and fixed the issues

Where ever suites are failed to do cleanup and next tests got failed, induced the failures to check cleanup is working or not and collected the logs

Logs:- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZSRDYV_20th_april_26_regression_fixes/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3XEB2T_20th_april_26_ha_nonmtls_fix/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8RPPO3_20_april_26_events/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VZM53O_20_apr_26_alerts_cleanup_issue/
Note:- couldn't collect the logs for all changes because of setup issues
