### PR TITLE
Accept IBM call-home alerts automatically during bootstrap

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -403,6 +403,10 @@ class BootstrapMixin:
             if "automatically-accept-license" not in cmd:
                 cmd += " --automatically-accept-license"
 
+            # By default, call home is disabled when no call home options are
+            # are found
+            if "call-home" not in cmd:
+                cmd += " --disable-ibm-call-home"
         out, err = self.installer.exec_command(
             sudo=True,
             cmd=cmd,
@@ -417,7 +421,10 @@ class BootstrapMixin:
             and LooseVersion(str(manifest_obj.release)) >= LooseVersion("9.1")
             and "call-home" not in cmd
         ):
-            self.shell(args=["ceph", "orch", "accept", "call-home-enabled"], timeout=60)
+            self.shell(
+                args=["ceph", "orch", "accept", "call-home-enabled"],
+                timeout=60,
+            )
 
         logger.info("Bootstrap output : %s", out)
         logger.error("Bootstrap error: %s", err)
@@ -500,6 +507,19 @@ class BootstrapMixin:
             self.shell(
                 args=["ceph", "config", "set", "global cluster_network", cluster_nws]
             )
+        if self.cluster.rhcs_version >= LooseVersion("8.0"):
+            wa_txt = """
+            Disabling the balancer module as a WA for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2314146
+            Issue : If any mgr module based operation is performed right after mgr failover, The command execution fails
+            as the module isn't loaded by mgr daemon. Issue was identified to be with Balancer module.
+            Disabling automatic balancing on the cluster as a WA until we get the fix for the same.
+            Disabling balancer should unblock Upgrade tests.
+            Error snippet :
+    Error ENOTSUP: Warning: due to ceph-mgr restart, some PG states may not be up to date
+    Module 'crash' is not enabled/loaded (required by command 'crash ls'): use `ceph mgr module enable crash` to enable
+            """
+            logger.info(wa_txt)
+            self.shell(args=["ceph balancer off"])
 
         # validate spec file
         if specs:


### PR DESCRIPTION
## Summary

Automatically accept IBM call-home alerts during bootstrap for IBM 9.1+ deployments.

## Changes

* Added automatic `ceph orch accept call-home-enabled`
* Triggered only for IBM builds >= 9.1
* Executed only when call-home options are not explicitly provided

## Issue

Downstream tests can fail due to unaccepted call-home alerts after bootstrap on IBM clusters.

This change ensures the alert is acknowledged automatically during bootstrap to avoid unrelated downstream failures.
