### PR TITLE
Fix cephadm bootstrap for signed & unsigned Podman images

### DIFF
--- a/conf/inventory/ibm-eu-rhel-10.1.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.1.yaml
@@ -84,6 +84,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser

--- a/conf/inventory/ibm-eu-rhel-9.7.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.7.yaml
@@ -84,6 +84,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser


### PR DESCRIPTION
PR Description:

Problem: cephadm bootstrap failed with Podman due to signature verification errors:

Error: invalid policy in "/etc/containers/policy.json": Default policy is missing

Root Cause:

The current /etc/containers/policy.json did not include a proper "default" policy, which is mandatory for Podman. Additionally, critical registries used in Ceph CI (registry.redhat.io, registry.stage.redhat.io, quay.io) were rejected due to missing or strict signature policies.

Solution:

Added a "default": [{"type": "insecureAcceptAnything"}] policy to satisfy Podman’s requirement.

Added "insecureAcceptAnything" for the following registries:

registry.redhat.io

registry.stage.redhat.io

quay.io

Impact:

Fixes cephadm bootstrap and image pull failures for critical CI registries.
No global insecure policies beyond the necessary default; all other registries remain unaffected.
Verified successfully on test VMs.

Initially i added below content to the inventory and tried. This worked for images from registry.redhat.io (which are signed).

However, during upgrade testing, pulls from quay.io failed because Podman rejected the image based on the container signature policy. The reason was that /etc/containers/policy.json did not properly allow images from quay.io.

registry.redhat.io → worked
quay.io → failed (rejected by policy)
Log: https://149.81.216.83/view/Executor/job/tentacle-test-executor/851/
- content: | { "default": [ { "type": "reject" } ], "transports": { "docker": { "registry.redhat.io": [ { "type": "insecureAcceptAnything" } ] } } } path: /etc/containers/policy.json owner: root:root permissions: '0644'

I have updated policy:

Adds a valid "default" policy (required by Podman).
Sets "default": [{"type": "insecureAcceptAnything"}] so other registries are not rejected.
Explicitly allows:

registry.redhat.io
registry.stage.redhat.io
quay.io
Now both signed and unsigned images can be pulled successfully, and cephadm bootstrap and upgrade checks complete without policy errors.