### PR TITLE
Revert the fix for IBMCEPH-13427

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -379,8 +379,9 @@ class BootstrapMixin:
 
         # IBM Storage Ceph 9.1 and greater would require to accept the license
         # There is '--automatically-accept-license' option
-        # FixMe: Unblocking RH build testing - IBMCEPH-13427
-        if LooseVersion(str(manifest_obj.release)) >= LooseVersion("9.1"):
+        if manifest_obj.product == "ibm" and LooseVersion(
+            str(manifest_obj.release)
+        ) >= LooseVersion("9.1"):
             if "automatically-accept-license" not in cmd:
                 cmd += " --automatically-accept-license"
 


### PR DESCRIPTION
# Description

As a workaround for the bug [IBMCEPH-13427](https://ibm-ceph.atlassian.net/browse/IBMCEPH-13427) , the `--automatically-accept-license` flag was added for both IBM and RH ceph deployments.

Since, this flag is only applicable for IBM ceph and the bug has been fixed, reverting the workaround to work for only IBM clusters.