### PR TITLE
Update erasure suite client node to node8 for common config

### DIFF
--- a/suites/squid/cephfs/tier-2_fs_erasure.yaml
+++ b/suites/squid/cephfs/tier-2_fs_erasure.yaml
@@ -93,8 +93,54 @@ tests:
         id: client.1
         install_packages:
           - ceph-common
-        node: node7
+          - ceph-fuse
+        node: node8
       desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
       destroy-cluster: false
       module: test_client.py
       name: "configure client"


### PR DESCRIPTION
Change client node reference from node7 to node8 so the erasure suite can use tier-2_cephfs_7-node-cluster.yaml where clients are on node8-11 (node7 is mds/nfs/osd in that config).

