### PR TITLE
add ibmc ingress vip for tentacle suites

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -83,37 +83,6 @@ tests:
       name: deploy cluster
 
   - test:
-      name: Monitoring Services deployment
-      desc: Add monitoring services using spec file.
-      module: test_cephadm.py
-      polarion-id: CEPH-83574727
-      config:
-        steps:
-          - config:
-              command: apply_spec
-              service: orch
-              validate-spec-services: true
-              specs:
-                - service_type: prometheus
-                  placement:
-                    count: 1
-                    nodes:
-                      - node1
-                - service_type: grafana
-                  placement:
-                    nodes:
-                      - node1
-                - service_type: alertmanager
-                  placement:
-                    count: 1
-                - service_type: node-exporter
-                  placement:
-                    host_pattern: "*"
-                - service_type: crash
-                  placement:
-                    host_pattern: "*"
-
-  - test:
       abort-on-fail: true
       config:
         cephadm: true
@@ -164,7 +133,7 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 10.0.195.174/24 # floating ip1 in rhos-01
+                    virtual_ip: 10.245.128.250/18 # floating ip1 in ibmc env
                     frontend_port: 443
                     monitor_port: 1967
                     ssl: true
@@ -191,7 +160,7 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 10.0.195.111/24 # floating ip2 in rhos-01
+                    virtual_ip: 10.245.128.251/18 # floating ip2 in ibmc env
                     frontend_port: 8083
                     monitor_port: 1967
 


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
updated the VIP to use ibmc vpc for rgw

pass log - https://149.81.216.83/view/Executor/job/tentacle-test-executor/1243/stages/log?nodeId=179 
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
