### PR TITLE
Ensure empty string is not incorrectly parsed by Version module

### DIFF
--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -93,9 +93,13 @@ class UpgradeMixin:
             )
             LOG.debug("MGR common version: %s", mgr_version_common)
             LOG.debug("MGR downstream version: %s", mgr_version_downstream)
-            if Version(mgr_version_common) >= Version("20.2.1") or Version(
+            common_ver_check = mgr_version_common and Version(
+                mgr_version_common
+            ) >= Version("20.2.1")
+            downstream_ver_check = mgr_version_downstream and Version(
                 mgr_version_downstream
-            ) >= Version("9.9.1.0"):
+            ) >= Version("9.9.1.0")
+            if common_ver_check or downstream_ver_check:
                 cmd.append("--automatically-accept-license")
 
         return self.shell(args=cmd)


### PR DESCRIPTION
Regression introduced with PR #5828 

Downstream version does not exist for daemons that are below 9.1, from such daemons, the downstream version string was empty.

Empty string cannot be parsed by packaging.version.Version() resulting in failures. 

The initial checks and validations were done when code was comparing strings, but as per the correct suggestion from Bob, such comparisons are problematic when comparing semantic versions.

Failure log - 
https://149.81.216.83/view/Tentacle/job/tentacle-sanity-ci/598/stages/log?nodeId=392
https://149.81.216.83/view/Tentacle/job/tentacle-sanity-ci/598/stages/log?nodeId=393

This PR addresses the issue by ensuring packaging.version.Version() does not parse empty strings.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
