### PR TITLE
Add NFS-over-RDMA transport support to test infrastructure

### DIFF
--- a/cli/ceph/nfs/cluster/cluster.py
+++ b/cli/ceph/nfs/cluster/cluster.py
@@ -27,6 +27,8 @@ class Cluster(Cli):
         active_standby=False,
         nfs_nodes_obj=None,
         check_ec=True,
+        enable_rdma=False,
+        rdma_port=None,
         **kwargs,
     ):
         """
@@ -37,6 +39,8 @@ class Cluster(Cli):
             ha (bool): Flag to check if HA is required
             vip (str): Vip for the HA cluster
             active_standby (bool): Flag to check if active standby is required
+            enable_rdma (bool): Pass --enable-rdma to enable RDMA transport
+            rdma_port (int|str|None): RDMA listener port (--rdma_port)
             **kwargs: Additional keyword arguments.
             If nfs_version=3 is provided and ceph version > 19.2.1-300,
                     --enable-nfsv3 flag will be added
@@ -48,6 +52,11 @@ class Cluster(Cli):
         cmd = "{0} create {1} '{2}'".format(self.base_cmd, name, nfs_server)
         if ha:
             cmd += " --ingress --virtual-ip {0}".format(vip)
+
+        if enable_rdma:
+            cmd += " --enable-rdma"
+            if rdma_port is not None:
+                cmd += f" --rdma_port {rdma_port}"
 
         # Check if --enable-nfsv3 flag needs to be added
         # Condition: ceph version > 19.2.1-300 AND nfs_version == 3

--- a/cli/utilities/filesys.py
+++ b/cli/utilities/filesys.py
@@ -23,14 +23,34 @@ class Mount(Cli):
             self.execute(cmd="dnf install -y nfs-utils", sudo=True, timeout=600)
 
     def nfs(self, mount, version, port, server, export, **kwargs):
-        """
-        Perform nfs mount
+        """Perform an NFS mount on the client node.
+
+        Installs nfs-utils if missing, creates the mount directory,
+        and runs ``mount -t nfs`` with the assembled option string.
+
+        The resulting command looks like::
+
+            mount -t nfs -o vers=<version>,port=<port>[,proto=<proto>]
+                [,xprtsec=<xprtsec>] <server>:<export> <mount>
+
         Args:
-            mount (str): nfs mount path
-            version (str): Nfs version (4.0, 4.1, 4.2 etc)
-            port (str): nfs port to bind
-            server (str): Nfs server hostname
-            export (str): nfs export path)
+            mount (str): Local mount-point path.
+            version (str): NFS version string (e.g. "3", "4.0",
+                "4.1", "4.2").
+            port (str): NFS port to connect to.  When using RDMA
+                this should be the RDMA listener port.
+            server (str): NFS server hostname or IP address.
+            export (str): NFS export pseudo-path.
+
+        Keyword Args:
+            proto (str): Transport protocol option appended to
+                ``-o``.  Pass ``"rdma"`` for NFS-over-RDMA mounts.
+            xprtsec (str): Transport-security option (e.g. ``"tls"``
+                for RPC-with-TLS).
+
+        Raises:
+            MountFailedError: If the mount point does not appear in
+                the ``mount`` table after the command completes.
         """
         self._ensure_nfs_utils()
 
@@ -39,8 +59,10 @@ class Mount(Cli):
         if not out[0]:
             self.execute(cmd=f"mkdir {mount}", sudo=True)
 
-        # Create the mount point
         cmd = f"{self.base_cmd} -t nfs -o vers={version},port={port}"
+        proto = kwargs.get("proto")
+        if proto:
+            cmd += f",proto={proto}"
         xprtsec = kwargs.get("xprtsec")
         if xprtsec:
             cmd += f",xprtsec={xprtsec}"

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-rdma.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-rdma.yaml
@@ -1,0 +1,257 @@
+#===============================================================================================
+#---    Test Suite for NFS Ganesha over RDMA Transport   ---
+#===============================================================================================
+# Conf: conf/tentacle/nfs/1admin-7node-3client.yaml
+#
+# Pre-requisites (run before this suite or chain after a deploy suite):
+#   1. install_prereq.py          — install software pre-requisites
+#   2. test_cephadm.py            — bootstrap cluster, deploy OSD/RGW/MDS,
+#                                   create cephfs volume and rbd pool
+#   3. test_client.py (x4)        — configure client.1..client.4 on node4..node7
+#                                   with ceph-common, ceph-fuse, admin keyring
+#
+# All tests use enable_rdma: true with proto=rdma for client mounts.
+# Direct daemon mounts only (no VIP/ingress RDMA tests yet).
+# Tests are sorted by number of clients required: 1-client, 2-client, 3+ client.
+#
+#===============================================================================================
+
+# --- 1-client tests ---
+
+tests:
+  - test:
+      name: NFS RDMA - Export Readonly
+      module: test_export_readonly.py
+      desc: Test NFS export with readonly over RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 1
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  # --- 2-client tests ---
+
+  - test:
+      name: NFS RDMA - File Operations
+      module: nfs_verify_file_operations.py
+      desc: Verify file create, softlink and lookups over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+        operations:
+          client01: create_files
+          client02: perform_lookups
+
+  - test:
+      name: NFS RDMA - File Lock
+      module: nfs_verify_file_lock.py
+      desc: Perform file locking from 2 clients over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Read Write Operations
+      module: nfs_verify_read_write_operations.py
+      desc: Verify read and write operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Soft Links
+      module: nfs_verify_file_ops_soft_links.py
+      desc: Verify soft link operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Truncate
+      module: nfs_file_truncate.py
+      desc: Verify file truncate operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Stress Test
+      module: nfs_verify_stress.py
+      desc: Verify NFS stress operations over RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Directory Depth and Permissions
+      module: nfs_verify_multi_depth_dir_and_permissions.py
+      desc: Verify deep directory creation and permission handling over RDMA
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Export Rootsquash
+      module: test_export_rootsquash.py
+      desc: Verify rootsquash enforcement over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Get Set Attributes
+      module: test_nfs_get_set_attr_operation.py
+      desc: Verify get/set attribute operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Pynfs Test Suite
+      module: nfs_verify_pynfs.py
+      desc: Run pynfs compliance tests over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Xattr Operations
+      module: nfs_test_xattr_across_file_operations.py
+      desc: Verify extended attribute operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  # --- 3-client tests ---
+
+  - test:
+      name: NFS RDMA - Hard Links
+      module: nfs_verify_file_ops_hard_links.py
+      desc: Verify hard link operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Modification
+      module: nfs_verify_file_modification.py
+      desc: Verify file modification and timestamps over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Parallel IO and Lookups
+      module: nfs_verify_multiple_parallel_io_and_lookups.py
+      desc: Verify parallel IO and lookups over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Append
+      module: nfs_file_append.py
+      desc: Verify file append operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Copy Operations
+      module: test_file_ops_copy.py
+      desc: Verify file and directory copy operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Rename Operations
+      module: test_file_ops_renames.py
+      desc: Verify file and directory rename operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  # --- 4-client tests ---
+
+  - test:
+      name: NFS RDMA - Readdir Operations
+      module: nfs_verify_readdir_ops.py
+      desc: Verify directory listing operations over RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 4
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"

--- a/tests/nfs/acl/test_nfs_acl_functional.py
+++ b/tests/nfs/acl/test_nfs_acl_functional.py
@@ -107,6 +107,8 @@ def run(ceph_cluster, **kw):
                 nfs_export,
                 fs,
                 ceph_cluster=ceph_cluster,
+                enable_rdma=config.get("enable_rdma", False),
+                rdma_port=config.get("rdma_port"),
             )
         else:
             log.error(

--- a/tests/nfs/acl/test_nfs_acl_negative.py
+++ b/tests/nfs/acl/test_nfs_acl_negative.py
@@ -96,6 +96,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         client = clients[0]

--- a/tests/nfs/acl/test_nfs_acl_scale.py
+++ b/tests/nfs/acl/test_nfs_acl_scale.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         client = clients[0]

--- a/tests/nfs/nfs_client_permission_export.py
+++ b/tests/nfs/nfs_client_permission_export.py
@@ -49,6 +49,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with client permission

--- a/tests/nfs/nfs_conflicting_locks.py
+++ b/tests/nfs/nfs_conflicting_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_edit_export_config_with_1client_access.py
+++ b/tests/nfs/nfs_edit_export_config_with_1client_access.py
@@ -96,6 +96,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_edit_export_config_with_access_none.py
+++ b/tests/nfs/nfs_edit_export_config_with_access_none.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Create export
         Ceph(clients[0]).nfs.export.create(

--- a/tests/nfs/nfs_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_edit_export_config_with_ro.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_export_rootsquash_windows.py
+++ b/tests/nfs/nfs_export_rootsquash_windows.py
@@ -63,6 +63,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with squash permission

--- a/tests/nfs/nfs_failover_with_rm_operation_windows.py
+++ b/tests/nfs/nfs_failover_with_rm_operation_windows.py
@@ -73,6 +73,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_file_append.py
+++ b/tests/nfs/nfs_file_append.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create files from client 1

--- a/tests/nfs/nfs_file_truncate.py
+++ b/tests/nfs/nfs_file_truncate.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create files from dd on client 1

--- a/tests/nfs/nfs_ha_client_update_permission_windows.py
+++ b/tests/nfs/nfs_ha_client_update_permission_windows.py
@@ -84,6 +84,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_ha_export_delete_windows.py
+++ b/tests/nfs/nfs_ha_export_delete_windows.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create exports

--- a/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
@@ -78,6 +78,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
@@ -78,6 +78,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_ha_failover_with_untar.py
+++ b/tests/nfs/nfs_ha_failover_with_untar.py
@@ -57,6 +57,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         sleep(3)

--- a/tests/nfs/nfs_ha_readdir_operation.py
+++ b/tests/nfs/nfs_ha_readdir_operation.py
@@ -86,6 +86,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_ha_reboot_with_file_modify.py
+++ b/tests/nfs/nfs_ha_reboot_with_file_modify.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_hard_links_delete_file.py
+++ b/tests/nfs/nfs_hard_links_delete_file.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_hard_symbolic_links_rename.py
+++ b/tests/nfs/nfs_hard_symbolic_links_rename.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_multi_client_byterange_filelock.py
+++ b/tests/nfs/nfs_multi_client_byterange_filelock.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             fs_name,
             ceph_cluster=ceph_cluster,
             single_export=True,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_multi_mount_version_4x.py
+++ b/tests/nfs/nfs_multi_mount_version_4x.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Run parallel IO on v4.1 and v4.2 mounts

--- a/tests/nfs/nfs_multiple_xattr_set_and_delete.py
+++ b/tests/nfs/nfs_multiple_xattr_set_and_delete.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/nfs_multivolume_rootsquash.py
+++ b/tests/nfs/nfs_multivolume_rootsquash.py
@@ -79,6 +79,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Change the permission of mount dir from Linux client

--- a/tests/nfs/nfs_non_overlapping_locks.py
+++ b/tests/nfs/nfs_non_overlapping_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -10,6 +10,7 @@ from time import sleep
 import yaml
 from looseversion import LooseVersion
 
+from ceph.ceph import CommandFailed
 from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
@@ -58,7 +59,44 @@ def setup_nfs_cluster(
     active_standby=False,
     round_robin=False,
     single_export=False,
+    enable_rdma=False,
+    rdma_port=None,
 ):
+    """Set up an NFS-Ganesha cluster with exports and client mounts.
+
+    End-to-end helper used by most NFS test modules.  It enables the
+    NFS manager module, creates an NFS-Ganesha cluster, creates one
+    export per client (or a single shared export), and mounts the
+    export(s) on each client.
+
+    Args:
+        clients (list): Client CephNode objects to mount on.
+        nfs_server (str | list): NFS server hostname(s) for the
+            cluster placement.
+        port (str): TCP NFS port (e.g. ``"2049"``).
+        version: NFS version(s) to use for mounts.  May be a single
+            value (``"4.2"``) or a dict mapping versions to client
+            lists for multi-version mounts.
+        nfs_name (str): NFS cluster name.
+        nfs_mount (str): Local mount-point path on clients.
+        fs_name (str): CephFS filesystem name (e.g. ``"cephfs"``).
+        export (str): Base export pseudo-path prefix.
+        fs (str): Filesystem backend identifier.
+        ha (bool): Enable HA with ingress (requires *vip*).
+        vip (str | None): Virtual IP for HA ingress.
+        ceph_cluster: CephCluster object for node lookups.
+        active_standby (bool): Use active-standby HA placement.
+        round_robin (bool): Distribute mounts across all servers
+            in round-robin fashion.
+        single_export (bool): Create only one export shared by
+            all clients instead of one per client.
+        enable_rdma (bool): Create the cluster with ``--enable-rdma``
+            and mount clients using ``proto=rdma``.
+        rdma_port (str | int | None): RDMA listener port passed to
+            ``--rdma_port`` on cluster create and used as the mount
+            port when *enable_rdma* is True.  Falls back to *port*
+            if not specified.
+    """
     # Get ceph cluter object and setup start time
     global ceph_cluster_obj
     global setup_start_time
@@ -114,6 +152,8 @@ def setup_nfs_cluster(
         vip=vip,
         active_standby=active_standby,
         nfs_nodes_obj=nfs_nodes,
+        enable_rdma=enable_rdma,
+        rdma_port=rdma_port,
         **create_kwargs,
     )
     sleep(3)
@@ -168,6 +208,14 @@ def setup_nfs_cluster(
         else:
             mount_servers = [servers[0]]
 
+    mount_kwargs = {}
+    if enable_rdma:
+        mount_kwargs["proto"] = "rdma"
+        mount_port = rdma_port or port
+        log.info("RDMA enabled: mounts will use proto=rdma, port=%s", mount_port)
+    else:
+        mount_port = port
+
     i = 0
     server_idx = 0
     for version, clients in mount_versions.items():
@@ -182,9 +230,34 @@ def setup_nfs_cluster(
             else:
                 current_export = export_name  # Fallback
 
+            # Clear any stale mount left by a previous test before mkdir
+            try:
+                client.exec_command(sudo=True, cmd=f"stat {nfs_mount}")
+            except CommandFailed:
+                try:
+                    client.exec_command(
+                        sudo=True, cmd=f"umount -l {nfs_mount}", check_ec=False
+                    )
+                    client.exec_command(
+                        sudo=True, cmd=f"rm -rf {nfs_mount}", check_ec=False
+                    )
+                except Exception:
+                    pass
+                log.info(
+                    "Cleared stale/leftover mount at %s on %s",
+                    nfs_mount,
+                    client.hostname,
+                )
+
             client.create_dirs(dir_path=nfs_mount, sudo=True)
             if mount_retry(
-                client, nfs_mount, version, port, current_server, current_export
+                client,
+                nfs_mount,
+                version,
+                mount_port,
+                current_server,
+                current_export,
+                **mount_kwargs,
             ):
                 log.info(
                     "Mount succeeded on %s using server %s and export %s"
@@ -1156,9 +1229,19 @@ def mount_retry(client, mount_name, version, port, nfs_server, export_name, **kw
 
 @retry(OperationFailedError, tries=5, delay=10, backoff=2)
 def mount_cleanup_retry(client, mount_name):
-    _, err = client.exec_command(sudo=True, cmd=f"rm -rf {mount_name}/*", timeout=120)
-    if err:
-        raise OperationFailedError("Failed to clenaup the mount directory")
+    try:
+        _, err = client.exec_command(
+            sudo=True, cmd=f"rm -rf {mount_name}/*", timeout=120
+        )
+        if err:
+            raise OperationFailedError("Failed to cleanup the mount directory")
+    except CommandFailed as e:
+        log.warning(
+            "rm -rf %s/* failed on %s: %s — skipping, will proceed to unmount",
+            mount_name,
+            client.hostname,
+            e,
+        )
     return True
 
 

--- a/tests/nfs/nfs_overlapping_locks.py
+++ b/tests/nfs/nfs_overlapping_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_queue_management_locks.py
+++ b/tests/nfs/nfs_queue_management_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
+++ b/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
@@ -64,6 +64,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_rootsquash_using_conf.py
+++ b/tests/nfs/nfs_rootsquash_using_conf.py
@@ -75,6 +75,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_run_nfslocktest_suite.py
+++ b/tests/nfs/nfs_run_nfslocktest_suite.py
@@ -60,6 +60,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
+++ b/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount the export on client 2

--- a/tests/nfs/nfs_single_client_byterange_filelock.py
+++ b/tests/nfs/nfs_single_client_byterange_filelock.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_spec_storage.py
+++ b/tests/nfs/nfs_spec_storage.py
@@ -43,6 +43,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         log.info(f"Run SPECstorage with {benchmark} benchmark")

--- a/tests/nfs/nfs_test_allocation_beyond_size.py
+++ b/tests/nfs/nfs_test_allocation_beyond_size.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file

--- a/tests/nfs/nfs_test_multiple_filesystem_exports.py
+++ b/tests/nfs/nfs_test_multiple_filesystem_exports.py
@@ -142,6 +142,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         for i in range(1, 5):

--- a/tests/nfs/nfs_test_remount_windows.py
+++ b/tests/nfs/nfs_test_remount_windows.py
@@ -58,6 +58,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_test_selinux_context_moving_files.py
+++ b/tests/nfs/nfs_test_selinux_context_moving_files.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             fs,
             ceph_cluster=ceph_cluster,
             single_export=True,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create 5 file on Mount point from client 1

--- a/tests/nfs/nfs_test_setting_selinux_context.py
+++ b/tests/nfs/nfs_test_setting_selinux_context.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             fs,
             ceph_cluster=ceph_cluster,
             single_export=True,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point from client 1

--- a/tests/nfs/nfs_test_space_allocation_diff_sizes.py
+++ b/tests/nfs/nfs_test_space_allocation_diff_sizes.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # List of files and sizes to create and verify

--- a/tests/nfs/nfs_test_xattr_across_file_operations.py
+++ b/tests/nfs/nfs_test_xattr_across_file_operations.py
@@ -64,6 +64,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/nfs_validate_cmount_path_export_conf.py
+++ b/tests/nfs/nfs_validate_cmount_path_export_conf.py
@@ -44,6 +44,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the export info

--- a/tests/nfs/nfs_verify_bonnie.py
+++ b/tests/nfs/nfs_verify_bonnie.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Install bonnie++ on clients

--- a/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
+++ b/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
@@ -69,6 +69,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_failover_with_file_ops.py
+++ b/tests/nfs/nfs_verify_failover_with_file_ops.py
@@ -79,6 +79,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_failover_with_io.py
+++ b/tests/nfs/nfs_verify_failover_with_io.py
@@ -57,6 +57,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Trigger smallfile IO

--- a/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
+++ b/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
@@ -63,6 +63,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_file_lock.py
+++ b/tests/nfs/nfs_verify_file_lock.py
@@ -63,6 +63,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")

--- a/tests/nfs/nfs_verify_file_lock_ha.py
+++ b/tests/nfs/nfs_verify_file_lock_ha.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")

--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_verify_file_modification.py
+++ b/tests/nfs/nfs_verify_file_modification.py
@@ -73,6 +73,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_operations.py
+++ b/tests/nfs/nfs_verify_file_operations.py
@@ -60,6 +60,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_ops_hard_links.py
+++ b/tests/nfs/nfs_verify_file_ops_hard_links.py
@@ -60,6 +60,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_ops_soft_links.py
+++ b/tests/nfs/nfs_verify_file_ops_soft_links.py
@@ -85,6 +85,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_ha_readonly_windows.py
+++ b/tests/nfs/nfs_verify_ha_readonly_windows.py
@@ -65,6 +65,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_verify_hard_links_inode.py
+++ b/tests/nfs/nfs_verify_hard_links_inode.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
+++ b/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
@@ -64,6 +64,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
+++ b/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
+++ b/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_multi_client_failover_windows.py
+++ b/tests/nfs/nfs_verify_multi_client_failover_windows.py
@@ -70,6 +70,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Mount NFS-Ganesha V3 to window clients
         for windows_client in windows_clients:

--- a/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
+++ b/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window clients

--- a/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
+++ b/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
@@ -45,6 +45,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create multi depth dirs under nfs share

--- a/tests/nfs/nfs_verify_multi_mount_version.py
+++ b/tests/nfs/nfs_verify_multi_mount_version.py
@@ -52,6 +52,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Run parallel IO on each client's mount

--- a/tests/nfs/nfs_verify_multi_node_cluster.py
+++ b/tests/nfs/nfs_verify_multi_node_cluster.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Perform file creation on client 1
         for i in range(100):

--- a/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
+++ b/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
@@ -53,6 +53,8 @@ def run(ceph_cluster, **kw):
                 nfs_export,
                 fs,
                 ceph_cluster=ceph_cluster,
+                enable_rdma=config.get("enable_rdma", False),
+                rdma_port=config.get("rdma_port"),
             )
 
         if io:

--- a/tests/nfs/nfs_verify_nfs_ha.py
+++ b/tests/nfs/nfs_verify_nfs_ha.py
@@ -53,6 +53,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("Successfully setup NFS HA cluster")
         return 0

--- a/tests/nfs/nfs_verify_nfs_kill_process_failover.py
+++ b/tests/nfs/nfs_verify_nfs_kill_process_failover.py
@@ -55,6 +55,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("Successfully setup NFS HA cluster")
 

--- a/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
+++ b/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
@@ -61,6 +61,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         operations = []

--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -58,6 +58,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         ceph_ver = None

--- a/tests/nfs/nfs_verify_pynfs_ha.py
+++ b/tests/nfs/nfs_verify_pynfs_ha.py
@@ -56,6 +56,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Client 1

--- a/tests/nfs/nfs_verify_read_write_operations.py
+++ b/tests/nfs/nfs_verify_read_write_operations.py
@@ -45,6 +45,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if operation == "verify_permission":

--- a/tests/nfs/nfs_verify_readdir_operation.py
+++ b/tests/nfs/nfs_verify_readdir_operation.py
@@ -74,6 +74,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Change the permission of mount dir from Linux client

--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Linux untar on client 1

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -108,6 +108,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with squash permission

--- a/tests/nfs/nfs_verify_stress.py
+++ b/tests/nfs/nfs_verify_stress.py
@@ -59,6 +59,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("Successfully setup NFS cluster")
 

--- a/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
+++ b/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_verify_symbolic_links_permissions.py
+++ b/tests/nfs/nfs_verify_symbolic_links_permissions.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file

--- a/tests/nfs/nfs_verify_symbolic_links_users.py
+++ b/tests/nfs/nfs_verify_symbolic_links_users.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file

--- a/tests/nfs/nfs_verify_v3_mount_window_linux.py
+++ b/tests/nfs/nfs_verify_v3_mount_window_linux.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
+++ b/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window clients

--- a/tests/nfs/nfs_verify_windows_client.py
+++ b/tests/nfs/nfs_verify_windows_client.py
@@ -68,6 +68,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # If windows clients are present, perform mount
         if win_clients:

--- a/tests/nfs/nfs_verify_windows_parallel_readdir.py
+++ b/tests/nfs/nfs_verify_windows_parallel_readdir.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window clients

--- a/tests/nfs/nfs_verify_xattr_readonly_file.py
+++ b/tests/nfs/nfs_verify_xattr_readonly_file.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/qos/test_nfs_qos_on_cluster_level_enablement.py
+++ b/tests/nfs/qos/test_nfs_qos_on_cluster_level_enablement.py
@@ -792,6 +792,8 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             round_robin=True if cluster_qos else False,
             single_export=True if cluster_qos else False,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Process QoS operations

--- a/tests/nfs/qos/test_nfs_qos_on_export_level_enablement.py
+++ b/tests/nfs/qos/test_nfs_qos_on_export_level_enablement.py
@@ -178,6 +178,8 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             round_robin=True if cluster_qos else False,
             single_export=True if cluster_qos else False,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Process QoS operations

--- a/tests/nfs/qos/test_nfs_qos_ops_control.py
+++ b/tests/nfs/qos/test_nfs_qos_ops_control.py
@@ -124,6 +124,8 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             round_robin=True if cluster_qos else False,
             single_export=True if cluster_qos else False,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         target_clients = clients if cluster_qos else client

--- a/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare.py
+++ b/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare.py
@@ -111,6 +111,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         nfs_export = f"{nfs_export}_0"

--- a/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare_perclient.py
+++ b/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare_perclient.py
@@ -121,6 +121,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Enable QoS at cluster level first (required)

--- a/tests/nfs/security/test_nfs_ldap_mapping.py
+++ b/tests/nfs/security/test_nfs_ldap_mapping.py
@@ -450,6 +450,8 @@ def run(ceph_cluster, **kw):
             export=nfs_export,
             fs=fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Allow writing to the mount point (chmod 777) for setup

--- a/tests/nfs/test_export_readonly.py
+++ b/tests/nfs/test_export_readonly.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with RO permission

--- a/tests/nfs/test_export_rootsquash.py
+++ b/tests/nfs/test_export_rootsquash.py
@@ -68,6 +68,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with squash permission

--- a/tests/nfs/test_file_ops_copy.py
+++ b/tests/nfs/test_file_ops_copy.py
@@ -95,6 +95,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Create files and dirs from client 1 and copy files and dirs from client 2
         client1 = clients[0]

--- a/tests/nfs/test_file_ops_renames.py
+++ b/tests/nfs/test_file_ops_renames.py
@@ -94,6 +94,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create files from Client 1 and perform lookups and rename from client 2 and client 3

--- a/tests/nfs/test_nfs_export_readonly_windows.py
+++ b/tests/nfs/test_nfs_export_readonly_windows.py
@@ -74,6 +74,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/test_nfs_extended_attribute_rootsquash.py
+++ b/tests/nfs/test_nfs_extended_attribute_rootsquash.py
@@ -71,6 +71,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Change the permission of mount dir from Linux client

--- a/tests/nfs/test_nfs_get_set_attr_operation.py
+++ b/tests/nfs/test_nfs_get_set_attr_operation.py
@@ -44,6 +44,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/test_nfs_grpc.py
+++ b/tests/nfs/test_nfs_grpc.py
@@ -477,6 +477,8 @@ def run(ceph_cluster, **kw):
             export=nfs_export,
             fs=fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("NFS cluster setup complete.")
 

--- a/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
+++ b/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
@@ -111,6 +111,8 @@ def create_nfs_cluster(
     ha=False,
     vip=None,
     active_standby=False,
+    enable_rdma=False,
+    rdma_port=None,
 ):
     """Create NFS cluster"""
     try:
@@ -130,6 +132,8 @@ def create_nfs_cluster(
             ha=ha,
             vip=vip,
             active_standby=active_standby,
+            enable_rdma=enable_rdma,
+            rdma_port=rdma_port,
         )
     except Exception as e:
         raise ConfigError(f"Failed to create NFS cluster: {e}")
@@ -187,6 +191,8 @@ def run(ceph_cluster, **kw):
                 ha=ha,
                 vip=vip,
                 active_standby=active_standby,
+                enable_rdma=config.get("enable_rdma", False),
+                rdma_port=config.get("rdma_port"),
             )
             # Create file in parellel using ThreadPoolExecutor
             log.info("Creating files in parallel using ThreadPoolExecutor")

--- a/tests/nfs/test_nfs_partial_deallocation.py
+++ b/tests/nfs/test_nfs_partial_deallocation.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file

--- a/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
+++ b/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         Ceph(clients[0]).nfs.export.create(

--- a/tests/nfs/test_nfs_selinux_context_symlinks.py
+++ b/tests/nfs/test_nfs_selinux_context_symlinks.py
@@ -44,6 +44,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on mount point

--- a/tests/nfs/test_nfs_selinux_label_while_mounting.py
+++ b/tests/nfs/test_nfs_selinux_label_while_mounting.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Remount the share on Client with selinux label
         cmd = f"umount -l {nfs_mount}"


### PR DESCRIPTION
Wire RDMA cluster creation and RDMA client mounts into the standard NFS test path so any existing test can run over RDMA by setting enable_rdma: true and rdma_port in the suite YAML config.

Changes:
- Mount.nfs(): accept proto kwarg (e.g. proto=rdma) for transport
- Cluster.create(): accept enable_rdma / rdma_port for --enable-rdma
- setup_nfs_cluster(): forward RDMA params to create + mount, with support for direct-daemon and VIP/HA topologies
- 103 test files: forward enable_rdma/rdma_port from config
- New suite: tier1-nfs-ganesha-rdma.yaml with 20 RDMA sanity tests

Pass logs : http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-Z6U4R1

Note : Pynfs Test Suite | FAILED — upstream pynfs repo missing `nfs4.2` dir (pre-existing, not RDMA related) |

Few general issues fixed as well.
1. **`mount_cleanup_retry` crash on stale/busy NFS mounts**: `rm -rf /mnt/nfs/*` raises `CommandFailed` on stale file handle or directory-not-empty errors. The `@Retry` decorator only catches `OperationFailedError`, so `CommandFailed` propagates up and kills the entire cleanup before it can unmount. Fix: catch `CommandFailed` in `mount_cleanup_retry` and let cleanup proceed to the unmount step.
2. **`setup_nfs_cluster` crash on leftover stale mounts**: if a previous test's cleanup failed, `mkdir -p /mnt/nfs` hits "Stale file handle" and the next test crashes at setup. Fix: before `mkdir`, run `stat` on the mount point — if it fails, lazy-unmount and remove the stale mount before proceeding.


Fail log : http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-8IFN87/ 
```
Test 1 (Export Readonly)  → PASSED  (1 client, grim037 not used for mount)
Test 2 (Bonnie)           → bonnie++ times out after 600s
  → cleanup: rm -rf /mnt/nfs/* fails with "Directory not empty" (NOT stale handle)
  → CommandFailed propagates, cleanup crashes
  → mount on grim037 never unmounted, NFS cluster never deleted
Test 3 (File Operations)  → setup_nfs_cluster recreates "cephfs-nfs" cluster
  → NFS daemon restarts → grim037's existing mount goes STALE
  → mkdir -p /mnt/nfs → "Stale file handle" → crash
  → cleanup also crashes on stale handle
Tests 4-13: same cascade — grim037 stale mount never cleared
```


Error snippet : 
```
ceph.ceph.CommandFailed: mkdir -p /mnt/nfs returned mkdir: cannot stat ‘/mnt/nfs’: Stale file handle
 and code 1 on grim037 [10.64.66.86]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pawandhiran/ci/latest-rdma/cephci/tests/nfs/test_nfs_get_set_attr_operation.py", line 85, in run
    cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandhiran/ci/latest-rdma/cephci/tests/nfs/nfs_operations.py", line 320, in cleanup_cluster
    if not mount_cleanup_retry(client, nfs_mount):
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandhiran/ci/latest-rdma/cephci/utility/retry.py", line 27, in f_retry
    return f(*args, **kwargs)
  File "/Users/pawandhiran/ci/latest-rdma/cephci/tests/nfs/nfs_operations.py", line 1212, in mount_cleanup_retry
    _, err = client.exec_command(sudo=True, cmd=f"rm -rf {mount_name}/*", timeout=120)
             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandhiran/ci/latest-rdma/cephci/ceph/ceph.py", line 2114, in exec_command
    raise CommandFailed(
        f"{cmd} returned {_err} and code {_exit} on {self.hostname} [{self.ip_address}]"
    )
ceph.ceph.CommandFailed: rm -rf /mnt/nfs/* returned rm: cannot remove '/mnt/nfs/*': Stale file handle
 and code 1 on grim037 [10.64.66.86]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pawandhiran/ci/latest-rdma/cephci/run.py", line 1079, in run
    rc = test_mod.run(
        ceph_cluster=ceph_cluster_dict[cluster_name],
    ...<6 lines>...
        run_config=run_config,
    )
  File "/Users/pawandhiran/ci/latest-rdma/cephci/tests/nfs/test_nfs_get_set_attr_operation.py", line 91, in run
    cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandhiran/ci/latest-rdma/cephci/tests/nfs/nfs_operations.py", line 320, in cleanup_cluster
    if not mount_cleanup_retry(client, nfs_mount):
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandhiran/ci/latest-rdma/cephci/utility/retry.py", line 27, in f_retry
    return f(*args, **kwargs)
  File "/Users/pawandhiran/ci/latest-rdma/cephci/tests/nfs/nfs_operations.py", line 1212, in mount_cleanup_retry
    _, err = client.exec_command(sudo=True, cmd=f"rm -rf {mount_name}/*", timeout=120)
             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandhiran/ci/latest-rdma/cephci/ceph/ceph.py", line 2114, in exec_command
    raise CommandFailed(
        f"{cmd} returned {_err} and code {_exit} on {self.hostname} [{self.ip_address}]"
    )
ceph.ceph.CommandFailed: rm -rf /mnt/nfs/* returned rm: cannot remove '/mnt/nfs/*': Stale file handle
 and code 1 on grim037 [10.64.66.86]
```