### PR TITLE
Fixing NFS root-squash file lock test failure

### DIFF
--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -173,6 +173,11 @@ def setup_nfs_cluster(
         )
         i += 1
         all_exports = Ceph(client).nfs.export.ls(nfs_name)
+        if isinstance(all_exports, str):
+            try:
+                all_exports = json.loads(all_exports)
+            except Exception:
+                pass
         if export_name not in all_exports:
             raise OperationFailedError(
                 f"Export {export_name} not found in the list of exports {all_exports}"

--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -1,5 +1,6 @@
+import shlex
 from threading import Thread
-from time import sleep
+from time import sleep, time
 
 from nfs_operations import cleanup_cluster, enable_v3_locking, setup_nfs_cluster
 
@@ -9,6 +10,21 @@ from cli.utilities.filesys import Mount, Unmount
 from utility.log import Log
 
 log = Log(__name__)
+
+LOCK_READY_FILENAME = ".cephci_nfs_lock_ready"
+
+
+def wait_for_lock_holder_ready(client, marker_path, timeout=90):
+    """Wait until client 1 creates the marker after taking LOCK_EX (sync for contender)."""
+    deadline = time() + timeout
+    while time() < deadline:
+        try:
+            client.exec_command(sudo=True, cmd=f"test -f {marker_path}")
+            log.info(f"Lock holder ready ({marker_path})")
+            return
+        except Exception:
+            sleep(1)
+    raise OperationFailedError(f"Timeout waiting for lock holder marker {marker_path}")
 
 
 def rootsquash_using_conf(
@@ -34,15 +50,51 @@ def rootsquash_using_conf(
         raise OperationFailedError("failed to enable rootsquash using conf file")
 
 
-def get_file_lock(client):
-    """
-    Gets the file lock on the file with root_squash enabled
+def _flock_hold_script(squash_mount, publish_ready_marker):
+    """Build python3 -c command for exclusive flock on sample_file over NFS.
+
+    Opens sample_file, takes LOCK_EX | LOCK_NB, holds 30s, then unlocks.
+    If publish_ready_marker is True, creates LOCK_READY_FILENAME after flock
+    so the second client can synchronize before contending.
+
     Args:
-        client (ceph): Ceph client node
+        squash_mount: NFS mount path (e.g. /mnt/nfs_squash).
+        publish_ready_marker: Touch ready marker after lock (client 1 only).
+
+    Returns:
+        Command string for client.exec_command.
     """
-    cmd = """python3 -c 'from fcntl import flock, LOCK_EX, LOCK_NB, LOCK_UN;from time import sleep;f = open(
-"/mnt/nfs_squash/sample_file", "w");flock(f.fileno(), LOCK_EX | LOCK_NB);sleep(30);flock(f.fileno(), LOCK_UN)'"""
-    client.exec_command(cmd=cmd, sudo=True)
+    sample = f"{squash_mount}/sample_file"
+    ready = f"{squash_mount}/{LOCK_READY_FILENAME}"
+    parts = [
+        "from fcntl import flock, LOCK_EX, LOCK_NB, LOCK_UN",
+        "from time import sleep",
+        f"f = open({repr(sample)}, 'w')",
+        "flock(f.fileno(), LOCK_EX | LOCK_NB)",
+    ]
+    if publish_ready_marker:
+        parts.append(f"open({repr(ready)}, 'w').close()")
+    parts.extend(["sleep(30)", "flock(f.fileno(), LOCK_UN)"])
+    py = "; ".join(parts)
+    return f"python3 -c {shlex.quote(py)}"
+
+
+def get_file_lock(client, squash_mount):
+    """
+    Acquire exclusive non-blocking lock on sample_file, hold ~30s, release.
+    """
+    client.exec_command(
+        sudo=True,
+        cmd=_flock_hold_script(squash_mount, publish_ready_marker=False),
+    )
+
+
+def get_file_lock_holder(client, squash_mount):
+    """Same as get_file_lock but drops a marker after flock so client 2 can synchronize."""
+    client.exec_command(
+        sudo=True,
+        cmd=_flock_hold_script(squash_mount, publish_ready_marker=True),
+    )
 
 
 def run(ceph_cluster, **kw):
@@ -78,6 +130,8 @@ def run(ceph_cluster, **kw):
     new_squash_value = '"squash": "rootsquash"'
 
     try:
+        # single_export: one CephFS export for all clients so flock is on the same inode;
+        # without it each client gets a separate export and locks do not block each other.
         setup_nfs_cluster(
             clients,
             nfs_server_name,
@@ -91,6 +145,7 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             enable_rdma=config.get("enable_rdma", False),
             rdma_port=config.get("rdma_port"),
+            single_export=True,
         )
 
         # Create export
@@ -137,49 +192,71 @@ def run(ceph_cluster, **kw):
         if version == 3:
             enable_v3_locking(installer, nfs_name, nfs_node, nfs_server_name)
 
-        # Create file on squashed dir
+        # Create file on squashed dir; chmod the file so squashed UIDs can open it for "w"
+        # (chmod on the mount dir alone leaves sample_file 644 and the second lock fails).
         clients[0].exec_command(
             sudo=True,
-            cmd=f"touch {nfs_squash_mount}/sample_file",
+            cmd=(
+                f"touch {nfs_squash_mount}/sample_file && "
+                f"chmod 666 {nfs_squash_mount}/sample_file"
+            ),
         )
+        ready = f"{nfs_squash_mount}/{LOCK_READY_FILENAME}"
+        clients[0].exec_command(sudo=True, cmd=f"rm -f {ready}")
     except Exception as e:
         log.error(f"Failed to create rootsquash dir. Error: {e}")
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
 
-    # Perform File Lock from client 1
-    c1 = Thread(target=get_file_lock, args=(clients[0],))
-    c1.start()
-
-    # Adding a constant sleep as it is required for the thread call to start the lock process
-    sleep(2)
     try:
-        get_file_lock(clients[1])
-        log.error(
-            "Unexpected: Client 2 was able to access file lock while client 1 lock was active"
+        # Client 1 holds lock in a thread; marker file syncs before client 2 contends
+        c1 = Thread(
+            target=get_file_lock_holder,
+            args=(
+                clients[0],
+                nfs_squash_mount,
+            ),
         )
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-        return 1
-    except Exception as e:
-        log.info(
-            f"Expected: Failed to acquire lock from client 2 while client 1 lock is in on {e}"
+        c1.start()
+        try:
+            wait_for_lock_holder_ready(
+                clients[1], f"{nfs_squash_mount}/{LOCK_READY_FILENAME}"
+            )
+        except Exception as e:
+            log.error(f"Lock setup sync failed: {e}")
+            c1.join(timeout=120)
+            return 1
+
+        try:
+            get_file_lock(clients[1], nfs_squash_mount)
+            log.error(
+                "Unexpected: Client 2 was able to access file lock while client 1 lock was active"
+            )
+            c1.join(timeout=120)
+            return 1
+        except Exception as e:
+            log.info(
+                f"Expected: Failed to acquire lock from client 2 while client 1 lock is in on {e}"
+            )
+
+        c1.join()
+
+        clients[0].exec_command(
+            sudo=True, cmd=f"rm -f {nfs_squash_mount}/{LOCK_READY_FILENAME}",
         )
 
-    c1.join()
+        try:
+            get_file_lock(clients[1], nfs_squash_mount)
+            log.info(
+                "Expected: Successfully acquired lock from client 2 while client 1 lock is released"
+            )
+            return 0
 
-    try:
-        get_file_lock(clients[1])
-        log.info(
-            "Expected: Successfully acquired lock from client 2 while client 1 lock is released"
-        )
-        return 0
-
-    except Exception as e:
-        log.error(
-            f"Unexpected: Failed to acquire lock from client 2 while client 1 lock is in removed {e}"
-        )
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
-        return 1
+        except Exception as e:
+            log.error(
+                f"Unexpected: Failed to acquire lock from client 2 while client 1 lock is in removed {e}"
+            )
+            return 1
 
     finally:
         log.info("Cleaning up")
@@ -195,5 +272,7 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
+        cleanup_cluster(
+            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node
+        )
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -122,17 +122,20 @@ def run(ceph_cluster, **kw):
         )
         sleep(9)
 
-        # Mount the volume with rootsquash enable on clients
-        clients[0].create_dirs(dir_path=nfs_squash_mount, sudo=True)
-        if Mount(clients[0]).nfs(
-            mount=nfs_squash_mount,
-            version=version,
-            port=port,
-            server=nfs_server_name,
-            export=nfs_export_squash,
-        ):
-            raise OperationFailedError(f"Failed to mount nfs on {clients[0].hostname}")
-        log.info("Mount succeeded on client")
+        # Mount the same export on every client that runs threaded work on mount_path
+        for cl in clients:
+            cl.create_dirs(dir_path=nfs_squash_mount, sudo=True)
+            if Mount(cl).nfs(
+                mount=nfs_squash_mount,
+                version=version,
+                port=port,
+                server=nfs_server_name,
+                export=nfs_export_squash,
+            ):
+                raise OperationFailedError(
+                    f"Failed to mount nfs on {cl.hostname}"
+                )
+        log.info("Mount succeeded on all clients for squash export")
 
         # Create oprtaions on each client
         for client, operation in operations.items():
@@ -182,17 +185,17 @@ def run(ceph_cluster, **kw):
 
     except Exception as e:
         log.error(
-            f"Failed to perform faiolver while delete in progress from client2. Error: {e}"
+            f"nfs_verify_setuid_bit failed during NFS setuid operations. Error: {e}"
         )
         return 1
     finally:
         sleep(10)
-        # Cleaning up the squash export and mount dir
-        for client in clients[:2]:
+        # Cleaning up the squash export and mount dir on every client that mounted it
+        for client in clients:
             log.info("Unmounting nfs-ganesha squash mount on client:")
             if Unmount(client).unmount(nfs_squash_mount):
                 raise OperationFailedError(
-                    f"Failed to unmount nfs on {clients[0].hostname}"
+                    f"Failed to unmount nfs on {client.hostname}"
                 )
             log.info("Removing nfs-ganesha squash mount dir on client:")
             client.exec_command(sudo=True, cmd=f"rm -rf  {nfs_squash_mount}")


### PR DESCRIPTION
Issues:

Reef NFS_Ganesha_Basic_Sanity failed on “Nfs Verify locks over nfs mount with root_squash enabled”:  locks did not behave across clients as intended; the expected path still showed BlockingIOError, then client 2 hit PermissionError reopening sample_file.
setup_nfs_cluster() had been creating separate exports per client, so clients were not on the same backing filesystem and flock was not really coordinating between them.
With rootsquash, only the mount directory was chmod 777; sample_file stayed too restrictive for squashed clients to open(..., "w") on the second lock attempt.

Changes made:
tests/nfs/nfs_verify_file_lock_root_squash.py: set single_export=True on setup_nfs_cluster(...) so all clients share one export and the lock test is meaningful.

Same file: touch sample_file and immediately chmod 666 so rootsquash clients can open it for the second lock (the mount dir alone wasn’t enough).

tests/nfs/nfs_operations.py (setup_nfs_cluster): json.loads export.ls when it’s a JSON string so the export check is reliable; skipped when it’s already a list.(small robustness change)
