### PR TITLE
Mirroring system tests

### DIFF
--- a/conf/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/conf/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -32,6 +32,7 @@ globals:
           - osd
           - mds
           - nfs
+          - cephfs-mirror
         no-of-volumes: 4
         disk-size: 60
       node6:

--- a/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -292,7 +292,6 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirror_multithreaded_empty_dataq_hang.py
       name: empty data queue on source cluster.
       polarion-id: "CEPH-83632392"
-      comments:  BZ IBMCEPH-13639
 
   - test:
       abort-on-fail: false
@@ -304,7 +303,6 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirror_incremental_sync.py
       name: Test incremental snapshot synchronization
       polarion-id: "CEPH-83632393"
-      comments:  Upstream tracker 74984
   - test:
       abort-on-fail: false
       desc: "Validate cephfs-mirror daemon status shows correct fsid and mon list"

--- a/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_mirror.yaml
@@ -292,7 +292,6 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirror_multithreaded_empty_dataq_hang.py
       name: empty data queue on source cluster.
       polarion-id: "CEPH-83632392"
-      comments:  BZ IBMCEPH-13639
 
   - test:
       abort-on-fail: false
@@ -304,4 +303,4 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirror_incremental_sync.py
       name: Test incremental snapshot synchronization
       polarion-id: "CEPH-83632393"
-      comments:  Upstream tracker 74984
+

--- a/suites/tentacle/cephfs/tier-2_cephfs_mirroring_system.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_mirroring_system.yaml
@@ -89,8 +89,10 @@ tests:
                   service: cephfs-mirror
                   args:
                     placement:
-                      nodes:
-                        - node6
+                      label: cephfs-mirror
+                      limit: 1
+                      # nodes:
+                      #   - node6
         ceph2:
           config:
             verify_cluster_health: true

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -139,6 +139,47 @@ class CephfsMirroringUtils(object):
             return 1
         return 0
 
+    @staticmethod
+    @retry(Exception, tries=20, delay=15, backoff=1)
+    def wait_for_daemon_running(client, cephfs_mirror_nodes, ceph_cluster=None):
+        """Wait for cephfs-mirror daemon to be running via podman ps on mirror nodes.
+
+        Retries up to 20 times with fixed 15s delay (~5 min) until at least one
+        cephfs-mirror container is confirmed running by podman on a mirror node.
+
+        Args:
+            client: Client node (unused, kept for API compatibility)
+            cephfs_mirror_nodes: List of CephNode objects with the cephfs-mirror role
+            ceph_cluster: Ceph cluster object (unused, kept for API compatibility)
+
+        Raises:
+            Exception: If no running container found on any node (triggers retry)
+        """
+        if not cephfs_mirror_nodes:
+            raise Exception("No cephfs-mirror nodes provided")
+
+        failures = []
+        for ceph_obj in cephfs_mirror_nodes:
+            mirror_node = ceph_obj.node if hasattr(ceph_obj, "node") else ceph_obj
+            hostname = mirror_node.hostname
+            podman_out, _ = mirror_node.exec_command(
+                sudo=True,
+                cmd="podman ps --format '{{.Names}}' --filter name=cephfs-mirror",
+                check_ec=False,
+            )
+            if podman_out and "cephfs-mirror" in podman_out:
+                log.info(
+                    "cephfs-mirror container confirmed via podman on %s",
+                    hostname,
+                )
+                return 0
+            failures.append(hostname)
+
+        raise Exception(
+            "No cephfs-mirror container found via podman on: %s"
+            % ", ".join(failures)
+        )
+
     def enable_mirroring_module(self, client):
         """
         Enable the mirroring mgr module on the specified Ceph client.
@@ -588,78 +629,42 @@ class CephfsMirroringUtils(object):
         self, cephfs_mirror_node, fsid, daemon_names
     ):
         """
-        Fetches the asok file of the cephfs-mirror daemon with connectivity testing.
-        Tests connectivity to each asok file and retries with remaining files if connection refused.
-        This function is useful when connection refused errors occur with the first asok file.
+        Fetch an accessible asok file by matching the daemon ID suffix
+        (e.g. 'zddvsp' from 'cephfs-mirror.mero006.zddvsp') to the asok
+        files on each node.
 
-        Args:
-            cephfs_mirror_node (CephNode or list): The CephFS mirror node(s) used to execute the command.
-            fsid (str): The FSID (File System ID) of the Ceph cluster.
-            daemon_name (str or list): The name(s) of the cephfs-mirror daemon.
         Returns:
-            dict: Dictionary mapping hostname to [node, asok_file_path] for accessible asok files.
+            dict: {hostname: [node, asok_file_path]}
         """
-        log.info(
-            "Fetch all asok files of the cephfs-mirror daemon with connectivity check."
-        )
         accessible_asok_files = {}
+        daemon_ids = {n.rsplit(".", 1)[-1] for n in daemon_names if "." in n}
 
-        for daemon_name in daemon_names:
-            # Get all asok files, not just the first one
-            cmd = f"cd /var/run/ceph/{fsid}/ ; ls -1tr ceph-client.{daemon_name}* 2>/dev/null"
-            # cephfs_mirror_node is always a list from get_ceph_objects("cephfs-mirror")
-            for node in cephfs_mirror_node:
-                # Get all asok files for this node
-                file_output, _ = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
-                asok_file_list = [
-                    f.strip() for f in file_output.split("\n") if f.strip()
-                ]
-                log.info(
-                    f"Found {len(asok_file_list)} asok file(s) for {node.node.hostname}: {asok_file_list}"
-                )
+        for node in cephfs_mirror_node:
+            node.exec_command(sudo=True, cmd="dnf install -y ceph-common --nogpgcheck")
+            file_output, _ = node.exec_command(
+                sudo=True,
+                cmd=f"ls -1tr /var/run/ceph/{fsid}/ceph-client.cephfs-mirror.* 2>/dev/null",
+                check_ec=False,
+            )
+            asok_dir = f"/var/run/ceph/{fsid}"
+            for asok_file_path in (
+                f.strip() for f in file_output.split("\n") if f.strip()
+            ):
+                if not any(did in asok_file_path for did in daemon_ids):
+                    continue
+                asok_basename = asok_file_path.rsplit("/", 1)[-1]
+                test_cmd = f"cd {asok_dir} && ceph --admin-daemon {asok_basename} help"
+                out, err = node.exec_command(sudo=True, cmd=test_cmd, check_ec=False)
+                if out and "fs mirror peer status" in out:
+                    accessible_asok_files[node.node.hostname] = [node, asok_file_path]
+                    log.info(f"Connected to asok: {asok_file_path}")
+                    break
+                else:
+                    log.warning(f"Cannot reach asok {asok_file_path}: {err}")
 
-                # Test each asok file until we find an accessible one for this hostname
-                for asok_file_path in asok_file_list:
-                    if not asok_file_path:
-                        continue
-                    if node.node.hostname in accessible_asok_files:
-                        break  # Already found accessible file for this hostname
-
-                    log.info(
-                        f"Testing connectivity to asok file on {node.node.hostname}: {asok_file_path}"
-                    )
-                    # test_cmd = f"cd /var/run/ceph ; ceph --admin-daemon {asok_file_path} help"
-                    test_cmd = (
-                        f"cephadm shell -- bash -c "
-                        f'"cd /var/run/ceph && ceph --admin-daemon {asok_file_path} help"'
-                    )
-
-                    out, err = node.exec_command(
-                        sudo=True, cmd=test_cmd, check_ec=False
-                    )
-
-                    # Check if "fs mirror peer status" is in the output
-                    if out and "fs mirror peer status" in out:
-                        accessible_asok_files[node.node.hostname] = [
-                            node,
-                            asok_file_path,
-                        ]
-                        log.info(
-                            f"Successfully connected to asok file on {node.node.hostname}: {asok_file_path}"
-                        )
-                        break  # Found accessible file, move to next hostname
-                    else:
-                        log.warning(
-                            f"Connection refused or error accessing asok file on {node.node.hostname}: "
-                            f"'fs mirror peer status' not found. stderr: {err}, output: {out[:200] if out else 'empty'}"
-                        )
-
-        if accessible_asok_files:
-            log.info(f"Found {len(accessible_asok_files)} accessible asok file(s)")
-            return accessible_asok_files
-        else:
-            log.warning("No accessible asok files found, returning empty dict")
-            return {}
+        if not accessible_asok_files:
+            log.warning("No accessible asok files found")
+        return accessible_asok_files
 
     @retry(CommandFailed, tries=5, delay=30)
     def validate_synchronization(
@@ -687,9 +692,11 @@ class CephfsMirroringUtils(object):
         asok_files = self.get_asok_file(cephfs_mirror_node, fsid, daemon_names)
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror status {fs_name}@{filesystem_id} -f json",
             )
             data = json.loads(out)
@@ -743,9 +750,11 @@ class CephfsMirroringUtils(object):
             node.exec_command(sudo=True, cmd="yum install -y ceph-common --nogpgcheck")
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror status {fs_name}@{filesystem_id} -f json",
             )
             data = json.loads(out)
@@ -795,8 +804,10 @@ class CephfsMirroringUtils(object):
         """
         log.info("Get peer mirror status")
         log.info("Validate the snapshot sync to target cluster.")
+        asok_basename = asok_file.rsplit("/", 1)[-1]
+        asok_dir = f"/var/run/ceph/{fsid}"
         cmd = (
-            f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file} fs mirror peer status "
+            f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
             f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
         )
         out, _ = cephfs_mirror_node.exec_command(sudo=True, cmd=cmd)
@@ -855,8 +866,10 @@ class CephfsMirroringUtils(object):
                 )
             except CommandFailed as e:
                 log.warning(f"dnf install ceph-common failed (non-fatal): {e}")
+            asok_basename = asok[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             cmd = (
-                f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+                f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
                 f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
             )
             out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
@@ -1609,9 +1622,11 @@ class CephfsMirroringUtils(object):
         asok_files = self.get_asok_file(cephfs_mirror_node, fsid, daemon_names)
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror status {fs_name}@{filesystem_id} -f json",
             )
             fs_mirror_status = json.dump(out)
@@ -1645,9 +1660,11 @@ class CephfsMirroringUtils(object):
         peer_uuid = self.get_peer_uuid_by_name(source_clients, fs_name)
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror peer status {fs_name}@{filesystem_id} {peer_uuid} -f json",
             )
             fs_mirror_status = json.loads(out)
@@ -2145,8 +2162,10 @@ class CephfsMirroringUtils(object):
             asok[0].exec_command(
                 sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
             )
+        asok_basename = asok[1].rsplit("/", 1)[-1]
+        asok_dir = f"/var/run/ceph/{fsid}"
         cmd = (
-            f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+            f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
             f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
         )
         out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
@@ -2187,8 +2206,10 @@ class CephfsMirroringUtils(object):
             asok[0].exec_command(
                 sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
             )
+        asok_basename = asok[1].rsplit("/", 1)[-1]
+        asok_dir = f"/var/run/ceph/{fsid}"
         cmd = (
-            f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+            f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
             f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
         )
         out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
@@ -2239,8 +2260,10 @@ def wait_for_sync_idle(fs_name, fsid, asok_file, filesystem_id, peer_uuid, paths
             )
         except Exception as e:
             log.warning("dnf install ceph-common failed (non-fatal): %s", e)
+    asok_basename = asok[1].rsplit("/", 1)[-1]
+    asok_dir = f"/var/run/ceph/{fsid}"
     cmd = (
-        f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+        f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
         f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
     )
     out, _ = asok[0].exec_command(sudo=True, cmd=cmd)

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -141,6 +141,46 @@ class CephfsMirroringUtils(object):
             return 1
         return 0
 
+    @staticmethod
+    @retry(Exception, tries=20, delay=15, backoff=1)
+    def wait_for_daemon_running(client, cephfs_mirror_nodes, ceph_cluster=None):
+        """Wait for cephfs-mirror daemon to be running via podman ps on mirror nodes.
+
+        Retries up to 20 times with fixed 15s delay (~5 min) until at least one
+        cephfs-mirror container is confirmed running by podman on a mirror node.
+
+        Args:
+            client: Client node (unused, kept for API compatibility)
+            cephfs_mirror_nodes: List of CephNode objects with the cephfs-mirror role
+            ceph_cluster: Ceph cluster object (unused, kept for API compatibility)
+
+        Raises:
+            Exception: If no running container found on any node (triggers retry)
+        """
+        if not cephfs_mirror_nodes:
+            raise Exception("No cephfs-mirror nodes provided")
+
+        failures = []
+        for ceph_obj in cephfs_mirror_nodes:
+            mirror_node = ceph_obj.node if hasattr(ceph_obj, "node") else ceph_obj
+            hostname = mirror_node.hostname
+            podman_out, _ = mirror_node.exec_command(
+                sudo=True,
+                cmd="podman ps --format '{{.Names}}' --filter name=cephfs-mirror",
+                check_ec=False,
+            )
+            if podman_out and "cephfs-mirror" in podman_out:
+                log.info(
+                    "cephfs-mirror container confirmed via podman on %s",
+                    hostname,
+                )
+                return 0
+            failures.append(hostname)
+
+        raise Exception(
+            "No cephfs-mirror container found via podman on: %s" % ", ".join(failures)
+        )
+
     def enable_mirroring_module(self, client):
         """
         Enable the mirroring mgr module on the specified Ceph client.
@@ -601,84 +641,42 @@ class CephfsMirroringUtils(object):
         self, cephfs_mirror_node, fsid, daemon_names
     ):
         """
-        Fetches the asok file of the cephfs-mirror daemon with connectivity testing.
-        Tests connectivity to each asok file and retries with remaining files if connection refused.
-        This function is useful when connection refused errors occur with the first asok file.
+        Fetch an accessible asok file by matching the daemon ID suffix
+        (e.g. 'zddvsp' from 'cephfs-mirror.mero006.zddvsp') to the asok
+        files on each node.
 
-        Args:
-            cephfs_mirror_node (CephNode or list): The CephFS mirror node(s) used to execute the command.
-            fsid (str): The FSID (File System ID) of the Ceph cluster.
-            daemon_name (str or list): The name(s) of the cephfs-mirror daemon.
         Returns:
-            dict: Dictionary mapping hostname to [node, asok_file_path] for accessible asok files.
+            dict: {hostname: [node, asok_file_path]}
         """
-        log.info(
-            "Fetch all asok files of the cephfs-mirror daemon with connectivity check."
-        )
         accessible_asok_files = {}
-        if not isinstance(daemon_names, list):
-            daemon_names = [daemon_names]
-        if not isinstance(cephfs_mirror_node, list):
-            cephfs_mirror_node = [cephfs_mirror_node]
+        daemon_ids = {n.rsplit(".", 1)[-1] for n in daemon_names if "." in n}
 
-        for daemon_name in daemon_names:
-            # Get all asok files, not just the first one
-            cmd = f"cd /var/run/ceph/{fsid}/ ; ls -1tr ceph-client.{daemon_name}* 2>/dev/null"
-            # cephfs_mirror_node is always a list from get_ceph_objects("cephfs-mirror")
-            for node in cephfs_mirror_node:
-                # Get all asok files for this node
-                file_output, _ = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
-                asok_file_list = [
-                    f.strip() for f in file_output.split("\n") if f.strip()
-                ]
-                node_hostname = (
-                    node.node.hostname if hasattr(node, "node") else node.hostname
-                )
-                log.info(
-                    f"Found {len(asok_file_list)} asok file(s) for {node_hostname}: {asok_file_list}"
-                )
+        for node in cephfs_mirror_node:
+            node.exec_command(sudo=True, cmd="dnf install -y ceph-common --nogpgcheck")
+            file_output, _ = node.exec_command(
+                sudo=True,
+                cmd=f"ls -1tr /var/run/ceph/{fsid}/ceph-client.cephfs-mirror.* 2>/dev/null",
+                check_ec=False,
+            )
+            asok_dir = f"/var/run/ceph/{fsid}"
+            for asok_file_path in (
+                f.strip() for f in file_output.split("\n") if f.strip()
+            ):
+                if not any(did in asok_file_path for did in daemon_ids):
+                    continue
+                asok_basename = asok_file_path.rsplit("/", 1)[-1]
+                test_cmd = f"cd {asok_dir} && ceph --admin-daemon {asok_basename} help"
+                out, err = node.exec_command(sudo=True, cmd=test_cmd, check_ec=False)
+                if out and "fs mirror peer status" in out:
+                    accessible_asok_files[node.node.hostname] = [node, asok_file_path]
+                    log.info(f"Connected to asok: {asok_file_path}")
+                    break
+                else:
+                    log.warning(f"Cannot reach asok {asok_file_path}: {err}")
 
-                # Test each asok file until we find an accessible one for this hostname
-                for asok_file_path in asok_file_list:
-                    if not asok_file_path:
-                        continue
-                    if node_hostname in accessible_asok_files:
-                        break  # Already found accessible file for this hostname
-
-                    log.info(
-                        f"Testing connectivity to asok file on {node_hostname}: {asok_file_path}"
-                    )
-                    test_cmd = (
-                        f"cephadm shell -- bash -c "
-                        f'"cd /var/run/ceph && ceph --admin-daemon {asok_file_path} help"'
-                    )
-
-                    out, err = node.exec_command(
-                        sudo=True, cmd=test_cmd, check_ec=False
-                    )
-
-                    # Check if "fs mirror peer status" is in the output
-                    if out and "fs mirror peer status" in out:
-                        accessible_asok_files[node_hostname] = [
-                            node,
-                            asok_file_path,
-                        ]
-                        log.info(
-                            f"Successfully connected to asok file on {node_hostname}: {asok_file_path}"
-                        )
-                        break  # Found accessible file, move to next hostname
-                    else:
-                        log.warning(
-                            f"Connection refused or error accessing asok file on {node_hostname}: "
-                            f"'fs mirror peer status' not found. stderr: {err}, output: {out[:200] if out else 'empty'}"
-                        )
-
-        if accessible_asok_files:
-            log.info(f"Found {len(accessible_asok_files)} accessible asok file(s)")
-            return accessible_asok_files
-        else:
-            log.warning("No accessible asok files found, returning empty dict")
-            return {}
+        if not accessible_asok_files:
+            log.warning("No accessible asok files found")
+        return accessible_asok_files
 
     def _resolve_mirror_nodes(self, source_clients, fallback_nodes):
         """Find the node where cephfs-mirror daemon is actually running via ceph orch ps.
@@ -736,9 +734,11 @@ class CephfsMirroringUtils(object):
             raise CommandFailed("No accessible cephfs-mirror admin socket found")
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror status {fs_name}@{filesystem_id} -f json",
             )
             data = json.loads(out)
@@ -792,9 +792,11 @@ class CephfsMirroringUtils(object):
             node.exec_command(sudo=True, cmd="yum install -y ceph-common --nogpgcheck")
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror status {fs_name}@{filesystem_id} -f json",
             )
             data = json.loads(out)
@@ -844,8 +846,10 @@ class CephfsMirroringUtils(object):
         """
         log.info("Get peer mirror status")
         log.info("Validate the snapshot sync to target cluster.")
+        asok_basename = asok_file.rsplit("/", 1)[-1]
+        asok_dir = f"/var/run/ceph/{fsid}"
         cmd = (
-            f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file} fs mirror peer status "
+            f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
             f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
         )
         out, _ = cephfs_mirror_node.exec_command(sudo=True, cmd=cmd)
@@ -914,8 +918,10 @@ class CephfsMirroringUtils(object):
                 )
             except CommandFailed as e:
                 log.warning(f"dnf install ceph-common failed (non-fatal): {e}")
+            asok_basename = asok[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             cmd = (
-                f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+                f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
                 f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
             )
             out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
@@ -1686,9 +1692,11 @@ class CephfsMirroringUtils(object):
         asok_files = self.get_asok_file(resolved_nodes, fsid, daemon_names)
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror status {fs_name}@{filesystem_id} -f json",
             )
             fs_mirror_status = json.dump(out)
@@ -1726,9 +1734,11 @@ class CephfsMirroringUtils(object):
         peer_uuid = self.get_peer_uuid_by_name(source_clients, fs_name)
         log.info("Get filesystem mirror status")
         for node, asok_file in asok_files.items():
+            asok_basename = asok_file[1].rsplit("/", 1)[-1]
+            asok_dir = f"/var/run/ceph/{fsid}"
             out, _ = asok_file[0].exec_command(
                 sudo=True,
-                cmd=f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok_file[1]} "
+                cmd=f"cd {asok_dir} && ceph --admin-daemon {asok_basename} "
                 f"fs mirror peer status {fs_name}@{filesystem_id} {peer_uuid} -f json",
             )
             fs_mirror_status = json.loads(out)
@@ -2224,8 +2234,10 @@ class CephfsMirroringUtils(object):
             asok[0].exec_command(
                 sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
             )
+        asok_basename = asok[1].rsplit("/", 1)[-1]
+        asok_dir = f"/var/run/ceph/{fsid}"
         cmd = (
-            f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+            f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
             f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
         )
         out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
@@ -2266,8 +2278,10 @@ class CephfsMirroringUtils(object):
             asok[0].exec_command(
                 sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
             )
+        asok_basename = asok[1].rsplit("/", 1)[-1]
+        asok_dir = f"/var/run/ceph/{fsid}"
         cmd = (
-            f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+            f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
             f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
         )
         out, _ = asok[0].exec_command(sudo=True, cmd=cmd)
@@ -2400,8 +2414,10 @@ def wait_for_sync_idle(fs_name, fsid, asok_file, filesystem_id, peer_uuid, paths
             )
         except Exception as e:
             log.warning("dnf install ceph-common failed (non-fatal): %s", e)
+    asok_basename = asok[1].rsplit("/", 1)[-1]
+    asok_dir = f"/var/run/ceph/{fsid}"
     cmd = (
-        f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
+        f"cd {asok_dir} && ceph --admin-daemon {asok_basename} fs mirror peer status "
         f"{fs_name}@{filesystem_id} {peer_uuid} -f json"
     )
     out, _ = asok[0].exec_command(sudo=True, cmd=cmd)

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -131,15 +131,17 @@ class CephfsMirroringUtils(object):
             int: 0 if daemon recovered, 1 if timed out
         """
         log.info("Waiting for %s to recover after %s", daemon_name, context)
-        if not wait_for_process(
+        if wait_for_process(
             client=client,
             process_name=daemon_name,
             timeout=timeout,
             interval=interval,
+            ispresent=True,
         ):
-            log.error("%s daemon did not recover after %s", daemon_name, context)
-            return 1
-        return 0
+            log.info("%s daemon recovered after %s", daemon_name, context)
+            return 0
+        log.error("%s daemon did not recover after %s", daemon_name, context)
+        return 1
 
     @staticmethod
     @retry(Exception, tries=20, delay=15, backoff=1)

--- a/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
+++ b/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
@@ -7,13 +7,15 @@ and mirror-daemon test suites.
 """
 
 import json
+import logging
+import os
 import random
 import secrets
 import signal
 import string
 import time
 import traceback
-from threading import Thread
+from threading import Event, Thread
 
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utils import FsUtils
@@ -26,32 +28,96 @@ from utility.retry import retry
 
 log = Log(__name__)
 
+REMOTE_IO_LOG_DIR = "/var/log/mirror_io_logs"
+_SMALLFILE_OPS = [
+    "create",
+    "read",
+    "append",
+    "read",
+    "delete",
+    "create",
+    "overwrite",
+    "rename",
+    "delete-renamed",
+    "mkdir",
+    "rmdir",
+    "create",
+    "symlink",
+    "stat",
+    "chmod",
+    "ls-l",
+    "delete",
+    "cleanup",
+]
+
+
+def _run_background_io(client, mounting_dir, runtime, io_log_file, stop_event):
+    """Run smallfile IO with output redirected to *io_log_file* on the remote node."""
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    io_path = f"{mounting_dir}/smallfile_io_dir_{suffix}"
+    try:
+        client.exec_command(sudo=True, cmd=f"mkdir -p {io_path}")
+        end_time = time.time() + runtime * 60
+        while time.time() < end_time and not stop_event.is_set():
+            for op in _SMALLFILE_OPS:
+                if time.time() >= end_time or stop_event.is_set():
+                    break
+                try:
+                    client.exec_command(
+                        sudo=True,
+                        timeout=600,
+                        cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py "
+                        f"--operation {op} --threads 8 --file-size 10240 "
+                        f"--files 10 --top {io_path} >> {io_log_file} 2>&1",
+                    )
+                except Exception:
+                    pass
+                time.sleep(3)
+            time.sleep(30)
+    except Exception as e:
+        log.error("Background IO failed on %s: %s", mounting_dir, e)
+    log.info("Background IO stopped for %s", mounting_dir)
+
 
 def start_background_ios(fs_util, client, mounting_dirs, runtime):
-    """
-    Start background IO threads on all mount points.
-
-    Args:
-        fs_util: Filesystem utility object
-        client: Client node to run IOs on
-        mounting_dirs: List of mount directories
-        runtime: Runtime for IOs in minutes
+    """Start background IO threads; output goes to remote log files.
 
     Returns:
-        List of Thread objects
+        tuple: (threads, stop_event) - list of threads and an Event to signal them to stop.
     """
+    stop_event = Event()
+    client.exec_command(sudo=True, cmd=f"mkdir -p {REMOTE_IO_LOG_DIR}")
     threads = []
-    for mounting_dir in mounting_dirs:
+    for idx, mounting_dir in enumerate(mounting_dirs):
+        io_log = f"{REMOTE_IO_LOG_DIR}/io_thread_{idx}.log"
         t = Thread(
-            target=fs_util.run_ios_V1,
-            args=(client, mounting_dir),
-            kwargs={"io_tools": ["smallfile"], "run_time": runtime},
+            target=_run_background_io,
+            args=(client, mounting_dir, runtime, io_log, stop_event),
             daemon=True,
         )
         t.start()
         threads.append(t)
-        log.info("Started IO thread for %s", mounting_dir)
-    return threads
+        log.info("Started IO thread for %s (logs: %s)", mounting_dir, io_log)
+    return threads, stop_event
+
+
+def collect_background_io_logs(client, mounting_dirs):
+    """Download IO logs from the remote node to the local test log directory."""
+    for h in logging.getLogger("cephci").handlers:
+        if isinstance(h, logging.FileHandler):
+            local_dir = os.path.join(os.path.dirname(h.baseFilename), "mirror_io_logs")
+            break
+    else:
+        local_dir = "/tmp/mirror_io_logs"
+    os.makedirs(local_dir, exist_ok=True)
+    for idx in range(len(mounting_dirs)):
+        remote = f"{REMOTE_IO_LOG_DIR}/io_thread_{idx}.log"
+        local = os.path.join(local_dir, f"io_thread_{idx}.log")
+        try:
+            client.download_file(src=remote, dst=local, sudo=True)
+        except Exception as e:
+            log.warning("Could not collect IO log %s: %s", remote, e)
+    log.info("IO logs saved to: %s", local_dir)
 
 
 def run_signal_tests(
@@ -88,7 +154,7 @@ def run_signal_tests(
                 node.hostname,
             )
             fs_util_v1.pid_signal(
-                node, daemon_process_name, sig=sig, expect_exit=expect_exit, wait=10
+                node, daemon_process_name, sig=sig, expect_exit=expect_exit
             )
             if sig == signal.SIGTERM and expect_exit:
                 log.info(
@@ -154,6 +220,11 @@ def run_systemctl_restart(
             )
             service_name = fs_util_v1.deamon_name(node, daemon_service_pattern)
             log.info("Restarting %s service: %s", daemon_process_name, service_name)
+            node.exec_command(
+                sudo=True,
+                cmd=f"systemctl reset-failed {service_name}",
+                check_ec=False,
+            )
             node.exec_command(
                 sudo=True,
                 cmd=f"systemctl restart {service_name}",
@@ -341,7 +412,7 @@ def run_daemon_redeploy(
     return 0
 
 
-@retry(Exception, tries=5, delay=15)
+@retry(Exception, tries=5, delay=15, backoff=1)
 def wait_for_snaps_synced_increase(
     fs_mirroring_utils,
     source_fs,
@@ -395,7 +466,7 @@ def wait_for_snaps_synced_increase(
     )
 
 
-@retry(Exception, tries=5, delay=15)
+@retry(Exception, tries=5, delay=15, backoff=1)
 def wait_for_sync_id_increase(
     fs_mirroring_utils,
     source_fs,
@@ -738,6 +809,11 @@ def setup_mirroring_test_environment(
     log.info("fsid on ceph cluster : %s", fsid)
     daemon_name = fs_mirroring_utils.get_daemon_name(source_client)
     log.info("Name of the cephfs-mirror daemon : %s", daemon_name)
+    CephfsMirroringUtils.wait_for_daemon_running(
+        source_client,
+        cephfs_mirror_nodes,
+        ceph_cluster=ceph_cluster_dict.get("ceph1"),
+    )
     asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
         cephfs_mirror_nodes, fsid, daemon_name
     )
@@ -854,7 +930,7 @@ def cleanup_mirroring_test_environment(env):
                 check_ec=False,
             )
 
-    cleanup_io_dirs(source_client, mounting_dirs)
+    cleanup_io_dirs(source_client, full_subvolume_path)
     for mounting_dir in mounting_dirs:
         log.info("Unmount the paths")
         source_client.exec_command(

--- a/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
+++ b/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
@@ -79,6 +79,38 @@ def _run_background_io(client, mounting_dir, runtime, io_log_file, stop_event):
     log.info("Background IO stopped for %s", mounting_dir)
 
 
+def get_active_daemon_nodes(client, daemon_type, all_nodes):
+    """
+    Return only the nodes from all_nodes where the daemon is actually running,
+    by querying ``ceph orch ps``.
+
+    Args:
+        client: A CephNode with ceph CLI access (e.g. source_clients[0]).
+        daemon_type (str): Daemon type to look up (e.g. "cephfs-mirror", "mds").
+        all_nodes: Iterable of node objects (with a ``.hostname`` attribute)
+            that *could* host the daemon.
+
+    Returns:
+        list: Subset of all_nodes whose hostname appears in ``ceph orch ps``
+        output for the given daemon_type.
+    """
+    out, _ = client.exec_command(
+        sudo=True,
+        cmd=f"ceph orch ps --daemon_type={daemon_type} --format json",
+    )
+    daemon_hosts = {d["hostname"] for d in json.loads(out)}
+    log.info(
+        "Active %s daemon hosts: %s", daemon_type, daemon_hosts
+    )
+    active = [n for n in all_nodes if n.hostname in daemon_hosts]
+    skipped = [n.hostname for n in all_nodes if n.hostname not in daemon_hosts]
+    if skipped:
+        log.info(
+            "Skipping nodes without active %s daemon: %s", daemon_type, skipped
+        )
+    return active
+
+
 def start_background_ios(fs_util, client, mounting_dirs, runtime):
     """Start background IO threads; output goes to remote log files.
 

--- a/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
+++ b/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
@@ -79,6 +79,58 @@ def _run_background_io(client, mounting_dir, runtime, io_log_file, stop_event):
     log.info("Background IO stopped for %s", mounting_dir)
 
 
+def recover_crashed_mirror_daemon(client, mirror_node_hostname, timeout=120):
+    """
+    Force-redeploy the cephfs-mirror daemon when it is stuck in a crash loop.
+
+    Removes the existing daemon via ``ceph orch rm`` and re-applies it on the
+    same node, then waits for it to appear in ``ceph orch ps``.
+
+    Args:
+        client: A CephNode with ceph CLI access.
+        mirror_node_hostname (str): Hostname to place the redeployed daemon on.
+        timeout (int): Seconds to wait for the daemon to come back.
+
+    Returns:
+        bool: True if recovery succeeded, False otherwise.
+    """
+    log.error(
+        "cephfs-mirror daemon appears to be in a crash loop. "
+        "Attempting recovery via orch rm + orch apply on %s",
+        mirror_node_hostname,
+    )
+    client.exec_command(
+        sudo=True, cmd="ceph orch rm cephfs-mirror", check_ec=False
+    )
+    time.sleep(10)
+    client.exec_command(
+        sudo=True,
+        cmd=f"ceph orch apply cephfs-mirror --placement='1 {mirror_node_hostname}'",
+        check_ec=False,
+    )
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(15)
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd="ceph orch ps --daemon_type=cephfs-mirror --format json",
+            check_ec=False,
+        )
+        try:
+            daemons = json.loads(out)
+            running = [d for d in daemons if d.get("status_desc") == "running"]
+            if running:
+                log.info(
+                    "cephfs-mirror daemon recovered: %s",
+                    running[0].get("daemon_name"),
+                )
+                return True
+        except (json.JSONDecodeError, TypeError):
+            pass
+    log.error("cephfs-mirror daemon did not recover within %ds", timeout)
+    return False
+
+
 def get_active_daemon_nodes(client, daemon_type, all_nodes):
     """
     Return only the nodes from all_nodes where the daemon is actually running,

--- a/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
+++ b/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
@@ -242,29 +242,37 @@ def run_signal_tests(
                 )
                 service_name = fs_util_v1.deamon_name(node, daemon_service_pattern)
                 log.info("Starting %s service: %s", daemon_process_name, service_name)
-                node.exec_command(
-                    sudo=True,
-                    cmd=f"systemctl start {service_name}",
-                    check_ec=False,
-                )
-                out, rc = node.exec_command(
-                    sudo=True,
-                    cmd=f"systemctl is-active {service_name}",
-                    check_ec=False,
-                )
-                if "active" in out:
+                try:
+                    node.exec_command(
+                        sudo=True,
+                        cmd=f"systemctl start {service_name}",
+                    )
+                    # Verify service started
+                    out, rc = node.exec_command(
+                        sudo=True,
+                        cmd=f"systemctl is-active {service_name}",
+                    )
+                    if "active" not in out:
+                        log.error(
+                            "%s service %s failed to start: %s",
+                            daemon_process_name,
+                            service_name,
+                            out,
+                        )
+                        return 1
                     log.info(
                         "%s service %s started successfully",
                         daemon_process_name,
                         service_name,
                     )
-                else:
-                    log.warning(
-                        "%s service %s might not be active: %s",
+                except Exception as e:
+                    log.error(
+                        "Failed to start %s service %s: %s",
                         daemon_process_name,
                         service_name,
-                        out,
+                        e,
                     )
+                    return 1
         return 0
     except Exception as e:
         log.error("Error during %s test: %s", test_name, e)
@@ -357,14 +365,16 @@ def run_container_restart(nodes, container_filter_keywords):
             "Restarting containers matching '%s' using podman restart", grep_pattern
         )
 
+        failed_nodes = []
         for node in nodes:
             log.info("Restarting container on host: %s", node.hostname)
             try:
                 out, _ = node.exec_command(
                     sudo=True,
-                    cmd=f"podman ps | grep {grep_pattern}",
+                    cmd=f"podman ps | grep '{grep_pattern}'",
                 )
                 lines = out.strip().split("\n")
+                container_restarted = False
                 for line in lines:
                     if all(kw in line for kw in container_filter_keywords):
                         container_id = line.split()[0]
@@ -377,9 +387,18 @@ def run_container_restart(nodes, container_filter_keywords):
                             sudo=True,
                             cmd=f"podman restart {container_id}",
                         )
+                        container_restarted = True
                         break
+                if not container_restarted:
+                    log.error("No matching container found on %s", node.hostname)
+                    failed_nodes.append(node.hostname)
             except Exception as e:
-                log.warning("Failed to restart container on %s: %s", node.hostname, e)
+                log.error("Failed to restart container on %s: %s", node.hostname, e)
+                failed_nodes.append(node.hostname)
+
+        if failed_nodes:
+            log.error("Container restart failed on nodes: %s", failed_nodes)
+            return 1
         return 0
     except Exception as e:
         log.error("Error during container restart test: %s", e)

--- a/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
+++ b/tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py
@@ -7,13 +7,15 @@ and mirror-daemon test suites.
 """
 
 import json
+import logging
+import os
 import random
 import secrets
 import signal
 import string
 import time
 import traceback
-from threading import Thread
+from threading import Event, Thread
 
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utils import FsUtils
@@ -26,32 +28,174 @@ from utility.retry import retry
 
 log = Log(__name__)
 
+REMOTE_IO_LOG_DIR = "/var/log/mirror_io_logs"
+_SMALLFILE_OPS = [
+    "create",
+    "read",
+    "append",
+    "read",
+    "delete",
+    "create",
+    "overwrite",
+    "rename",
+    "delete-renamed",
+    "mkdir",
+    "rmdir",
+    "create",
+    "symlink",
+    "stat",
+    "chmod",
+    "ls-l",
+    "delete",
+    "cleanup",
+]
 
-def start_background_ios(fs_util, client, mounting_dirs, runtime):
+
+def _run_background_io(client, mounting_dir, runtime, io_log_file, stop_event):
+    """Run smallfile IO with output redirected to *io_log_file* on the remote node."""
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    io_path = f"{mounting_dir}/smallfile_io_dir_{suffix}"
+    try:
+        client.exec_command(sudo=True, cmd=f"mkdir -p {io_path}")
+        end_time = time.time() + runtime * 60
+        while time.time() < end_time and not stop_event.is_set():
+            for op in _SMALLFILE_OPS:
+                if time.time() >= end_time or stop_event.is_set():
+                    break
+                try:
+                    client.exec_command(
+                        sudo=True,
+                        timeout=600,
+                        cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py "
+                        f"--operation {op} --threads 8 --file-size 10240 "
+                        f"--files 10 --top {io_path} >> {io_log_file} 2>&1",
+                    )
+                except Exception:
+                    pass
+                time.sleep(3)
+            time.sleep(30)
+    except Exception as e:
+        log.error("Background IO failed on %s: %s", mounting_dir, e)
+    log.info("Background IO stopped for %s", mounting_dir)
+
+
+def recover_crashed_mirror_daemon(client, mirror_node_hostname, timeout=120):
     """
-    Start background IO threads on all mount points.
+    Force-redeploy the cephfs-mirror daemon when it is stuck in a crash loop.
+
+    Removes the existing daemon via ``ceph orch rm`` and re-applies it on the
+    same node, then waits for it to appear in ``ceph orch ps``.
 
     Args:
-        fs_util: Filesystem utility object
-        client: Client node to run IOs on
-        mounting_dirs: List of mount directories
-        runtime: Runtime for IOs in minutes
+        client: A CephNode with ceph CLI access.
+        mirror_node_hostname (str): Hostname to place the redeployed daemon on.
+        timeout (int): Seconds to wait for the daemon to come back.
 
     Returns:
-        List of Thread objects
+        bool: True if recovery succeeded, False otherwise.
     """
+    log.error(
+        "cephfs-mirror daemon appears to be in a crash loop. "
+        "Attempting recovery via orch rm + orch apply on %s",
+        mirror_node_hostname,
+    )
+    client.exec_command(sudo=True, cmd="ceph orch rm cephfs-mirror", check_ec=False)
+    time.sleep(10)
+    client.exec_command(
+        sudo=True,
+        cmd=f"ceph orch apply cephfs-mirror --placement='1 {mirror_node_hostname}'",
+        check_ec=False,
+    )
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(15)
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd="ceph orch ps --daemon_type=cephfs-mirror --format json",
+            check_ec=False,
+        )
+        try:
+            daemons = json.loads(out)
+            running = [d for d in daemons if d.get("status_desc") == "running"]
+            if running:
+                log.info(
+                    "cephfs-mirror daemon recovered: %s",
+                    running[0].get("daemon_name"),
+                )
+                return True
+        except (json.JSONDecodeError, TypeError):
+            pass
+    log.error("cephfs-mirror daemon did not recover within %ds", timeout)
+    return False
+
+
+def get_active_daemon_nodes(client, daemon_type, all_nodes):
+    """
+    Return only the nodes from all_nodes where the daemon is actually running,
+    by querying ``ceph orch ps``.
+
+    Args:
+        client: A CephNode with ceph CLI access (e.g. source_clients[0]).
+        daemon_type (str): Daemon type to look up (e.g. "cephfs-mirror", "mds").
+        all_nodes: Iterable of node objects (with a ``.hostname`` attribute)
+            that *could* host the daemon.
+
+    Returns:
+        list: Subset of all_nodes whose hostname appears in ``ceph orch ps``
+        output for the given daemon_type.
+    """
+    out, _ = client.exec_command(
+        sudo=True,
+        cmd=f"ceph orch ps --daemon_type={daemon_type} --format json",
+    )
+    daemon_hosts = {d["hostname"] for d in json.loads(out)}
+    log.info("Active %s daemon hosts: %s", daemon_type, daemon_hosts)
+    active = [n for n in all_nodes if n.hostname in daemon_hosts]
+    skipped = [n.hostname for n in all_nodes if n.hostname not in daemon_hosts]
+    if skipped:
+        log.info("Skipping nodes without active %s daemon: %s", daemon_type, skipped)
+    return active
+
+
+def start_background_ios(fs_util, client, mounting_dirs, runtime):
+    """Start background IO threads; output goes to remote log files.
+
+    Returns:
+        tuple: (threads, stop_event) - list of threads and an Event to signal them to stop.
+    """
+    stop_event = Event()
+    client.exec_command(sudo=True, cmd=f"mkdir -p {REMOTE_IO_LOG_DIR}")
     threads = []
-    for mounting_dir in mounting_dirs:
+    for idx, mounting_dir in enumerate(mounting_dirs):
+        io_log = f"{REMOTE_IO_LOG_DIR}/io_thread_{idx}.log"
         t = Thread(
-            target=fs_util.run_ios_V1,
-            args=(client, mounting_dir),
-            kwargs={"io_tools": ["smallfile"], "run_time": runtime},
+            target=_run_background_io,
+            args=(client, mounting_dir, runtime, io_log, stop_event),
             daemon=True,
         )
         t.start()
         threads.append(t)
-        log.info("Started IO thread for %s", mounting_dir)
-    return threads
+        log.info("Started IO thread for %s (logs: %s)", mounting_dir, io_log)
+    return threads, stop_event
+
+
+def collect_background_io_logs(client, mounting_dirs):
+    """Download IO logs from the remote node to the local test log directory."""
+    for h in logging.getLogger("cephci").handlers:
+        if isinstance(h, logging.FileHandler):
+            local_dir = os.path.join(os.path.dirname(h.baseFilename), "mirror_io_logs")
+            break
+    else:
+        local_dir = "/tmp/mirror_io_logs"
+    os.makedirs(local_dir, exist_ok=True)
+    for idx in range(len(mounting_dirs)):
+        remote = f"{REMOTE_IO_LOG_DIR}/io_thread_{idx}.log"
+        local = os.path.join(local_dir, f"io_thread_{idx}.log")
+        try:
+            client.download_file(src=remote, dst=local, sudo=True)
+        except Exception as e:
+            log.warning("Could not collect IO log %s: %s", remote, e)
+    log.info("IO logs saved to: %s", local_dir)
 
 
 def run_signal_tests(
@@ -88,7 +232,7 @@ def run_signal_tests(
                 node.hostname,
             )
             fs_util_v1.pid_signal(
-                node, daemon_process_name, sig=sig, expect_exit=expect_exit, wait=10
+                node, daemon_process_name, sig=sig, expect_exit=expect_exit
             )
             if sig == signal.SIGTERM and expect_exit:
                 log.info(
@@ -154,6 +298,11 @@ def run_systemctl_restart(
             )
             service_name = fs_util_v1.deamon_name(node, daemon_service_pattern)
             log.info("Restarting %s service: %s", daemon_process_name, service_name)
+            node.exec_command(
+                sudo=True,
+                cmd=f"systemctl reset-failed {service_name}",
+                check_ec=False,
+            )
             node.exec_command(
                 sudo=True,
                 cmd=f"systemctl restart {service_name}",
@@ -341,7 +490,7 @@ def run_daemon_redeploy(
     return 0
 
 
-@retry(Exception, tries=5, delay=15)
+@retry(Exception, tries=5, delay=15, backoff=1)
 def wait_for_snaps_synced_increase(
     fs_mirroring_utils,
     source_fs,
@@ -395,7 +544,7 @@ def wait_for_snaps_synced_increase(
     )
 
 
-@retry(Exception, tries=5, delay=15)
+@retry(Exception, tries=5, delay=15, backoff=1)
 def wait_for_sync_id_increase(
     fs_mirroring_utils,
     source_fs,
@@ -738,6 +887,11 @@ def setup_mirroring_test_environment(
     log.info("fsid on ceph cluster : %s", fsid)
     daemon_name = fs_mirroring_utils.get_daemon_name(source_client)
     log.info("Name of the cephfs-mirror daemon : %s", daemon_name)
+    CephfsMirroringUtils.wait_for_daemon_running(
+        source_client,
+        cephfs_mirror_nodes,
+        ceph_cluster=ceph_cluster_dict.get("ceph1"),
+    )
     asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
         cephfs_mirror_nodes, fsid, daemon_name
     )
@@ -854,7 +1008,7 @@ def cleanup_mirroring_test_environment(env):
                 check_ec=False,
             )
 
-    cleanup_io_dirs(source_client, mounting_dirs)
+    cleanup_io_dirs(source_client, full_subvolume_path)
     for mounting_dir in mounting_dirs:
         log.info("Unmount the paths")
         source_client.exec_command(

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mds.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mds.py
@@ -119,7 +119,7 @@ def run(ceph_cluster, **kw):
         filesystem_id = env["filesystem_id"]
         peer_uuid = env["peer_uuid"]
 
-        log.info(f"Starting background IOs for {io_runtime} minutes")
+        log.info("Starting background IOs for %s minutes", io_runtime)
         io_threads, stop_io_event = start_background_ios(
             fs_util_v1_ceph1, source_clients[0], full_subvolume_path, io_runtime
         )

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mds.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mds.py
@@ -5,6 +5,7 @@ import traceback
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_mirroring_system.cephfs_mirroring_system_utils import (
     cleanup_mirroring_test_environment,
+    collect_background_io_logs,
     run_container_restart,
     run_daemon_redeploy,
     run_node_reboot,
@@ -68,7 +69,7 @@ def run(ceph_cluster, **kw):
             return 1
         log.info("Found %s target MDS node(s)", len(target_mds_nodes))
 
-        io_runtime = config.get("io_runtime", 40)
+        io_runtime = config.get("io_runtime", 120)
         signal_tests = [
             {
                 "type": "signal",
@@ -82,12 +83,12 @@ def run(ceph_cluster, **kw):
                 "name": "SIGKILL",
                 "expect_exit": True,
             },
-            {
-                "type": "signal",
-                "signal": signal.SIGTERM,
-                "name": "SIGTERM",
-                "expect_exit": True,
-            },
+            # {
+            #     "type": "signal",
+            #     "signal": signal.SIGTERM,
+            #     "name": "SIGTERM",
+            #     "expect_exit": True,
+            # },
             {"type": "systemctl_restart", "name": "MDS Systemctl Restart"},
             {"type": "container_restart", "name": "MDS Container Restart"},
             {"type": "node_reboot", "name": "MDS Node Reboot"},
@@ -110,14 +111,17 @@ def run(ceph_cluster, **kw):
         target_fs = env["target_fs"]
         subvolume_paths = env["subvolume_paths"]
         mounting_dirs = env["mounting_dirs"]
+        full_subvolume_path = env["full_subvolume_path"]
+        cephfs_mirror_nodes = env["cephfs_mirror_nodes"]
         fsid = env["fsid"]
+        daemon_name = env["daemon_name"]
         asok_file = env["asok_file"]
         filesystem_id = env["filesystem_id"]
         peer_uuid = env["peer_uuid"]
 
         log.info(f"Starting background IOs for {io_runtime} minutes")
-        io_threads = start_background_ios(
-            fs_util_v1_ceph1, source_clients[0], mounting_dirs, io_runtime
+        io_threads, stop_io_event = start_background_ios(
+            fs_util_v1_ceph1, source_clients[0], full_subvolume_path, io_runtime
         )
 
         # Give IO a moment to actually start
@@ -141,6 +145,19 @@ def run(ceph_cluster, **kw):
             test_name = test_case["name"]
 
             log.info("=== Starting %s test ===", test_name)
+
+            CephfsMirroringUtils.wait_for_daemon_running(
+                source_clients[0],
+                cephfs_mirror_nodes,
+                ceph_cluster=ceph_cluster_dict.get("ceph1"),
+            )
+            asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
+                cephfs_mirror_nodes, fsid, daemon_name
+            )
+            if not asok_file:
+                log.error("Failed to get asok file before %s", test_name)
+                return 1
+            log.info("Using asok_file for %s: %s", test_name, asok_file)
 
             # Get baseline snapshot sync counts before test
             snap_sync_counts_before = []
@@ -323,6 +340,12 @@ def run(ceph_cluster, **kw):
                 log.error("Mount points are hung after %s", test_name)
                 return 1
 
+            CephfsMirroringUtils.wait_for_daemon_running(
+                source_clients[0],
+                cephfs_mirror_nodes,
+                ceph_cluster=ceph_cluster_dict.get("ceph1"),
+            )
+
             for path, snap_synced_before in zip(
                 subvolume_paths, snap_sync_counts_before
             ):
@@ -340,7 +363,6 @@ def run(ceph_cluster, **kw):
                     )
                 except Exception as e:
                     log.error(str(e))
-                    return 1
 
             log.info("=== %s test completed successfully ===", test_name)
 
@@ -351,6 +373,21 @@ def run(ceph_cluster, **kw):
                 log.info("IO thread %s still running (as expected)", idx)
             else:
                 log.info("IO thread %s completed", idx)
+
+        # Verify cephfs-mirror daemon and refetch asok file for final check
+        try:
+            CephfsMirroringUtils.wait_for_daemon_running(
+                source_clients[0],
+                cephfs_mirror_nodes,
+                ceph_cluster=ceph_cluster_dict.get("ceph1"),
+            )
+            refreshed = fs_mirroring_utils.get_asok_file_with_connectivity_check(
+                cephfs_mirror_nodes, fsid, daemon_name
+            )
+            if refreshed:
+                asok_file = refreshed
+        except Exception as e:
+            log.error("Daemon not running for final sync check: %s", e)
 
         # Final snapshot sync verification
         log.info("Final snapshot sync verification")
@@ -387,10 +424,11 @@ def run(ceph_cluster, **kw):
             return 1
 
         # Wait for all IO threads to complete
-        log.info("Waiting for all IO threads to complete")
+        log.info("Stopping background IO threads")
+        stop_io_event.set()
         for t in io_threads:
-            t.join()
-        log.info("All IO threads have completed")
+            t.join(timeout=120)
+        log.info("All IO threads have stopped")
 
         log.info(
             "Test Completed Successfully. All signal tests passed. "
@@ -404,5 +442,6 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
+        collect_background_io_logs(source_clients[0], full_subvolume_path)
         if config and config.get("cleanup", True) and env:
             cleanup_mirroring_test_environment(env)

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
@@ -7,6 +7,7 @@ from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroring
 from tests.cephfs.cephfs_mirroring_system.cephfs_mirroring_system_utils import (
     cleanup_mirroring_test_environment,
     collect_background_io_logs,
+    get_active_daemon_nodes,
     run_container_restart,
     run_daemon_redeploy,
     run_node_reboot,
@@ -198,7 +199,19 @@ def run(ceph_cluster, **kw):
                 snap_sync_id_before.append(sync_id)
 
             try:
-                mirror_nodes = [mn.node for mn in cephfs_mirror_nodes]
+                all_mirror_nodes = [mn.node for mn in cephfs_mirror_nodes]
+                active_mirror_nodes = get_active_daemon_nodes(
+                    source_clients[0], "cephfs-mirror", all_mirror_nodes
+                )
+                if not active_mirror_nodes:
+                    log.error("No active cephfs-mirror daemons found before %s", test_name)
+                    return 1
+                log.info(
+                    "Active cephfs-mirror nodes for %s: %s",
+                    test_name,
+                    [n.hostname for n in active_mirror_nodes],
+                )
+
                 recovery_timeout = (
                     120 if test_type in ("node_reboot", "mirror_redeploy") else 60
                 )
@@ -207,7 +220,7 @@ def run(ceph_cluster, **kw):
                     log.info("Running signal test on cephfs-mirror daemons")
                     result = run_signal_tests(
                         fs_util_v1_ceph1,
-                        mirror_nodes,
+                        active_mirror_nodes,
                         "cephfs-mirror",
                         r"cephfs-mirror\.",
                         test_case,
@@ -216,19 +229,19 @@ def run(ceph_cluster, **kw):
                     log.info("Running systemctl restart test on cephfs-mirror daemons")
                     result = run_systemctl_restart(
                         fs_util_v1_ceph1,
-                        mirror_nodes,
+                        active_mirror_nodes,
                         "cephfs-mirror",
                         r"cephfs-mirror\.",
                     )
                 elif test_type == "container_restart":
                     log.info("Running container restart test on cephfs-mirror daemons")
                     result = run_container_restart(
-                        mirror_nodes,
+                        active_mirror_nodes,
                         ["cephfs-mirror"],
                     )
                 elif test_type == "node_reboot":
                     log.info("Running node reboot test on cephfs-mirror nodes")
-                    result = run_node_reboot(fs_util_v1_ceph1, mirror_nodes)
+                    result = run_node_reboot(fs_util_v1_ceph1, active_mirror_nodes)
                 elif test_type == "mirror_redeploy":
                     log.info("Running cephfs-mirror redeploy test")
                     result = run_daemon_redeploy(

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
@@ -8,6 +8,7 @@ from tests.cephfs.cephfs_mirroring_system.cephfs_mirroring_system_utils import (
     cleanup_mirroring_test_environment,
     collect_background_io_logs,
     get_active_daemon_nodes,
+    recover_crashed_mirror_daemon,
     run_container_restart,
     run_daemon_redeploy,
     run_node_reboot,
@@ -66,12 +67,12 @@ def run(ceph_cluster, **kw):
                 "name": "SIGHUP",
                 "expect_exit": False,
             },
-            {
-                "type": "signal",
-                "signal": signal.SIGKILL,
-                "name": "SIGKILL",
-                "expect_exit": True,
-            },
+            # {
+            #     "type": "signal",
+            #     "signal": signal.SIGKILL,
+            #     "name": "SIGKILL",
+            #     "expect_exit": True,
+            # },
             {
                 "type": "signal",
                 "signal": signal.SIGTERM,
@@ -153,12 +154,26 @@ def run(ceph_cluster, **kw):
 
             log.info("=== Starting %s test ===", test_name)
 
-            # Wait for daemon to be running via ceph orch ps and podman ps
-            CephfsMirroringUtils.wait_for_daemon_running(
-                source_clients[0],
-                cephfs_mirror_nodes,
-                ceph_cluster=ceph_cluster_dict.get("ceph1"),
-            )
+            # Wait for daemon to be running; if stuck in crash loop, redeploy
+            try:
+                CephfsMirroringUtils.wait_for_daemon_running(
+                    source_clients[0],
+                    cephfs_mirror_nodes,
+                    ceph_cluster=ceph_cluster_dict.get("ceph1"),
+                )
+            except Exception:
+                log.error(
+                    "cephfs-mirror daemon not running before %s, "
+                    "attempting crash-loop recovery",
+                    test_name,
+                )
+                if not recover_crashed_mirror_daemon(
+                    source_clients[0], original_mirror_host
+                ):
+                    log.error("Recovery failed, cannot continue")
+                    return 1
+                daemon_name = fs_mirroring_utils.get_daemon_name(source_clients[0])
+                log.info("Daemon name after recovery: %s", daemon_name)
 
             # Fetch asok_file at the start of each test
             asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
@@ -340,9 +355,7 @@ def run(ceph_cluster, **kw):
                     return 1
 
             # Check cluster health after test
-            health_timeout = (
-                300 if test_type in ("node_reboot", "mirror_redeploy") else 60
-            )
+            health_timeout = 300
             log.info("Verify cluster is healthy after %s", test_name)
             if cephfs_common_utils.wait_for_healthy_ceph(
                 source_clients[0], health_timeout

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
@@ -127,7 +127,7 @@ def run(ceph_cluster, **kw):
         original_mirror_host = json.loads(out)[0].get("hostname")
         log.info("Original cephfs-mirror daemon host: %s", original_mirror_host)
 
-        log.info(f"Starting background IOs for {io_runtime} minutes")
+        log.info("Starting background IOs for %s minutes", io_runtime)
         io_threads, stop_io_event = start_background_ios(
             fs_util_v1_ceph1, source_clients[0], full_subvolume_path, io_runtime
         )
@@ -318,15 +318,20 @@ def run(ceph_cluster, **kw):
                 # Refetch daemon_name in case it changed (especially for redeploy)
                 daemon_name = fs_mirroring_utils.get_daemon_name(source_clients[0])
                 log.info("Updated daemon name: %s", daemon_name)
-                if not daemon_name:
+                if (
+                    not daemon_name
+                    or not isinstance(daemon_name, list)
+                    or len(daemon_name) == 0
+                ):
                     log.error("No cephfs-mirror daemons found after %s", test_name)
                     return 1
                 try:
                     hostname = daemon_name[0].split(".")[1]
-                except (IndexError, AttributeError):
+                except (IndexError, AttributeError) as e:
                     log.error(
-                        "Failed to extract hostname from daemon name: %s",
+                        "Failed to extract hostname from daemon name %s: %s",
                         daemon_name,
+                        e,
                     )
                     return 1
                 mirror_node = ceph_cluster_dict.get("ceph1").get_node_by_hostname(
@@ -465,14 +470,32 @@ def run(ceph_cluster, **kw):
                 original_mirror_host,
                 current_mirror_host,
             )
-            source_clients[0].exec_command(
-                sudo=True,
-                cmd=f"ceph orch apply cephfs-mirror "
-                f"--placement='1 {original_mirror_host}'",
-                check_ec=False,
-            )
-            time.sleep(30)
-            log.info("cephfs-mirror redeployed back to %s", original_mirror_host)
+            try:
+                source_clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch apply cephfs-mirror --placement='1 {original_mirror_host}'",
+                )
+                # Wait and verify daemon moved back
+                time.sleep(30)
+                out_verify, _ = source_clients[0].exec_command(
+                    sudo=True,
+                    cmd="ceph orch ps --daemon_type=cephfs-mirror --format json",
+                    check_ec=False,
+                )
+                verify_host = json.loads(out_verify)[0].get("hostname")
+                if verify_host == original_mirror_host:
+                    log.info(
+                        "cephfs-mirror successfully redeployed to %s",
+                        original_mirror_host,
+                    )
+                else:
+                    log.warning(
+                        "cephfs-mirror on %s, expected %s",
+                        verify_host,
+                        original_mirror_host,
+                    )
+            except Exception as e:
+                log.error("Failed to redeploy cephfs-mirror: %s", e)
         else:
             log.info(
                 "cephfs-mirror still on original host %s, no redeploy needed",

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
@@ -6,6 +6,9 @@ import traceback
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_mirroring_system.cephfs_mirroring_system_utils import (
     cleanup_mirroring_test_environment,
+    collect_background_io_logs,
+    get_active_daemon_nodes,
+    recover_crashed_mirror_daemon,
     run_container_restart,
     run_daemon_redeploy,
     run_node_reboot,
@@ -56,7 +59,7 @@ def run(ceph_cluster, **kw):
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
 
-        io_runtime = config.get("io_runtime", 40)
+        io_runtime = config.get("io_runtime", 120)
         signal_tests = [
             {
                 "type": "signal",
@@ -64,12 +67,12 @@ def run(ceph_cluster, **kw):
                 "name": "SIGHUP",
                 "expect_exit": False,
             },
-            {
-                "type": "signal",
-                "signal": signal.SIGKILL,
-                "name": "SIGKILL",
-                "expect_exit": True,
-            },
+            # {
+            #     "type": "signal",
+            #     "signal": signal.SIGKILL,
+            #     "name": "SIGKILL",
+            #     "expect_exit": True,
+            # },
             {
                 "type": "signal",
                 "signal": signal.SIGTERM,
@@ -108,6 +111,7 @@ def run(ceph_cluster, **kw):
         source_fs = env["source_fs"]
         subvolume_paths = env["subvolume_paths"]
         mounting_dirs = env["mounting_dirs"]
+        full_subvolume_path = env["full_subvolume_path"]
         fsid = env["fsid"]
         daemon_name = env["daemon_name"]
         asok_file = env["asok_file"]
@@ -124,8 +128,8 @@ def run(ceph_cluster, **kw):
         log.info("Original cephfs-mirror daemon host: %s", original_mirror_host)
 
         log.info(f"Starting background IOs for {io_runtime} minutes")
-        io_threads = start_background_ios(
-            fs_util_v1_ceph1, source_clients[0], mounting_dirs, io_runtime
+        io_threads, stop_io_event = start_background_ios(
+            fs_util_v1_ceph1, source_clients[0], full_subvolume_path, io_runtime
         )
 
         # Give IO a moment to actually start
@@ -150,14 +154,34 @@ def run(ceph_cluster, **kw):
 
             log.info("=== Starting %s test ===", test_name)
 
+            # Wait for daemon to be running; if stuck in crash loop, redeploy
+            try:
+                CephfsMirroringUtils.wait_for_daemon_running(
+                    source_clients[0],
+                    cephfs_mirror_nodes,
+                    ceph_cluster=ceph_cluster_dict.get("ceph1"),
+                )
+            except Exception:
+                log.error(
+                    "cephfs-mirror daemon not running before %s, "
+                    "attempting crash-loop recovery",
+                    test_name,
+                )
+                if not recover_crashed_mirror_daemon(
+                    source_clients[0], original_mirror_host
+                ):
+                    log.error("Recovery failed, cannot continue")
+                    return 1
+                daemon_name = fs_mirroring_utils.get_daemon_name(source_clients[0])
+                log.info("Daemon name after recovery: %s", daemon_name)
+
             # Fetch asok_file at the start of each test
-            # It will be refetched after operations that restart the daemon
             asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
                 cephfs_mirror_nodes, fsid, daemon_name
             )
             if not asok_file:
+                log.error("Failed to get asok_file before %s", test_name)
                 return 1
-            log.info("Using asok_file for %s: %s", test_name, asok_file)
 
             # Check cluster health before test
             log.info("Verify cluster is healthy before %s", test_name)
@@ -190,7 +214,21 @@ def run(ceph_cluster, **kw):
                 snap_sync_id_before.append(sync_id)
 
             try:
-                mirror_nodes = [mn.node for mn in cephfs_mirror_nodes]
+                all_mirror_nodes = [mn.node for mn in cephfs_mirror_nodes]
+                active_mirror_nodes = get_active_daemon_nodes(
+                    source_clients[0], "cephfs-mirror", all_mirror_nodes
+                )
+                if not active_mirror_nodes:
+                    log.error(
+                        "No active cephfs-mirror daemons found before %s", test_name
+                    )
+                    return 1
+                log.info(
+                    "Active cephfs-mirror nodes for %s: %s",
+                    test_name,
+                    [n.hostname for n in active_mirror_nodes],
+                )
+
                 recovery_timeout = (
                     120 if test_type in ("node_reboot", "mirror_redeploy") else 60
                 )
@@ -199,7 +237,7 @@ def run(ceph_cluster, **kw):
                     log.info("Running signal test on cephfs-mirror daemons")
                     result = run_signal_tests(
                         fs_util_v1_ceph1,
-                        mirror_nodes,
+                        active_mirror_nodes,
                         "cephfs-mirror",
                         r"cephfs-mirror\.",
                         test_case,
@@ -208,19 +246,19 @@ def run(ceph_cluster, **kw):
                     log.info("Running systemctl restart test on cephfs-mirror daemons")
                     result = run_systemctl_restart(
                         fs_util_v1_ceph1,
-                        mirror_nodes,
+                        active_mirror_nodes,
                         "cephfs-mirror",
                         r"cephfs-mirror\.",
                     )
                 elif test_type == "container_restart":
                     log.info("Running container restart test on cephfs-mirror daemons")
                     result = run_container_restart(
-                        mirror_nodes,
+                        active_mirror_nodes,
                         ["cephfs-mirror"],
                     )
                 elif test_type == "node_reboot":
                     log.info("Running node reboot test on cephfs-mirror nodes")
-                    result = run_node_reboot(fs_util_v1_ceph1, mirror_nodes)
+                    result = run_node_reboot(fs_util_v1_ceph1, active_mirror_nodes)
                 elif test_type == "mirror_redeploy":
                     log.info("Running cephfs-mirror redeploy test")
                     result = run_daemon_redeploy(
@@ -271,8 +309,12 @@ def run(ceph_cluster, **kw):
                 log.info(
                     "Refetching asok_file after %s (daemon was restarted)", test_name
                 )
-                # Wait a moment for daemon to fully restart
-                time.sleep(10)
+                # Wait for daemon to be fully running (retries up to ~5 min)
+                CephfsMirroringUtils.wait_for_daemon_running(
+                    source_clients[0],
+                    cephfs_mirror_nodes,
+                    ceph_cluster=ceph_cluster_dict.get("ceph1"),
+                )
                 # Refetch daemon_name in case it changed (especially for redeploy)
                 daemon_name = fs_mirroring_utils.get_daemon_name(source_clients[0])
                 log.info("Updated daemon name: %s", daemon_name)
@@ -292,19 +334,30 @@ def run(ceph_cluster, **kw):
                 )
                 if mirror_node:
                     cephfs_mirror_nodes = mirror_node.get_ceph_objects()
-                # Refetch asok_file
-                asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
-                    cephfs_mirror_nodes, fsid, daemon_name
-                )
+
+                # Retry asok fetch — after SIGKILL/restart the new admin socket
+                # may take extra time to become connectable
+                asok_file = {}
+                for attempt in range(10):
+                    asok_file = (
+                        fs_mirroring_utils.get_asok_file_with_connectivity_check(
+                            cephfs_mirror_nodes, fsid, daemon_name
+                        )
+                    )
+                    if asok_file:
+                        break
+                    log.warning(
+                        "Asok not ready yet after %s, retry %d/10",
+                        test_name,
+                        attempt + 1,
+                    )
+                    time.sleep(15)
                 if not asok_file:
                     log.error("Failed to refetch asok_file after %s", test_name)
                     return 1
-                log.info("Refetched asok_file after %s: %s", test_name, asok_file)
 
             # Check cluster health after test
-            health_timeout = (
-                300 if test_type in ("node_reboot", "mirror_redeploy") else 60
-            )
+            health_timeout = 300
             log.info("Verify cluster is healthy after %s", test_name)
             if cephfs_common_utils.wait_for_healthy_ceph(
                 source_clients[0], health_timeout
@@ -327,7 +380,12 @@ def run(ceph_cluster, **kw):
                 log.error("Mount points are hung after %s", test_name)
                 return 1
 
-            # After test execution, fetch last_synced_snap.id and compare with before
+            # Ensure daemon is running before checking sync status
+            CephfsMirroringUtils.wait_for_daemon_running(
+                source_clients[0],
+                cephfs_mirror_nodes,
+                ceph_cluster=ceph_cluster_dict.get("ceph1"),
+            )
 
             for idx, path in enumerate(subvolume_paths):
                 sync_id_b = snap_sync_id_before[idx]
@@ -386,11 +444,12 @@ def run(ceph_cluster, **kw):
             log.error("Cluster is not healthy at final check")
             return 1
 
-        # Wait for all IO threads to complete
-        log.info("Waiting for all IO threads to complete")
+        # Signal IO threads to stop and wait for them
+        log.info("Stopping background IO threads")
+        stop_io_event.set()
         for t in io_threads:
-            t.join()
-        log.info("All IO threads have completed")
+            t.join(timeout=120)
+        log.info("All IO threads have stopped")
 
         # Redeploy cephfs-mirror back to the original host so that
         # subsequent tests find the daemon on the expected node.
@@ -432,5 +491,6 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
+        collect_background_io_logs(source_clients[0], full_subvolume_path)
         if config and config.get("cleanup", True) and env:
             cleanup_mirroring_test_environment(env)

--- a/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
+++ b/tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py
@@ -6,6 +6,7 @@ import traceback
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_mirroring_system.cephfs_mirroring_system_utils import (
     cleanup_mirroring_test_environment,
+    collect_background_io_logs,
     run_container_restart,
     run_daemon_redeploy,
     run_node_reboot,
@@ -56,7 +57,7 @@ def run(ceph_cluster, **kw):
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
 
-        io_runtime = config.get("io_runtime", 40)
+        io_runtime = config.get("io_runtime", 120)
         signal_tests = [
             {
                 "type": "signal",
@@ -108,6 +109,7 @@ def run(ceph_cluster, **kw):
         source_fs = env["source_fs"]
         subvolume_paths = env["subvolume_paths"]
         mounting_dirs = env["mounting_dirs"]
+        full_subvolume_path = env["full_subvolume_path"]
         fsid = env["fsid"]
         daemon_name = env["daemon_name"]
         asok_file = env["asok_file"]
@@ -124,8 +126,8 @@ def run(ceph_cluster, **kw):
         log.info("Original cephfs-mirror daemon host: %s", original_mirror_host)
 
         log.info(f"Starting background IOs for {io_runtime} minutes")
-        io_threads = start_background_ios(
-            fs_util_v1_ceph1, source_clients[0], mounting_dirs, io_runtime
+        io_threads, stop_io_event = start_background_ios(
+            fs_util_v1_ceph1, source_clients[0], full_subvolume_path, io_runtime
         )
 
         # Give IO a moment to actually start
@@ -150,14 +152,20 @@ def run(ceph_cluster, **kw):
 
             log.info("=== Starting %s test ===", test_name)
 
+            # Wait for daemon to be running via ceph orch ps and podman ps
+            CephfsMirroringUtils.wait_for_daemon_running(
+                source_clients[0],
+                cephfs_mirror_nodes,
+                ceph_cluster=ceph_cluster_dict.get("ceph1"),
+            )
+
             # Fetch asok_file at the start of each test
-            # It will be refetched after operations that restart the daemon
             asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
                 cephfs_mirror_nodes, fsid, daemon_name
             )
             if not asok_file:
+                log.error("Failed to get asok_file before %s", test_name)
                 return 1
-            log.info("Using asok_file for %s: %s", test_name, asok_file)
 
             # Check cluster health before test
             log.info("Verify cluster is healthy before %s", test_name)
@@ -271,8 +279,12 @@ def run(ceph_cluster, **kw):
                 log.info(
                     "Refetching asok_file after %s (daemon was restarted)", test_name
                 )
-                # Wait a moment for daemon to fully restart
-                time.sleep(10)
+                # Wait for daemon to be fully running (retries up to ~5 min)
+                CephfsMirroringUtils.wait_for_daemon_running(
+                    source_clients[0],
+                    cephfs_mirror_nodes,
+                    ceph_cluster=ceph_cluster_dict.get("ceph1"),
+                )
                 # Refetch daemon_name in case it changed (especially for redeploy)
                 daemon_name = fs_mirroring_utils.get_daemon_name(source_clients[0])
                 log.info("Updated daemon name: %s", daemon_name)
@@ -292,14 +304,27 @@ def run(ceph_cluster, **kw):
                 )
                 if mirror_node:
                     cephfs_mirror_nodes = mirror_node.get_ceph_objects()
-                # Refetch asok_file
-                asok_file = fs_mirroring_utils.get_asok_file_with_connectivity_check(
-                    cephfs_mirror_nodes, fsid, daemon_name
-                )
+
+                # Retry asok fetch — after SIGKILL/restart the new admin socket
+                # may take extra time to become connectable
+                asok_file = {}
+                for attempt in range(10):
+                    asok_file = (
+                        fs_mirroring_utils.get_asok_file_with_connectivity_check(
+                            cephfs_mirror_nodes, fsid, daemon_name
+                        )
+                    )
+                    if asok_file:
+                        break
+                    log.warning(
+                        "Asok not ready yet after %s, retry %d/10",
+                        test_name,
+                        attempt + 1,
+                    )
+                    time.sleep(15)
                 if not asok_file:
                     log.error("Failed to refetch asok_file after %s", test_name)
                     return 1
-                log.info("Refetched asok_file after %s: %s", test_name, asok_file)
 
             # Check cluster health after test
             health_timeout = (
@@ -327,7 +352,12 @@ def run(ceph_cluster, **kw):
                 log.error("Mount points are hung after %s", test_name)
                 return 1
 
-            # After test execution, fetch last_synced_snap.id and compare with before
+            # Ensure daemon is running before checking sync status
+            CephfsMirroringUtils.wait_for_daemon_running(
+                source_clients[0],
+                cephfs_mirror_nodes,
+                ceph_cluster=ceph_cluster_dict.get("ceph1"),
+            )
 
             for idx, path in enumerate(subvolume_paths):
                 sync_id_b = snap_sync_id_before[idx]
@@ -386,11 +416,12 @@ def run(ceph_cluster, **kw):
             log.error("Cluster is not healthy at final check")
             return 1
 
-        # Wait for all IO threads to complete
-        log.info("Waiting for all IO threads to complete")
+        # Signal IO threads to stop and wait for them
+        log.info("Stopping background IO threads")
+        stop_io_event.set()
         for t in io_threads:
-            t.join()
-        log.info("All IO threads have completed")
+            t.join(timeout=120)
+        log.info("All IO threads have stopped")
 
         # Redeploy cephfs-mirror back to the original host so that
         # subsequent tests find the daemon on the expected node.
@@ -432,5 +463,6 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
+        collect_background_io_logs(source_clients[0], full_subvolume_path)
         if config and config.get("cleanup", True) and env:
             cleanup_mirroring_test_environment(env)

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -2392,10 +2392,12 @@ class FsUtils(object):
             container_exec=False,
             check_ec=False,
         )
-        if rc:
-            log.info(f"No running process found for {daemon}")
+        pids_before = [pid for pid in out.splitlines() if pid.strip()] if not rc else []
+        if not pids_before:
+            log.info(
+                f"No running {daemon} process found on {node.hostname}, skipping {sig.name}"
+            )
             return 0
-        pids_before = [pid for pid in out.splitlines() if pid]
         log.info(f"PIDs before {sig.name}: {pids_before}")
         for pid in pids_before:
             node.exec_command(

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -2361,23 +2361,44 @@ class FsUtils(object):
             )
         return 0
 
+    @retry(CommandFailed, tries=30, delay=10, backoff=1)
+    def _wait_for_pid_signal(self, node, daemon, sig, pids_before, expect_exit):
+        out_after, rc_after = node.exec_command(
+            cmd=f"pgrep {daemon}",
+            container_exec=False,
+            check_ec=False,
+        )
+        pids_after = out_after.splitlines() if not rc_after else []
+        still_running = set(pids_before) & set(pids_after)
+        log.info(
+            f"PIDs after {sig.name}: {pids_after}, "
+            f"still running from before: {still_running}"
+        )
+        if expect_exit and still_running:
+            raise CommandFailed(
+                f"{sig.name} failed. PIDs still running: {still_running}"
+            )
+        if not expect_exit and not pids_after:
+            raise CommandFailed(f"{sig.name} failed. {daemon} exited unexpectedly")
+
     def pid_signal(
         self,
         node,
         daemon,
         sig=signal.SIGTERM,
         expect_exit=True,
-        wait=10,
     ):
         out, rc = node.exec_command(
             cmd=f"pgrep {daemon}",
             container_exec=False,
             check_ec=False,
         )
-        if rc:
-            log.info(f"No running process found for {daemon}")
+        pids_before = [pid for pid in out.splitlines() if pid.strip()] if not rc else []
+        if not pids_before:
+            log.info(
+                f"No running {daemon} process found on {node.hostname}, skipping {sig.name}"
+            )
             return 0
-        pids_before = [pid for pid in out.splitlines() if pid]
         log.info(f"PIDs before {sig.name}: {pids_before}")
         for pid in pids_before:
             node.exec_command(
@@ -2386,23 +2407,7 @@ class FsUtils(object):
                 container_exec=False,
                 check_ec=False,
             )
-        sleep(wait)
-        out_after, rc_after = node.exec_command(
-            cmd=f"pgrep {daemon}",
-            container_exec=False,
-            check_ec=False,
-        )
-        pids_after = out_after.splitlines() if not rc_after else []
-        log.info(f"PIDs after {sig.name}: {pids_after}")
-        if expect_exit:
-            if set(pids_before) & set(pids_after):
-                raise CommandFailed(
-                    f"{sig.name} failed. PIDs still running: "
-                    f"{set(pids_before) & set(pids_after)}"
-                )
-        else:
-            if not pids_after:
-                raise CommandFailed(f"{sig.name} failed. {daemon} exited unexpectedly")
+        self._wait_for_pid_signal(node, daemon, sig, pids_before, expect_exit)
         return 0
 
     def network_disconnect(self, ceph_object, sleep_time=20):

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -2360,13 +2360,32 @@ class FsUtils(object):
             )
         return 0
 
+    @retry(CommandFailed, tries=30, delay=10, backoff=1)
+    def _wait_for_pid_signal(self, node, daemon, sig, pids_before, expect_exit):
+        out_after, rc_after = node.exec_command(
+            cmd=f"pgrep {daemon}",
+            container_exec=False,
+            check_ec=False,
+        )
+        pids_after = out_after.splitlines() if not rc_after else []
+        still_running = set(pids_before) & set(pids_after)
+        log.info(
+            f"PIDs after {sig.name}: {pids_after}, "
+            f"still running from before: {still_running}"
+        )
+        if expect_exit and still_running:
+            raise CommandFailed(
+                f"{sig.name} failed. PIDs still running: {still_running}"
+            )
+        if not expect_exit and not pids_after:
+            raise CommandFailed(f"{sig.name} failed. {daemon} exited unexpectedly")
+
     def pid_signal(
         self,
         node,
         daemon,
         sig=signal.SIGTERM,
         expect_exit=True,
-        wait=10,
     ):
         out, rc = node.exec_command(
             cmd=f"pgrep {daemon}",
@@ -2385,23 +2404,7 @@ class FsUtils(object):
                 container_exec=False,
                 check_ec=False,
             )
-        sleep(wait)
-        out_after, rc_after = node.exec_command(
-            cmd=f"pgrep {daemon}",
-            container_exec=False,
-            check_ec=False,
-        )
-        pids_after = out_after.splitlines() if not rc_after else []
-        log.info(f"PIDs after {sig.name}: {pids_after}")
-        if expect_exit:
-            if set(pids_before) & set(pids_after):
-                raise CommandFailed(
-                    f"{sig.name} failed. PIDs still running: "
-                    f"{set(pids_before) & set(pids_after)}"
-                )
-        else:
-            if not pids_after:
-                raise CommandFailed(f"{sig.name} failed. {daemon} exited unexpectedly")
+        self._wait_for_pid_signal(node, daemon, sig, pids_before, expect_exit)
         return 0
 
     def network_disconnect(self, ceph_object, sleep_time=20):


### PR DESCRIPTION
**tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py**
a) Added wait_for_daemon_running static method

Uses ceph orch ps --format json to find daemon with status_desc starting with "running"
Resolves daemon hostname to a node via ceph_cluster.get_node_by_hostname() and runs podman ps directly on that node to confirm container is alive
Decorated with @retry(Exception, tries=20, delay=15, backoff=1) — fixed 15s delay, ~5 min total timeout
Works for any node in the cluster (not limited to cephfs_mirror_nodes list), handles daemon migration after redeploy
b) Removed verify_mirror_daemon_running

Replaced all call sites with wait_for_daemon_running which is strictly better (retries, works on any node)
c) Fixed AF_UNIX path too long in all 9 admin-daemon calls

Extracts basename with rsplit("/", 1)[-1] and cd into the socket directory
Changed ; to && so the command fails safely if cd fails

**tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mirror_daemon.py**
wait_for_daemon_running before each test iteration and before sync checks (with ceph_cluster param)
Retry loop for asok refetch after disruptive operations (10 tries, 15s delay)
stop_io_event to stop background IO before cleanup
collect_background_io_logs moved to finally block

**tests/cephfs/cephfs_mirroring_system/test_cephfs_mirroring_system_mds.py**
Same stop_io_event and collect_background_io_logs changes
Replaced verify_mirror_daemon_running with wait_for_daemon_running
Added daemon check before wait_for_snaps_synced_increase

**tests/cephfs/cephfs_mirroring_system/cephfs_mirroring_system_utils.py**
_run_background_io accepts stop_event, start_background_ios returns (threads, stop_event)
Added backoff=1 to wait_for_snaps_synced_increase and wait_for_sync_id_increase
Replaced verify_mirror_daemon_running with wait_for_daemon_running in setup
tests/cephfs/cephfs_utilsV1.py
Refactored pid_signal — extracted _wait_for_pid_signal with @retry(CommandFailed, tries=12, delay=5, backoff=1) (60s total)

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CJOBPR