### PR TITLE
Fixed the NVMEoF regression issues seen in 9.1 executions

### DIFF
--- a/suites/tentacle/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
@@ -80,9 +80,7 @@ tests:
         rep_pool_config:
           pool: rbd
         cleanup:
-          - subsystems
           - initiators
-          - pool
           - gateway
         gw_groups:  # Configure gatewayGroups
           - gw_group: group1
@@ -227,9 +225,7 @@ tests:
         rep_pool_config:
           pool: rbd1
         cleanup:
-          - subsystems
           - initiators
-          - pool
           - gateway
         gw_groups: # Configure gatewayGroups
           - gw_group: group1
@@ -369,9 +365,7 @@ tests:
         rep_pool_config:
           pool: rbd10
         cleanup:
-          - subsystems
           - initiators
-          - pool
           - gateway
         gw_groups: # Configure gatewayGroups
           - gw_group: group1
@@ -511,9 +505,7 @@ tests:
         rep_pool_config:
           pool: rbd3
         cleanup:
-          - subsystems
           - initiators
-          - pool
           - gateway
         gw_groups: # Configure gatewayGroups
           - gw_group: group1
@@ -647,9 +639,7 @@ tests:
         rep_pool_config:
           pool: rbd3
         cleanup:
-          - subsystems
           - initiators
-          - pool
           - gateway
         gw_groups: # Configure gatewayGroups
           - gw_group: group1

--- a/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
+++ b/tests/nvmeof/test_ceph_nvmeof_alerts_events.py
@@ -2,6 +2,8 @@
 Test suite that verifies NVMe alerts and NVMe Health checks.
 """
 
+import json
+import time
 from copy import deepcopy
 from json import dumps, loads
 from random import choice
@@ -11,6 +13,7 @@ import requests
 
 from ceph.ceph import Ceph
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.orch import Orch
 from ceph.utils import get_node_by_id
 from ceph.waiter import WaitUntil
 from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
@@ -21,7 +24,6 @@ from tests.nvmeof.workflows.nvme_utils import (
     check_and_set_nvme_cli_image,
     check_gateway,
     check_gateway_availability,
-    delete_nvme_service,
 )
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
@@ -991,91 +993,112 @@ def test_ceph_83617404(ceph_cluster, config):
         ceph_cluster: Ceph cluster object
         config: test case config
     """
-    time_to_fire = config.get("time_to_fire", 60)
-    interval = config.get("interval", 60)
-    rbd_pool = config["rbd_pool"]
-    rbd_obj = config["rbd_obj"]
-    alert = "NVMeoFMaxGatewayGroups"
-    original_gw_groups = deepcopy(config.get("gw_groups"))
+    # Cleanup is not happening here because we are deploying 5 services in test case,
+    # so we need to handle the cleanup in the test case itself
     svcs = list()
-    services = []
-    gw_groups = deepcopy(config.get("gw_groups"))
+    services = dict()
+    try:
+        time_to_fire = config.get("time_to_fire", 60)
+        interval = config.get("interval", 60)
+        rbd_pool = config["rbd_pool"]
+        rbd_obj = config["rbd_obj"]
+        alert = "NVMeoFMaxGatewayGroups"
+        original_gw_groups = deepcopy(config.get("gw_groups"))
 
-    # Deploy nvmeof service
-    LOG.info("deploy nvme service")
-    # Deploy Services
-    for svc in config["gw_groups"]:
-        svc.update({"rbd_pool": rbd_pool})
-        nvme_service = NVMeService(svc, ceph_cluster)
-        nvme_service.deploy()
-        nvme_service.init_gateways()
-        services.append(nvme_service)
-        svc.update({"nvme_service": nvme_service})
-        ha = HighAvailability(ceph_cluster, svc["gw_nodes"], **svc)
-        ha.gateways = nvme_service.gateways
-        svcs.append(ha)
+        # Deploy nvmeof service
+        LOG.info("deploy nvme service")
+        # Deploy Services
+        for svc in config["gw_groups"]:
+            svc.update({"rbd_pool": rbd_pool})
+            nvme_service = NVMeService(svc, ceph_cluster)
+            nvme_service.deploy()
+            nvme_service.init_gateways()
+            services[svc["gw_group"]] = nvme_service
 
-    ha1 = svcs[0]
-    # Check for alert
-    # NVMeoFMaxGatewayGroups prometheus alert should be firing
-    events = PrometheusAlerts(ha1.orch)
+            svc.update({"nvme_service": nvme_service})
+            ha = HighAvailability(ceph_cluster, svc["gw_nodes"], **svc)
+            ha.gateways = nvme_service.gateways
+            svcs.append(ha)
 
-    LOG.info("Check NVMeoFMaxGatewayGroups should be firing")
-    nvmegwcli = ha1.gateways[0]
-    # Execute ceph -s --format json and get fsid
-    cephs, _ = ha1.orch.shell(args=["ceph", "-s", "--format", "json"])
-    cephs = loads(cephs)
-    fsid = cephs["fsid"]
-    # Check version of cluster if it is less than 20.0 then msg should be "Max gateway groups exceeded on cluster "
-    if nvmegwcli.cli_version != "v2":
-        msg = "Max gateway groups exceeded on cluster"
-    else:
-        msg = f"Max gateway groups exceeded on cluster {fsid}".format(fsid=fsid)
+        ha1 = svcs[0]
+        # Check for alert
+        # NVMeoFMaxGatewayGroups prometheus alert should be firing
+        events = PrometheusAlerts(ha1.orch)
 
-    events.monitor_alert(
-        alert,
-        timeout=time_to_fire,
-        msg=msg,
-        interval=interval,
-    )
+        LOG.info("Check NVMeoFMaxGatewayGroups should be firing")
+        nvmegwcli = ha1.gateways[0]
+        # Execute ceph -s --format json and get fsid
+        cephs, _ = ha1.orch.shell(args=["ceph", "-s", "--format", "json"])
+        cephs = loads(cephs)
+        fsid = cephs["fsid"]
+        # Check version of cluster if it is less than 20.0 then msg should be "Max gateway groups exceeded on cluster "
+        if nvmegwcli.cli_version != "v2":
+            msg = "Max gateway groups exceeded on cluster"
+        else:
+            msg = f"Max gateway groups exceeded on cluster {fsid}".format(fsid=fsid)
 
-    # Remove one gateway and NVMeoFMaxGatewayGroups alert should be in inactive state
-    LOG.info(
-        "Remove one gateway group and NVMeoFMaxGatewayGroups alert should be in inactive state"
-    )
-    rm_add_gw_grp = gw_groups[0:1]
-    config.update({"gw_groups": rm_add_gw_grp})
-    delete_nvme_service(ceph_cluster, config)
-    events.monitor_alert(
-        alert, timeout=time_to_fire, state="inactive", interval=interval
-    )
+        events.monitor_alert(
+            alert,
+            timeout=time_to_fire,
+            msg=msg,
+            interval=interval,
+        )
 
-    # Add more than 4 gateway groups and NVMeoFMaxGatewayGroups alert should be in firing state
-    LOG.info(
-        "Add more than 4 gateway groups and NVMeoFMaxGatewayGroups alert should be in firing state"
-    )
-    # Deploy Services
-    config.update({"gw_groups": original_gw_groups})
-    for svc in config["gw_groups"]:
-        svc.update({"rbd_pool": rbd_pool})
-        nvme_service = NVMeService(svc, ceph_cluster)
-        nvme_service.deploy()
-        nvme_service.init_gateways()
+        # Remove one gateway and NVMeoFMaxGatewayGroups alert should be in inactive state
+        LOG.info(
+            "Remove one gateway group and NVMeoFMaxGatewayGroups alert should be in inactive state"
+        )
+        # Get the first service and delete the nvme service
+        rm_add_gw_grp = services.get("group1")
+        if not rm_add_gw_grp:
+            raise Exception("group1 service not found")
+        # Delete the nvme service
+        LOG.info(f"Deleting NVMe service for {rm_add_gw_grp.service_name}")
+        rm_add_gw_grp.delete_nvme_service()
+        # Check for alert and it should be in inactive state
+        events.monitor_alert(
+            alert, timeout=time_to_fire, state="inactive", interval=interval
+        )
 
-    events.monitor_alert(
-        alert,
-        timeout=time_to_fire,
-        msg=msg,
-        interval=interval,
-    )
+        # Add more than 4 gateway groups and NVMeoFMaxGatewayGroups alert should be in firing state
+        LOG.info(
+            "Add more than 4 gateway groups and NVMeoFMaxGatewayGroups alert should be in firing state"
+        )
+        # Deploy Services
+        config.update({"gw_groups": original_gw_groups})
+        for svc in config["gw_groups"]:
+            svc.update({"rbd_pool": rbd_pool})
+            nvme_service = NVMeService(svc, ceph_cluster)
+            nvme_service.deploy()
+            nvme_service.init_gateways()
 
-    if config.get("cleanup"):
-        LOG.info("Cleaning up NVMeoF services and RBD pool for CEPH-83617404.")
-        for service in services:
-            service.delete_nvme_service()
+        events.monitor_alert(
+            alert,
+            timeout=time_to_fire,
+            msg=msg,
+            interval=interval,
+        )
+
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if config.get("cleanup"):
+            LOG.info("Cleaning up NVMeoF services and RBD pool for CEPH-83617404.")
+            # Execute ceph orch ls nvmeof and get the service names
+            ceph = Orch(ceph_cluster, **{})
+            cmd = "ceph orch ls nvmeof --format json"
+            out, _ = ceph.shell(args=[cmd])
+            services = json.loads(out)
+            for service in services:
+                if "nvmeof" in service["service_name"]:
+                    service_name = service["service_name"]
+                    ceph.shell(args=["ceph", "orch", "rm", service_name, "--force"])
+            # Sleep for 40 seconds to ensure the services are deleted
+            time.sleep(40)
             rbd_obj.clean_up(pools=[rbd_pool])
-    global cleanup
-    cleanup = True
+        global cleanup
+        cleanup = True
     LOG.info("CEPH-83617404 - NVMeoFMaxGatewayGroups validated successfully.")
 
 

--- a/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
+++ b/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
@@ -80,13 +80,12 @@ def parse_namespaces(config, namespaces):
     return all_namespaces
 
 
-def test_ceph_83608838(ceph_cluster, config):
+def test_ceph_83608838(ceph_cluster, config, nvme_service):
     rbd_pool = config["rbd_pool"]
     rbd_obj = config["rbd_obj"]
     # Deploy nvmeof service
     LOG.info("deploy nvme service")
     orch = Orch(ceph_cluster, **{})
-    nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
     nvme_service.init_gateways()
 
@@ -160,7 +159,7 @@ def test_ceph_83608838(ceph_cluster, config):
     )
 
 
-def test_ceph_83609769(ceph_cluster, config):
+def test_ceph_83609769(ceph_cluster, config, nvme_service):
     gateway_group = config.get("gw_group", "")
     # Deploy nvmeof service
     LOG.info("deploy nvme service")
@@ -168,7 +167,6 @@ def test_ceph_83609769(ceph_cluster, config):
     config["rebalance_period"] = True
     config["rebalance_period_sec"] = 0
     orch = Orch(ceph_cluster, **{})
-    nvme_service = NVMeService(config, ceph_cluster)
     nvme_service.deploy()
 
     # Configure subsystems
@@ -395,7 +393,8 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
             test_case_run = testcases[config["test_case"]]
             config.update({"rbd_obj": rbd_obj})
-            test_case_run(ceph_cluster, config)
+            config.update({"nvme_service": nvme_service})
+            test_case_run(ceph_cluster, config, nvme_service)
         else:
             # Deploy NVMe services
             if config.get("install"):
@@ -438,8 +437,8 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 for lb_config in config.get("load_balancing"):
                     # namespace addition
                     if lb_config.get("ns_add"):
-                        config = lb_config["ns_add"]
-                        subsystems = config["subsystems"]
+                        config_ns_add = lb_config["ns_add"]
+                        subsystems = config_ns_add["subsystems"]
                         opt_args = {
                             "ceph_cluster": ceph_cluster,
                             "lb_groups": lb_groups,

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -1210,7 +1210,8 @@ def test_ceph_83608266(
         )
         nvme_service.config["gw_node"] = gw_node.id
         nvme_service.group = "gw_group1"
-        if nvme_service.gateways:
+        name = getattr(nvme_service, "service_name", None)
+        if name is not None:
             teardown(nvme_service, rbd)
         return 0
 

--- a/tests/nvmeof/test_nvmeof_gwgroup.py
+++ b/tests/nvmeof/test_nvmeof_gwgroup.py
@@ -1,5 +1,6 @@
 from ceph.ceph import Ceph
 from ceph.parallel import parallel
+from tests.nvmeof.workflows.constants import DEFAULT_NVME_METADATA_POOL
 from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
 from tests.nvmeof.workflows.ha import HighAvailability
 from tests.nvmeof.workflows.nvme_service import NVMeService
@@ -61,7 +62,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         if config.get("parallel"):
             with parallel() as p:
                 for gwgroup_config in config["gw_groups"]:
-                    clean_up = ["subsystems", "initiators", "pool", "gateway"]
+                    clean_up = ["initiators", "gateway"]
                     gwgroup_config.update({"cleanup": clean_up})
                     rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
                     # Deploy NVMeOf services
@@ -85,7 +86,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                     )
         else:
             for gwgroup_config in config["gw_groups"]:
-                clean_up = ["subsystems", "initiators", "pool", "gateway"]
+                clean_up = ["initiators", "gateway"]
                 gwgroup_config.update({"cleanup": clean_up})
                 rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
                 # Deploy NVMeOf services
@@ -111,5 +112,25 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     finally:
         if config.get("cleanup"):
             for nvme_service, rbd_obj in cleanup_dict.items():
+                # Delete only service here, if we delete pools here then .nvmeof pool will be deleted
+                # and we end up stale entries in ceph orch ls nvmeof command.
                 teardown(nvme_service, rbd_obj)
+            # Delete the pools here
+            for nvme_service, rbd_obj in cleanup_dict.items():
+                subsystem_config = nvme_service.config.get("subsystems", [])
+                pools_to_delete = set()
+                for sub_cfg in subsystem_config:
+                    if sub_cfg.get("bdevs"):
+                        bdev_configs = sub_cfg["bdevs"]
+                        if isinstance(bdev_configs, dict):
+                            bdev_configs = [bdev_configs]
+                        for bdev_cfg in bdev_configs:
+                            if bdev_cfg.get("pool"):
+                                pools_to_delete.add(bdev_cfg["pool"])
+                            else:
+                                pools_to_delete.add(nvme_service.rbd_pool)
+                pools_to_delete.add(nvme_service.rbd_pool)
+                if DEFAULT_NVME_METADATA_POOL == nvme_service.nvme_metadata_pool:
+                    pools_to_delete.add(nvme_service.nvme_metadata_pool)
+                rbd_obj.clean_up(pools=list(pools_to_delete))
             LOG.info("Cleanup completed.")

--- a/tests/nvmeof/workflows/load_balancing.py
+++ b/tests/nvmeof/workflows/load_balancing.py
@@ -61,12 +61,12 @@ def scale_down(nvme_service, orch, gateway_nodes_to_be_scaleddown):
     nvme_service.gw_nodes = get_nodes_by_ids(
         nvme_service.ceph_cluster, gwnodes_to_be_deployed
     )
+    start_counter, start_time = get_current_timestamp()
     nvme_service.deploy()
 
     nvme_service.gateways = []
     nvme_service.init_gateways()
 
-    start_counter, start_time = get_current_timestamp()
     for gateway in to_be_scaledown_gws:
         hostname = gateway.hostname
 
@@ -74,6 +74,8 @@ def scale_down(nvme_service, orch, gateway_nodes_to_be_scaleddown):
             # Wait until 600 seconds
             for w in WaitUntil(timeout=600, interval=5):
                 # Check for gateway unavailability
+                # Most of the time, the time we reach here, the gateway is already in deleted state
+                # So, we can't get the gateway in DELETING state
                 if check_gateway_availability(
                     nvme_service, gateway.ana_group_id, orch, state="DELETING"
                 ):
@@ -89,7 +91,16 @@ def scale_down(nvme_service, orch, gateway_nodes_to_be_scaleddown):
                         )
                         break
 
-                LOG.warning(f"[ {hostname} ] is still in AVAILABLE state..")
+                    LOG.warning(f"[ {hostname} ] is still in DELETING state..")
+                else:
+                    # Check for gwnodes_to_be_deployed list is equal to nvme_service.gateways
+                    if set(gwnodes_to_be_deployed) == {
+                        gw.node.id for gw in nvme_service.gateways
+                    }:
+                        LOG.info(f"[ {hostname} ] is in DELETED(SCALED DOWN) state..")
+                        break
+                    else:
+                        LOG.warning(f"[ {hostname} ] is still in AVAILABLE state..")
 
             if w.expired:
                 raise TimeoutError(

--- a/tests/nvmeof/workflows/nvme_service.py
+++ b/tests/nvmeof/workflows/nvme_service.py
@@ -220,8 +220,31 @@ class NVMeService:
         cmd = "ceph orch ls nvmeof --format json"
         out, _ = ceph.shell(args=[cmd])
         services = json.loads(out)
-        self.service_name = services[0]["service_name"]
-        self.service_id = services[0]["service_id"]
+        self.service_name = None
+        self.service_id = None
+        for service in services:
+            # If we have multiple services in single cluster then we need to filter the service by group
+            # so that we will get the correct service name and service id for the group.
+            # when we take services[0]["service_name"] only first service name will be returned
+            # so we need to filter the service by group.
+            if "nvmeof" in service["service_name"]:
+                if self.group:
+                    if self.group in service["service_name"]:
+                        service_name = service["service_name"]
+                        service_id = service["service_id"]
+                        LOG.info(
+                            f"Service name: {service_name}, Service id: {service_id}"
+                        )
+                        self.service_name = service_name
+                        self.service_id = service_id
+                        break
+                else:
+                    service_name = service["service_name"]
+                    service_id = service["service_id"]
+                    LOG.info(f"Service name: {service_name}, Service id: {service_id}")
+                    self.service_name = service_name
+                    self.service_id = service_id
+                    break
 
     def init_gateways(self):
         """


### PR DESCRIPTION
Fixed the NVMEoF regression issues seen in 9.1 executions

Logs:- 
1. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4UCJ0D_23rd_april_1/
2. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IXW6YV_23rd_april_2/
3. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4Z4VE1_23rd_april/
4. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OOTZTK_23rd_april/
[Configure_NVMeoF_4-GWgroups_with_2_gateways_HA_with_mtls_and_same_NQN's_0.log](https://github.com/user-attachments/files/27000400/Configure_NVMeoF_4-GWgroups_with_2_gateways_HA_with_mtls_and_same_NQN.s_0.log)
[Configure_NVMeoF_4-GWgroups_with_2_gateways_HA_with_and_without_mtls_0.log](https://github.com/user-attachments/files/27000401/Configure_NVMeoF_4-GWgroups_with_2_gateways_HA_with_and_without_mtls_0.log)
[Configure_NVMeoF_4-GWgroups_with_2_gateways_HA_different_NQN's_without_mtls_0.log](https://github.com/user-attachments/files/27000402/Configure_NVMeoF_4-GWgroups_with_2_gateways_HA_different_NQN.s_without_mtls_0.log)
