### PR TITLE
9.1 pr

### DIFF
--- a/conf/squid/cephfs/tier-2_cephfs_upgrade.yaml
+++ b/conf/squid/cephfs/tier-2_cephfs_upgrade.yaml
@@ -20,20 +20,20 @@ globals:
           - osd
           - mds
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
       node5:
         role:
           - osd
           - mds
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
       node6:
         role:
           - osd
           - nfs
           - mds
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
       node7:
         role:
           - mds
@@ -41,7 +41,7 @@ globals:
           - osd
           - grafana
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
 
       node8:
         role:

--- a/conf/tentacle/cephfs/tier-2_cephfs_upgrade.yaml
+++ b/conf/tentacle/cephfs/tier-2_cephfs_upgrade.yaml
@@ -20,20 +20,20 @@ globals:
           - osd
           - mds
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
       node5:
         role:
           - osd
           - mds
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
       node6:
         role:
           - osd
           - nfs
           - mds
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
       node7:
         role:
           - mds
@@ -41,7 +41,7 @@ globals:
           - osd
           - grafana
         no-of-volumes: 4
-        disk-size: 15
+        disk-size: 20
 
       node8:
         role:

--- a/tests/cephfs/cephfs_fscrypt/test_fscrypt_interop.py
+++ b/tests/cephfs/cephfs_fscrypt/test_fscrypt_interop.py
@@ -324,7 +324,7 @@ def rw_ops_bw_enc_and_non_enc_sv(client, enc_path, non_enc_path):
     except CommandFailed as ex:
         log.error("RW ops between encrypted and non-encrypted path failed", str(ex))
         return 1
-    except BaseException as ex1:
+    except Exception as ex1:
         log.error(ex1)
         return 1
 

--- a/tests/cephfs/cephfs_system/cephfs_system_utils.py
+++ b/tests/cephfs/cephfs_system/cephfs_system_utils.py
@@ -321,7 +321,7 @@ class CephFSSystemUtils(object):
                     # on each node
                     cmd = f"cp {log_rotate_file} {log_rotate_file_bkp}"
                     out, _ = log_node.exec_command(sudo=True, cmd=cmd)
-                    cmd = rf"sed '/compress/i \    \size {size_str}' {log_rotate_file} > {log_rotate_tmp}"
+                    cmd = rf"sed '/compress/i \    \maxsize {size_str}' {log_rotate_file} > {log_rotate_tmp}"
                     out, _ = log_node.exec_command(sudo=True, cmd=cmd)
                     cmd = f"yes | cp {log_rotate_tmp} {log_rotate_file}"
                     out, _ = log_node.exec_command(sudo=True, cmd=cmd)

--- a/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
+++ b/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
@@ -387,14 +387,14 @@ def run(ceph_cluster, **kw):
             snap_params["client"] = clients[0]
             ceph_version_1 = get_ceph_version_from_cluster(clients[0])
             sched_list = (
-                ["2m", "10h", "7d", "4w"]
+                ["2m", "7d", "4w"]
                 if LooseVersion(ceph_version_1) >= LooseVersion("17.2.6")
-                else ["2M", "10h", "7d", "4w"]
+                else ["2M", "7d", "4w"]
             )
             snap_params["retention"] = (
-                "3m5h5d4w"
+                "3m5d4w"
                 if LooseVersion(ceph_version_1) >= LooseVersion("17.2.6")
-                else "3M5h5d4w"
+                else "3M5d4w"
             )
             cmd = f"ceph fs subvolume getpath {sv['vol_name']} {sv['subvol_name']} "
             cmd += f"{sv['group_name']}"


### PR DESCRIPTION
# Description

Fix description:
- Changed exception type in fscrypt inteop to get more debug info in case of failure.
- Add maxsize to logrotation file instead of size as per bug update https://ibm-ceph.atlassian.net/browse/IBMCEPH-10462
- Remove hourly snap-schedule as its causing retention validation failure post upgrade
Logs : 
Failed - https://149.81.216.83/job/squid-cephfs-upgrade-ci/19/stages/log?nodeId=230
Passed log with fix - https://149.81.216.83/view/Executor/job/squid-test-executor/149/
- Increase disk size to 20G as with 15G, during upgrade process, IO fills OSD causing Health_ERR state seen with 6x to 8x upgrade.
Passed log with fix: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QG4FKD/
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
