### PR TITLE
Fix QE compose Tools repo handling for IBM and RH sanity runs

### DIFF
--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -9,6 +9,7 @@ from cli.ops.cephadm_ansible import (
     exec_cephadm_preflight,
 )
 from cli.utilities.packages import Package, Repos
+from cli.utilities.utils import repo_uses_flat_tools_compose_layout
 from utility.log import Log
 
 from .configs import get_registry_details
@@ -390,10 +391,7 @@ def get_tools_repo(repo, ibm_build=False):
     if repo.endswith(".repo"):
         return repo
 
-    if "repo.qe.ceph.lab" in repo:
-        return f"{repo}/Tools"
-
-    if ibm_build:
+    if repo_uses_flat_tools_compose_layout(repo, ibm_build):
         return f"{repo}/Tools"
 
     return f"{repo}/compose/Tools/x86_64/os"

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -204,6 +204,25 @@ def get_node_ip(nodes, node_name):
     return False
 
 
+def repo_uses_flat_tools_compose_layout(
+    repo_url, ibm_build=False, cloud_type="openstack"
+):
+    """True when RPM Tools live at {compose}/Tools/ (not compose/Tools/x86_64/os/).
+
+    QE lab composes, IP mirrors of the same layout, IBM composes, and IBM Cloud
+    metal (ibmc) use this layout; downstream RH compose trees use the deeper path.
+    """
+    if ibm_build or cloud_type == "ibmc":
+        return True
+    lowered = repo_url.lower()
+    if "repo.qe.ceph.lab" in lowered:
+        return True
+    # Jenkins / internal mirrors often expose compose roots without the QE hostname.
+    if "/repos/ceph/" in lowered:
+        return True
+    return False
+
+
 def get_custom_repo_url(base_url, cloud_type="openstack"):
     """Add the given custom repo on every node part of the cluster.
 
@@ -214,18 +233,19 @@ def get_custom_repo_url(base_url, cloud_type="openstack"):
     if base_url.endswith(".repo"):
         return base_url
 
-    if not base_url.endswith("/"):
-        base_url += "/"
+    trimmed = base_url.rstrip("/")
+    lowered = trimmed.lower()
+    if lowered.endswith("/tools") or "/tools/" in lowered:
+        return trimmed + "/"
+
+    base_url = trimmed + "/"
 
     if base_url.endswith("x86_64/"):
         return base_url
 
-    if cloud_type == "ibmc":
-        base_url += "Tools"
-    else:
-        base_url += "compose/Tools/x86_64/os/"
-
-    return base_url
+    if repo_uses_flat_tools_compose_layout(base_url, cloud_type=cloud_type):
+        return base_url + "Tools/"
+    return base_url + "compose/Tools/x86_64/os/"
 
 
 def get_nodes_by_ids(nodes, ids):

--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -4,7 +4,16 @@ from cli.utilities.packages import Package, PackageError, ReposError, Rpm
 from cli.utilities.utils import get_custom_repo_url
 
 YUM_REPO_DIR = "/etc/yum.repos.d"
-REG_IMAGE = "registry.redhat.io/openshift4/{}:latest"
+
+
+def openshift_monitoring_image(image_name, tag):
+    """registry.redhat.io/openshift4 image ref using the suite tag (not :latest).
+
+    Internal mirrors often omit :latest; tags match monitoring_images values
+    (e.g. v4.13.0).
+    """
+    t = (tag or "latest").strip() or "latest"
+    return f"registry.redhat.io/openshift4/{image_name}:{t}"
 
 
 def compare_packages(node, pkgs):
@@ -60,8 +69,8 @@ def pull_images(node, images):
         node (ceph): ceph node objects
         images (dict): container images
     """
-    for image, _ in images.items():
-        Container(node).pull(REG_IMAGE.format(image))
+    for image, ver in images.items():
+        Container(node).pull(openshift_monitoring_image(image, ver))
 
 
 def compare_images(node, images):
@@ -71,10 +80,9 @@ def compare_images(node, images):
         images (dict): container images
     """
     for image, ver in images.items():
-        if Container(node).compare(REG_IMAGE.format(image), ver) == -1:
-            raise PackageError(
-                f"Expected version for {REG_IMAGE.format(image)} is {ver}"
-            )
+        ref = openshift_monitoring_image(image, ver)
+        if Container(node).compare(ref, ver) == -1:
+            raise PackageError(f"Expected version for {ref} is {ver}")
 
 
 def validate_packages(node, pkgs):
@@ -131,7 +139,8 @@ def run(ceph_cluster, **kwargs):
     # Get config details
     config = kwargs.get("config")
     base_url = config.get("base_url")
-    cloud_type = config.get("cloud_type")
+    # run.py sets "cloud-type" (hyphen); accept both spellings
+    cloud_type = config.get("cloud_type") or config.get("cloud-type")
 
     # Get expected package versions from config
     client_pkgs = config.get("client_packages")
@@ -152,7 +161,7 @@ def run(ceph_cluster, **kwargs):
     if build_type == "rh":
         _files = [repo for repo in out if "Tools" in repo or "RHCEPH" in repo]
     elif build_type == "ibm":
-        _files = [repo for repo in out if "IBM" in repo]
+        _files = [repo for repo in out if "ibm" in repo.lower()]
     # Raise error if expected repository is not added
     if not _files:
         raise ResourceNotFoundError("Expected repository not added to node")


### PR DESCRIPTION
## Problem

QE composes and IBMC builds expose the Tools repo at:
    .../Tools/

But existing logic incorrectly generated:
    .../compose/Tools/x86_64/os/

This caused:
- repomd.xml 404 failures
- repo validation failures  
- IBM sanity failures in DMFG runs
- Image pull failures due to wrong :latest tag on internal mirrors
- cloud_type not being detected due to hyphen vs underscore mismatch
- IBM repo validation missing lowercase repo filenames

---

## Changes

### 1. cli/utilities/configure.py
- Replaced hardcoded QE and IBM repo detection with new helper function
- Added import for repo_uses_flat_tools_compose_layout

### 2. cli/utilities/utils.py

**New helper function — repo_uses_flat_tools_compose_layout()**
- Central place to detect if repo uses flat Tools/ layout
- Handles QE lab composes, internal mirrors, IBM builds, IBMC cloud
- Returns True for flat layout, False for deep layout

**Updated get_custom_repo_url()**
- Fixed URL pattern matching bug (blocker fix by reviewer rakeshcn)
  - Old: "/tools/" in (lowered + "/") — could match /toolset/ accidentally
  - New: "/tools/" in lowered — exact match only
- Better trailing slash handling
- Now uses helper function to decide correct path

### 3. tests/cephadm/test_package_validation.py

**New function — openshift_monitoring_image()**
- Old code always used :latest tag
- Internal mirrors don't have :latest — they use version tags like v4.13.0
- New function builds correct versioned image URL

**Fixed pull_images() and compare_images()**
- Now uses openshift_monitoring_image() with actual version tag
- Fixes image pull and comparison failures on internal mirrors

**Fixed cloud_type detection**
- run.py passes cloud-type with hyphen
- Config was reading cloud_type with underscore
- Now accepts both spellings

**Fixed IBM repo detection**
- Old: "IBM" in repo — missed lowercase filenames
- New: "ibm" in repo.lower() — catches all cases

---

## Root Cause Fix

| Before | After |
|--------|-------|
| .../compose/Tools/x86_64/os/ | .../Tools/ |
| :latest image tag | versioned tag e.g v4.13.0 |
| cloud-type not detected | accepts both hyphen and underscore |
| missed lowercase IBM repos | case insensitive check |

---

## Testing

- Verified fix in manual executor run
- repo URL correctly generated as .../Tools/
- cephadm-ansible installed successfully
- No 404 errors
- Test passed

---

## No Breaking Changes

All changes are backward compatible:
- Default parameters preserved
- Existing callers work without modification
- No dependent function breakouts

failed sanity log-Log: https://149.81.216.83/job/reef-sanity-ci/41/stages/log?nodeId=214
manual executor log--https://149.81.216.83/job/reef-test-executor/102/stages/log?nodeId=98 (passed)
the manual executor passed at repo reading and cephadm-ansible installation