### PR TITLE
Fixed 8.1 regression issues in nvmeof

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
+++ b/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
@@ -103,7 +103,7 @@ def test_ceph_83608838(ceph_cluster, config, nvme_service):
         configure_listeners(nvme_service.gateways, config, listeners=listeners)
     lb_groups = fetch_lb_groups(nvme_service, listeners)
     opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": lb_groups}
-    configure_namespaces(nvme_service.gateways[0], config, opt_args)
+    configure_namespaces(nvme_service.gateways[0], config, opt_args, rbd_obj=rbd_obj)
 
     # Configure namespaces
     LOG.info("Configure namespaces")
@@ -163,6 +163,7 @@ def test_ceph_83609769(ceph_cluster, config, nvme_service):
     gateway_group = config.get("gw_group", "")
     # Deploy nvmeof service
     LOG.info("deploy nvme service")
+    rbd_obj = config["rbd_obj"]
     config["spec_deployment"] = True
     config["rebalance_period"] = True
     config["rebalance_period_sec"] = 0
@@ -183,7 +184,7 @@ def test_ceph_83609769(ceph_cluster, config, nvme_service):
         configure_listeners(nvme_service.gateways, config, listeners=listeners)
     opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": "sequential"}
     LOG.info("Configure namespaces")
-    configure_namespaces(nvme_service.gateways[0], config, opt_args)
+    configure_namespaces(nvme_service.gateways[0], config, opt_args, rbd_obj=rbd_obj)
 
     # Check for num-namespaces is 10 in all gateways
     LOG.info("Check for num-namespaces is 10 in all gateways")
@@ -424,7 +425,9 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 lb_groups = fetch_lb_groups(nvme_service, listeners)
                 opt_args = {"ceph_cluster": ceph_cluster, "lb_groups": lb_groups}
                 LOG.info("Configure namespaces")
-                configure_namespaces(nvme_service.gateways[0], config, opt_args)
+                configure_namespaces(
+                    nvme_service.gateways[0], config, opt_args, rbd_obj=rbd_obj
+                )
 
                 if ceph_cluster.rhcs_version > "8.0":
                     time.sleep(120)
@@ -444,7 +447,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                             "lb_groups": lb_groups,
                         }
                         configure_namespaces(
-                            nvme_service.gateways[0], nvme_service.config, opt_args
+                            nvme_service.gateways[0],
+                            nvme_service.config,
+                            opt_args,
+                            rbd_obj=rbd_obj,
                         )
                         if ceph_cluster.rhcs_version > "8.0":
                             validate_auto_loadbalance(
@@ -578,7 +584,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                                 "lb_groups": lb_groups,
                             }
                             configure_namespaces(
-                                nvme_service.gateways[-1], nvme_service.config, opt_args
+                                nvme_service.gateways[-1],
+                                nvme_service.config,
+                                opt_args,
+                                rbd_obj=rbd_obj,
                             )
 
                             # Prepare FIO Execution for new namespaces


### PR DESCRIPTION
In 9.1 suite file we are passing option ns_create_image: true as below, so we are not hitting any issues in 9.1 executions
```
        subsystems:
          - nqn: nqn.2016-06.io.spdk:cnode1
            serial: 1
            max_ns: 100
            bdevs:
            - count: 8
              size: 5G
              ns_create_image: true
            listener_port: 4420
            listeners: [node6, node7, node8, node9]
            allow_host: "*"
```

In 8.1 suites we are not passing the ns_create_image: true option so in ns create module it is expected to pass rbd_obj. Currently we are not passing it so it is failing. Included rbd_obj in ns create module to fix the issue

```
        subsystems:                             # Configure subsystems with all sub-entities
          - nqn: nqn.2016-06.io.spdk:cnode1
            serial: 1
            bdevs:
            - count: 5
              size: 5G
            listener_port: 4420
            listeners: [node6, node7, node8, node9]
            allow_host: "*"
```

Failure logs:- https://149.81.216.83/view/Squid/job/squid-nvmeof-regression-ci/9/stages/log?nodeId=331


Logs:-

```
2026-04-24 10:52:31,023 - cephci - test_ceph_nvmeof_loadbalancing:427 - INFO - Configure namespaces
2026-04-24 10:52:31,024 - cephci - base_cli:60 - INFO - NVMeoF command - ns add
2026-04-24 10:52:31,024 - cephci - base_cli:60 - INFO - NVMeoF command - ns add
2026-04-24 10:52:31,275 - cephci - ceph:1677 - INFO - Execute cephadm shell -- ceph nvmeof  ns add  --nqn nqn.2016-06.io.spdk:cnode1 --rbd_pool rbd2 --size 5G --create-image --rbd_image_name 6OTY-image0 --gw_group gw_group1 --server_address 10.0.66.56  on ceph-jp91-u6v6uc-node1-installer [10.0.66.60]
2026-04-24 10:52:31,525 - cephci - ceph:1677 - INFO - Execute cephadm shell -- ceph nvmeof  ns add  --nqn nqn.2016-06.io.spdk:cnode1 --rbd_pool rbd2 --size 5G --create-image --rbd_image_name 6OTY-image1 --gw_group gw_group1 --server_address 10.0.66.56  on ceph-jp91-u6v6uc-node1-installer [10.0.66.60]
2026-04-24 10:52:34,102 - cephci - ceph:1712 - INFO - Execution of cephadm shell -- ceph nvmeof  ns add  --nqn nqn.2016-06.io.spdk:cnode1 --rbd_pool rbd2 --size 5G --create-image --rbd_image_name 6OTY-image1 --gw_group gw_group1 --server_address 10.0.66.56  took 2.576059 seconds on ceph-jp91-u6v6uc-node1-installer by user root [10.0.66.60]
2026-04-24 10:52:34,103 - cephci - ceph:1209 - DEBUG - Adding namespace 2 to nqn.2016-06.io.spdk:cnode1: Successful
2026-04-24 10:52:34,104 - cephci - ceph:1790 - INFO - 
Command:    cephadm shell -- ceph nvmeof  ns add  --nqn nqn.2016-06.io.spdk:cnode1 --rbd_pool rbd2 --size 5G --create-image --rbd_image_name 6OTY-image1 --gw_group gw_group1 --server_address 10.0.66.56 
Duration:   2.576059 seconds
Exit Code:  0
Stdout:     Adding namespace 2 to nqn.2016-06.io.spdk:cnode1: Successful

Stderr:      Inferring fsid bac583aa-3eca-11f1-ad88-fa163ef09a2c
Inferring config /var/lib/ceph/bac583aa-3eca-11f1-ad88-fa163ef09a2c/mon.ceph-jp91-u6v6uc-node1-installer/config

2026-04-24 10:52:34,104 - cephci - shell:64 - DEBUG - Adding namespace 2 to nqn.2016-06.io.spdk:cnode1: Successful

2026-04-24 10:52:34,531 - cephci - ceph:1712 - INFO - Execution of cephadm shell -- ceph nvmeof  ns add  --nqn nqn.2016-06.io.spdk:cnode1 --rbd_pool rbd2 --size 5G --create-image --rbd_image_name 6OTY-image0 --gw_group gw_group1 --server_address 10.0.66.56  took 3.255226 seconds on ceph-jp91-u6v6uc-node1-installer by user root [10.0.66.60]
2026-04-24 10:52:34,531 - cephci - ceph:1790 - INFO - 
Command:    cephadm shell -- ceph nvmeof  ns add  --nqn nqn.2016-06.io.spdk:cnode1 --rbd_pool rbd2 --size 5G --create-image --rbd_image_name 6OTY-image0 --gw_group gw_group1 --server_address 10.0.66.56 
Duration:   3.255226 seconds
Exit Code:  0
Stdout:     Adding namespace 1 to nqn.2016-06.io.spdk:cnode1: Successful

Stderr:      Inferring fsid bac583aa-3eca-11f1-ad88-fa163ef09a2c
Inferring config /var/lib/ceph/bac583aa-3eca-11f1-ad88-fa163ef09a2c/mon.ceph-jp91-u6v6uc-node1-installer/config

2026-04-24 10:52:34,532 - cephci - shell:64 - DEBUG - Adding namespace 1 to nqn.2016-06.io.spdk:cnode1: Successful

2026-04-24 10:52:37,037 - cephci - base_cli:60 - INFO - NVMeoF command - ns list
2026-04-24 10:52:37,288 - cephci - ceph:1677 - INFO - Execute cephadm shell -- ceph nvmeof  ns list  --nqn nqn.2016-06.io.spdk:cnode1 --gw_group gw_group1 --server_address 10.0.66.56  --format json on ceph-jp91-u6v6uc-node1-installer [10.0.66.60]
2026-04-24 10:52:39,788 - cephci - ceph:1712 - INFO - Execution of cephadm shell -- ceph nvmeof  ns list  --nqn nqn.2016-06.io.spdk:cnode1 --gw_group gw_group1 --server_address 10.0.66.56  --format json took 2.500067 seconds on ceph-jp91-u6v6uc-node1-installer by user root [10.0.66.60]
2026-04-24 10:52:39,789 - cephci - ceph:1790 - INFO - 
Command:    cephadm shell -- ceph nvmeof  ns list  --nqn nqn.2016-06.io.spdk:cnode1 --gw_group gw_group1 --server_address 10.0.66.56  --format json
Duration:   2.500067 seconds
Exit Code:  0
Stdout:     
{
    "status": 0,
    "error_message": "Success",
    "namespaces": [
        {
            "bdev_name": "bdev_73bb2b1f-2bed-409b-9b63-edebe4cdc6b7",
            "rbd_image_name": "6OTY-image0",
            "rados_namespace_name": "",
            "rbd_pool_name": "rbd2",
            "load_balancing_group": 1,
            "rbd_image_size": "5368709120",
            "block_size": 512,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": true,
            "hosts": [],
            "nsid": 1,
            "uuid": "73bb2b1f-2bed-409b-9b63-edebe4cdc6b7",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode1",
            "trash_image": false,
            "disable_auto_resize": false,
            "read_only": false,
            "location": "",
            "encryption_algorithm": "no_algorithm",
            "encryption_entries": []
        },
        {
            "bdev_name": "bdev_2df4f933-8b09-474f-b501-e62b9728f8db",
            "rbd_image_name": "6OTY-image1",
            "rados_namespace_name": "",
            "rbd_pool_name": "rbd2",
            "load_balancing_group": 2,
            "rbd_image_size": "5368709120",
            "block_size": 512,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": true,
            "hosts": [],
            "nsid": 2,
            "uuid": "2df4f933-8b09-474f-b501-e62b9728f8db",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode1",
            "trash_image": false,
            "disable_auto_resize": false,
            "read_only": false,
            "location": "",
            "encryption_algorithm": "no_algorithm",
            "encryption_entries": []
        }
    ]
}

Stderr:      Inferring fsid bac583aa-3eca-11f1-ad88-fa163ef09a2c
Inferring config /var/lib/ceph/bac583aa-3eca-11f1-ad88-fa163ef09a2c/mon.ceph-jp91-u6v6uc-node1-installer/config

2026-04-24 10:52:39,790 - cephci - shell:64 - DEBUG - 
{
    "status": 0,
    "error_message": "Success",
    "namespaces": [
        {
            "bdev_name": "bdev_73bb2b1f-2bed-409b-9b63-edebe4cdc6b7",
            "rbd_image_name": "6OTY-image0",
            "rados_namespace_name": "",
            "rbd_pool_name": "rbd2",
            "load_balancing_group": 1,
            "rbd_image_size": "5368709120",
            "block_size": 512,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": true,
            "hosts": [],
            "nsid": 1,
            "uuid": "73bb2b1f-2bed-409b-9b63-edebe4cdc6b7",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode1",
            "trash_image": false,
            "disable_auto_resize": false,
            "read_only": false,
            "location": "",
            "encryption_algorithm": "no_algorithm",
            "encryption_entries": []
        },
        {
            "bdev_name": "bdev_2df4f933-8b09-474f-b501-e62b9728f8db",
            "rbd_image_name": "6OTY-image1",
            "rados_namespace_name": "",
            "rbd_pool_name": "rbd2",
            "load_balancing_group": 2,
            "rbd_image_size": "5368709120",
            "block_size": 512,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": true,
            "hosts": [],
            "nsid": 2,
            "uuid": "2df4f933-8b09-474f-b501-e62b9728f8db",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode1",
            "trash_image": false,
            "disable_auto_resize": false,
            "read_only": false,
            "location": "",
            "encryption_algorithm": "no_algorithm",
            "encryption_entries": []
        }
    ]
}

```