### PR TITLE
Remove TC: 	Test single delete marker for versioned object using s3cmd

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -164,15 +164,6 @@ tests:
         config-file-name: ../../s3cmd/configs/test_rgw_opslog.yaml
         run-on-rgw: true # as logs generated on rgw nodes
 
-  - test:
-      name: Test single delete marker for versioned object using s3cmd
-      desc: Test single delete marker for versioned object using s3cmd
-      polarion-id: CEPH-83574806
-      module: sanity_rgw.py
-      comments: Known regression issue BZ2400398 in 9.0
-      config:
-        script-name: ../s3cmd/test_s3cmd.py
-        config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
 
 # Testing s3cmd malformed url
   - test:


### PR DESCRIPTION
# Description
Remove TC: Test single delete marker for versioned object using s3cmd
As per https://bugzilla.redhat.com/show_bug.cgi?id=2400398 its a known feature change done 9.x onwords


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
