### PR TITLE
Use suite YAML tags for OpenShift monitoring images

### DIFF
--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -4,7 +4,16 @@ from cli.utilities.packages import Package, PackageError, ReposError, Rpm
 from cli.utilities.utils import get_custom_repo_url
 
 YUM_REPO_DIR = "/etc/yum.repos.d"
-REG_IMAGE = "registry.redhat.io/openshift4/{}:latest"
+
+
+def openshift4_monitoring_image(short_name, tag):
+    """Build registry.redhat.io/openshift4/<name>:<tag> using the suite YAML tag.
+
+    Tags must match what is mirrored (e.g. v4.13.0). Using :latest breaks pulls when
+    the lab mirror only syncs versioned tags.
+    """
+    suffix = (tag or "").strip() or "latest"
+    return f"registry.redhat.io/openshift4/{short_name}:{suffix}"
 
 
 def compare_packages(node, pkgs):
@@ -60,8 +69,8 @@ def pull_images(node, images):
         node (ceph): ceph node objects
         images (dict): container images
     """
-    for image, _ in images.items():
-        Container(node).pull(REG_IMAGE.format(image))
+    for image, tag in images.items():
+        Container(node).pull(openshift4_monitoring_image(image, tag))
 
 
 def compare_images(node, images):
@@ -71,10 +80,9 @@ def compare_images(node, images):
         images (dict): container images
     """
     for image, ver in images.items():
-        if Container(node).compare(REG_IMAGE.format(image), ver) == -1:
-            raise PackageError(
-                f"Expected version for {REG_IMAGE.format(image)} is {ver}"
-            )
+        ref = openshift4_monitoring_image(image, ver)
+        if Container(node).compare(ref, ver) == -1:
+            raise PackageError(f"Expected version for {ref} is {ver}")
 
 
 def validate_packages(node, pkgs):
@@ -153,6 +161,7 @@ def run(ceph_cluster, **kwargs):
         _files = [repo for repo in out if "Tools" in repo or "RHCEPH" in repo]
     elif build_type == "ibm":
         _files = [repo for repo in out if "IBM" in repo]
+
     # Raise error if expected repository is not added
     if not _files:
         raise ResourceNotFoundError("Expected repository not added to node")

--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -4,7 +4,16 @@ from cli.utilities.packages import Package, PackageError, ReposError, Rpm
 from cli.utilities.utils import get_custom_repo_url
 
 YUM_REPO_DIR = "/etc/yum.repos.d"
-REG_IMAGE = "registry.redhat.io/openshift4/{}:latest"
+
+
+def openshift4_monitoring_image(short_name, tag):
+    """Build registry.redhat.io/openshift4/<name>:<tag> using the suite YAML tag.
+
+    Tags must match what is mirrored (e.g. v4.13.0). Using :latest breaks pulls when
+    the lab mirror only syncs versioned tags.
+    """
+    suffix = (tag or "").strip() or "latest"
+    return f"registry.redhat.io/openshift4/{short_name}:{suffix}"
 
 
 def compare_packages(node, pkgs):
@@ -60,8 +69,8 @@ def pull_images(node, images):
         node (ceph): ceph node objects
         images (dict): container images
     """
-    for image, _ in images.items():
-        Container(node).pull(REG_IMAGE.format(image))
+    for image, tag in images.items():
+        Container(node).pull(openshift4_monitoring_image(image, tag))
 
 
 def compare_images(node, images):
@@ -71,10 +80,9 @@ def compare_images(node, images):
         images (dict): container images
     """
     for image, ver in images.items():
-        if Container(node).compare(REG_IMAGE.format(image), ver) == -1:
-            raise PackageError(
-                f"Expected version for {REG_IMAGE.format(image)} is {ver}"
-            )
+        ref = openshift4_monitoring_image(image, ver)
+        if Container(node).compare(ref, ver) == -1:
+            raise PackageError(f"Expected version for {ref} is {ver}")
 
 
 def validate_packages(node, pkgs):
@@ -153,6 +161,7 @@ def run(ceph_cluster, **kwargs):
         _files = [repo for repo in out if "Tools" in repo or "RHCEPH" in repo]
     elif build_type == "ibm":
         _files = [repo for repo in out if "IBM" in repo]
+
     # Raise error if expected repository is not added
     if not _files:
         raise ResourceNotFoundError("Expected repository not added to node")
@@ -183,3 +192,4 @@ def run(ceph_cluster, **kwargs):
             Package(node).clean()
 
     return 0
+    


### PR DESCRIPTION
Summary

Use versioned OpenShift monitoring image tags from suite YAML instead of always pulling `:latest`.

## Changes

* Added helper to build monitoring image references using suite YAML tags
* Updated image pull logic to use versioned tags
* Updated image comparison logic to validate expected tag versions

## Issue

The existing logic always pulled:
`registry.redhat.io/openshift4/<image>:latest`

However QE mirrors often sync only versioned tags such as:
`v4.13.0`

This caused podman pull failures with:
`manifest unknown`
when the mirror did not expose `:latest`.
