### PR TITLE
Install python pip3 package explicitly during install pre-requisite

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -50,6 +50,7 @@ rpm_packages = {
         "wget",
         "git-core",
         "python3-devel",
+        "python3-pip",
         "chrony",
         "yum-utils",
         "net-tools",


### PR DESCRIPTION
At times it has been observed that pip3 module is unavailable resulting in pip3 install <> commands failing. Previously it was more prevalent in IBM Cloud pipeline, however, it has recently been observed in rhos-d VM's as well that caused unnecessary delay in 9.1 bug validations. 

Scope of this PR is to ensure that `python3-pip` package is installed on all the nodes as part of `install pre-requisite` test case.

Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NIX8B5/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>