### PR TITLE
Restore cluster log collection during test failures

### DIFF
--- a/cephci/cluster_info.py
+++ b/cephci/cluster_info.py
@@ -21,6 +21,7 @@ from utility.log import Log
 log = Log(__name__)
 
 CEPH_VAR_LOG_DIR = "/var/log/ceph"
+_CEPH_VAR_LOG_DIR = "var/log/ceph"
 CEPH_COREDUMP_DIR = "/var/lib/systemd/coredump/"
 
 doc = """
@@ -170,7 +171,10 @@ def get_ceph_var_logs(cluster, log_dir):
     os.makedirs(download_dir, exist_ok=True)
     for node in cluster.get_nodes():
         tar_file = f"{node.hostname}-cephlog.tar"
-        node.exec_command(cmd=f"tar -cvzf {tar_file} {CEPH_VAR_LOG_DIR}", sudo=True)
+        node.exec_command(
+            cmd=f"tar -C / --warning=no-file-changed -cvzf {tar_file} {_CEPH_VAR_LOG_DIR}",
+            sudo=True,
+        )
 
         node.download_file(
             src=tar_file,

--- a/run.py
+++ b/run.py
@@ -701,6 +701,8 @@ def run(args):
     skip_sos_report = args.get("--skip-sos-report")
     if "collect-coredump" in custom_config_dict.keys():
         collect_coredump = bool(custom_config_dict["collect-coredump"])
+    if "collect-ceph-logs" in custom_config_dict.keys():
+        collect_ceph_logs = bool(custom_config_dict["collect-ceph-logs"])
 
     # load config, suite and inventory yaml files
     conf = load_file(glb_file)
@@ -1288,10 +1290,18 @@ def run(args):
                 installer.password or "cephuser",
                 run_dir,
             )
-            # This can be Removed as sos report will have this details as well
-            get_ceph_var_logs(ceph_cluster_dict[cluster], run_dir)
 
         log.info(f"Generated sosreports location : {url_base}/sosreports\n")
+
+    if jenkins_rc or collect_ceph_logs:
+        log.info(
+            "\n\nCopying Ceph cluster logs due to failures in testcase or user instructed"
+        )
+        for cluster in ceph_cluster_dict.keys():
+            # method to collect logs from ceph nodes
+            get_ceph_var_logs(ceph_cluster_dict[cluster], run_dir)
+
+        log.info(f"Generated cluster log location : {url_base}/ceph_logs\n")
 
     return jenkins_rc
 


### PR DESCRIPTION
With the introduction of IBM jenkins, collection of sos report during test failures was no longer continued. As sos report collection and ceph cluster log collection were coupled together, this resulted in discontinuation of ceph cluster log collection during failures.

Few crashes and test failures observed during pipeline runs are intermittent and would take duplicated effort to reproduce locally in order to gather required debug logs.

This PR 
- decouples sos report collection and ceph cluster log collection.
- introduces a custom config parameter `collect-ceph-logs` to give users the ability to collect ceph cluster log regardless or test result

Pass log-
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/regression/20.2.1-286/rados/57/logs/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
