### PR TITLE
Fix nfs-utils installation before mount

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -28,6 +28,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
+from cli.utilities.filesys import Mount
 from compute.openstack import get_openstack_driver
 from tests.cephfs.exceptions import ValueMismatchError
 from utility.log import Log
@@ -3284,6 +3285,8 @@ os.system('sudo systemctl start  network')
         :param nfs_export:
         :param nfs_mount_dir:
         """
+        Mount(client)._ensure_nfs_utils()
+
         client.exec_command(sudo=True, cmd=f"mkdir -p {nfs_mount_dir}")
         command = f"mount -t nfs -o vers=4,port={kwargs.get('port', '2049')} {nfs_server}:{nfs_export} {nfs_mount_dir}"
         if kwargs.get("fstab"):


### PR DESCRIPTION
NFS mount was failing in AWS env because nfs-utils were not installed.
Pass logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-237/cephfs/1441/logs/tier_0_fs/