### PR TITLE
Fix exec_command argument in 'get_daemon_metadata'

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -2079,7 +2079,7 @@ def get_daemon_metadata(node, daemon_type: str, daemon_id: str = None):
 
     for _ in range(3):
         try:
-            out, _ = node.exec_command(args=[base_cmd], sudo=True)
+            out, _ = node.exec_command(cmd=base_cmd, sudo=True)
             break
         except Exception as e:
             debug_msg = f"Passed daemon type : {daemon_type}, Daemon ID : {daemon_id}, Error : {e}"


### PR DESCRIPTION
Code error introduced with PR https://github.com/red-hat-storage/cephci/pull/5840

exec_command module was being sent incorrect argument.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>