### PR TITLE
Fixing dependencies for PyNFS test

### DIFF
--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -1,13 +1,23 @@
+import shlex
+
+from looseversion import LooseVersion
 from nfs_operations import cleanup_cluster, setup_nfs_cluster
 
 from cli.exceptions import ConfigError, OperationFailedError
 from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster
 
 log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-    """Verify file lock operation
+    """Run pynfs testserver against the NFS export and check results.
+
+    On Ceph >= 20.2, runs ``ceph nfs export update ... rw`` for delegation export
+    semantics. Failures are matched against defaults plus version rules: all ``DELEG*``
+    allowed when Ceph is unknown or < 20.2; all ``ALLOC*`` allowed when NFS minor is
+    < 4.2 (e.g. Ganesha may not support OP_ALLOCATE on older exports).
+
     Args:
         **kw: Key/value pairs of configuration information to be used in the test.
     """
@@ -17,6 +27,8 @@ def run(ceph_cluster, **kw):
 
     port = config.get("port", "2049")
     version = config.get("nfs_version", "4.0")
+    # YAML often parses 4.1 as float; ``version == "4.1"`` would be False.
+    pynfs_nfs_minor = str(version).strip()
     no_clients = int(config.get("clients", "2"))
 
     # If the setup doesn't have required number of clients, exit.
@@ -31,6 +43,7 @@ def run(ceph_cluster, **kw):
     nfs_mount = "/mnt/nfs"
     fs = "cephfs"
     nfs_server_name = nfs_node.hostname
+    pynfs_workdir = None
 
     try:
         # Setup nfs cluster
@@ -47,34 +60,96 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
         )
 
-        # Create a file on Client 1
+        ceph_ver = None
+        try:
+            ceph_ver = get_ceph_version_from_cluster(clients[0])
+        except Exception as exc:
+            log.warning("Could not get ceph version from cluster: %s", exc)
+
+        # Allowed failures for pynfs
+        allowed_exact_failures = {"EID9", "SEQ6", "DELEG7"}
+        allowed_prefixes_failures = set()
+
+        # Checking if the Cluster supports delegation
+        # Delegation is supported only on Ceph versions >= 20.2.x
+        if bool(ceph_ver) and LooseVersion(ceph_ver) >= LooseVersion("20.2"):
+
+            log.info("Running ceph nfs export update for ceph %s (>= 20.2.", ceph_ver)
+            # Also set the export Delegatio to rw
+            clients[0].exec_command(
+                cmd=f"ceph nfs export update {nfs_name} {nfs_export}_0 rw",
+                sudo=True,
+            )
+        else:
+            allowed_prefixes_failures.add("DELEG")
+
+        # Only if the NFS version is < 4.2, we allow the ALLOC failures
+        if LooseVersion(pynfs_nfs_minor) < LooseVersion("4.2"):
+            allowed_prefixes_failures.add("ALLOC")
+
+        log.info(f"Allowed failures: {allowed_prefixes_failures}")
+        log.info(f"Allowed exact failures: {allowed_exact_failures}")
+
+        # Creating a temporary directory for pynfs
+        out_mk, _ = clients[0].exec_command(
+            cmd="mktemp -d /tmp/cephci-pynfs.XXXXXX",
+            sudo=True,
+        )
+        pynfs_workdir = out_mk.strip().splitlines()[-1].strip()
+        if not pynfs_workdir.startswith("/tmp/cephci-pynfs."):
+            raise OperationFailedError(
+                f"Refusing to use unexpected mktemp path: {pynfs_workdir!r}"
+            )
+
+        log.info(f"Setting up and running pynfs on {clients[0].hostname}")
+
+        repo = f"{pynfs_workdir}/pynfs"
+        qrepo = shlex.quote(repo)
+        # Isolate clone/build under /tmp (unique per run); testserver targets the NFS export over the network.
         cmd = (
-            "python3 -m pip install ply;"
-            f"cd {nfs_mount};"
-            "git clone git://git.linux-nfs.org/projects/bfields/pynfs.git;cd pynfs;-- "
-            f"yes |"
-            f"python setup.py build;cd nfs{version};./testserver.py {nfs_server_name}:{nfs_export}_0 -v --outfile "
+            "dnf install -y python3-ply && "
+            f"git clone https://github.com/s-athani/pynfs.git {qrepo} && "
+            # f"git clone git://git.linux-nfs.org/projects/cdmackay/pynfs.git {qrepo} && "
+            f"cd {qrepo} && "
+            "yes | python setup.py build && "
+            f"cd {qrepo}/nfs{pynfs_nfs_minor} && "
+            f"./testserver.py {nfs_server_name}:{nfs_export}_0 -v --outfile "
             f"~/pynfs.run --maketree --showomit --rundep all"
         )
 
         out, _ = clients[0].exec_command(cmd=cmd, sudo=True, timeout=600)
+        log.info(f"Pynfs Output:\n {out}")
+
         if "FailureException" in out:
-            OperationFailedError(f"Failed to run {cmd} on {clients[0].hostname}")
+            raise OperationFailedError(f"Failed to run {cmd} on {clients[0].hostname}")
 
         # Parse test output to detect failures
         failed_tests = []
-        allowed_failures = {"EID9", "SEQ6"}
 
+        # Check for allowed failures
         for line in out.splitlines():
             line = line.strip()
-            if line.endswith(": FAILURE"):
-                test_id = line.split()[0]
-                if test_id not in allowed_failures:
-                    failed_tests.append(test_id)
+            if not line.endswith(": FAILURE"):
+                continue
+            test_id = line.split()[0]
+            if test_id in allowed_exact_failures:
+                log.info(f"Skipping {test_id} as it is an allowed failure")
+                continue
+            if any(test_id.startswith(p) for p in allowed_prefixes_failures):
+                log.info(f"Skipping {test_id} as it is an allowed failure")
+                continue
+            failed_tests.append(test_id)
 
         if failed_tests:
-            log.error(f"Unexpected pynfs test failures: {failed_tests}")
+            log.error(
+                "Unexpected pynfs test failures: %s",
+                sorted(set(failed_tests)),
+            )
             return 1
+
+        log.info("================================================")
+        log.info("Pynfs test completed successfully")
+        log.info("================================================")
         return 0
 
     except Exception as e:
@@ -82,5 +157,15 @@ def run(ceph_cluster, **kw):
         return 1
 
     finally:
+        if pynfs_workdir:
+            wd = shlex.quote(pynfs_workdir)
+            try:
+                clients[0].exec_command(
+                    cmd=f"rm -rf -- {wd}",
+                    sudo=True,
+                    check_ec=False,
+                )
+            except Exception as exc:
+                log.warning("Could not remove pynfs workdir %s: %s", pynfs_workdir, exc)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")


### PR DESCRIPTION
# Description

PyNFS had dependenc issues and has been fixed

1. Ignore deleg failures in ceph versions < 20.2.x (9.1)
2. Igore Alloc failures in NFSv4.0 and NFSv4.1
3. Better logging of PyNFS results
4. Fix False positives

Logs: 
https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/8.1/rhel-9/executor/19.2.1-363/nfs/148/logs/tier0_nfs_ganesha/