### PR TITLE
Remove orch upgrade retries if mgr version is 9.1 and above

### DIFF
--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -112,27 +112,56 @@ class UpgradeMixin:
             upgrade Status (Dict)
 
         """
-        # Retry upgrade command for interval time until it pass till timeout
-        for w in WaitUntil(timeout=timeout, interval=interval):
-            try:
-                out, _ = self.shell(args=["ceph", "orch", "upgrade", "status"])
-            except CommandFailed as e:
-                msg = f"Upgrade command status failed due to error - {e},"
-                msg += f"\n\nRetrying upgrade status after {interval}..."
-                LOG.info(msg)
+        cmd = ["ceph", "orch", "upgrade", "status"]
 
-                # Continue in case command fails
-                continue
+        # these additional checks are in place because the fix is currently
+        # available in only 9.1, once back-ported to all relevant versions,
+        # retry mechanism can be removed completely
+        # determine mgr version to decide retry logic
+        # check if active mgr daemon has upgraded to 9.1 or above
+        out, _ = self.shell(args=["ceph", "mgr", "stat"])
+        active_mgr = loads(out)["active_name"]
+        LOG.debug("Active Mgr for the cluster: %s", active_mgr)
+        mgr_version_common, mgr_version_downstream = get_daemon_versions(
+            node=self.installer, daemon_type="mgr", daemon_id=active_mgr
+        )
+        LOG.debug("MGR common version: %s", mgr_version_common)
+        LOG.debug("MGR downstream version: %s", mgr_version_downstream)
 
-            # Break in case no exception raised
-            break
+        common_ver_check = mgr_version_common and Version(
+            mgr_version_common
+        ) >= Version("20.2.1")
+        downstream_ver_check = mgr_version_downstream and Version(
+            mgr_version_downstream
+        ) >= Version("9.9.1.0")
 
-        # Check if command is even after timeout
-        if w.expired:
-            msg = f"Upgrade status failed even after {timeout} sec "
-            msg += "due to mgr loading issue. "
-            msg += "Refer Bzs 2314146, 2313471, 2361844."
-            raise CommandFailed(msg)
+        needs_retry = not (common_ver_check or downstream_ver_check)
+
+        if not needs_retry:
+            LOG.debug("------- Skipping retry workaround -------")
+            out, _ = self.shell(args=cmd)
+        else:
+            # Retry upgrade command for interval time until it pass till timeout
+            for w in WaitUntil(timeout=timeout, interval=interval):
+                try:
+                    out, _ = self.shell(args=cmd)
+                except CommandFailed as e:
+                    msg = f"Upgrade command status failed due to error - {e},"
+                    msg += f"\n\nRetrying upgrade status after {interval}..."
+                    LOG.info(msg)
+
+                    # Continue in case command fails
+                    continue
+
+                # Break in case no exception raised
+                break
+
+            # Check if command is even after timeout
+            if w.expired:
+                msg = f"Upgrade status failed even after {timeout} sec "
+                msg += "due to mgr loading issue. "
+                msg += "Refer Bzs 2314146, 2313471, 2361844."
+                raise CommandFailed(msg)
 
         try:
             return loads(out)

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -2027,7 +2027,7 @@ def enable_coredump(node):
         log.info("Out: %s \n Err: %s" % (out, err))
 
 
-def get_daemon_versions(node, daemon_type: str):
+def get_daemon_versions(node, daemon_type: str, daemon_id: str = None):
     """
     Method to get a ceph daemon's versions.
     Note that in case multiple versions of input daemon type exist, \
@@ -2035,11 +2035,15 @@ def get_daemon_versions(node, daemon_type: str):
     Args:
         node: ceph node object having cephadm package
         daemon_type: The type of ceph daemon e.g. mgr, mon, osd, etc
+        daemon_id: name or id of ceph daemon e.g. 0, ceph-name-dc0dxh-node2
     Returns:
         a tuple of (common_version, downstream_version)
         e.g. 20.2.1,9.9.1.0
     """
-    out, _ = node.exec_command(sudo=True, cmd="cephadm shell ceph versions -f json")
+    if daemon_id:
+        out = get_daemon_metadata(node, daemon_type, daemon_id)
+    else:
+        out, _ = node.exec_command(sudo=True, cmd="cephadm shell ceph versions -f json")
     try:
         ceph_versions = json.loads(out)
     except json.JSONDecodeError as e:
@@ -2052,3 +2056,44 @@ def get_daemon_versions(node, daemon_type: str):
 
     log.warning("No versions found for %s", daemon_type)
     return "", ""
+
+
+def get_daemon_metadata(node, daemon_type: str, daemon_id: str = None):
+    """
+    Method to fetch the metadata for any daemon
+    If daemon id is not provided, return complete output of
+    ceph <daemon_type> metadata
+    Args:
+        node: ceph node object having cephadm package
+        daemon_type: The type of ceph daemon e.g. mgr, mon, osd, etc
+        daemon_id: name or id of ceph daemon e.g. 0, ceph-name-dc0dxh-node2
+    Returns:
+        metadata (List) -> If daemon_id is not provided
+        metadata (Dict) -> If daemon_id is provided
+        None if metadata is not found
+    """
+    log.debug("Passed daemon type : %s, Daemon ID : %s", daemon_type, daemon_id)
+    base_cmd = f"cephadm shell ceph {daemon_type} metadata "
+    if daemon_id is not None:
+        base_cmd += daemon_id
+
+    for _ in range(3):
+        try:
+            out, _ = node.exec_command(args=[base_cmd], sudo=True)
+            break
+        except Exception as e:
+            debug_msg = f"Passed daemon type : {daemon_type}, Daemon ID : {daemon_id}, Error : {e}"
+            log.debug(debug_msg)
+            log.warning("ceph metadata command failed. retrying after 30 seconds.")
+            time.sleep(30)
+    else:
+        log.debug("Metadata command execution failed 3 consecutive tries")
+        return None
+
+    if out is None:
+        log.error(
+            "Metadata info for the input daemon: %s.%s not found",
+            daemon_type,
+            daemon_id,
+        )
+    return out


### PR DESCRIPTION
Retry logic was implemented as a workaround because `ceph orch upgrade status` command used to fail intermittently due to an issue in mgr loading all it's module during start-up. Refer: https://github.com/red-hat-storage/cephci/pull/4741

With the fix provided in 9.1 build-200, Manager daemons above this version should no longer fail. Refer: https://ibm-ceph.atlassian.net/browse/IBMCEPH-9881

Should only be merged after PR https://github.com/red-hat-storage/cephci/pull/5828 is merged and this one is rebased
`
Signed-off-by: Harsh Kumar <hakumar@redhat.com>