### PR TITLE
Tfa fixes for regression + extended regression suite

### DIFF
--- a/tests/cephfs/cephfs_bugs/test_cephfs_pool_size_change.py
+++ b/tests/cephfs/cephfs_bugs/test_cephfs_pool_size_change.py
@@ -67,14 +67,11 @@ def run(ceph_cluster, **kw):
     2. Remove all the cephfs mounts
     3. Reset pg_autoscale_mode for cephfs pools to on
     """
-    orig_data_pool_pg_num = None
-    orig_metadata_pool_pg_num = None
     try:
         tc = "CEPH-83574596"
         log.info(f"Running cephfs {tc} test case")
 
         config = kw["config"]
-        rhbuild = config.get("rhbuild")
         build = config.get("build", config.get("rhbuild"))
         mdss = ceph_cluster.get_ceph_objects("mds")
 
@@ -139,8 +136,6 @@ def run(ceph_cluster, **kw):
             cmd=f"ceph osd pool get {metadata_pool} pg_num | awk '{{print $2}}'",
         )
         log.debug("metadata_pool_pg_num : {}".format(metadata_pool_pg_num))
-        orig_data_pool_pg_num = data_pool_pg_num.strip()
-        orig_metadata_pool_pg_num = metadata_pool_pg_num.strip()
         for num in range(1, 7):
             log.info("Creating Directories")
             out, rc = clients[0].exec_command(
@@ -219,34 +214,9 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning up the system")
-        out, rc = clients[0].exec_command(sudo=True, cmd=f"rm -rf {mount_points[1]}/*")
         for mount_point in mount_points:
-            clients[0].exec_command(sudo=True, cmd=f"umount {mount_point}")
-        if orig_data_pool_pg_num and orig_metadata_pool_pg_num:
-            log.info("Restoring original pg_num values")
-            clients[0].exec_command(
-                sudo=True,
-                cmd=f"ceph osd pool set {data_pool} pg_num {orig_data_pool_pg_num}",
-                timeout=3600,
+            fs_util.client_clean_up(
+                "umount", kernel_clients=[clients[0]], mounting_dir=mount_point
             )
-            clients[0].exec_command(
-                sudo=True,
-                cmd=f"ceph osd pool set {metadata_pool} pg_num {orig_metadata_pool_pg_num}",
-                timeout=3600,
-            )
-        if "4." in rhbuild:
-            commands = [
-                f"ceph osd pool set {data_pool} pg_autoscale_mode warn",
-                f"ceph osd pool set {metadata_pool} pg_autoscale_mode warn",
-            ]
-            for command in commands:
-                clients[0].exec_command(sudo=True, cmd=command, timeout=3600)
-        else:
-            commands = [
-                f"ceph osd pool set {data_pool} pg_autoscale_mode on",
-                f"ceph osd pool set {metadata_pool} pg_autoscale_mode on",
-            ]
-            for command in commands:
-                clients[0].exec_command(sudo=True, cmd=command, timeout=3600)
-        for mount_point in mount_points:
-            clients[0].exec_command(sudo=True, cmd=f"rm -rf {mount_point}")
+        log.info("Removing the test filesystem to avoid leftover health warnings")
+        fs_util.remove_fs(clients[0], fs_name, validate=True, check_ec=False)

--- a/tests/cephfs/cephfs_nfs/move_data_bw_nfs_and_cephfs_mounts.py
+++ b/tests/cephfs/cephfs_nfs/move_data_bw_nfs_and_cephfs_mounts.py
@@ -34,6 +34,11 @@ def run(ceph_cluster, **kw):
     1. Remove cephfs nfs export
     2. Remove NFS Cluster
     """
+    nfs_mounting_dir = None
+    kernel_mounting_dir_1 = None
+    fuse_mounting_dir_1 = None
+    nfs_name = "cephfs-nfs"
+    nfs_export_name = None
     try:
         tc = "CEPH-11309"
         log.info(f"Running cephfs {tc} test case")
@@ -53,7 +58,6 @@ def run(ceph_cluster, **kw):
         rhbuild = config.get("rhbuild")
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
-        nfs_name = "cephfs-nfs"
         default_fs = "cephfs" if not erasure else "cephfs-ec"
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
         fs_util.create_nfs(
@@ -134,12 +138,14 @@ def run(ceph_cluster, **kw):
                 [clients[0]],
                 kernel_mounting_dir_1,
                 ",".join(mon_node_ips),
+                extra_params=f",fs={default_fs}",
             )
 
             fuse_mounting_dir_1 = f"/mnt/cephfs_fuse{mounting_dir}_1/"
             fs_util.fuse_mount(
                 [clients[0]],
                 fuse_mounting_dir_1,
+                extra_params=f" --client_fs {default_fs}",
             )
 
         run_ios(
@@ -195,31 +201,34 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Cleaning Up")
-        client1.exec_command(
-            sudo=True, cmd=f"umount -f {nfs_mounting_dir}", check_ec=False
-        )
-        client1.exec_command(
-            sudo=True, cmd=f"umount -l {kernel_mounting_dir_1}", check_ec=False
-        )
-        client1.exec_command(
-            sudo=True, cmd=f"umount -l {fuse_mounting_dir_1}", check_ec=False
-        )
-        client1.exec_command(
-            sudo=True, cmd=f"rm -rf {nfs_mounting_dir}", check_ec=False
-        )
-        client1.exec_command(
-            sudo=True, cmd=f"rm -rf {kernel_mounting_dir_1}", check_ec=False
-        )
-        client1.exec_command(
-            sudo=True, cmd=f"rm -rf {fuse_mounting_dir_1}", check_ec=False
-        )
-        log.info("Removing the Export")
-        client1.exec_command(
-            sudo=True,
-            cmd=f"ceph nfs export delete {nfs_name} {nfs_export_name}",
-            check_ec=False,
-        )
-
+        if nfs_mounting_dir:
+            client1.exec_command(
+                sudo=True, cmd=f"umount -f {nfs_mounting_dir}", check_ec=False
+            )
+            client1.exec_command(
+                sudo=True, cmd=f"rm -rf {nfs_mounting_dir}", check_ec=False
+            )
+        if kernel_mounting_dir_1:
+            client1.exec_command(
+                sudo=True, cmd=f"umount -l {kernel_mounting_dir_1}", check_ec=False
+            )
+            client1.exec_command(
+                sudo=True, cmd=f"rm -rf {kernel_mounting_dir_1}", check_ec=False
+            )
+        if fuse_mounting_dir_1:
+            client1.exec_command(
+                sudo=True, cmd=f"umount -l {fuse_mounting_dir_1}", check_ec=False
+            )
+            client1.exec_command(
+                sudo=True, cmd=f"rm -rf {fuse_mounting_dir_1}", check_ec=False
+            )
+        if nfs_export_name:
+            log.info("Removing the Export")
+            client1.exec_command(
+                sudo=True,
+                cmd=f"ceph nfs export delete {nfs_name} {nfs_export_name}",
+                check_ec=False,
+            )
         log.info("Removing NFS Cluster")
         client1.exec_command(
             sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
@@ -117,7 +117,7 @@ def run(ceph_cluster, **kw):
         log.info("Make export as Readonly")
         client1.exec_command(
             sudo=True,
-            cmd="sed -i 's/RW/RO/g' export.conf",
+            cmd="sed -i 's/rw/ro/gI' export.conf",
         )
         out, rc = client1.exec_command(
             sudo=True,
@@ -145,7 +145,7 @@ def run(ceph_cluster, **kw):
         log.info("Make export as ReadWrite")
         client1.exec_command(
             sudo=True,
-            cmd="sed -i 's/RO/RW/g' export.conf",
+            cmd="sed -i 's/ro/rw/gI' export.conf",
         )
         out, rc = client1.exec_command(
             sudo=True,

--- a/tests/cephfs/cephfs_system/cephfs_system_utils.py
+++ b/tests/cephfs/cephfs_system/cephfs_system_utils.py
@@ -149,6 +149,7 @@ class CephFSSystemUtils(object):
                         crash_ready_nodes.append(node.node.hostname)
                     except BaseException as ex:
                         if "No such file" in str(ex):
+                            node.exec_command(sudo=True, cmd="mkdir -p /etc/ceph")
                             for file_name in ["ceph.conf", "ceph.client.admin.keyring"]:
                                 src_path = f"{log_base_dir}/{file_name}"
                                 dst_path = f"/etc/ceph/{file_name}"

--- a/tests/cephfs/cephfs_system/mds_nfs_node_failure_ops.py
+++ b/tests/cephfs/cephfs_system/mds_nfs_node_failure_ops.py
@@ -24,6 +24,8 @@ def start_io_time(fs_util, client1, mounting_dir, timeout=300):
     global stop_flag
     stop_flag = False
     iter = 0
+    success = 0
+    failures = 0
     if timeout:
         stop = datetime.now() + timedelta(seconds=timeout)
     else:
@@ -33,12 +35,31 @@ def start_io_time(fs_util, client1, mounting_dir, timeout=300):
         if stop and datetime.now() > stop:
             log.info("Timed out *************************")
             break
-        client1.exec_command(sudo=True, cmd=f"mkdir -p {mounting_dir}/run_ios_{iter}")
-        fs_util.run_ios(client1, f"{mounting_dir}/run_ios_{iter}/", io_tools=["dd"])
-        client1.exec_command(
-            sudo=True, cmd=f"rm -rf {mounting_dir}/run_ios_{iter}", timeout=3600
-        )
+        try:
+            client1.exec_command(
+                sudo=True, cmd=f"mkdir -p {mounting_dir}/run_ios_{iter}"
+            )
+            fs_util.run_ios(client1, f"{mounting_dir}/run_ios_{iter}/", io_tools=["dd"])
+            success += 1
+        except CommandFailed as e:
+            failures += 1
+            log.warning(f"IO command failed during disruption (expected): {e}")
+        except Exception as e:
+            failures += 1
+            log.warning(f"IO operation hit an error during disruption: {e}")
+        finally:
+            client1.exec_command(
+                sudo=True,
+                cmd=f"rm -rf {mounting_dir}/run_ios_{iter}",
+                timeout=3600,
+                check_ec=False,
+            )
         iter = iter + 1
+
+    log.info(f"IO loop summary: success={success}, failures={failures}")
+    if success == 0:
+        log.error("No successful IO during disruption window")
+        raise Exception("IO loop completed with zero successful iterations")
 
 
 @retry(CommandFailed, tries=3, delay=60)

--- a/tests/cephfs/cephfs_system/snap_rollback_with_node_reboots.py
+++ b/tests/cephfs/cephfs_system/snap_rollback_with_node_reboots.py
@@ -155,12 +155,14 @@ def run(ceph_cluster, **kw):
         files_checksum_snap_4 = fs_util.get_files_and_checksum(
             client1, fuse_mounting_dir_1
         )
+        retry_revert = retry(CommandFailed, tries=3, delay=60)(client1.exec_command)
+
+        client1.exec_command(
+            sudo=True,
+            cmd=f'test -n "{kernel_mounting_dir_1}" && cd "{kernel_mounting_dir_1}" && rm -rf -- *',
+        )
+
         with parallel() as p:
-            client1.exec_command(
-                sudo=True,
-                cmd=f"cd {kernel_mounting_dir_1};rm -rf *",
-            )
-            retry_revert = retry(CommandFailed, tries=3, delay=60)(client1.exec_command)
             p.spawn(
                 retry_revert,
                 sudo=True,
@@ -170,14 +172,14 @@ def run(ceph_cluster, **kw):
                 fs_util.reboot_node(ceph_node=mds)
             for mon in mon_nodes:
                 fs_util.reboot_node(ceph_node=mon)
+        files_checksum_snap_1_revert = fs_util.get_files_and_checksum(
+            client1, f"/mnt/cephfs_kernel{mounting_dir}_1"
+        )
+        if files_checksum_snap_1_revert != files_checksum_snap_1:
+            log.error("checksum is not matching after snapshot1 revert")
+            return 1
 
-            files_checksum_snap_1_revert = fs_util.get_files_and_checksum(
-                client1, f"/mnt/cephfs_kernel{mounting_dir}_1"
-            )
-            if files_checksum_snap_1_revert != files_checksum_snap_1:
-                log.error("checksum is not matching after snapshot1 revert")
-                return 1
-
+        with parallel() as p:
             p.spawn(
                 retry_revert,
                 sudo=True,
@@ -187,12 +189,14 @@ def run(ceph_cluster, **kw):
                 fs_util.reboot_node(ceph_node=mds)
             for mon in mon_nodes:
                 fs_util.reboot_node(ceph_node=mon)
-            files_checksum_snap_2_revert = fs_util.get_files_and_checksum(
-                client1, f"/mnt/cephfs_kernel{mounting_dir}_1"
-            )
-            if files_checksum_snap_2_revert != files_checksum_snap_2:
-                log.error("checksum is not matching after snapshot2 revert")
-                return 1
+        files_checksum_snap_2_revert = fs_util.get_files_and_checksum(
+            client1, f"/mnt/cephfs_kernel{mounting_dir}_1"
+        )
+        if files_checksum_snap_2_revert != files_checksum_snap_2:
+            log.error("checksum is not matching after snapshot2 revert")
+            return 1
+
+        with parallel() as p:
             p.spawn(
                 retry_revert,
                 sudo=True,
@@ -202,13 +206,14 @@ def run(ceph_cluster, **kw):
                 fs_util.reboot_node(ceph_node=mds)
             for mon in mon_nodes:
                 fs_util.reboot_node(ceph_node=mon)
-            files_checksum_snap_3_revert = fs_util.get_files_and_checksum(
-                client1, fuse_mounting_dir_1
-            )
-            if files_checksum_snap_3_revert != files_checksum_snap_3:
-                log.error("checksum is not matching after snapshot3 revert")
-                return 1
+        files_checksum_snap_3_revert = fs_util.get_files_and_checksum(
+            client1, fuse_mounting_dir_1
+        )
+        if files_checksum_snap_3_revert != files_checksum_snap_3:
+            log.error("checksum is not matching after snapshot3 revert")
+            return 1
 
+        with parallel() as p:
             p.spawn(
                 retry_revert,
                 sudo=True,
@@ -218,12 +223,12 @@ def run(ceph_cluster, **kw):
                 fs_util.reboot_node(ceph_node=mds)
             for mon in mon_nodes:
                 fs_util.reboot_node(ceph_node=mon)
-            files_checksum_snap_4_revert = fs_util.get_files_and_checksum(
-                client1, fuse_mounting_dir_1
-            )
-            if files_checksum_snap_4_revert != files_checksum_snap_4:
-                log.error("checksum is not matching after snapshot4 revert")
-                return 1
+        files_checksum_snap_4_revert = fs_util.get_files_and_checksum(
+            client1, fuse_mounting_dir_1
+        )
+        if files_checksum_snap_4_revert != files_checksum_snap_4:
+            log.error("checksum is not matching after snapshot4 revert")
+            return 1
 
         return 0
     except Exception as e:

--- a/tests/cephfs/cephfs_top/cephfs_top_dump.py
+++ b/tests/cephfs/cephfs_top/cephfs_top_dump.py
@@ -212,6 +212,13 @@ def verify_read_write_io_progress(before_total_read, before_total_write):
 
 
 def run(ceph_cluster, **kw):
+    fuse_mounting_dir_1 = None
+    fuse_mounting_dir_2 = None
+    fuse_mounting_dir_3 = None
+    kernel_mounting_dir_1 = None
+    kernel_mounting_dir_2 = None
+    cephfs_name1 = None
+    cephfs_name2 = None
     try:
         global fs_util, client1, fs_name, client_id
 
@@ -462,13 +469,19 @@ def run(ceph_cluster, **kw):
             fuse_mounting_dir_2,
             fuse_mounting_dir_3,
         ]:
-            fs_util.client_clean_up(
-                "umount", fuse_clients=[client1], mounting_dir=mount_dir
-            )
+            if mount_dir:
+                fs_util.client_clean_up(
+                    "umount", fuse_clients=[client1], mounting_dir=mount_dir
+                )
 
-        fs_util.client_clean_up(
-            "umount", kernel_clients=[client1], mounting_dir=kernel_mounting_dir_1
-        )
+        for mount_dir in [kernel_mounting_dir_1, kernel_mounting_dir_2]:
+            if mount_dir:
+                fs_util.client_clean_up(
+                    "umount",
+                    kernel_clients=[client1],
+                    mounting_dir=mount_dir,
+                )
 
         for fs_delete in [cephfs_name1, cephfs_name2]:
-            fs_util.remove_fs(client1, fs_delete)
+            if fs_delete:
+                fs_util.remove_fs(client1, fs_delete)

--- a/tests/cephfs/clients/test_selinux_relabel.py
+++ b/tests/cephfs/clients/test_selinux_relabel.py
@@ -32,13 +32,19 @@ def run(ceph_cluster, **kw):
         int: 0 if the test case executes successfully, 1 if an error occurs.
     """
 
+    kernel_mounting_dir_1 = None
+    kernel_mounting_dir_2 = None
+    kernel_mounting_dir = None
+    subvolume_list = []
+    default_fs = "cephfs"
+    subvolume_group_name = "subvol_group1"
+    clients = ceph_cluster.get_ceph_objects("client")
+    fs_util_v1 = FsUtilsV1(ceph_cluster)
     try:
         tc = "CEPH-83595737"
         log.info(f"Running cephfs {tc} test case")
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
         config = kw.get("config")
         build = config.get("build", config.get("rhbuild"))
-        clients = ceph_cluster.get_ceph_objects("client")
         log.info("checking Pre-requisites")
         if len(clients) < 2:
             log.error(
@@ -127,6 +133,7 @@ def run(ceph_cluster, **kw):
         ]
 
         num_files = 1000000
+        file_create_parallelism = config.get("file_create_parallelism", 16)
         label_to_apply = "mnt_t"
 
         for td in test_dirs:
@@ -139,7 +146,8 @@ def run(ceph_cluster, **kw):
             log.info(f"Creating {num_files} files in {test_dir}")
             client.exec_command(
                 sudo=True,
-                cmd=f"for i in $(seq 1 {num_files}); do touch {test_dir}/file_$i; done",
+                cmd=f"seq 1 {num_files} | xargs -n 500 -P {file_create_parallelism} "
+                f"sh -c 'for f; do touch {test_dir}/file_$f; done' _",
                 timeout=14400,
             )
 
@@ -210,7 +218,8 @@ def run(ceph_cluster, **kw):
         num_files = 1000000
         clients[0].exec_command(
             sudo=True,
-            cmd=f"for i in $(seq 1 {num_files}); do touch {test_dir_s3}/file_$i; done",
+            cmd=f"seq 1 {num_files} | xargs -n 500 -P {file_create_parallelism} "
+            f"sh -c 'for f; do touch {test_dir_s3}/file_$f; done' _",
             timeout=14400,
         )
 
@@ -317,13 +326,15 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
-        log.error("Clean up the system")
-        kernel_mounts = [
-            (clients[0], kernel_mounting_dir_1),
-            (clients[1], kernel_mounting_dir_2),
-            (clients[0], kernel_mounting_dir),
-            (clients[1], kernel_mounting_dir),
-        ]
+        log.info("Clean up the system")
+        kernel_mounts = []
+        if kernel_mounting_dir_1:
+            kernel_mounts.append((clients[0], kernel_mounting_dir_1))
+        if kernel_mounting_dir_2:
+            kernel_mounts.append((clients[1], kernel_mounting_dir_2))
+        if kernel_mounting_dir:
+            kernel_mounts.append((clients[0], kernel_mounting_dir))
+            kernel_mounts.append((clients[1], kernel_mounting_dir))
 
         for client, mounting_dir in kernel_mounts:
             fs_util_v1.client_clean_up(
@@ -333,9 +344,10 @@ def run(ceph_cluster, **kw):
         for subvolume in subvolume_list:
             fs_util_v1.remove_subvolume(clients[0], **subvolume)
 
-        fs_util_v1.remove_subvolumegroup(
-            clients[0], default_fs, subvolume_group_name, force=True
-        )
+        if subvolume_group_name:
+            fs_util_v1.remove_subvolumegroup(
+                clients[0], default_fs, subvolume_group_name, force=True
+            )
 
 
 def apply_selinux_label(client, label, path):


### PR DESCRIPTION
Regression Suite:
1. move_data_bw_nfs_and_cephfs_mounts.py: Added extra_params for fs= on kernel mount and --client_fs on fuse mount so the correct filesystem is targeted. Initialised variables to avoid cleanup crash.
2. nfs_ro_rw_access.py: Fixed sed pattern from 's/RW/RO/g' to 's/rw/ro/gI' (case-insensitive) because the NFS export config now uses lowercase rw/ro.
Logs: http://10.64.24.74/logs/ceph-qe-logs/IBM/9.1/rhel-10/regression/20.2.1-173/cephfs/48/logs/

Extended Regression:
1. test_cephfs_pool_size_change.py: Remove the test filesystem and avoid leftover health warnings instead of setting the config back.
2. snap_rollback_with_node_reboots.py: Broke one large parallel() block into 4 separate parallel() blocks. Previously, checksum verification ran inside the parallel context (racing with the revert), causing false failures. Now each snapshot revert + reboot runs in its own parallel block, and checksum validation happens after each block completes. Also moved rm -rf * out of the parallel block.
3. mds_nfs_node_failure_ops.py: Wrapped IO loop body in try/except for CommandFailed and generic Exception, since IO failures are expected during node-disruption tests. Without this, a transient IO error would abort the entire test.
4. cephfs_system_utils.py: Added mkdir -p /etc/ceph before copying ceph.conf and keyring files, fixing "No such file or directory" errors on nodes where /etc/ceph doesn't exist yet.
5. cephfs_top_dump.py: Added fs_util.wait_for_mds_process() after filesystem creation. 
6. test_selinux_relabel.py: modified file creation with xargs -n 500 -P 16 for parallel file creation (1M files).  It was failing with timeout issue at file creation.

Logs: http://10.64.24.74/logs/ceph-qe-logs/IBM/8.1/rhel-9/extended_regression/19.2.1-355/cephfs/4/logs/
