### PR TITLE
Add call_home_enabled warning in accepted health warnings

### DIFF
--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -51,6 +51,7 @@ class CephFSCommonUtils(FsUtils):
             "experiencing slow operations in BlueStore",
             "Slow OSD heartbeats",
             "stray daemon(s) not managed by cephadm",
+            "CALL_HOME_ENABLED_AUTOMATICALLY",
         ]
         non_accepted_list = ["OSD_DOWN", "OSD_HOST_DOWN"]
         while ceph_healthy == 0 and (datetime.datetime.now() < end_time):


### PR DESCRIPTION
Pass Results: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-271/cephfs/1564/logs/tier_0_fs/

Added CALL_HOME_ENABLED_AUTOMATICALLY to accepted warnings.