### PR TITLE
Enable rhceph tools repo on CDN cluster clients 

### DIFF
--- a/conf/reef/integrations/ocs_rgw_ssl_openstack_conf.yaml
+++ b/conf/reef/integrations/ocs_rgw_ssl_openstack_conf.yaml
@@ -3,8 +3,6 @@ globals:
       name: ceph
       node1:
         role:
-          - _admin
-          - installer
           - osd
           - mds
           - grafana
@@ -12,6 +10,8 @@ globals:
         disk-size: 15
       node2:
         role:
+          - _admin
+          - installer
           - osd
           - mon
           - mgr

--- a/conf/squid/integrations/ocs_rgw_ssl_openstack_conf.yaml
+++ b/conf/squid/integrations/ocs_rgw_ssl_openstack_conf.yaml
@@ -3,8 +3,6 @@ globals:
       name: ceph
       node1:
         role:
-          - _admin
-          - installer
           - osd
           - mds
           - grafana
@@ -12,6 +10,8 @@ globals:
         disk-size: 15
       node2:
         role:
+          - _admin
+          - installer
           - osd
           - mon
           - mgr

--- a/suites/reef/integrations/ocs.yaml
+++ b/suites/reef/integrations/ocs.yaml
@@ -14,7 +14,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
         command: bootstrap
         service: cephadm
       desc: "Bootstrap the cluster with minimal configuration."

--- a/suites/reef/integrations/ocs_rgw_ssl.yaml
+++ b/suites/reef/integrations/ocs_rgw_ssl.yaml
@@ -14,7 +14,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
         command: bootstrap
         service: cephadm
       desc: "Bootstrap the cluster with minimal configuration."

--- a/suites/reef/integrations/ocs_rgw_with_ssl_ibm.yaml
+++ b/suites/reef/integrations/ocs_rgw_with_ssl_ibm.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/reef/integrations/ocs_rgw_with_ssl_vsphere.yaml
+++ b/suites/reef/integrations/ocs_rgw_with_ssl_vsphere.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/reef/integrations/ocs_rgw_without_ssl_ibm.yaml
+++ b/suites/reef/integrations/ocs_rgw_without_ssl_ibm.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/reef/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/reef/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/squid/integrations/ocs.yaml
+++ b/suites/squid/integrations/ocs.yaml
@@ -14,7 +14,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
         command: bootstrap
         service: cephadm
       desc: "Bootstrap the cluster with minimal configuration."

--- a/suites/squid/integrations/ocs.yaml
+++ b/suites/squid/integrations/ocs.yaml
@@ -72,7 +72,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -87,7 +87,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true

--- a/suites/squid/integrations/ocs_rgw_ssl.yaml
+++ b/suites/squid/integrations/ocs_rgw_ssl.yaml
@@ -14,7 +14,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
         command: bootstrap
         service: cephadm
       desc: "Bootstrap the cluster with minimal configuration."

--- a/suites/squid/integrations/ocs_rgw_ssl.yaml
+++ b/suites/squid/integrations/ocs_rgw_ssl.yaml
@@ -75,7 +75,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -90,7 +90,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true

--- a/suites/squid/integrations/ocs_rgw_with_ssl_ibm.yaml
+++ b/suites/squid/integrations/ocs_rgw_with_ssl_ibm.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/squid/integrations/ocs_rgw_with_ssl_ibm.yaml
+++ b/suites/squid/integrations/ocs_rgw_with_ssl_ibm.yaml
@@ -112,7 +112,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -127,7 +127,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -151,7 +151,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/squid/integrations/ocs_rgw_with_ssl_vsphere.yaml
+++ b/suites/squid/integrations/ocs_rgw_with_ssl_vsphere.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/squid/integrations/ocs_rgw_with_ssl_vsphere.yaml
+++ b/suites/squid/integrations/ocs_rgw_with_ssl_vsphere.yaml
@@ -125,7 +125,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -149,7 +149,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/squid/integrations/ocs_rgw_without_ssl_ibm.yaml
+++ b/suites/squid/integrations/ocs_rgw_without_ssl_ibm.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/squid/integrations/ocs_rgw_without_ssl_ibm.yaml
+++ b/suites/squid/integrations/ocs_rgw_without_ssl_ibm.yaml
@@ -110,7 +110,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -125,7 +125,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -149,7 +149,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/squid/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/squid/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/squid/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/squid/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -107,7 +107,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -122,7 +122,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -146,7 +146,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/integrations/ocs_rgw_with_ssl_ibm.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_with_ssl_ibm.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/tentacle/integrations/ocs_rgw_with_ssl_ibm.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_with_ssl_ibm.yaml
@@ -112,7 +112,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -127,7 +127,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -151,7 +151,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/integrations/ocs_rgw_with_ssl_vsphere.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_with_ssl_vsphere.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/tentacle/integrations/ocs_rgw_with_ssl_vsphere.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_with_ssl_vsphere.yaml
@@ -110,7 +110,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -125,7 +125,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -149,7 +149,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/integrations/ocs_rgw_without_ssl_ibm.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_without_ssl_ibm.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/tentacle/integrations/ocs_rgw_without_ssl_ibm.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_without_ssl_ibm.yaml
@@ -110,7 +110,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -125,7 +125,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true
@@ -149,7 +149,7 @@ tests:
           - "radosgw-admin user create --uid=rgw-admin-ops-user --display_name='rgw-admin-ops-user' --email rgw-admin-ops-user@foo.foo"
       desc: Execute radosgw-admin commands for zone
       module: exec.py
-      name: rgw-admin-user
+      name: rgw-admin-user create ops user
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -16,7 +16,7 @@ tests:
       abort-on-fail: true
       config:
         args:
-          mon-ip: node1
+          mon-ip: node2
           allow-fqdn-hostname: true
           allow-overwrite: true
         command: bootstrap

--- a/suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml
+++ b/suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml
@@ -107,7 +107,7 @@ tests:
       desc: "Create and configure a volume with 2 MDS limit"
       destroy-cluster: false
       module: exec.py
-      name: "Create volume with"
+      name: Create volume with 2 MDS limit
 
   - test:
       abort-on-fail: true
@@ -122,7 +122,7 @@ tests:
       desc: Test deploying MDS daemons on hosts with label mds.
       destroy-cluster: false
       module: test_mds.py
-      name: Test OSD daemon deployment with all-available-devices enabled.
+      name: Deploy MDS
 
   - test:
       abort-on-fail: true

--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -144,6 +144,13 @@ def add(cls, config: Dict) -> None:
                     _node.exec_command(
                         sudo=True, cmd=f"{enable_cmd}{manifest_obj.repo_id}"
                     )
+                elif use_cdn:
+                    _manifest = cls.config.get("manifest")
+                    if _manifest and _manifest.repo_id:
+                        _node.exec_command(
+                            sudo=True,
+                            cmd=f"{enable_cmd}{_manifest.repo_id}",
+                        )
 
                 # Clearing the release preference set and cleaning all yum repos
                 # Observing selinux package dependency issues for ceph-base


### PR DESCRIPTION
**Issue**
```
2026-05-21 12:03:08  2026-05-21 06:03:07,623 - cephci - ceph:2004 - INFO - Execute yum install -y --nogpgcheck ceph-common on ceph-client [10.1.112.100]
2026-05-21 12:03:46  2026-05-21 06:03:40,414 - cephci - ceph:2039 - INFO - Execution of yum install -y --nogpgcheck ceph-common took 32.790251 seconds on ceph-client by user root [10.1.112.100]
2026-05-21 12:03:46  2026-05-21 06:03:41,604 - ceph.parallel - parallel:143 - ERROR - Encountered an exception during parallel execution.
2026-05-21 12:03:46  Traceback (most recent call last):
2026-05-21 12:03:46    File "/home/jenkins/workspace/qe-standalone-ceph-deployment/cephci/ceph/parallel.py", line 141, in __exit__
2026-05-21 12:03:46      self._results.append(_f.result())
2026-05-21 12:03:46    File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 439, in result
2026-05-21 12:03:46      return self.__get_result()
2026-05-21 12:03:46    File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 391, in __get_result
2026-05-21 12:03:46      raise self._exception
2026-05-21 12:03:46    File "/usr/lib64/python3.9/concurrent/futures/thread.py", line 58, in run
2026-05-21 12:03:46      result = self.fn(*self.args, **self.kwargs)
2026-05-21 12:03:46    File "/home/jenkins/workspace/qe-standalone-ceph-deployment/cephci/tests/cephadm/test_client.py", line 180, in setup
2026-05-21 12:03:46      _node.exec_command(
2026-05-21 12:03:46    File "/home/jenkins/workspace/qe-standalone-ceph-deployment/cephci/ceph/ceph.py", line 2135, in exec_command
2026-05-21 12:03:46      raise CommandFailed(
2026-05-21 12:03:46  ceph.ceph.CommandFailed: yum install -y --nogpgcheck ceph-common returned Error: Unable to find a match: ceph-common
2026-05-21 12:03:46   and code 1 on ceph-client [10.1.112.100]

```

**Solution:**
- Enable RHCeph tools for CDN cluster client in case of no data provided to client test case.
- Minor fixes at suites and config file.

**Test results:**
```
python3 run.py --log-level DEBUG \                                                                                                                                                                                                      ─╯
   --instances-name sunilk-00 \
   --rhbuild 9.0 \
   --platform rhel-10 \
   --global-conf conf/squid/integrations/ocs_rgw_ssl_openstack_conf.yaml \
   --suite suites/tentacle/integrations/ocs_rgw_without_ssl_vsphere.yaml \
   --osp-cred /Users/sunilkumarn/osp-ceph-ci.yaml \
   --inventory conf/inventory/rhel-10.1-server-x86_64.yaml \
   --build released
   
 ...
....
....
TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
test suite setup                 Install prerequisites for RHCeph cluster deployment.           0:05:31.437559                   Pass
Test cluster deployment using    Bootstrap the cluster with minimal configuration.              0:07:03.408013                   Pass
Test host add with labels and    Adding hosts to the cluster using labels and IP information.   0:01:29.639580                   Pass
Test MON daemon deployment usi   Test deploying MON daemons using labels.                       0:02:33.592983                   Pass
Test apply osd with all-availa   Deploying OSD daemons using all-available-devices option.      0:03:46.741179                   Pass
Create rbd pool and initialize   create rbd pool and initialize                                 0:00:13.344686                   Pass
Test rgw without ssl endpoint    Deploying RGW endpoint which is SSL terminated.                0:00:32.353337                   Pass
Create volume with               Create and configure a volume with 2 MDS limit                 0:00:13.131737                   Pass
Test OSD daemon deployment wit   Test deploying MDS daemons on hosts with label mds.            0:02:25.886151                   Pass
configure client                 Configure the ceph client                                      0:07:06.677510                   Pass
rgw-admin-user                   Execute radosgw-admin commands for zone                        0:00:06.481539                   Pass
Get ceph cluster details.        Retrieve the deployed cluster information.                     0:00:36.294573                   Pass

```