### PR TITLE
Enable call home by default for 9.1 and above

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -403,11 +403,6 @@ class BootstrapMixin:
             if "automatically-accept-license" not in cmd:
                 cmd += " --automatically-accept-license"
 
-            # By default, call home is disabled when no call home options are
-            # are found
-            if "call-home" not in cmd:
-                cmd += " --disable-ibm-call-home"
-
         out, err = self.installer.exec_command(
             sudo=True,
             cmd=cmd,


### PR DESCRIPTION
# Description

Call Home by design is now enabled by default for IBM based builds where the version is greater than 9.1

- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve