### PR TITLE
TFA fixes for restore, test integration for k/v store

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -535,20 +535,6 @@ tests:
       name: Start Sync daemons on Secondary and check sync
       polarion-id: CEPH-10703
 
-  # Test work flow
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            git_clone_configs_repo: true
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_restore_object.yaml
-      desc: test s3 object restore and download, and restore attrs
-      module: sanity_rgw_multisite.py
-      name: test s3 object restore and download, and restore attrs
-      polarion-id: CEPH-83591622 #CEPH-83591672 #CEPH-83591621
-
 # configuring vault agent on all the sites
 
   - test:

--- a/suites/tentacle/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_regression_extended.yaml
@@ -265,3 +265,11 @@ tests:
       config:
         script-name: test_bypass_gc_corruption.py
         config-file-name: test_bypass_gc_versioned_multipart.yaml
+  - test:
+      name: reshard never finishes and inflates kv store
+      desc: reshard never finishes and inflates kv store #IBMCEPH-12991 #IBMCEPH-12291 #IBMCEPH-12936
+      polarion-id: CEPH-83632407
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_unicode_bi_list.yaml


### PR DESCRIPTION
- Removing the cloud transition tests with retain-head true and also removing the cloud restore tests from the 3-way multisite, since they have been added to a new cephci suite for cloud restore. 
passed log for cloud restore http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EIWIN0

- Adding test automation integration for [reshard never finishes and inflates the KV store]
logs http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HYJH8S/

logs for "Reshard never finished and inflates the KV store" --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G46J9L/reshard_never_finishes_and_inflates_kv_store_0.log

