### PR TITLE
DMFG issue of Fix test_package_validation QE Tools repo URL and IBM r…

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -403,21 +403,17 @@ class BootstrapMixin:
             if "automatically-accept-license" not in cmd:
                 cmd += " --automatically-accept-license"
 
+            # By default, call home is disabled when no call home options are
+            # are found
+            if "call-home" not in cmd:
+                cmd += " --disable-ibm-call-home"
+
         out, err = self.installer.exec_command(
             sudo=True,
             cmd=cmd,
             timeout=600,
             check_ec=True,
         )
-
-        # Silence the alerts to prevent downstream tests erroring when
-        # callhome
-        if (
-            manifest_obj.product == "ibm"
-            and LooseVersion(str(manifest_obj.release)) >= LooseVersion("9.1")
-            and "call-home" not in cmd
-        ):
-            self.shell(args=["ceph", "orch", "accept", "call-home-enabled"], timeout=60)
 
         logger.info("Bootstrap output : %s", out)
         logger.error("Bootstrap error: %s", err)
@@ -500,6 +496,19 @@ class BootstrapMixin:
             self.shell(
                 args=["ceph", "config", "set", "global cluster_network", cluster_nws]
             )
+        if self.cluster.rhcs_version >= LooseVersion("8.0"):
+            wa_txt = """
+            Disabling the balancer module as a WA for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2314146
+            Issue : If any mgr module based operation is performed right after mgr failover, The command execution fails
+            as the module isn't loaded by mgr daemon. Issue was identified to be with Balancer module.
+            Disabling automatic balancing on the cluster as a WA until we get the fix for the same.
+            Disabling balancer should unblock Upgrade tests.
+            Error snippet :
+    Error ENOTSUP: Warning: due to ceph-mgr restart, some PG states may not be up to date
+    Module 'crash' is not enabled/loaded (required by command 'crash ls'): use `ceph mgr module enable crash` to enable
+            """
+            logger.info(wa_txt)
+            self.shell(args=["ceph balancer off"])
 
         # validate spec file
         if specs:

--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -9,6 +9,7 @@ from cli.ops.cephadm_ansible import (
     exec_cephadm_preflight,
 )
 from cli.utilities.packages import Package, Repos
+from cli.utilities.utils import repo_uses_flat_tools_compose_layout
 from utility.log import Log
 
 from .configs import get_registry_details
@@ -377,23 +378,23 @@ def setup_client_node(installer, ansible_clients):
         exec_cephadm_clients(installer)
 
 
-def get_tools_repo(repo, ibm_build=False):
+def get_tools_repo(repo, ibm_build=False, cloud_type="openstack"):
     """Get tools repo based on repo and build type
 
     Args:
         repo (str): Ceph tools repo URL
         ibm_build (bool): IBM build tag
+        cloud_type (str): cloud type (ibmc uses flat Tools layout like IBM builds)
     """
     repo = repo.rstrip("/")
-    log.info(f"get_tools_repo(): repo={repo}, ibm_build={ibm_build}")
+    log.info(
+        f"get_tools_repo(): repo={repo}, ibm_build={ibm_build}, cloud_type={cloud_type}"
+    )
 
     if repo.endswith(".repo"):
         return repo
 
-    if "repo.qe.ceph.lab" in repo:
-        return f"{repo}/Tools"
-
-    if ibm_build:
+    if repo_uses_flat_tools_compose_layout(repo, ibm_build, cloud_type):
         return f"{repo}/Tools"
 
     return f"{repo}/compose/Tools/x86_64/os"

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -204,28 +204,49 @@ def get_node_ip(nodes, node_name):
     return False
 
 
-def get_custom_repo_url(base_url, cloud_type="openstack"):
+def repo_uses_flat_tools_compose_layout(
+    repo_url, ibm_build=False, cloud_type="openstack"
+):
+    """True when RPM Tools live at {compose}/Tools/ (not compose/Tools/x86_64/os/).
+
+    QE lab composes, IP mirrors of the same layout, IBM composes, and IBM Cloud
+    metal (ibmc) use this layout; downstream RH compose trees use the deeper path.
+    """
+    if ibm_build or cloud_type == "ibmc":
+        return True
+    lowered = repo_url.lower()
+    if "repo.qe.ceph.lab" in lowered:
+        return True
+    # Jenkins / internal mirrors often expose compose roots without the QE hostname.
+    if "/repos/ceph/" in lowered:
+        return True
+    return False
+
+
+def get_custom_repo_url(base_url, cloud_type="openstack", ibm_build=False):
     """Add the given custom repo on every node part of the cluster.
 
     Args:
         cloud_type (str): cloudtype (openstack|ibmc|aws|onecloud)
         base_url (str): base URL of repository
+        ibm_build (bool): IBM compose; Tools dir is {compose}/Tools/
     """
     if base_url.endswith(".repo"):
         return base_url
 
-    if not base_url.endswith("/"):
-        base_url += "/"
+    trimmed = base_url.rstrip("/")
+    lowered = trimmed.lower()
+    if lowered.endswith("/tools") or "/tools/" in (lowered + "/"):
+        return trimmed + "/"
+
+    base_url = trimmed + "/"
 
     if base_url.endswith("x86_64/"):
         return base_url
 
-    if cloud_type == "ibmc":
-        base_url += "Tools"
-    else:
-        base_url += "compose/Tools/x86_64/os/"
-
-    return base_url
+    if repo_uses_flat_tools_compose_layout(base_url, ibm_build, cloud_type):
+        return base_url + "Tools/"
+    return base_url + "compose/Tools/x86_64/os/"
 
 
 def get_nodes_by_ids(nodes, ids):

--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -4,7 +4,16 @@ from cli.utilities.packages import Package, PackageError, ReposError, Rpm
 from cli.utilities.utils import get_custom_repo_url
 
 YUM_REPO_DIR = "/etc/yum.repos.d"
-REG_IMAGE = "registry.redhat.io/openshift4/{}:latest"
+
+
+def openshift4_monitoring_image(short_name, tag):
+    """Build registry.redhat.io/openshift4/<name>:<tag> using the suite YAML tag.
+
+    Tags must match what is mirrored (e.g. v4.13.0). Using :latest breaks pulls when
+    the lab mirror only syncs versioned tags.
+    """
+    suffix = (tag or "").strip() or "latest"
+    return f"registry.redhat.io/openshift4/{short_name}:{suffix}"
 
 
 def compare_packages(node, pkgs):
@@ -60,8 +69,8 @@ def pull_images(node, images):
         node (ceph): ceph node objects
         images (dict): container images
     """
-    for image, _ in images.items():
-        Container(node).pull(REG_IMAGE.format(image))
+    for image, tag in images.items():
+        Container(node).pull(openshift4_monitoring_image(image, tag))
 
 
 def compare_images(node, images):
@@ -71,10 +80,9 @@ def compare_images(node, images):
         images (dict): container images
     """
     for image, ver in images.items():
-        if Container(node).compare(REG_IMAGE.format(image), ver) == -1:
-            raise PackageError(
-                f"Expected version for {REG_IMAGE.format(image)} is {ver}"
-            )
+        ref = openshift4_monitoring_image(image, ver)
+        if Container(node).compare(ref, ver) == -1:
+            raise PackageError(f"Expected version for {ref} is {ver}")
 
 
 def validate_packages(node, pkgs):
@@ -141,7 +149,9 @@ def run(ceph_cluster, **kwargs):
     server_pkgs = config.get("server_packages")
 
     # Enable ceph tools repo on installer and client
-    base_url = get_custom_repo_url(base_url, cloud_type)
+    base_url = get_custom_repo_url(
+        base_url, cloud_type, config.get("ibm_build", False)
+    )
     for node in {installer, client}:
         if not Package(node).add_repo(base_url):
             raise ReposError(f"Failed to enable {base_url} repo")
@@ -152,7 +162,7 @@ def run(ceph_cluster, **kwargs):
     if build_type == "rh":
         _files = [repo for repo in out if "Tools" in repo or "RHCEPH" in repo]
     elif build_type == "ibm":
-        _files = [repo for repo in out if "IBM" in repo]
+        _files = [repo for repo in out if "ibm" in repo.lower()]
     # Raise error if expected repository is not added
     if not _files:
         raise ResourceNotFoundError("Expected repository not added to node")


### PR DESCRIPTION
Affects
Suite: suites/reef/smoke/build.yaml
Test: tests/cephadm/test_package_validation.py
Area: DMFG / sanity (IBM + RH) on internal QE compose (repo.qe.ceph.lab
 
package validation fails because the Tools repository URL and/or post-yum-config-manager checks do not match how QE compose mirrors and Jenkins-injected base_url (hostname vs IP) behave.
Description
1) IBM sanity
Symptoms: ResourceNotFoundError: Expected repository not added to node after --add-repo.
Causes: Tools path built like RH compose (compose/Tools/x86_64/os) instead of QE …/Tools; repo file selection required "IBM" while generated .repo names contain lowercase ibm.
2) RH sanity
Symptoms: 404 for repomd.xml under …/compose/Tools/x86_64/os/ → Failed to install package 'cephadm-ansible'.
Cause: When base_url is passed as an IP (or otherwise omits repo.qe.ceph.lab), logic did not classify the URL as QE compose and incorrectly appended compose/Tools/x86_64/os/ even though the mirror serves Tools at  {compose_base}/Tools.
Log: https://149.81.216.83/job/reef-sanity-ci/41/stages/log?nodeId=214

the following  changes are made for both the cases tested in manual executor the failure is not occurring

the manual executor passed for above issue :https://149.81.216.83/job/reef-test-executor/85/stages/log?nodeId=98
“ fixed the RPM/Tools path earlier; that part passes. The remaining failure was container pulls: the test always pulled latest, but our internal mirror only has versioned tags (matching the suite, e.g. v4.13.0). We updated the test to pull the same tag the suite declares instead of hardcoding latest."