### PR TITLE
Fix QE Tools repo URL handling for IBM and QE composes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@
 approvers:
   - veera-raghava-reddy
   - cephci-admins
+  - ceph-qe-managers
 
 reviewers:
   - ceph-ci-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,14 @@ aliases:
     - sunilkumarn417
     - AmarnatReddy
     - psathyan
+    - rakeshcn
+
+  ceph-qe-managers:
+    - vdas-redhat
+    - neha-gangadhar
+    - Manohar-Murthy
+    - mkasturi18
+    - prshanthakumar
 
   # Members of Ceph Infra team
   ceph-infra-team:
@@ -16,11 +24,9 @@ aliases:
 
   # members of RBD team
   ceph-block-team:
-    - Manohar-Murthy
     - sunilangadi2
     - manasagowri
     - rahullepakshi
-    - HaruChebrolu
     - jprakash-redhat
     - sunilkumarn417
     - krishnaramaswamy
@@ -29,8 +35,6 @@ aliases:
 
   # Members of CI team
   ceph-ci-team:
-    - pavankumarag
-    - vdas-redhat
     - vamahaja
     - obannak
     - tintumathew10
@@ -39,17 +43,13 @@ aliases:
 
   # Members of DMFG
   ceph-dmfg-team:
-    - vdas-redhat
     - sayaleeraut
     - adityaramteke
     - vinpapnoi
-    - msainiRedhat
     - MohitBis
-    - pranavprakash20
 
   # Members of FS
   ceph-fs-team:
-    - neha-gangadhar
     - sumabai
     - hkadam134
     - Manimaran-MM
@@ -57,7 +57,6 @@ aliases:
 
   # Members of rados
   ceph-rados-team:
-    - neha-gangadhar
     - pdhiran
     - SrinivasaBharath
     - harshkumarRH
@@ -66,7 +65,6 @@ aliases:
 
   # Members of RGW
   ceph-rgw-team:
-    - mkasturi18
     - viduship
     - TejasC88
     - ckulal

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1794,14 +1794,41 @@ class CephNode(object):
                 ssh_env["SSH_ASKPASS_REQUIRE"] = "force"
                 ssh_env["DISPLAY"] = ":"
 
+            def _ssh_cmd(cmd, retries=1, retry_interval=15):
+                for attempt in range(retries):
+                    try:
+                        result = subprocess.run(
+                            ssh_base + [cmd],
+                            capture_output=True,
+                            text=True,
+                            timeout=60,
+                            env=ssh_env,
+                        )
+                        if result.returncode == 0 or attempt == retries - 1:
+                            return result
+                        logger.warning(
+                            "OneCloud SSH cmd failed (attempt %d/%d): exit=%s err=%r",
+                            attempt + 1,
+                            retries,
+                            result.returncode,
+                            result.stderr[:100],
+                        )
+                    except subprocess.TimeoutExpired:
+                        if attempt == retries - 1:
+                            raise
+                        logger.warning(
+                            "OneCloud SSH timed out (attempt %d/%d), retrying in %ds",
+                            attempt + 1,
+                            retries,
+                            retry_interval,
+                        )
+                    sleep(retry_interval)
+                return result
+
             try:
-                for cmd in setup_cmds:
-                    result = subprocess.run(
-                        ssh_base + [cmd],
-                        capture_output=True,
-                        text=True,
-                        timeout=60,
-                        env=ssh_env,
+                for i, cmd in enumerate(setup_cmds):
+                    result = _ssh_cmd(
+                        cmd, retries=20 if i == 0 else 1, retry_interval=15
                     )
                     logger.info(
                         "OneCloud setup: cmd=%s exit=%s out=%r err=%r",
@@ -1810,12 +1837,6 @@ class CephNode(object):
                         result.stdout[:200],
                         result.stderr[:200],
                     )
-                    if result.returncode != 0 and "chpasswd" in cmd:
-                        raise AssertionError(
-                            f"OneCloud setup failed on {self.ip_address}: "
-                            f"chpasswd exit={result.returncode} "
-                            f"err={result.stderr[:200]!r}"
-                        )
             finally:
                 if askpass_file:
                     try:

--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -5,10 +5,14 @@ from json import JSONDecodeError, loads
 from time import sleep
 from typing import Dict
 
+from looseversion import LooseVersion
+from packaging.version import Version
+
 from ceph.ceph import CommandFailed
 from ceph.waiter import WaitUntil
 from utility.log import Log
 
+from ..utils import get_daemon_versions
 from .common import config_dict_to_string
 from .typing_ import OrchProtocol
 
@@ -70,6 +74,29 @@ class UpgradeMixin:
         # Add optional services argument
         if args and "services" in args:
             cmd.append(f"--services {args['services']}")
+
+        skip_license = None
+        if (args and "skip_license" in args) or config.get("skip_license"):
+            skip_license = True
+
+        # IBM Storage Ceph 9.1 and greater would require license acceptance
+        # There is '--automatically-accept-license' option
+        if (
+            config.get("product") == "ibm"
+            and LooseVersion(str(config.get("release"))) >= LooseVersion("9.1")
+            and not skip_license
+        ):
+            LOG.debug("Ceph product: %s", config.get("product"))
+            LOG.debug("Target version: %s", config.get("release"))
+            mgr_version_common, mgr_version_downstream = get_daemon_versions(
+                node=self.installer, daemon_type="mgr"
+            )
+            LOG.debug("MGR common version: %s", mgr_version_common)
+            LOG.debug("MGR downstream version: %s", mgr_version_downstream)
+            if Version(mgr_version_common) >= Version("20.2.1") or Version(
+                mgr_version_downstream
+            ) >= Version("9.9.1.0"):
+                cmd.append("--automatically-accept-license")
 
         return self.shell(args=cmd)
 

--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -93,9 +93,13 @@ class UpgradeMixin:
             )
             LOG.debug("MGR common version: %s", mgr_version_common)
             LOG.debug("MGR downstream version: %s", mgr_version_downstream)
-            if Version(mgr_version_common) >= Version("20.2.1") or Version(
+            common_ver_check = mgr_version_common and Version(
+                mgr_version_common
+            ) >= Version("20.2.1")
+            downstream_ver_check = mgr_version_downstream and Version(
                 mgr_version_downstream
-            ) >= Version("9.9.1.0"):
+            ) >= Version("9.9.1.0")
+            if common_ver_check or downstream_ver_check:
                 cmd.append("--automatically-accept-license")
 
         return self.shell(args=cmd)

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -34,7 +34,12 @@ from compute.onecloud import (
 from compute.openstack import CephVMNodeV2, NetworkOpFailure, NodeError, VolumeOpFailure
 from utility.log import Log
 from utility.retry import retry
-from utility.utils import generate_node_name, parse_custom_config_list
+from utility.utils import (
+    extract_ceph_version,
+    extract_version,
+    generate_node_name,
+    parse_custom_config_list,
+)
 
 from .ceph import Ceph, CommandFailed, RolesContainer
 from .parallel import parallel
@@ -2020,3 +2025,30 @@ def enable_coredump(node):
     for _cmd in sys_cmds:
         out, err = node.exec_command(cmd=_cmd, sudo=True)
         log.info("Out: %s \n Err: %s" % (out, err))
+
+
+def get_daemon_versions(node, daemon_type: str):
+    """
+    Method to get a ceph daemon's versions.
+    Note that in case multiple versions of input daemon type exist, \
+    this method returns version of the first entry.
+    Args:
+        node: ceph node object having cephadm package
+        daemon_type: The type of ceph daemon e.g. mgr, mon, osd, etc
+    Returns:
+        a tuple of (common_version, downstream_version)
+        e.g. 20.2.1,9.9.1.0
+    """
+    out, _ = node.exec_command(sudo=True, cmd="cephadm shell ceph versions -f json")
+    try:
+        ceph_versions = json.loads(out)
+    except json.JSONDecodeError as e:
+        log.exception(e)
+        raise
+
+    if ceph_versions.get(daemon_type):
+        daemon_ver_text = next(iter(ceph_versions[daemon_type]))
+        return extract_ceph_version(daemon_ver_text), extract_version(daemon_ver_text)
+
+    log.warning("No versions found for %s", daemon_type)
+    return "", ""

--- a/cli/ceph/nfs/cluster/cluster.py
+++ b/cli/ceph/nfs/cluster/cluster.py
@@ -27,6 +27,8 @@ class Cluster(Cli):
         active_standby=False,
         nfs_nodes_obj=None,
         check_ec=True,
+        enable_rdma=False,
+        rdma_port=None,
         **kwargs,
     ):
         """
@@ -37,6 +39,8 @@ class Cluster(Cli):
             ha (bool): Flag to check if HA is required
             vip (str): Vip for the HA cluster
             active_standby (bool): Flag to check if active standby is required
+            enable_rdma (bool): Pass --enable-rdma to enable RDMA transport
+            rdma_port (int|str|None): RDMA listener port (--rdma_port)
             **kwargs: Additional keyword arguments.
             If nfs_version=3 is provided and ceph version > 19.2.1-300,
                     --enable-nfsv3 flag will be added
@@ -48,6 +52,11 @@ class Cluster(Cli):
         cmd = "{0} create {1} '{2}'".format(self.base_cmd, name, nfs_server)
         if ha:
             cmd += " --ingress --virtual-ip {0}".format(vip)
+
+        if enable_rdma:
+            cmd += " --enable-rdma"
+            if rdma_port is not None:
+                cmd += f" --rdma_port {rdma_port}"
 
         # Check if --enable-nfsv3 flag needs to be added
         # Condition: ceph version > 19.2.1-300 AND nfs_version == 3

--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -9,6 +9,7 @@ from cli.ops.cephadm_ansible import (
     exec_cephadm_preflight,
 )
 from cli.utilities.packages import Package, Repos
+from cli.utilities.utils import repo_uses_flat_tools_compose_layout
 from utility.log import Log
 
 from .configs import get_registry_details
@@ -377,23 +378,23 @@ def setup_client_node(installer, ansible_clients):
         exec_cephadm_clients(installer)
 
 
-def get_tools_repo(repo, ibm_build=False):
+def get_tools_repo(repo, ibm_build=False, cloud_type="openstack"):
     """Get tools repo based on repo and build type
 
     Args:
         repo (str): Ceph tools repo URL
         ibm_build (bool): IBM build tag
+        cloud_type (str): cloud type (ibmc uses flat Tools layout like IBM builds)
     """
     repo = repo.rstrip("/")
-    log.info(f"get_tools_repo(): repo={repo}, ibm_build={ibm_build}")
+    log.info(
+        f"get_tools_repo(): repo={repo}, ibm_build={ibm_build}, cloud_type={cloud_type}"
+    )
 
     if repo.endswith(".repo"):
         return repo
 
-    if "repo.qe.ceph.lab" in repo:
-        return f"{repo}/Tools"
-
-    if ibm_build:
+    if repo_uses_flat_tools_compose_layout(repo, ibm_build, cloud_type):
         return f"{repo}/Tools"
 
     return f"{repo}/compose/Tools/x86_64/os"

--- a/cli/utilities/filesys.py
+++ b/cli/utilities/filesys.py
@@ -23,14 +23,34 @@ class Mount(Cli):
             self.execute(cmd="dnf install -y nfs-utils", sudo=True, timeout=600)
 
     def nfs(self, mount, version, port, server, export, **kwargs):
-        """
-        Perform nfs mount
+        """Perform an NFS mount on the client node.
+
+        Installs nfs-utils if missing, creates the mount directory,
+        and runs ``mount -t nfs`` with the assembled option string.
+
+        The resulting command looks like::
+
+            mount -t nfs -o vers=<version>,port=<port>[,proto=<proto>]
+                [,xprtsec=<xprtsec>] <server>:<export> <mount>
+
         Args:
-            mount (str): nfs mount path
-            version (str): Nfs version (4.0, 4.1, 4.2 etc)
-            port (str): nfs port to bind
-            server (str): Nfs server hostname
-            export (str): nfs export path)
+            mount (str): Local mount-point path.
+            version (str): NFS version string (e.g. "3", "4.0",
+                "4.1", "4.2").
+            port (str): NFS port to connect to.  When using RDMA
+                this should be the RDMA listener port.
+            server (str): NFS server hostname or IP address.
+            export (str): NFS export pseudo-path.
+
+        Keyword Args:
+            proto (str): Transport protocol option appended to
+                ``-o``.  Pass ``"rdma"`` for NFS-over-RDMA mounts.
+            xprtsec (str): Transport-security option (e.g. ``"tls"``
+                for RPC-with-TLS).
+
+        Raises:
+            MountFailedError: If the mount point does not appear in
+                the ``mount`` table after the command completes.
         """
         self._ensure_nfs_utils()
 
@@ -39,8 +59,10 @@ class Mount(Cli):
         if not out[0]:
             self.execute(cmd=f"mkdir {mount}", sudo=True)
 
-        # Create the mount point
         cmd = f"{self.base_cmd} -t nfs -o vers={version},port={port}"
+        proto = kwargs.get("proto")
+        if proto:
+            cmd += f",proto={proto}"
         xprtsec = kwargs.get("xprtsec")
         if xprtsec:
             cmd += f",xprtsec={xprtsec}"

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -204,28 +204,49 @@ def get_node_ip(nodes, node_name):
     return False
 
 
-def get_custom_repo_url(base_url, cloud_type="openstack"):
+def repo_uses_flat_tools_compose_layout(
+    repo_url, ibm_build=False, cloud_type="openstack"
+):
+    """True when RPM Tools live at {compose}/Tools/ (not compose/Tools/x86_64/os/).
+
+    QE lab composes, IP mirrors of the same layout, IBM composes, and IBM Cloud
+    metal (ibmc) use this layout; downstream RH compose trees use the deeper path.
+    """
+    if ibm_build or cloud_type == "ibmc":
+        return True
+    lowered = repo_url.lower()
+    if "repo.qe.ceph.lab" in lowered:
+        return True
+    # Jenkins / internal mirrors often expose compose roots without the QE hostname.
+    if "/repos/ceph/" in lowered:
+        return True
+    return False
+
+
+def get_custom_repo_url(base_url, cloud_type="openstack", ibm_build=False):
     """Add the given custom repo on every node part of the cluster.
 
     Args:
         cloud_type (str): cloudtype (openstack|ibmc|aws|onecloud)
         base_url (str): base URL of repository
+        ibm_build (bool): IBM compose; Tools dir is {compose}/Tools/
     """
     if base_url.endswith(".repo"):
         return base_url
 
-    if not base_url.endswith("/"):
-        base_url += "/"
+    trimmed = base_url.rstrip("/")
+    lowered = trimmed.lower()
+    if lowered.endswith("/tools") or "/tools/" in (lowered + "/"):
+        return trimmed + "/"
+
+    base_url = trimmed + "/"
 
     if base_url.endswith("x86_64/"):
         return base_url
 
-    if cloud_type == "ibmc":
-        base_url += "Tools"
-    else:
-        base_url += "compose/Tools/x86_64/os/"
-
-    return base_url
+    if repo_uses_flat_tools_compose_layout(base_url, ibm_build, cloud_type):
+        return base_url + "Tools/"
+    return base_url + "compose/Tools/x86_64/os/"
 
 
 def get_nodes_by_ids(nodes, ids):

--- a/compute/onecloud.py
+++ b/compute/onecloud.py
@@ -349,6 +349,41 @@ def _image_matches_version(img: Dict, version_preference: str) -> bool:
     return vp in name or f"rhel-{vp}" in name or f"rhel {vp}" in name
 
 
+def _image_version_number(img: Dict) -> Optional[float]:
+    """Extract numeric version (e.g. 9.7) from image for sorting."""
+    ver = img.get("version_id") or img.get("version") or img.get("os_version")
+    if ver is not None:
+        try:
+            return float(str(ver).strip())
+        except (ValueError, TypeError):
+            pass
+    name = _image_display_name(img)
+    m = re.search(r"(\d+\.\d+)", name)
+    if m:
+        try:
+            return float(m.group(1))
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
+def _sort_images_by_version_proximity(
+    images: List[Dict], target_version: str
+) -> List[Dict]:
+    """Sort images by proximity to target version (closest first)."""
+    try:
+        target = float(target_version)
+    except (ValueError, TypeError):
+        return images
+    scored = []
+    for img in images:
+        ver = _image_version_number(img)
+        distance = abs(ver - target) if ver is not None else 999.0
+        scored.append((distance, img))
+    scored.sort(key=lambda x: x[0])
+    return [img for _, img in scored]
+
+
 def resolve_image_for_site(
     client,
     site: str,
@@ -517,6 +552,18 @@ def resolve_image_for_site(
     for_site_before_version = (
         for_site  # Keep for fallback if all version matches are excluded
     )
+    available_versions = [
+        (
+            _image_id(i),
+            _image_version_number(i),
+            _image_display_name(i)[:40],
+        )
+        for i in for_site
+    ]
+    LOG.debug(
+        "OneCloud: available images after filtering: %s",
+        [(vid, ver, n) for vid, ver, n in available_versions],
+    )
     if version_preference:
         matching = [
             i for i in for_site if _image_matches_version(i, version_preference)
@@ -542,21 +589,36 @@ def resolve_image_for_site(
         )
         return iid
 
-    # All version-preferred images excluded? Fall back to full platform list
+    # All version-preferred images excluded? Fall back to closest available version
     if (
         version_preference
         and for_site_before_version
         and for_site != for_site_before_version
     ):
-        picked = _pick_first_valid(for_site_before_version)
+        sorted_by_proximity = _sort_images_by_version_proximity(
+            for_site_before_version, version_preference
+        )
+        fallback_options = [
+            (_image_id(i), _image_version_number(i), _image_display_name(i)[:40])
+            for i in sorted_by_proximity
+        ]
+        LOG.debug(
+            "OneCloud: version %s unavailable, fallback options (closest first): %s",
+            version_preference,
+            fallback_options,
+        )
+        picked = _pick_first_valid(sorted_by_proximity)
         if picked is not None:
             iid, img = picked
             name = _image_display_name(img)
-            LOG.info(
-                "OneCloud: version %s image(s) excluded; using image_id %s (%s)",
+            ver = _image_version_number(img)
+            LOG.warning(
+                "OneCloud: version %s not available; using closest: image_id %s "
+                "(%s, version %s)",
                 version_preference,
                 iid,
                 name[:50] if name else "?",
+                ver or "?",
             )
             return iid
 
@@ -1108,6 +1170,148 @@ def _wait_until_vm_state(
     )
 
 
+def floating_ip_provision(
+    client,
+    cluster_id: int,
+    site: str,
+    vlan: int,
+) -> Optional[str]:
+    """
+    Provision a floating IP for a OneCloud cluster.
+
+    Args:
+        client: OneCloud API client.
+        cluster_id: Cluster ID from POST /clusters response.
+        site: Site code (e.g. POK).
+        vlan: VLAN ID the VMs belong to (from VM network.vlan).
+
+    Returns:
+        Floating IP address if returned by API, else None.
+    """
+    body = {"VLAN": int(vlan), "site": site}
+    resp = client.put(f"/clusters/{cluster_id}/floating-ip/provision", json=body)
+    if resp.status_code not in (200, 201):
+        raise NodeError(
+            f"OneCloud: failed to provision floating IP for cluster {cluster_id}: "
+            f"{resp.status_code} {resp.text[:200]}"
+        )
+    data = resp.json()
+    LOG.info(
+        "OneCloud: floating IP provision response for cluster %s: %s", cluster_id, data
+    )
+    ip = None
+    if isinstance(data, dict):
+        ip = data.get("floating_ip") or data.get("ip") or data.get("ipaddr")
+    return ip
+
+
+def floating_ip_release(client, cluster_id: int) -> None:
+    """
+    Release floating IP from a OneCloud cluster.
+
+    Args:
+        client: OneCloud API client.
+        cluster_id: Cluster ID.
+    """
+    resp = client.put(f"/clusters/{cluster_id}/floating-ip/release", json={})
+    if resp.status_code not in (200, 201, 204):
+        raise NodeError(
+            f"OneCloud: failed to release floating IP for cluster {cluster_id}: "
+            f"{resp.status_code} {resp.text[:200]}"
+        )
+    LOG.info("OneCloud: floating IP released for cluster %s", cluster_id)
+
+
+def floating_ip_get(client, cluster_id: int) -> Optional[str]:
+    """
+    Get the floating IP assigned to a OneCloud cluster.
+
+    Args:
+        client: OneCloud API client.
+        cluster_id: Cluster ID.
+
+    Returns:
+        Floating IP string, or None if not provisioned.
+    """
+    resp = client.get("/clusters")
+    if resp.status_code != 200:
+        LOG.warning("OneCloud: GET /clusters failed: %s", resp.status_code)
+        return None
+    data = resp.json()
+    clusters = data.get("data", []) if isinstance(data, dict) else data
+    for c in clusters:
+        if c.get("clusterid") == cluster_id or c.get("clusterID") == cluster_id:
+            return c.get("floating_ip")
+    return None
+
+
+def vm_resize(
+    client,
+    vmid: int,
+    cpu: int,
+    mem: int,
+    disk_total_gb: int,
+    justification: str = "CephCI resize",
+) -> None:
+    """
+    Resize a VM (CPU, memory, total disk).
+
+    Args:
+        client: OneCloud API client.
+        vmid: VM ID.
+        cpu: Number of vCPUs (max 8).
+        mem: Memory in GB (max 32).
+        disk_total_gb: Total disk size in GB (must be >= current, max 1024).
+        justification: Reason for resize.
+    """
+    if cpu > 8 or mem > 32 or disk_total_gb > 1024:
+        raise ValueError(
+            f"Resource limits exceeded (cpu<=8, mem<=32GB, disk<=1024GB): "
+            f"cpu={cpu}, mem={mem}, disk={disk_total_gb}GB"
+        )
+    body = {
+        "justification": justification,
+        "cpu": int(cpu),
+        "mem": int(mem),
+        "disk": [int(disk_total_gb)],
+    }
+    resp = client.put(f"/vm/{vmid}/resize", json=body)
+    if resp.status_code not in (200, 201):
+        raise NodeError(
+            f"OneCloud: failed to resize VM {vmid}: "
+            f"{resp.status_code} {resp.text[:300]}"
+        )
+    LOG.info(
+        "OneCloud: resize request created for VM %s (cpu=%s, mem=%s, disk=%sGB)",
+        vmid,
+        cpu,
+        mem,
+        disk_total_gb,
+    )
+
+
+def vm_get_details(client, vmid: int) -> Dict:
+    """
+    Get VM details from OneCloud API.
+
+    Args:
+        client: OneCloud API client.
+        vmid: VM ID.
+
+    Returns:
+        VM dict with resources, network, cluster info.
+    """
+    resp = client.get(f"/vm/{vmid}")
+    if resp.status_code != 200:
+        raise NodeError(f"OneCloud: GET /vm/{vmid} failed: {resp.status_code}")
+    data = resp.json()
+    if isinstance(data, dict):
+        vms = data.get("data", [data])
+        if isinstance(vms, list) and vms:
+            return vms[0]
+    return data
+
+
 class CephVMNodeOneCloud:
     """Represents a VM node from OneCloud API."""
 
@@ -1275,3 +1479,117 @@ class CephVMNodeOneCloud:
         vm_restart(client, vmid)
         if wait:
             _wait_until_vm_state(client, vmid, "on")
+
+    @property
+    def cluster_id(self) -> Optional[int]:
+        """Return the cluster ID this VM belongs to."""
+        cluster = self.node.get("cluster") or {}
+        cid = cluster.get("id") or cluster.get("clusterid") or cluster.get("clusterID")
+        if cid is not None:
+            try:
+                return int(cid)
+            except (TypeError, ValueError):
+                pass
+        return None
+
+    @property
+    def vlan(self) -> Optional[int]:
+        """Return the VLAN this VM is on (from network.vlan)."""
+        net = self.node.get("network") or {}
+        v = net.get("vlan")
+        if v is not None:
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                pass
+        return None
+
+    @property
+    def floating_ip(self) -> Optional[str]:
+        """Return the floating IP assigned to this VM's cluster, or None."""
+        cid = self.cluster_id
+        if cid is None:
+            return None
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        return floating_ip_get(client, cid)
+
+    def provision_floating_ip(self, site: str = "POK") -> Optional[str]:
+        """
+        Provision a floating IP for this VM's cluster.
+
+        Args:
+            site: Site code (default: POK).
+
+        Returns:
+            Floating IP address if returned, else None.
+        """
+        cid = self.cluster_id
+        v = self.vlan
+        if cid is None:
+            raise NodeError("Cannot provision floating IP: no cluster_id")
+        if v is None:
+            raise NodeError("Cannot provision floating IP: no VLAN on VM")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        return floating_ip_provision(client, cid, site, v)
+
+    def release_floating_ip(self) -> None:
+        """Release floating IP from this VM's cluster."""
+        cid = self.cluster_id
+        if cid is None:
+            raise NodeError("Cannot release floating IP: no cluster_id")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        floating_ip_release(client, cid)
+
+    def resize(
+        self,
+        cpu: Optional[int] = None,
+        mem: Optional[int] = None,
+        disk_total_gb: Optional[int] = None,
+        justification: str = "CephCI resize",
+    ) -> None:
+        """
+        Resize this VM (CPU, memory, disk).
+
+        Args:
+            cpu: vCPUs (default: keep current).
+            mem: Memory in GB (default: keep current).
+            disk_total_gb: Total disk in GB (default: keep current, must be >= current).
+            justification: Reason for resize.
+        """
+        vmid = self.vmid
+        if vmid is None:
+            raise NodeError("Cannot resize VM: no vmid")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        details = vm_get_details(client, int(vmid))
+        resources = details.get("resources") or {}
+        _cpu = cpu if cpu is not None else resources.get("cpu", 4)
+        _mem = mem if mem is not None else resources.get("mem", 16)
+        current_disks = resources.get("disk") or []
+        current_total = sum(current_disks) if current_disks else 100
+        _disk = disk_total_gb if disk_total_gb is not None else current_total
+        if _disk < current_total:
+            raise ValueError(
+                f"Disk shrinking not allowed: requested {_disk}GB "
+                f"< current {current_total}GB"
+            )
+        vm_resize(client, int(vmid), _cpu, _mem, _disk, justification)
+
+    def get_details(self) -> Dict:
+        """Refresh and return full VM details from the API."""
+        vmid = self.vmid
+        if vmid is None:
+            raise NodeError("Cannot get details: no vmid")
+        client = get_onecloud_client(
+            self._api_key, self._base_url, verify_ssl=self._verify_ssl
+        )
+        details = vm_get_details(client, int(vmid))
+        self.node.update(details)
+        return details

--- a/conf/inventory/ibm-eu-rhel-10.1.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.1.yaml
@@ -84,6 +84,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser

--- a/conf/inventory/ibm-eu-rhel-9.7.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.7.yaml
@@ -84,6 +84,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-rdma.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-rdma.yaml
@@ -1,0 +1,257 @@
+#===============================================================================================
+#---    Test Suite for NFS Ganesha over RDMA Transport   ---
+#===============================================================================================
+# Conf: conf/tentacle/nfs/1admin-7node-3client.yaml
+#
+# Pre-requisites (run before this suite or chain after a deploy suite):
+#   1. install_prereq.py          — install software pre-requisites
+#   2. test_cephadm.py            — bootstrap cluster, deploy OSD/RGW/MDS,
+#                                   create cephfs volume and rbd pool
+#   3. test_client.py (x4)        — configure client.1..client.4 on node4..node7
+#                                   with ceph-common, ceph-fuse, admin keyring
+#
+# All tests use enable_rdma: true with proto=rdma for client mounts.
+# Direct daemon mounts only (no VIP/ingress RDMA tests yet).
+# Tests are sorted by number of clients required: 1-client, 2-client, 3+ client.
+#
+#===============================================================================================
+
+# --- 1-client tests ---
+
+tests:
+  - test:
+      name: NFS RDMA - Export Readonly
+      module: test_export_readonly.py
+      desc: Test NFS export with readonly over RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 1
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  # --- 2-client tests ---
+
+  - test:
+      name: NFS RDMA - File Operations
+      module: nfs_verify_file_operations.py
+      desc: Verify file create, softlink and lookups over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+        operations:
+          client01: create_files
+          client02: perform_lookups
+
+  - test:
+      name: NFS RDMA - File Lock
+      module: nfs_verify_file_lock.py
+      desc: Perform file locking from 2 clients over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Read Write Operations
+      module: nfs_verify_read_write_operations.py
+      desc: Verify read and write operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Soft Links
+      module: nfs_verify_file_ops_soft_links.py
+      desc: Verify soft link operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Truncate
+      module: nfs_file_truncate.py
+      desc: Verify file truncate operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Stress Test
+      module: nfs_verify_stress.py
+      desc: Verify NFS stress operations over RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Directory Depth and Permissions
+      module: nfs_verify_multi_depth_dir_and_permissions.py
+      desc: Verify deep directory creation and permission handling over RDMA
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Export Rootsquash
+      module: test_export_rootsquash.py
+      desc: Verify rootsquash enforcement over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Get Set Attributes
+      module: test_nfs_get_set_attr_operation.py
+      desc: Verify get/set attribute operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Pynfs Test Suite
+      module: nfs_verify_pynfs.py
+      desc: Run pynfs compliance tests over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Xattr Operations
+      module: nfs_test_xattr_across_file_operations.py
+      desc: Verify extended attribute operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  # --- 3-client tests ---
+
+  - test:
+      name: NFS RDMA - Hard Links
+      module: nfs_verify_file_ops_hard_links.py
+      desc: Verify hard link operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Modification
+      module: nfs_verify_file_modification.py
+      desc: Verify file modification and timestamps over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - Parallel IO and Lookups
+      module: nfs_verify_multiple_parallel_io_and_lookups.py
+      desc: Verify parallel IO and lookups over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Append
+      module: nfs_file_append.py
+      desc: Verify file append operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Copy Operations
+      module: test_file_ops_copy.py
+      desc: Verify file and directory copy operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  - test:
+      name: NFS RDMA - File Rename Operations
+      module: test_file_ops_renames.py
+      desc: Verify file and directory rename operations over NFS RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 3
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"
+
+  # --- 4-client tests ---
+
+  - test:
+      name: NFS RDMA - Readdir Operations
+      module: nfs_verify_readdir_ops.py
+      desc: Verify directory listing operations over RDMA transport
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 4
+        port: "2049"
+        enable_rdma: true
+        rdma_port: "20049"

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
@@ -1,0 +1,303 @@
+##############################################################################################
+# Tier-Level: 1
+# Test-Suite: tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
+# Scenario: Upgrade Ceph 8.x(GA) cluster to Ceph 9(Latest) with NFS-Ganesha in RHEL9
+#
+# Cluster Configuration: Conf: conf/squid/nfs/1admin-3client-7node.yaml
+#
+# Test Steps:
+# - Deploy Ceph 9.0(GA) cluster in RHEL 9
+# - Deploy Ceph 9.0 client
+# - Upgrade cluster along with NFS-Ganesha IOs parllel
+################################################################################################
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap Ceph 9.0(GA) cluster and deploy services with label placements.
+      desc: Bootstrap Ceph 9.0(GA) cluster and deploy services with label placements.
+      polarion-id: CEPH-83573777
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                rhcs-version: 9.0
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client1
+      desc: Configure the RGW,RBD client system
+      module: test_client.py
+      polarion-id: CEPH-83573777
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client2
+      desc: Configure the RGW,RBD client system
+      module: test_client.py
+      polarion-id: CEPH-83573777
+      config:
+        command: add
+        id: client.2
+        node: node5
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client3
+      desc: Configure the RGW,RBD client system
+      module: test_client.py
+      polarion-id: CEPH-83573777
+      config:
+        command: add
+        id: client.3
+        node: node6
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client4
+      desc: Configure the RGW,RBD client system
+      module: test_client.py
+      polarion-id: CEPH-83573777
+      config:
+        command: add
+        id: client.4
+        node: node7
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Setup NFS-Ganesha cluster
+      desc: Setup NFS-Ganesha cluster
+      module: nfs_verify_multiple_parallel_io_and_lookups.py
+      polarion-id: CEPH-83581304
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 4
+        io: false
+        cleanup: false
+
+  - test:
+      name: Nfs Verify multiple io and lookups
+      module: nfs_verify_multiple_parallel_io_and_lookups.py
+      desc: Perform look ups while multiple parallel io are in progress
+      polarion-id: CEPH-83581304
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 4
+        setup: false
+
+  - test:
+      name: Nfsv4 multiple operations - pre_upgrade
+      module: test_nfs_multiple_operations_for_upgrade.py
+      desc: nfs multiple operations before upgrade create, delete, write, read, rename
+      polarion-id: CEPH-83620035
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        setup: false
+        file_count: 50
+        dd_command_size_in_M: 10
+        operation: before_upgrade
+
+  - test:
+      name: Upgrade along with IOs for nfs
+      module: test_parallel.py
+      desc: Upgrade along with IOs for nfs in parallel
+      parallel:
+        - test:
+            name: Upgrade cluster to latest Ceph 9.x
+            desc: Upgrade cluster to latest Ceph 9.x
+            module: test_cephadm_upgrade.py
+            polarion-id: CEPH-83573791,CEPH-83573790
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+
+        - test:
+            name: nfs operations during upgrade
+            module: test_nfs_io_operations_during_upgrade.py
+            desc: nfs multiple operations during upgrade create, delete, write, read, rename
+            polarion-id: CEPH-83620035
+            abort-on-fail: false
+            config:
+              nfs_version: 4.2
+              clients: 4
+              setup: false
+              file_count: 25
+              dd_command_size_in_M: 10
+              exports_number: 4
+              loop_count: 4
+      abort-on-fail: true
+
+  - test:
+      name: NFSv4 multiple operations - post_upgrade
+      module: test_nfs_multiple_operations_for_upgrade.py
+      desc: nfs multiple operations after upgrade create, delete, write, read, rename
+      polarion-id: CEPH-83620035
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 2
+        setup: false
+        file_count: 50
+        dd_command_size_in_M: 10
+        operation: after_upgrade
+
+  - test:
+      name: Nfs Verify rm write lookups in parellel from multi clients
+      module: nfs_verify_parallel_rm_write_lookup.py
+      desc: Perform lookups rm and write at the same time
+      polarion-id: CEPH-83577591
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 4
+
+  - test:
+      name: Nfsv4 Verify read write operation permissions
+      module: nfs_verify_read_write_operations.py
+      desc: Perform read write without permissions on nfs share
+      polarion-id: CEPH-83575941
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 3
+        operation: verify_permission
+
+  - test:
+      name: Nfsv3 Verify read write operation permissions
+      module: nfs_verify_read_write_operations.py
+      desc: Perform read write without permissions on nfs share
+      polarion-id: CEPH-83575941
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        operation: verify_permission
+
+  - test:
+      name: Nfs verify read and write non existing file
+      module: nfs_verify_read_write_operations.py
+      desc: Perform read write of no existing file on nfs share
+      polarion-id: CEPH-83575927
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        operation: verify_non_existing_file
+
+  - test:
+      name: Nfs verify export unexport while nfs share is in use
+      module: nfs_verify_stress.py
+      desc: Stress by performing admin ops like exports unexports while clients are actively using the NFS shares.
+      polarion-id: CEPH-83575994
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 3
+
+  - test:
+      name: Nfs Ganesha copy operations
+      module: test_file_ops_copy.py
+      desc: Perform file and dir copy and lookups in parallel
+      polarion-id: CEPH-83577595
+      abort-on-fail: true
+      config:
+        nfs_version: 4.1
+        clients: 3
+        num_files: 1000
+        num_dirs: 1000

--- a/suites/tentacle/rados/tier-3_rados_ec_partial_reads_writes.yaml
+++ b/suites/tentacle/rados/tier-3_rados_ec_partial_reads_writes.yaml
@@ -241,6 +241,16 @@ tests:
                 - mon_osd_down_out_subtree_limit
                 - host
 
+  # Test: Stripe unit and Fast EC default verification
+  - test:
+      name: Stripe unit and Fast EC default verification
+      module: test_fast_ec_config_params.py
+      polarion-id: CEPH-83632256
+      abort-on-fail: false
+      config:
+        test_stripe_unit_pool_creation: true
+      desc: Verify stripe_unit and Fast EC defaults for various EC configurations
+
   # ==========================================================================
   # ISA Plugin Tests (Default plugin from Tentacle onwards)
   # ==========================================================================

--- a/suites/tentacle/smb/OWNERS
+++ b/suites/tentacle/smb/OWNERS
@@ -8,7 +8,6 @@ approvers:
 
 reviewers:
   - adityaramteke
-  - vamahaja
 
 labels:
   - Samba

--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -65,6 +65,7 @@ def add(cls, config: Dict) -> None:
             rhcs_version = _build.get("release")
             _manifest_section = _build.get("tag")
             _node = get_node_by_id(cls.cluster, name)
+            manifest_obj = None
             _rpm_version = None
             if rhcs_version:
                 rhcs_version = str(rhcs_version)
@@ -98,25 +99,6 @@ def add(cls, config: Dict) -> None:
                 r"yum-config-manager --disable \*",
             ]
             cmd = 'subscription-manager repos --list-enabled | grep -i "Repo ID"'
-            # Added downstream test repos for RHEL 8 RHCS 6, Will add live repo once available.
-            cdn_ceph_repo = {
-                "7": {"4": ["rhel-7-server-rhceph-4-tools-rpms"]},
-                "8": {
-                    "4": ["rhceph-4-tools-for-rhel-8-x86_64-rpms"],
-                    "5": ["rhceph-5-tools-for-rhel-8-x86_64-rpms"],
-                    "6": [
-                        "http://download.eng.bos.redhat.com/rhel-8/composes/raw/"
-                        "ceph-6.1-rhel-8/RHCEPH-6.1-RHEL-8-20231004.t.1/compose/Tools/x86_64/os/"
-                    ],
-                },
-                "9": {
-                    "5": ["rhceph-5-tools-for-rhel-9-x86_64-rpms"],
-                    "6": ["rhceph-6-tools-for-rhel-9-x86_64-rpms"],
-                    "7": ["rhceph-7-tools-for-rhel-9-x86_64-rpms"],
-                    "8": ["rhceph-8-tools-for-rhel-9-x86_64-rpms"],
-                    "9": ["rhceph-9-tools-for-rhel-9-x86_64-rpms"],
-                },
-            }
 
             rhel_repos = {
                 "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
@@ -128,10 +110,10 @@ def add(cls, config: Dict) -> None:
                     "rhel-9-for-x86_64-appstream-rpms",
                     "rhel-9-for-x86_64-baseos-rpms",
                 ],
-                "10": {
+                "10": [
                     "rhel-10-for-x86_64-appstream-rpms",
                     "rhel-10-for-x86_64-baseos-rpms",
-                },
+                ],
             }
 
             # Collecting already enabled repos
@@ -144,7 +126,7 @@ def add(cls, config: Dict) -> None:
                     enabled_repos.append(repo)
             log.debug(f"Enabled repos on the system are : {enabled_repos}")
 
-            if rhcs_version != "default" and not _manifest_section:
+            if rhcs_version != "default":
                 try:
                     # Disabling all the repos and enabling the ones we need to install the ceph client
                     for cmd in disable_all:
@@ -158,14 +140,10 @@ def add(cls, config: Dict) -> None:
                 for repos in rhel_repos[rhel_version]:
                     _node.exec_command(sudo=True, cmd=f"{enable_cmd}{repos}")
 
-                for repos in cdn_ceph_repo[rhel_version][rhcs_version]:
-                    # This is workaround for  RHEL8 RHCS 6. Will remove once live repo available
-                    if rhel_version == "8" and rhcs_version == "6":
-                        _node.exec_command(
-                            sudo=True, cmd=f"yum-config-manager --add-repo={repos}"
-                        )
-                    else:
-                        _node.exec_command(sudo=True, cmd=f"{enable_cmd}{repos}")
+                if manifest_obj and manifest_obj.repo_id:
+                    _node.exec_command(
+                        sudo=True, cmd=f"{enable_cmd}{manifest_obj.repo_id}"
+                    )
 
                 # Clearing the release preference set and cleaning all yum repos
                 # Observing selinux package dependency issues for ceph-base

--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -141,7 +141,9 @@ def run(ceph_cluster, **kwargs):
     server_pkgs = config.get("server_packages")
 
     # Enable ceph tools repo on installer and client
-    base_url = get_custom_repo_url(base_url, cloud_type)
+    base_url = get_custom_repo_url(
+        base_url, cloud_type, config.get("ibm_build", False)
+    )
     for node in {installer, client}:
         if not Package(node).add_repo(base_url):
             raise ReposError(f"Failed to enable {base_url} repo")
@@ -152,7 +154,8 @@ def run(ceph_cluster, **kwargs):
     if build_type == "rh":
         _files = [repo for repo in out if "Tools" in repo or "RHCEPH" in repo]
     elif build_type == "ibm":
-        _files = [repo for repo in out if "IBM" in repo]
+        _files = [repo for repo in out if "ibm" in repo.lower()]
+
     # Raise error if expected repository is not added
     if not _files:
         raise ResourceNotFoundError("Expected repository not added to node")

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -50,6 +50,7 @@ rpm_packages = {
         "wget",
         "git-core",
         "python3-devel",
+        "python3-pip",
         "chrony",
         "yum-utils",
         "net-tools",

--- a/tests/nfs/acl/test_nfs_acl_functional.py
+++ b/tests/nfs/acl/test_nfs_acl_functional.py
@@ -107,6 +107,8 @@ def run(ceph_cluster, **kw):
                 nfs_export,
                 fs,
                 ceph_cluster=ceph_cluster,
+                enable_rdma=config.get("enable_rdma", False),
+                rdma_port=config.get("rdma_port"),
             )
         else:
             log.error(

--- a/tests/nfs/acl/test_nfs_acl_negative.py
+++ b/tests/nfs/acl/test_nfs_acl_negative.py
@@ -96,6 +96,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         client = clients[0]

--- a/tests/nfs/acl/test_nfs_acl_scale.py
+++ b/tests/nfs/acl/test_nfs_acl_scale.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         client = clients[0]

--- a/tests/nfs/nfs_client_permission_export.py
+++ b/tests/nfs/nfs_client_permission_export.py
@@ -49,6 +49,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with client permission

--- a/tests/nfs/nfs_conflicting_locks.py
+++ b/tests/nfs/nfs_conflicting_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_edit_export_config_with_1client_access.py
+++ b/tests/nfs/nfs_edit_export_config_with_1client_access.py
@@ -96,6 +96,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_edit_export_config_with_access_none.py
+++ b/tests/nfs/nfs_edit_export_config_with_access_none.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Create export
         Ceph(clients[0]).nfs.export.create(

--- a/tests/nfs/nfs_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_edit_export_config_with_ro.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_export_rootsquash_windows.py
+++ b/tests/nfs/nfs_export_rootsquash_windows.py
@@ -63,6 +63,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with squash permission

--- a/tests/nfs/nfs_failover_with_rm_operation_windows.py
+++ b/tests/nfs/nfs_failover_with_rm_operation_windows.py
@@ -73,6 +73,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_file_append.py
+++ b/tests/nfs/nfs_file_append.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create files from client 1

--- a/tests/nfs/nfs_file_truncate.py
+++ b/tests/nfs/nfs_file_truncate.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create files from dd on client 1

--- a/tests/nfs/nfs_ha_client_update_permission_windows.py
+++ b/tests/nfs/nfs_ha_client_update_permission_windows.py
@@ -84,6 +84,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_ha_export_delete_windows.py
+++ b/tests/nfs/nfs_ha_export_delete_windows.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create exports

--- a/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
@@ -78,6 +78,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
@@ -78,6 +78,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_ha_failover_with_untar.py
+++ b/tests/nfs/nfs_ha_failover_with_untar.py
@@ -57,6 +57,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         sleep(3)

--- a/tests/nfs/nfs_ha_readdir_operation.py
+++ b/tests/nfs/nfs_ha_readdir_operation.py
@@ -86,6 +86,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_ha_reboot_with_file_modify.py
+++ b/tests/nfs/nfs_ha_reboot_with_file_modify.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_hard_links_delete_file.py
+++ b/tests/nfs/nfs_hard_links_delete_file.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_hard_symbolic_links_rename.py
+++ b/tests/nfs/nfs_hard_symbolic_links_rename.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_multi_client_byterange_filelock.py
+++ b/tests/nfs/nfs_multi_client_byterange_filelock.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             fs_name,
             ceph_cluster=ceph_cluster,
             single_export=True,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_multi_mount_version_4x.py
+++ b/tests/nfs/nfs_multi_mount_version_4x.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Run parallel IO on v4.1 and v4.2 mounts

--- a/tests/nfs/nfs_multiple_xattr_set_and_delete.py
+++ b/tests/nfs/nfs_multiple_xattr_set_and_delete.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/nfs_multivolume_rootsquash.py
+++ b/tests/nfs/nfs_multivolume_rootsquash.py
@@ -79,6 +79,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Change the permission of mount dir from Linux client

--- a/tests/nfs/nfs_non_overlapping_locks.py
+++ b/tests/nfs/nfs_non_overlapping_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -10,6 +10,7 @@ from time import sleep
 import yaml
 from looseversion import LooseVersion
 
+from ceph.ceph import CommandFailed
 from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
@@ -58,7 +59,44 @@ def setup_nfs_cluster(
     active_standby=False,
     round_robin=False,
     single_export=False,
+    enable_rdma=False,
+    rdma_port=None,
 ):
+    """Set up an NFS-Ganesha cluster with exports and client mounts.
+
+    End-to-end helper used by most NFS test modules.  It enables the
+    NFS manager module, creates an NFS-Ganesha cluster, creates one
+    export per client (or a single shared export), and mounts the
+    export(s) on each client.
+
+    Args:
+        clients (list): Client CephNode objects to mount on.
+        nfs_server (str | list): NFS server hostname(s) for the
+            cluster placement.
+        port (str): TCP NFS port (e.g. ``"2049"``).
+        version: NFS version(s) to use for mounts.  May be a single
+            value (``"4.2"``) or a dict mapping versions to client
+            lists for multi-version mounts.
+        nfs_name (str): NFS cluster name.
+        nfs_mount (str): Local mount-point path on clients.
+        fs_name (str): CephFS filesystem name (e.g. ``"cephfs"``).
+        export (str): Base export pseudo-path prefix.
+        fs (str): Filesystem backend identifier.
+        ha (bool): Enable HA with ingress (requires *vip*).
+        vip (str | None): Virtual IP for HA ingress.
+        ceph_cluster: CephCluster object for node lookups.
+        active_standby (bool): Use active-standby HA placement.
+        round_robin (bool): Distribute mounts across all servers
+            in round-robin fashion.
+        single_export (bool): Create only one export shared by
+            all clients instead of one per client.
+        enable_rdma (bool): Create the cluster with ``--enable-rdma``
+            and mount clients using ``proto=rdma``.
+        rdma_port (str | int | None): RDMA listener port passed to
+            ``--rdma_port`` on cluster create and used as the mount
+            port when *enable_rdma* is True.  Falls back to *port*
+            if not specified.
+    """
     # Get ceph cluter object and setup start time
     global ceph_cluster_obj
     global setup_start_time
@@ -114,6 +152,8 @@ def setup_nfs_cluster(
         vip=vip,
         active_standby=active_standby,
         nfs_nodes_obj=nfs_nodes,
+        enable_rdma=enable_rdma,
+        rdma_port=rdma_port,
         **create_kwargs,
     )
     sleep(3)
@@ -168,6 +208,14 @@ def setup_nfs_cluster(
         else:
             mount_servers = [servers[0]]
 
+    mount_kwargs = {}
+    if enable_rdma:
+        mount_kwargs["proto"] = "rdma"
+        mount_port = rdma_port or port
+        log.info("RDMA enabled: mounts will use proto=rdma, port=%s", mount_port)
+    else:
+        mount_port = port
+
     i = 0
     server_idx = 0
     for version, clients in mount_versions.items():
@@ -182,9 +230,34 @@ def setup_nfs_cluster(
             else:
                 current_export = export_name  # Fallback
 
+            # Clear any stale mount left by a previous test before mkdir
+            try:
+                client.exec_command(sudo=True, cmd=f"stat {nfs_mount}")
+            except CommandFailed:
+                try:
+                    client.exec_command(
+                        sudo=True, cmd=f"umount -l {nfs_mount}", check_ec=False
+                    )
+                    client.exec_command(
+                        sudo=True, cmd=f"rm -rf {nfs_mount}", check_ec=False
+                    )
+                except Exception:
+                    pass
+                log.info(
+                    "Cleared stale/leftover mount at %s on %s",
+                    nfs_mount,
+                    client.hostname,
+                )
+
             client.create_dirs(dir_path=nfs_mount, sudo=True)
             if mount_retry(
-                client, nfs_mount, version, port, current_server, current_export
+                client,
+                nfs_mount,
+                version,
+                mount_port,
+                current_server,
+                current_export,
+                **mount_kwargs,
             ):
                 log.info(
                     "Mount succeeded on %s using server %s and export %s"
@@ -1156,9 +1229,19 @@ def mount_retry(client, mount_name, version, port, nfs_server, export_name, **kw
 
 @retry(OperationFailedError, tries=5, delay=10, backoff=2)
 def mount_cleanup_retry(client, mount_name):
-    _, err = client.exec_command(sudo=True, cmd=f"rm -rf {mount_name}/*", timeout=120)
-    if err:
-        raise OperationFailedError("Failed to clenaup the mount directory")
+    try:
+        _, err = client.exec_command(
+            sudo=True, cmd=f"rm -rf {mount_name}/*", timeout=120
+        )
+        if err:
+            raise OperationFailedError("Failed to cleanup the mount directory")
+    except CommandFailed as e:
+        log.warning(
+            "rm -rf %s/* failed on %s: %s — skipping, will proceed to unmount",
+            mount_name,
+            client.hostname,
+            e,
+        )
     return True
 
 

--- a/tests/nfs/nfs_overlapping_locks.py
+++ b/tests/nfs/nfs_overlapping_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_queue_management_locks.py
+++ b/tests/nfs/nfs_queue_management_locks.py
@@ -51,6 +51,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
+++ b/tests/nfs/nfs_rootsquash_post_io_operation_windows.py
@@ -64,6 +64,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_rootsquash_using_conf.py
+++ b/tests/nfs/nfs_rootsquash_using_conf.py
@@ -75,6 +75,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_run_nfslocktest_suite.py
+++ b/tests/nfs/nfs_run_nfslocktest_suite.py
@@ -60,6 +60,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
+++ b/tests/nfs/nfs_set_retrieve_xattr_multi_client.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount the export on client 2

--- a/tests/nfs/nfs_single_client_byterange_filelock.py
+++ b/tests/nfs/nfs_single_client_byterange_filelock.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if version == 3:

--- a/tests/nfs/nfs_spec_storage.py
+++ b/tests/nfs/nfs_spec_storage.py
@@ -43,6 +43,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         log.info(f"Run SPECstorage with {benchmark} benchmark")

--- a/tests/nfs/nfs_test_allocation_beyond_size.py
+++ b/tests/nfs/nfs_test_allocation_beyond_size.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file

--- a/tests/nfs/nfs_test_multiple_filesystem_exports.py
+++ b/tests/nfs/nfs_test_multiple_filesystem_exports.py
@@ -142,6 +142,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         for i in range(1, 5):

--- a/tests/nfs/nfs_test_remount_windows.py
+++ b/tests/nfs/nfs_test_remount_windows.py
@@ -58,6 +58,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_test_selinux_context_moving_files.py
+++ b/tests/nfs/nfs_test_selinux_context_moving_files.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             fs,
             ceph_cluster=ceph_cluster,
             single_export=True,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create 5 file on Mount point from client 1

--- a/tests/nfs/nfs_test_setting_selinux_context.py
+++ b/tests/nfs/nfs_test_setting_selinux_context.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             fs,
             ceph_cluster=ceph_cluster,
             single_export=True,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point from client 1

--- a/tests/nfs/nfs_test_space_allocation_diff_sizes.py
+++ b/tests/nfs/nfs_test_space_allocation_diff_sizes.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # List of files and sizes to create and verify

--- a/tests/nfs/nfs_test_xattr_across_file_operations.py
+++ b/tests/nfs/nfs_test_xattr_across_file_operations.py
@@ -64,6 +64,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/nfs_validate_cmount_path_export_conf.py
+++ b/tests/nfs/nfs_validate_cmount_path_export_conf.py
@@ -44,6 +44,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the export info

--- a/tests/nfs/nfs_verify_bonnie.py
+++ b/tests/nfs/nfs_verify_bonnie.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Install bonnie++ on clients

--- a/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
+++ b/tests/nfs/nfs_verify_enable_rootsquash_window_v3_linux_v4.py
@@ -69,6 +69,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_failover_with_file_ops.py
+++ b/tests/nfs/nfs_verify_failover_with_file_ops.py
@@ -79,6 +79,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_failover_with_io.py
+++ b/tests/nfs/nfs_verify_failover_with_io.py
@@ -57,6 +57,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Trigger smallfile IO

--- a/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
+++ b/tests/nfs/nfs_verify_file_access_linux_v4_windows_v3.py
@@ -63,6 +63,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_file_lock.py
+++ b/tests/nfs/nfs_verify_file_lock.py
@@ -63,6 +63,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")

--- a/tests/nfs/nfs_verify_file_lock_ha.py
+++ b/tests/nfs/nfs_verify_file_lock_ha.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")

--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -89,6 +89,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export

--- a/tests/nfs/nfs_verify_file_modification.py
+++ b/tests/nfs/nfs_verify_file_modification.py
@@ -73,6 +73,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_operations.py
+++ b/tests/nfs/nfs_verify_file_operations.py
@@ -60,6 +60,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_ops_hard_links.py
+++ b/tests/nfs/nfs_verify_file_ops_hard_links.py
@@ -60,6 +60,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_ops_soft_links.py
+++ b/tests/nfs/nfs_verify_file_ops_soft_links.py
@@ -85,6 +85,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_ha_readonly_windows.py
+++ b/tests/nfs/nfs_verify_ha_readonly_windows.py
@@ -65,6 +65,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Fetch the VIP

--- a/tests/nfs/nfs_verify_hard_links_inode.py
+++ b/tests/nfs/nfs_verify_hard_links_inode.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
+++ b/tests/nfs/nfs_verify_linux_windows_clients_v3_io.py
@@ -64,6 +64,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
+++ b/tests/nfs/nfs_verify_mount_linux_v4_windows_clinet_v3.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
+++ b/tests/nfs/nfs_verify_mount_mutli_os_with_mount_combinations.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_multi_client_failover_windows.py
+++ b/tests/nfs/nfs_verify_multi_client_failover_windows.py
@@ -70,6 +70,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Mount NFS-Ganesha V3 to window clients
         for windows_client in windows_clients:

--- a/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
+++ b/tests/nfs/nfs_verify_multi_client_reboot_with_io.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window clients

--- a/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
+++ b/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
@@ -45,6 +45,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create multi depth dirs under nfs share

--- a/tests/nfs/nfs_verify_multi_mount_version.py
+++ b/tests/nfs/nfs_verify_multi_mount_version.py
@@ -52,6 +52,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Run parallel IO on each client's mount

--- a/tests/nfs/nfs_verify_multi_node_cluster.py
+++ b/tests/nfs/nfs_verify_multi_node_cluster.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Perform file creation on client 1
         for i in range(100):

--- a/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
+++ b/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
@@ -53,6 +53,8 @@ def run(ceph_cluster, **kw):
                 nfs_export,
                 fs,
                 ceph_cluster=ceph_cluster,
+                enable_rdma=config.get("enable_rdma", False),
+                rdma_port=config.get("rdma_port"),
             )
 
         if io:

--- a/tests/nfs/nfs_verify_nfs_ha.py
+++ b/tests/nfs/nfs_verify_nfs_ha.py
@@ -53,6 +53,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("Successfully setup NFS HA cluster")
         return 0

--- a/tests/nfs/nfs_verify_nfs_kill_process_failover.py
+++ b/tests/nfs/nfs_verify_nfs_kill_process_failover.py
@@ -55,6 +55,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("Successfully setup NFS HA cluster")
 

--- a/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
+++ b/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
@@ -61,6 +61,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         operations = []

--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -58,6 +58,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         ceph_ver = None

--- a/tests/nfs/nfs_verify_pynfs_ha.py
+++ b/tests/nfs/nfs_verify_pynfs_ha.py
@@ -56,6 +56,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Client 1

--- a/tests/nfs/nfs_verify_read_write_operations.py
+++ b/tests/nfs/nfs_verify_read_write_operations.py
@@ -45,6 +45,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         if operation == "verify_permission":

--- a/tests/nfs/nfs_verify_readdir_operation.py
+++ b/tests/nfs/nfs_verify_readdir_operation.py
@@ -74,6 +74,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Change the permission of mount dir from Linux client

--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Linux untar on client 1

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -108,6 +108,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with squash permission

--- a/tests/nfs/nfs_verify_stress.py
+++ b/tests/nfs/nfs_verify_stress.py
@@ -59,6 +59,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("Successfully setup NFS cluster")
 

--- a/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
+++ b/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_verify_symbolic_links_permissions.py
+++ b/tests/nfs/nfs_verify_symbolic_links_permissions.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file

--- a/tests/nfs/nfs_verify_symbolic_links_users.py
+++ b/tests/nfs/nfs_verify_symbolic_links_users.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create file

--- a/tests/nfs/nfs_verify_v3_mount_window_linux.py
+++ b/tests/nfs/nfs_verify_v3_mount_window_linux.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
+++ b/tests/nfs/nfs_verify_window_clinets_file_rename_lookups.py
@@ -62,6 +62,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window clients

--- a/tests/nfs/nfs_verify_windows_client.py
+++ b/tests/nfs/nfs_verify_windows_client.py
@@ -68,6 +68,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # If windows clients are present, perform mount
         if win_clients:

--- a/tests/nfs/nfs_verify_windows_parallel_readdir.py
+++ b/tests/nfs/nfs_verify_windows_parallel_readdir.py
@@ -72,6 +72,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window clients

--- a/tests/nfs/nfs_verify_xattr_readonly_file.py
+++ b/tests/nfs/nfs_verify_xattr_readonly_file.py
@@ -48,6 +48,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/qos/test_nfs_qos_on_cluster_level_enablement.py
+++ b/tests/nfs/qos/test_nfs_qos_on_cluster_level_enablement.py
@@ -792,6 +792,8 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             round_robin=True if cluster_qos else False,
             single_export=True if cluster_qos else False,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Process QoS operations

--- a/tests/nfs/qos/test_nfs_qos_on_export_level_enablement.py
+++ b/tests/nfs/qos/test_nfs_qos_on_export_level_enablement.py
@@ -178,6 +178,8 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             round_robin=True if cluster_qos else False,
             single_export=True if cluster_qos else False,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Process QoS operations

--- a/tests/nfs/qos/test_nfs_qos_ops_control.py
+++ b/tests/nfs/qos/test_nfs_qos_ops_control.py
@@ -124,6 +124,8 @@ def run(ceph_cluster, **kw):
             ceph_cluster=ceph_cluster,
             round_robin=True if cluster_qos else False,
             single_export=True if cluster_qos else False,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         target_clients = clients if cluster_qos else client

--- a/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare.py
+++ b/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare.py
@@ -111,6 +111,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         nfs_export = f"{nfs_export}_0"

--- a/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare_perclient.py
+++ b/tests/nfs/qos/test_nfs_qos_update_on_export_level_pershare_perclient.py
@@ -121,6 +121,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Enable QoS at cluster level first (required)

--- a/tests/nfs/security/test_nfs_ldap_mapping.py
+++ b/tests/nfs/security/test_nfs_ldap_mapping.py
@@ -450,6 +450,8 @@ def run(ceph_cluster, **kw):
             export=nfs_export,
             fs=fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Allow writing to the mount point (chmod 777) for setup

--- a/tests/nfs/test_export_readonly.py
+++ b/tests/nfs/test_export_readonly.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with RO permission

--- a/tests/nfs/test_export_rootsquash.py
+++ b/tests/nfs/test_export_rootsquash.py
@@ -68,6 +68,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create export with squash permission

--- a/tests/nfs/test_file_ops_copy.py
+++ b/tests/nfs/test_file_ops_copy.py
@@ -95,6 +95,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Create files and dirs from client 1 and copy files and dirs from client 2
         client1 = clients[0]

--- a/tests/nfs/test_file_ops_renames.py
+++ b/tests/nfs/test_file_ops_renames.py
@@ -94,6 +94,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create files from Client 1 and perform lookups and rename from client 2 and client 3

--- a/tests/nfs/test_nfs_export_readonly_windows.py
+++ b/tests/nfs/test_nfs_export_readonly_windows.py
@@ -74,6 +74,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Mount NFS-Ganesha V3 to window

--- a/tests/nfs/test_nfs_extended_attribute_rootsquash.py
+++ b/tests/nfs/test_nfs_extended_attribute_rootsquash.py
@@ -71,6 +71,8 @@ def run(ceph_cluster, **kw):
             ha,
             vip,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Change the permission of mount dir from Linux client

--- a/tests/nfs/test_nfs_get_set_attr_operation.py
+++ b/tests/nfs/test_nfs_get_set_attr_operation.py
@@ -44,6 +44,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on Mount point

--- a/tests/nfs/test_nfs_grpc.py
+++ b/tests/nfs/test_nfs_grpc.py
@@ -477,6 +477,8 @@ def run(ceph_cluster, **kw):
             export=nfs_export,
             fs=fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         log.info("NFS cluster setup complete.")
 

--- a/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
+++ b/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
@@ -111,6 +111,8 @@ def create_nfs_cluster(
     ha=False,
     vip=None,
     active_standby=False,
+    enable_rdma=False,
+    rdma_port=None,
 ):
     """Create NFS cluster"""
     try:
@@ -130,6 +132,8 @@ def create_nfs_cluster(
             ha=ha,
             vip=vip,
             active_standby=active_standby,
+            enable_rdma=enable_rdma,
+            rdma_port=rdma_port,
         )
     except Exception as e:
         raise ConfigError(f"Failed to create NFS cluster: {e}")
@@ -187,6 +191,8 @@ def run(ceph_cluster, **kw):
                 ha=ha,
                 vip=vip,
                 active_standby=active_standby,
+                enable_rdma=config.get("enable_rdma", False),
+                rdma_port=config.get("rdma_port"),
             )
             # Create file in parellel using ThreadPoolExecutor
             log.info("Creating files in parallel using ThreadPoolExecutor")

--- a/tests/nfs/test_nfs_partial_deallocation.py
+++ b/tests/nfs/test_nfs_partial_deallocation.py
@@ -46,6 +46,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file

--- a/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
+++ b/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs_name,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         Ceph(clients[0]).nfs.export.create(

--- a/tests/nfs/test_nfs_selinux_context_symlinks.py
+++ b/tests/nfs/test_nfs_selinux_context_symlinks.py
@@ -44,6 +44,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
 
         # Create a file on mount point

--- a/tests/nfs/test_nfs_selinux_label_while_mounting.py
+++ b/tests/nfs/test_nfs_selinux_label_while_mounting.py
@@ -47,6 +47,8 @@ def run(ceph_cluster, **kw):
             nfs_export,
             fs,
             ceph_cluster=ceph_cluster,
+            enable_rdma=config.get("enable_rdma", False),
+            rdma_port=config.get("rdma_port"),
         )
         # Remount the share on Client with selinux label
         cmd = f"umount -l {nfs_mount}"

--- a/tests/rados/test_fast_ec_config_params.py
+++ b/tests/rados/test_fast_ec_config_params.py
@@ -1826,18 +1826,28 @@ def run(ceph_cluster, **kw):
         Test: Stripe Unit and Fast EC Default Verification
 
         Verifies that Fast EC is enabled by default only for supported configurations,
-        and that stripe_unit defaults are correct.
+        and that stripe_unit defaults are correct. Also verifies that enabling Fast EC
+        on ineligible pools (unsupported plugin/technique or non-4K-aligned stripe_unit)
+        is correctly rejected.
+
+        Stripe Unit Alignment Rules:
+        - Hard check: stripe_unit must be a multiple of 32 bytes (ISA SIMD alignment).
+          Cannot be overridden; Ceph rejects with EINVAL.
+        - Soft check: stripe_unit should be a multiple of 4096 bytes (page alignment).
+          Can be overridden with --force, but resulting pool cannot be fast EC.
 
         Expected Defaults:
         - Fast EC pools: stripe_unit = 16K, allow_ec_optimizations = True
         - Non-Fast EC pools: stripe_unit = 4K, allow_ec_optimizations = False
 
         Workflow:
-        1. Create EC pools with various plugin/technique/k/m combinations
-        2. Verify allow_ec_optimizations matches expected
-        3. Verify stripe_unit matches expected (16K for Fast EC, 4K otherwise)
-        4. Write data to verify pool functionality
-        5. Cleanup all test pools
+        0. Verify global config precondition (osd_pool_default_flag_ec_optimizations=true)
+        1. Create EC pools with various plugin/technique/k/m/stripe_unit combinations
+        2. Verify allow_ec_optimizations, stripe_unit, stripe_width for each pool
+        2.5. Negative test: attempt to enable Fast EC on ineligible pools and verify
+             the correct EINVAL error and that the property stays False
+        3. Write data to verify pool functionality
+        4. Cleanup all test pools
         """
         log.info("=" * 80)
         log.info("TEST: STRIPE UNIT AND FAST EC DEFAULT VERIFICATION")
@@ -1848,54 +1858,290 @@ def run(ceph_cluster, **kw):
         test_failed = False
         created_pools = []
         pool_fast_ec_expected = {}  # pool_name -> fast_ec_expected
+        pool_stripe_unit_config = {}  # pool_name -> stripe_unit value from config
 
-        # Pool configurations: (k, m, plugin, technique, fast_ec_expected, d, description)
+        # Pool configurations:
+        # (k, m, plugin, technique, fast_ec_expected, d, description, stripe_unit, force)
+        #   stripe_unit: None = use Ceph default, or explicit int value
+        #   force: True = pass --force to bypass soft 4K alignment check
         # Fast EC supported: Jerasure+reed_sol_van, ISA+reed_sol_van, ISA+cauchy
         pool_configs = [
-            # Jerasure with reed_sol_van - Fast EC SUPPORTED
-            (2, 2, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k2m2"),
-            (4, 2, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k4m2"),
-            (4, 3, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k4m3"),
-            (5, 2, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k5m2"),
-            (6, 2, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k6m2"),
-            (8, 4, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k8m4"),
-            (8, 6, "jerasure", "reed_sol_van", True, None, "jerasure-rsv-k8m6"),
-            # ISA with reed_sol_van - Fast EC SUPPORTED
-            (2, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k2m2"),
-            (4, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k4m2"),
-            (4, 3, "isa", "reed_sol_van", True, None, "isa-rsv-k4m3"),
-            (5, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k5m2"),
-            (6, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k6m2"),
-            (8, 4, "isa", "reed_sol_van", True, None, "isa-rsv-k8m4"),
-            (8, 6, "isa", "reed_sol_van", True, None, "isa-rsv-k8m6"),
-            # ISA with cauchy - Fast EC SUPPORTED
-            (2, 2, "isa", "cauchy", True, None, "isa-cauchy-k2m2"),
-            (4, 2, "isa", "cauchy", True, None, "isa-cauchy-k4m2"),
-            (4, 3, "isa", "cauchy", True, None, "isa-cauchy-k4m3"),
-            (5, 2, "isa", "cauchy", True, None, "isa-cauchy-k5m2"),
-            (6, 2, "isa", "cauchy", True, None, "isa-cauchy-k6m2"),
-            (8, 4, "isa", "cauchy", True, None, "isa-cauchy-k8m4"),
-            (8, 6, "isa", "cauchy", True, None, "isa-cauchy-k8m6"),
+            # Jerasure with reed_sol_van - Fast EC SUPPORTED (default stripe_unit)
+            (
+                2,
+                2,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k2m2",
+                None,
+                False,
+            ),
+            (
+                4,
+                2,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k4m2",
+                None,
+                False,
+            ),
+            (
+                4,
+                3,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k4m3",
+                None,
+                False,
+            ),
+            (
+                5,
+                2,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k5m2",
+                None,
+                False,
+            ),
+            (
+                6,
+                2,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k6m2",
+                None,
+                False,
+            ),
+            (
+                8,
+                4,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k8m4",
+                None,
+                False,
+            ),
+            (
+                8,
+                6,
+                "jerasure",
+                "reed_sol_van",
+                True,
+                None,
+                "jerasure-rsv-k8m6",
+                None,
+                False,
+            ),
+            # ISA with reed_sol_van - Fast EC SUPPORTED (default stripe_unit)
+            (2, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k2m2", None, False),
+            (4, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k4m2", None, False),
+            (4, 3, "isa", "reed_sol_van", True, None, "isa-rsv-k4m3", None, False),
+            (5, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k5m2", None, False),
+            (6, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k6m2", None, False),
+            (8, 4, "isa", "reed_sol_van", True, None, "isa-rsv-k8m4", None, False),
+            (8, 6, "isa", "reed_sol_van", True, None, "isa-rsv-k8m6", None, False),
+            # ISA with cauchy - Fast EC SUPPORTED (default stripe_unit)
+            (2, 2, "isa", "cauchy", True, None, "isa-cauchy-k2m2", None, False),
+            (4, 2, "isa", "cauchy", True, None, "isa-cauchy-k4m2", None, False),
+            (4, 3, "isa", "cauchy", True, None, "isa-cauchy-k4m3", None, False),
+            (5, 2, "isa", "cauchy", True, None, "isa-cauchy-k5m2", None, False),
+            (6, 2, "isa", "cauchy", True, None, "isa-cauchy-k6m2", None, False),
+            (8, 4, "isa", "cauchy", True, None, "isa-cauchy-k8m4", None, False),
+            (8, 6, "isa", "cauchy", True, None, "isa-cauchy-k8m6", None, False),
             # ISA with reed_sol_van but m > 4 - falls back to cauchy - Fast EC supported
-            (4, 5, "isa", "reed_sol_van", True, None, "isa-rsv-m5-fallback-k4m5"),
-            (5, 5, "isa", "reed_sol_van", True, None, "isa-rsv-m5-fallback-k5m5"),
-            (6, 5, "isa", "reed_sol_van", True, None, "isa-rsv-m5-fallback-k6m5"),
-            (4, 6, "isa", "reed_sol_van", True, None, "isa-rsv-m6-fallback-k4m6"),
-            (6, 6, "isa", "reed_sol_van", True, None, "isa-rsv-m6-fallback-k6m6"),
+            (
+                4,
+                5,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-m5-fallback-k4m5",
+                None,
+                False,
+            ),
+            (
+                5,
+                5,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-m5-fallback-k5m5",
+                None,
+                False,
+            ),
+            (
+                6,
+                5,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-m5-fallback-k6m5",
+                None,
+                False,
+            ),
+            (
+                4,
+                6,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-m6-fallback-k4m6",
+                None,
+                False,
+            ),
+            (
+                6,
+                6,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-m6-fallback-k6m6",
+                None,
+                False,
+            ),
+            # Fast EC with various 4K-aligned stripe_unit values
+            (2, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k2m2-su4k", 4096, False),
+            (2, 2, "isa", "reed_sol_van", True, None, "isa-rsv-k2m2-su8k", 8192, False),
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-k2m2-su32k",
+                32768,
+                False,
+            ),
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-k2m2-su64k",
+                65536,
+                False,
+            ),
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                True,
+                None,
+                "isa-rsv-k2m2-su128k",
+                131072,
+                False,
+            ),
             # Clay plugin - Fast EC NOT supported
-            (2, 2, "clay", None, False, 3, "clay-k2m2d3"),
-            (3, 2, "clay", None, False, 4, "clay-k3m2d4"),
-            (4, 2, "clay", None, False, 5, "clay-k4m2d5"),
+            (2, 2, "clay", None, False, 3, "clay-k2m2d3", None, False),
+            (3, 2, "clay", None, False, 4, "clay-k3m2d4", None, False),
+            (4, 2, "clay", None, False, 5, "clay-k4m2d5", None, False),
+            # Non-4K-aligned stripe_unit (multiples of 32 but not 4096) - Fast EC NOT supported
+            # These require --force to bypass the soft page-alignment check
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                False,
+                None,
+                "isa-rsv-k2m2-su6112",
+                6112,
+                True,
+            ),
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                False,
+                None,
+                "isa-rsv-k2m2-su7168",
+                7168,
+                True,
+            ),
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                False,
+                None,
+                "isa-rsv-k2m2-su5120",
+                5120,
+                True,
+            ),
+            (
+                2,
+                2,
+                "isa",
+                "reed_sol_van",
+                False,
+                None,
+                "isa-rsv-k2m2-su2048",
+                2048,
+                True,
+            ),
         ]
 
         try:
+            # Step 0: Verify global config preconditions
+            log.info("\nStep 0: Verifying global config preconditions...")
+
+            ec_opt_flag = mon_obj.get_config(
+                section="osd", param="osd_pool_default_flag_ec_optimizations"
+            )
+
+            log.info("  osd_pool_default_flag_ec_optimizations: %s", ec_opt_flag)
+
+            if str(ec_opt_flag).strip().lower() != "true":
+                log.error(
+                    "osd_pool_default_flag_ec_optimizations is not true. Cannot proceed."
+                )
+                raise Exception(
+                    "Precondition failed: osd_pool_default_flag_ec_optimizations != true"
+                )
+
+            log.info("  Preconditions PASSED")
+
+            # Step 1: Create EC pools with various configurations
             log.info("\nStep 1: Creating EC pools with various configurations...")
 
             # Get number of OSD hosts to determine failure domain
             num_osd_hosts = len(rados_obj.get_osd_hosts())
             log.info("  Number of OSD hosts: %d", num_osd_hosts)
 
-            for k, m, plugin, technique, fast_ec_expected, d, desc in pool_configs:
+            for (
+                k,
+                m,
+                plugin,
+                technique,
+                fast_ec_expected,
+                d,
+                desc,
+                stripe_unit_val,
+                force_val,
+            ) in pool_configs:
                 pool_name = f"stripe-unit-test-{desc}"
                 profile_name = f"ec_profile_{pool_name}"
 
@@ -1905,7 +2151,7 @@ def run(ceph_cluster, **kw):
 
                 log.info(
                     "  Creating: %s (k=%d, m=%d, plugin=%s, technique=%s, d=%s, "
-                    "fast_ec=%s, failure_domain=%s)",
+                    "fast_ec=%s, stripe_unit=%s, force=%s, failure_domain=%s)",
                     pool_name,
                     k,
                     m,
@@ -1913,6 +2159,8 @@ def run(ceph_cluster, **kw):
                     technique or "default",
                     d,
                     fast_ec_expected,
+                    stripe_unit_val,
+                    force_val,
                     failure_domain,
                 )
 
@@ -1930,21 +2178,28 @@ def run(ceph_cluster, **kw):
                         pool_kwargs["technique"] = technique
                     if d is not None:
                         pool_kwargs["d"] = d
+                    if stripe_unit_val is not None:
+                        pool_kwargs["stripe_unit"] = stripe_unit_val
+                    if force_val:
+                        pool_kwargs["force"] = True
 
                     if not rados_obj.create_erasure_pool(**pool_kwargs):
                         raise Exception(f"Failed to create pool {pool_name}")
 
                     created_pools.append(pool_name)
                     pool_fast_ec_expected[pool_name] = fast_ec_expected
+                    pool_stripe_unit_config[pool_name] = stripe_unit_val
                     log.info("    Created successfully")
 
                 except Exception as e:
                     log.error("    Failed to create pool %s: %s", pool_name, e)
                     raise
 
+            # Step 2: Verify Fast EC, stripe_unit and stripe_width
             log.info("\nStep 2: Verifying Fast EC, stripe_unit and stripe_width...")
             verification_passed = True
             fast_ec_count, non_fast_ec_count = 0, 0
+            explicit_su_count, non_4k_su_count = 0, 0
 
             # Fetch all pool details and convert to dict for O(1) lookups
             pool_details_map = {
@@ -1957,6 +2212,7 @@ def run(ceph_cluster, **kw):
 
             for pool_name in created_pools:
                 fast_ec_expected = pool_fast_ec_expected[pool_name]
+                su_config = pool_stripe_unit_config[pool_name]
                 pool_detail = pool_details_map.get(pool_name, {})
                 ec_profile_name = pool_detail.get("erasure_code_profile", "")
 
@@ -1982,7 +2238,17 @@ def run(ceph_cluster, **kw):
                     stripe_unit_actual = int(stripe_width_actual / k_val)
 
                 # Expected values
-                expected_stripe_unit = 16384 if fast_ec_expected else 4096
+                if su_config is not None:
+                    expected_stripe_unit = su_config
+                    explicit_su_count += 1
+                    if su_config % 4096 != 0:
+                        non_4k_su_count += 1
+                elif fast_ec_expected:
+                    expected_stripe_unit = 16384
+                else:
+                    # Non-fast-EC pools without explicit stripe_unit: the default
+                    # varies by plugin/technique, so just accept whatever Ceph set
+                    expected_stripe_unit = stripe_unit_actual
                 expected_stripe_width = k_val * stripe_unit_actual
 
                 # Verify
@@ -2017,6 +2283,76 @@ def run(ceph_cluster, **kw):
             if not verification_passed:
                 raise Exception("Pool property verification failed")
 
+            # Step 2.5: Negative test - attempt to enable Fast EC on ineligible pools
+            log.info(
+                "\nStep 2.5: Negative test - attempting to enable Fast EC "
+                "on ineligible pools..."
+            )
+            neg_test_passed = True
+            neg_test_count = 0
+
+            for pool_name in created_pools:
+                if pool_fast_ec_expected[pool_name]:
+                    continue
+
+                neg_test_count += 1
+                su_val = pool_stripe_unit_config.get(pool_name)
+                is_non_4k_aligned = su_val is not None and su_val % 4096 != 0
+
+                log.info(
+                    "  Testing: %s (non_4k_aligned=%s)", pool_name, is_non_4k_aligned
+                )
+
+                cmd = f"ceph osd pool set {pool_name} allow_ec_optimizations true"
+                try:
+                    rados_obj.node.shell([cmd])
+                    log.error(
+                        "  FAIL: %s - command should have failed but succeeded",
+                        pool_name,
+                    )
+                    neg_test_passed = False
+                except Exception as e:
+                    err_msg = str(e)
+                    log.info("  Command failed as expected: %s", err_msg)
+                    if is_non_4k_aligned:
+                        if "stripe_unit must be divisible by 4096" not in err_msg:
+                            log.error(
+                                "  FAIL: %s - expected 'stripe_unit must be divisible "
+                                "by 4096' in error but got: %s",
+                                pool_name,
+                                err_msg,
+                            )
+                            neg_test_passed = False
+                        else:
+                            log.info(
+                                "  PASS: %s - correct EINVAL error for "
+                                "non-4K-aligned stripe_unit",
+                                pool_name,
+                            )
+                    else:
+                        log.info("  PASS: %s - command rejected as expected", pool_name)
+
+                ec_opt = rados_obj.get_pool_property(
+                    pool=pool_name, props="allow_ec_optimizations"
+                )
+                actual_val = ec_opt.get("allow_ec_optimizations")
+                if actual_val is True:
+                    log.error(
+                        "  FAIL: %s - allow_ec_optimizations is True after failed set",
+                        pool_name,
+                    )
+                    neg_test_passed = False
+                else:
+                    log.info(
+                        "  PASS: %s - allow_ec_optimizations correctly remained %s",
+                        pool_name,
+                        actual_val,
+                    )
+
+            if not neg_test_passed:
+                raise Exception("Negative validation failed")
+
+            # Step 3: Write data to verify pool functionality
             log.info("\nStep 3: Writing data to verify pool functionality...")
 
             for pool_name in created_pools:
@@ -2036,6 +2372,9 @@ def run(ceph_cluster, **kw):
             log.info("Total pools tested: %d", len(created_pools))
             log.info("Fast EC enabled pools: %d", fast_ec_count)
             log.info("Non-Fast EC pools: %d", non_fast_ec_count)
+            log.info("Pools with explicit stripe_unit: %d", explicit_su_count)
+            log.info("Pools with non-4K-aligned stripe_unit: %d", non_4k_su_count)
+            log.info("Negative tests (enable on ineligible): %d", neg_test_count)
             log.info("All verifications: PASSED")
             log.info("=" * 80)
 

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -13,6 +13,8 @@ import datetime
 import json
 import time
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.orch import Orch
@@ -122,6 +124,7 @@ def run(ceph_cluster, **kw):
         _platform = args.get("platform", config["platform"])
         _custom_image = args.get("custom_image", None)
         _custom_repo = args.get("custom_repo", None)
+        product: str = args.get("--product", config["product"])
         _rpm_version = None
         if _rhcs_release and _rhcs_version:
             curr_ver, _ = cephadm_obj.shell(args=["ceph version | awk '{print $3}'"])
@@ -129,7 +132,6 @@ def run(ceph_cluster, **kw):
                 "Upgrading the cluster from ceph version %s to %s-%s "
                 % (curr_ver, _rhcs_version, _rhcs_release)
             )
-            product: str = args.get("--product", config["product"])
             ctm: CephTestManifest = CephTestManifest(
                 product=product,
                 release=_rhcs_version,
@@ -157,6 +159,15 @@ def run(ceph_cluster, **kw):
             config["args"]["image"] = config["container_image"]
             os_ver = rhbuild.split("-")[-1]
             _rpm_version = f"2:{_ver}.el{os_ver}cp"
+
+            # IBM Storage Ceph 9.1 and greater would require license acceptance
+            # There is '--automatically-accept-license' option
+            if product == "ibm" and LooseVersion(_rhcs_version) >= LooseVersion("9.1"):
+                license_cmd = (
+                    f"ceph orch accept-license --image {config['container_image']}"
+                )
+                out, _ = cephadm_obj.shell(args=[license_cmd], check_status=False)
+                log.debug(out)
         elif _custom_image and _custom_repo:
             _registry, _image_name = _custom_image.split(":")[0].split("/", 1)
             _image_tag = _custom_image.split(":")[-1]
@@ -219,6 +230,17 @@ def run(ceph_cluster, **kw):
             if hostnames:
                 config["args"]["hosts"] = ",".join(hostnames)
                 log.info(f"Converted node IDs to hostnames: {hostnames}")
+
+        # IBM Storage Ceph 9.1 and greater would require license acceptance
+        # There is '--automatically-accept-license' option
+        if product == "ibm" and LooseVersion(
+            str(config.get("release"))
+        ) >= LooseVersion("9.1"):
+            license_cmd = (
+                f"ceph orch accept-license --image {config['container_image']}"
+            )
+            out, _ = cephadm_obj.shell(args=[license_cmd], check_status=False)
+            log.debug(out)
 
         # Start Upgrade
         cluster_obj.start_upgrade(config)

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from jinja_markdown import MarkdownExtension
+from packaging.version import InvalidVersion, Version
 
 from cli.exceptions import ConfigError
 from utility.log import Log
@@ -2925,3 +2926,41 @@ def setup_gklm_prereq(ceph_cluster, cloud_type, custom_config):
     client_node.exec_command(sudo=True, cmd="ceph orch apply -i /root/rgw_spec.yaml")
     log.info("sleeping for 20 seconds")
     time.sleep(20)
+
+
+def extract_version(text: str) -> str:
+    """
+    Extract the first valid version token from a text string.
+
+    Args:
+        text: Command output string containing a version value.
+
+    Returns:
+        First token that parses as a packaging.version ``Version``; empty string if none.
+        e.g. 9.9.1.0 or 9.9.2.0
+    """
+    log.debug("Extracting version token from text: %s", text)
+
+    for token in text.split():
+        try:
+            Version(token)
+            log.debug("Extracted version token: %s", token)
+            return token
+        except InvalidVersion:
+            continue
+    log.warning("No valid version token found in text: %s", text)
+    return ""
+
+
+def extract_ceph_version(text: str) -> str:
+    """
+    Extract 'ceph' version from a text string.
+    Args:
+        text: Command output string containing a version value.
+
+    Returns:
+        19.2.1 or 20.2.1
+    """
+    match = re.search(r"\d+\.\d+\.\d+", text)
+
+    return match.group() if match else ""


### PR DESCRIPTION

Fix QE compose Tools repo handling for IBM and RH sanity runs.

## Changes

* Added shared helper to detect flat Tools compose layout
* Fixed QE/IP mirror compose detection
* Added ibmc flat Tools layout handling
* Passed ibm_build flag into get_custom_repo_url()
* Fixed IBM repo validation to handle lowercase repo filenames

## Issue

QE composes and IBMC builds expose Tools repo at:
`.../Tools/`

but existing logic incorrectly generated:
`.../compose/Tools/x86_64/os/`

This caused:

* repomd.xml 404 failures
* repo validation failures
* IBM sanity failures in DMFG runs
failed sanity log-Log: https://149.81.216.83/job/reef-sanity-ci/41/stages/log?nodeId=214
manual executor log--https://149.81.216.83/job/reef-test-executor/102/stages/log?nodeId=98 (passed)
the manual executor passed at repo reading and  cephadm-ansible installation
