### PR TITLE
Revert disabling Ceph Mgr balancer module during bootstrap

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -496,19 +496,6 @@ class BootstrapMixin:
             self.shell(
                 args=["ceph", "config", "set", "global cluster_network", cluster_nws]
             )
-        if self.cluster.rhcs_version >= LooseVersion("8.0"):
-            wa_txt = """
-            Disabling the balancer module as a WA for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2314146
-            Issue : If any mgr module based operation is performed right after mgr failover, The command execution fails
-            as the module isn't loaded by mgr daemon. Issue was identified to be with Balancer module.
-            Disabling automatic balancing on the cluster as a WA until we get the fix for the same.
-            Disabling balancer should unblock Upgrade tests.
-            Error snippet :
-    Error ENOTSUP: Warning: due to ceph-mgr restart, some PG states may not be up to date
-    Module 'crash' is not enabled/loaded (required by command 'crash ls'): use `ceph mgr module enable crash` to enable
-            """
-            logger.info(wa_txt)
-            self.shell(args=["ceph balancer off"])
 
         # validate spec file
         if specs:


### PR DESCRIPTION
Bugzilla tracker - https://bugzilla.redhat.com/show_bug.cgi?id=2314146

Jira tracker - https://ibm-ceph.atlassian.net/browse/IBMCEPH-9881

> If any mgr module based operation is performed right after mgr failover, The command execution fails as the module isn't loaded by mgr daemon. Issue was identified to be with Balancer module.
> 
> Disabling automatic balancing on the cluster as a WA until we get the fix for the same.
> Disabling balancer should unblock Upgrade tests.

Error snippet :
```
    Error ENOTSUP: Warning: due to ceph-mgr restart, some PG states may not be up to date
    Module 'crash' is not enabled/loaded (required by command 'crash ls'): use `ceph mgr module enable crash` to enable
```

We have the fix merged in downstream that has passed initial qualification. We would like a more holistic coverage so removing the workaround to let all the upgrade pipelines get triggered with all the mgr modules enabled.

Signed-off-by: Harsh Kumar <harsh@corpha2-int.rdu.redhat.com>