### PR TITLE
Use rhcs-version / release for IBM cephadm bootstrap in upgrade suites (reef, squid, tentacle)

### DIFF
--- a/suites/reef/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_7x.yaml
+++ b/suites/reef/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_7x.yaml
@@ -16,11 +16,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -76,11 +75,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts

--- a/suites/reef/cephfs/archive/tier-0_cephfs_upgrade_ibm_6x_to_7x.yaml
+++ b/suites/reef/cephfs/archive/tier-0_cephfs_upgrade_ibm_6x_to_7x.yaml
@@ -25,11 +25,10 @@ tests:
           -
             config:
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                rhcs-version: 6.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                registry-url: registry.redhat.io
                 skip-monitoring-stack: true
               base_cmd_args:
                 verbose: true

--- a/suites/reef/nfs/tier1-nfs-ganesha-upgrade-ibm-7x-to-7x-latest.yaml
+++ b/suites/reef/nfs/tier1-nfs-ganesha-upgrade-ibm-7x-to-7x-latest.yaml
@@ -29,8 +29,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                rhcs-version: 7.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
@@ -25,8 +25,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
@@ -72,8 +72,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123

--- a/suites/reef/upgrades/tier1-upgrade-ibm-6x-to-7x.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-ibm-6x-to-7x.yaml
@@ -28,8 +28,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                rhcs-version: 6.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier1-upgrade-ibm-7x-to-7x-latest.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-ibm-7x-to-7x-latest.yaml
@@ -30,8 +30,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                rhcs-version: 7.0
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier1-upgrade-with-monitoring-stack-ibm-7x-to-7x.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-with-monitoring-stack-ibm-7x-to-7x.yaml
@@ -30,8 +30,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                rhcs-version: 7.0
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
           - config:

--- a/suites/reef/upgrades/tier2-upgrade-ibm-staggered-6x-to-7x.yaml
+++ b/suites/reef/upgrades/tier2-upgrade-ibm-staggered-6x-to-7x.yaml
@@ -36,8 +36,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                rhcs-version: 6.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/squid/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_8x.yaml
+++ b/suites/squid/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_8x.yaml
@@ -16,11 +16,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -76,11 +75,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts

--- a/suites/squid/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_8x.yaml
+++ b/suites/squid/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_8x.yaml
@@ -16,11 +16,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -76,11 +75,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts

--- a/suites/squid/cephfs/archive/tier-0_cephfs_upgrade_ibm_6x_to_8x.yaml
+++ b/suites/squid/cephfs/archive/tier-0_cephfs_upgrade_ibm_6x_to_8x.yaml
@@ -25,11 +25,10 @@ tests:
           -
             config:
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                rhcs-version: 6.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                registry-url: registry.redhat.io
                 skip-monitoring-stack: true
               base_cmd_args:
                 verbose: true

--- a/suites/squid/cephfs/archive/tier-0_cephfs_upgrade_ibm_7x_to_8x.yaml
+++ b/suites/squid/cephfs/archive/tier-0_cephfs_upgrade_ibm_7x_to_8x.yaml
@@ -26,11 +26,10 @@ tests:
           -
             config:
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                rhcs-version: 7.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                registry-url: registry.redhat.io
                 skip-monitoring-stack: true
               base_cmd_args:
                 verbose: true

--- a/suites/squid/cephfs/archive/tier-0_cephfs_upgrade_ibm_8x_latest_to_81x_latest.yaml
+++ b/suites/squid/cephfs/archive/tier-0_cephfs_upgrade_ibm_8x_latest_to_81x_latest.yaml
@@ -26,11 +26,10 @@ tests:
           -
             config:
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                rhcs-version: 8.0
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                registry-url: registry.redhat.io
                 skip-monitoring-stack: true
               base_cmd_args:
                 verbose: true

--- a/suites/squid/rbd/tier-3_ibm_rbd_mirror_upgrade_6x_to_8x.yaml
+++ b/suites/squid/rbd/tier-3_ibm_rbd_mirror_upgrade_6x_to_8x.yaml
@@ -25,8 +25,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
@@ -61,8 +61,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                    rhcs-version: 6.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true

--- a/suites/squid/rbd/tier-3_ibm_rbd_mirror_upgrade_7x_to_8x.yaml
+++ b/suites/squid/rbd/tier-3_ibm_rbd_mirror_upgrade_7x_to_8x.yaml
@@ -25,8 +25,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
@@ -61,8 +61,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true

--- a/suites/squid/rbd/tier-3_ibm_rbd_mirror_upgrade_8xGA_to_8x_latest.yaml
+++ b/suites/squid/rbd/tier-3_ibm_rbd_mirror_upgrade_8xGA_to_8x_latest.yaml
@@ -25,8 +25,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                    rhcs-version: 8.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
@@ -61,8 +61,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                    rhcs-version: 8.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true

--- a/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
@@ -25,8 +25,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
@@ -72,8 +72,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123

--- a/suites/squid/upgrades/tier1-upgrade-ibm-6x-to-8x.yaml
+++ b/suites/squid/upgrades/tier1-upgrade-ibm-6x-to-8x.yaml
@@ -28,8 +28,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                rhcs-version: 6.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/squid/upgrades/tier2-upgrade-ibm-staggered-6x-to-8x.yaml
+++ b/suites/squid/upgrades/tier2-upgrade-ibm-staggered-6x-to-8x.yaml
@@ -36,8 +36,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+                rhcs-version: 6.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_9x.yaml
@@ -16,11 +16,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -76,11 +75,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                    rhcs-version: 7.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts

--- a/suites/tentacle/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/archive/tier-0_cephfs_mirrror_upgrade_ibm_8x_to_9x.yaml
@@ -16,11 +16,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                    rhcs-version: 8.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -76,11 +75,10 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                    custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                    rhcs-version: 8.1
+                    release: released
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    registry-url: registry.redhat.io
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts

--- a/suites/tentacle/cephfs/archive/tier-0_cephfs_upgrade_ibm_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/archive/tier-0_cephfs_upgrade_ibm_7x_to_9x.yaml
@@ -22,11 +22,10 @@ tests:
         steps:
           - config:
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-7-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+                rhcs-version: 7.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                registry-url: registry.redhat.io
                 skip-monitoring-stack: true
               base_cmd_args:
                 verbose: true

--- a/suites/tentacle/cephfs/archive/tier-0_cephfs_upgrade_ibm_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/archive/tier-0_cephfs_upgrade_ibm_8x_to_9x.yaml
@@ -23,11 +23,10 @@ tests:
         steps:
           - config:
               args:
-                custom_image: "cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:latest"
-                custom_repo: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-8-rhel-9.repo"
+                rhcs-version: 8.1
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                registry-url: registry.redhat.io
                 skip-monitoring-stack: true
               base_cmd_args:
                 verbose: true


### PR DESCRIPTION
Replace explicit custom_image, custom_repo, and (where present) registry-url on cephadm bootstrap with rhcs-version and release: released so baseline clusters align with the standard RHCS/IBM released-build flow instead of pinned staging images and public .repo URLs.

Sample issue due to the hard coded custom_image, custom_repo values.

> 2026-04-28 23:42:28,836 - cephci - ceph:1677 - INFO - Execute yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]
2026-04-28 23:42:32,578 - cephci - ceph:1712 - INFO - Execution of yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo took 3.741402 seconds on ceph-pri-rgw-up11-koue-e4khbk-node1-installer by user root [10.245.0.138]
2026-04-28 23:42:32,826 - cephci - ceph:1677 - INFO - Execute yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo on ceph-pri-rgw-up11-koue-e4khbk-node2 [10.245.0.139]
2026-04-28 23:42:34,189 - cephci - ceph:1712 - INFO - Execution of yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo took 1.362805 seconds on ceph-pri-rgw-up11-koue-e4khbk-node2 by user root [10.245.0.139]
2026-04-28 23:42:34,437 - cephci - ceph:1677 - INFO - Execute yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo on ceph-pri-rgw-up11-koue-e4khbk-node3 [10.245.0.140]
2026-04-28 23:42:35,843 - cephci - ceph:1712 - INFO - Execution of yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo took 1.405899 seconds on ceph-pri-rgw-up11-koue-e4khbk-node3 by user root [10.245.0.140]
2026-04-28 23:42:36,091 - cephci - ceph:1677 - INFO - Execute yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo on ceph-pri-rgw-up11-koue-e4khbk-node4 [10.245.0.141]
2026-04-28 23:42:38,419 - cephci - ceph:1712 - INFO - Execution of yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo took 2.327639 seconds on ceph-pri-rgw-up11-koue-e4khbk-node4 by user root [10.245.0.141]
2026-04-28 23:42:38,667 - cephci - ceph:1677 - INFO - Execute yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo on ceph-pri-rgw-up11-koue-e4khbk-node5 [10.245.0.142]
2026-04-28 23:42:40,004 - cephci - ceph:1712 - INFO - Execution of yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo took 1.337406 seconds on ceph-pri-rgw-up11-koue-e4khbk-node5 by user root [10.245.0.142]
2026-04-28 23:42:40,253 - cephci - ceph:1677 - INFO - Execute yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo on ceph-pri-rgw-up11-koue-e4khbk-node6 [10.245.0.143]
2026-04-28 23:42:41,619 - cephci - ceph:1712 - INFO - Execution of yum-config-manager --add-repo https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo took 1.365914 seconds on ceph-pri-rgw-up11-koue-e4khbk-node6 by user root [10.245.0.143]
2026-04-28 23:42:41,620 - cephci - build_info:204 - DEBUG - Retreving build details of ibm - 8.1. Looking up rc section.
2026-04-28 23:42:41,663 - cephci - build_info:204 - DEBUG - Retreving build details of ibm - 8.1. Looking up rc section.
2026-04-28 23:42:41,953 - cephci - ceph:1677 - INFO - Execute ACCEPT_EULA=Y yum install -y ibm-storage-ceph-license --nogpgcheck on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]
2026-04-28 23:42:46,208 - cephci - ceph:1209 - DEBUG - ibm-storage-ceph-7                               41 kB/s | 108 kB     00:02    
2026-04-28 23:42:46,849 - cephci - ceph:1209 - DEBUG - Dependencies resolved.
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG - ================================================================================
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG -  Package                     Arch      Version      Repository             Size
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG - ================================================================================
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG - Installing:
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG -  ibm-storage-ceph-license    noarch    7-2.el9cp    ibm-storage-ceph-7    458 k
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG - 
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG - Transaction Summary
2026-04-28 23:42:46,850 - cephci - ceph:1209 - DEBUG - ================================================================================
2026-04-28 23:42:46,851 - cephci - ceph:1209 - DEBUG - Install  1 Package
2026-04-28 23:42:46,851 - cephci - ceph:1209 - DEBUG - 
2026-04-28 23:42:46,851 - cephci - ceph:1209 - DEBUG - Total download size: 458 k
2026-04-28 23:42:46,851 - cephci - ceph:1209 - DEBUG - Installed size: 5.4 M
2026-04-28 23:42:46,851 - cephci - ceph:1209 - DEBUG - Downloading Packages:
2026-04-28 23:42:48,998 - cephci - ceph:1209 - DEBUG - ibm-storage-ceph-license-7-2.el9cp.noarch.rpm   213 kB/s | 458 kB     00:02    
2026-04-28 23:42:48,999 - cephci - ceph:1209 - DEBUG - --------------------------------------------------------------------------------
2026-04-28 23:42:48,999 - cephci - ceph:1209 - DEBUG - Total                                           213 kB/s | 458 kB     00:02     
2026-04-28 23:42:48,999 - cephci - ceph:1209 - DEBUG - Running transaction check
2026-04-28 23:42:49,004 - cephci - ceph:1209 - DEBUG - Transaction check succeeded.
2026-04-28 23:42:49,004 - cephci - ceph:1209 - DEBUG - Running transaction test
2026-04-28 23:42:49,013 - cephci - ceph:1209 - DEBUG - Transaction test succeeded.
2026-04-28 23:42:49,013 - cephci - ceph:1209 - DEBUG - Running transaction
2026-04-28 23:42:49,028 - cephci - ceph:1209 - DEBUG -   Preparing        :                                                        1/1
2026-04-28 23:42:49,089 - cephci - ceph:1209 - DEBUG -  
2026-04-28 23:42:49,089 - cephci - ceph:1209 - DEBUG -   Installing       : ibm-storage-ceph-license-7-2.el9cp.noarch              1/1
2026-04-28 23:42:49,245 - cephci - ceph:1209 - DEBUG -  
2026-04-28 23:42:49,245 - cephci - ceph:1209 - DEBUG -   Running scriptlet: ibm-storage-ceph-license-7-2.el9cp.noarch              1/1
2026-04-28 23:42:49,245 - cephci - ceph:1209 - DEBUG -  
2026-04-28 23:42:49,245 - cephci - ceph:1209 - DEBUG -   Verifying        : ibm-storage-ceph-license-7-2.el9cp.noarch              1/1
2026-04-28 23:42:49,658 - cephci - ceph:1209 - DEBUG -  
2026-04-28 23:42:49,658 - cephci - ceph:1209 - DEBUG - 
2026-04-28 23:42:49,658 - cephci - ceph:1209 - DEBUG - Installed:
2026-04-28 23:42:49,659 - cephci - ceph:1209 - DEBUG -   ibm-storage-ceph-license-7-2.el9cp.noarch                                     
2026-04-28 23:42:49,659 - cephci - ceph:1209 - DEBUG - 
2026-04-28 23:42:49,659 - cephci - ceph:1209 - DEBUG - Complete!
2026-04-28 23:42:49,725 - cephci - ceph:1712 - INFO - Execution of ACCEPT_EULA=Y yum install -y ibm-storage-ceph-license --nogpgcheck took 7.770669 seconds on ceph-pri-rgw-up11-koue-e4khbk-node1-installer by user root [10.245.0.138]
2026-04-28 23:42:50,260 - cephci - ceph:1677 - INFO - Execute cat /usr/share/ibm-storage-ceph-license/accept on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]
2026-04-28 23:42:51,511 - cephci - ceph:1712 - INFO - Execution of cat /usr/share/ibm-storage-ceph-license/accept took 1.250445 seconds on ceph-pri-rgw-up11-koue-e4khbk-node1-installer by user root [10.245.0.138]
2026-04-28 23:42:51,760 - cephci - ceph:1677 - INFO - Execute yum -y install [cephadm-2](https://redhat.atlassian.net/browse/cephadm-2):19.2.1-363.el9cp --nogpgcheck on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]
2026-04-28 23:42:53,010 - cephci - ceph:1209 - DEBUG - Last metadata expiration check: 0:00:07 ago on Wed Apr 29 03:42:45 2026.
2026-04-28 23:42:53,382 - cephci - ceph:1209 - DEBUG - No match for argument: [cephadm-2](https://redhat.atlassian.net/browse/cephadm-2):19.2.1-363.el9cp
2026-04-28 23:42:53,453 - cephci - ceph:1209 - ERROR - Error: Unable to find a match: [cephadm-2](https://redhat.atlassian.net/browse/cephadm-2):19.2.1-363.el9cp
2026-04-28 23:42:53,453 - cephci - ceph:1712 - INFO - Execution of yum -y install [cephadm-2](https://redhat.atlassian.net/browse/cephadm-2):19.2.1-363.el9cp --nogpgcheck took 1.693213 seconds on ceph-pri-rgw-up11-koue-e4khbk-node1-installer by user root [10.245.0.138]
2026-04-28 23:42:53,700 - cephci - ceph:1677 - INFO - Execute rpm -qa | grep cephadm on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]
2026-04-28 23:42:54,950 - cephci - ceph:1712 - INFO - Execution of rpm -qa | grep cephadm took 1.24944 seconds on ceph-pri-rgw-up11-koue-e4khbk-node1-installer by user cephuser [10.245.0.138]
2026-04-28 23:42:54,951 - cephci - test_cephadm:188 - ERROR - rpm -qa | grep cephadm returned  and code 1 on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/upgrade/19.2.1-363/rgw/11/cephci/tests/ceph_installer/test_cephadm.py", line 172, in run
    func(cfg)
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/upgrade/19.2.1-363/rgw/11/cephci/ceph/ceph_admin/bootstrap.py", line 283, in bootstrap
    self.install(**{"rpm_version": _rpm_version})
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/upgrade/19.2.1-363/rgw/11/cephci/ceph/ceph_admin/__init__.py", line 278, in install
    node.exec_command(cmd="rpm -qa | grep cephadm")
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/upgrade/19.2.1-363/rgw/11/cephci/ceph/ceph.py", line 1808, in exec_command
    raise CommandFailed(
ceph.ceph.CommandFailed: rpm -qa | grep cephadm returned  and code 1 on ceph-pri-rgw-up11-koue-e4khbk-node1-installer [10.245.0.138]

