### PR TITLE
remove the ssl spec in non-ssl test cases

### DIFF
--- a/suites/squid/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/squid/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -92,13 +92,10 @@ tests:
             placement:
               nodes:
                 - node2
-            spec:
-              ssl: false
-              generate_cert: true
       desc: "Deploying RGW endpoint which is SSL terminated."
       destroy-cluster: false
       module: test_rgw.py
-      name: "Test rgw ssl endpoint using spec"
+      name: "Test rgw without ssl endpoint using spec"
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -92,13 +92,10 @@ tests:
             placement:
               nodes:
                 - node2
-            spec:
-              ssl: false
-              generate_cert: true
       desc: "Deploying RGW endpoint which is SSL terminated."
       destroy-cluster: false
       module: test_rgw.py
-      name: "Test rgw ssl endpoint using spec"
+      name: "Test rgw without ssl endpoint using spec"
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
Issue:
Error EINVAL: "ssl" field must be set to true
when "generate_cert" is set to true

Fix:
remove ssl spec which is not required as per test case
