### PR TITLE
chore(owners): extend approver list across core paths

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@
 approvers:
   - veera-raghava-reddy
   - cephci-admins
+  - ceph-qe-managers
 
 reviewers:
   - ceph-ci-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,14 @@ aliases:
     - sunilkumarn417
     - AmarnatReddy
     - psathyan
+    - rakeshcn
+
+  ceph-qe-managers:
+    - vdas-redhat
+    - neha-gangadhar
+    - Manohar-Murthy
+    - mkasturi18
+    - prshanthakumar
 
   # Members of Ceph Infra team
   ceph-infra-team:
@@ -16,11 +24,9 @@ aliases:
 
   # members of RBD team
   ceph-block-team:
-    - Manohar-Murthy
     - sunilangadi2
     - manasagowri
     - rahullepakshi
-    - HaruChebrolu
     - jprakash-redhat
     - sunilkumarn417
     - krishnaramaswamy
@@ -29,8 +35,6 @@ aliases:
 
   # Members of CI team
   ceph-ci-team:
-    - pavankumarag
-    - vdas-redhat
     - vamahaja
     - obannak
     - tintumathew10
@@ -39,17 +43,13 @@ aliases:
 
   # Members of DMFG
   ceph-dmfg-team:
-    - vdas-redhat
     - sayaleeraut
     - adityaramteke
     - vinpapnoi
-    - msainiRedhat
     - MohitBis
-    - pranavprakash20
 
   # Members of FS
   ceph-fs-team:
-    - neha-gangadhar
     - sumabai
     - hkadam134
     - Manimaran-MM
@@ -57,7 +57,6 @@ aliases:
 
   # Members of rados
   ceph-rados-team:
-    - neha-gangadhar
     - pdhiran
     - SrinivasaBharath
     - harshkumarRH
@@ -66,7 +65,6 @@ aliases:
 
   # Members of RGW
   ceph-rgw-team:
-    - mkasturi18
     - viduship
     - TejasC88
     - ckulal

--- a/suites/tentacle/smb/OWNERS
+++ b/suites/tentacle/smb/OWNERS
@@ -8,7 +8,6 @@ approvers:
 
 reviewers:
   - adityaramteke
-  - vamahaja
 
 labels:
   - Samba


### PR DESCRIPTION
Changes consists of - 

- Create new owners alias `ceph-qe-managers` with `vdas-redhat`, `neha-gangadhar`, `Manohar-Murthy`, `mkasturi18`, `prshanthakumar`.
- Add managers `ceph-qe-managers` group and add as approvers in the core `OWNERS` file.
- Remove `HaruChebrolu`, `pavankumarag`, `pranavprakash20`, `msaniniRedhat` from team aliases.
