### PR TITLE
TFA fix for subvol metrics post upgrade test

### DIFF
--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation_ext.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation_ext.py
@@ -1,5 +1,6 @@
 import json
 import random
+import string
 import time
 import traceback
 from typing import Any, Dict, List, Optional, Tuple
@@ -37,20 +38,14 @@ def _get_quota_and_used_from_metrics(
     return None
 
 
-def _get_du_bytes(client, path: str) -> Optional[int]:
-    """Run du -sb on path and return total size in bytes."""
-    path = path.rstrip("/")
-    out, rc = client.exec_command(
-        sudo=True, cmd=f"du -sb {path} 2>/dev/null", check_ec=False
+def _get_expected_used_bytes(
+    client, vol_name: str, subvol_name: str, svg: str
+) -> Optional[int]:
+    """Get bytes_used from subvolume info."""
+    subvol_info = fs_util.get_subvolume_info(
+        client, vol_name=vol_name, subvol_name=subvol_name, group_name=svg
     )
-    if rc != 0:
-        log.error("du -sb failed for %s: %s", path, out)
-        return None
-    try:
-        return int(out.strip().split()[0])
-    except (ValueError, IndexError) as e:
-        log.error("Failed to parse du output %r: %s", out, e)
-        return None
+    return subvol_info.get("bytes_used", 0)
 
 
 def snap_visibility_test():
@@ -131,8 +126,7 @@ def snap_visibility_test():
                 "Snapshot Visibility on existing subvolume post upgrade is not as Expected.%s",
                 str1,
             )
-            log.info("This is due to BZ2404075, ignoring the issue")
-            # return 1
+            return 1
 
     def get_nfs_details():
         nfs_config = config["NFS"]
@@ -200,7 +194,6 @@ def subvolume_metrics_quota_used_test():
     helper = test_reqs["helper"]
     vol_name = test_reqs.get("vol_name", "cephfs")
     ranks = [0]
-    test_status = 0
 
     # Collect fuse-mounted subvolumes from pre_upgrade_config
     fuse_sv_list: List[Dict[str, Any]] = []
@@ -249,10 +242,12 @@ def subvolume_metrics_quota_used_test():
         )
         return 0
 
-    # Prefer subvolumes with quota enabled; else use all
-    candidates = [e for e in fuse_sv_list if e["quota_enabled"]] or fuse_sv_list
-
-    # Step 2: Validate metrics vs get_quota_attrs and du for existing mount
+    # Prefer subvolumes with quota enabled;
+    candidates = [e for e in fuse_sv_list if e["quota_enabled"]]
+    if not candidates:
+        log.warning("No subvolumes with quota enabled; skipping subvolume metrics test")
+        return 0
+    # Step 2: Validate metrics vs get_quota_attrs and used_bytes for existing subvolume
     for entry in candidates:
         mnt_client = entry["mnt_client"]
         mnt_pt = entry["mnt_pt"]
@@ -265,138 +260,171 @@ def subvolume_metrics_quota_used_test():
             log.error(
                 "Failed to get subvolume path for %s/%s", entry["svg"], entry["sv"]
             )
-            test_status = 1
             continue
-        time.sleep(1)
-        result = _get_quota_and_used_from_metrics(
-            helper, mnt_client, entry["vol_name"], subvol_path, ranks
-        )
-        if result is None:
-            log.error("No subvolume metrics for %s", subvol_path)
-            test_status = 1
-            continue
-        metrics_quota, metrics_used = result
-        try:
-            quota_attrs = fs_util.get_quota_attrs(mnt_client, mnt_pt)
-            expected_quota = int(quota_attrs.get("bytes", 0))
-        except Exception as e:
-            log.error("get_quota_attrs failed for %s: %s", mnt_pt, e)
-            test_status = 1
-            continue
-        du_bytes = _get_du_bytes(mnt_client, mnt_pt)
-        if du_bytes is None:
-            test_status = 1
-            continue
-        if metrics_quota != expected_quota:
-            log.error(
-                "quota_bytes mismatch: subvol %s/%s metrics=%s get_quota_attrs=%s",
-                entry["svg"],
-                entry["sv"],
-                metrics_quota,
-                expected_quota,
+
+        rand_str = "".join(random.choices(string.ascii_letters + string.digits, k=3))
+        quota_attrs = fs_util.get_quota_attrs(mnt_client, mnt_pt)
+        expected_quota = int(quota_attrs.get("bytes", 0))
+        # Add small dataset (e.g. 10MB)
+        dd_cmd = f"dd if=/dev/urandom of={mnt_pt}/data_{rand_str}.bin bs=1M count=10 conv=fsync 2>/dev/null"
+        mnt_client.exec_command(sudo=True, cmd=dd_cmd)
+        time.sleep(2)
+        retry_count = 0
+        test_fail = 0
+        while retry_count < 5:
+            test_fail = 0
+            result = _get_quota_and_used_from_metrics(
+                helper, mnt_client, entry["vol_name"], subvol_path, ranks
             )
-            test_status = 1
-        if metrics_used != du_bytes:
-            log.error(
-                "used_bytes mismatch: subvol %s/%s metrics=%s du -sb=%s",
-                entry["svg"],
-                entry["sv"],
-                metrics_used,
-                du_bytes,
-            )
-            test_status = 1
-        if test_status == 0:
-            log.info(
-                "Subvolume %s/%s: quota_bytes=%s used_bytes=%s (match get_quota_attrs and du)",
-                entry["svg"],
-                entry["sv"],
-                metrics_quota,
-                metrics_used,
+            if result is None:
+                log.error("No subvolume metrics for %s", subvol_path)
+                retry_count += 1
+                test_fail += 1
+                time.sleep(5)
+                continue
+            metrics_quota, metrics_used = result
+
+            expected_used_bytes = _get_expected_used_bytes(
+                mnt_client, entry["vol_name"], entry["sv"], entry["svg"]
             )
 
-    # Step 3: Create new dir on first candidate's mount, add dataset, set quota, verify
-    if test_status != 0:
-        return test_status
+            if metrics_quota != expected_quota:
+                log.error(
+                    "Step 2: quota_bytes mismatch: expected %s got %s",
+                    expected_quota,
+                    metrics_quota,
+                )
+                test_fail += 1
+            else:
+                log.info(
+                    "Step 2: quota_bytes matched: expected %s got %s",
+                    expected_quota,
+                    metrics_quota,
+                )
+
+            if metrics_used != expected_used_bytes:
+                log.error(
+                    "Step 2: used_bytes mismatch: expected %s got %s",
+                    expected_used_bytes,
+                    metrics_used,
+                )
+                test_fail += 1
+            else:
+                log.info(
+                    "Step 2: used_bytes matched: expected %s got %s",
+                    expected_used_bytes,
+                    metrics_used,
+                )
+            if test_fail == 0:
+                log.info(
+                    "Subvolume %s/%s: quota_bytes=%s used_bytes=%s (match get_quota_attrs and expected_used_bytes)",
+                    entry["svg"],
+                    entry["sv"],
+                    metrics_quota,
+                    metrics_used,
+                )
+                break
+            else:
+                retry_count += 1
+                time.sleep(5)
+        if test_fail != 0:
+            log.error(
+                "Failed to validate subvolume metrics for %s/%s",
+                entry["svg"],
+                entry["sv"],
+            )
+            return 1
+
+    # Step 3: On first candidate's mount, add dataset, set quota, verify
 
     entry = candidates[0]
     mnt_client = entry["mnt_client"]
     mnt_pt = entry["mnt_pt"]
-    # Remove existing quota on mount path before creating new dir and applying quota
-    log.info("Removing existing quota on mount path %s", mnt_pt)
-    fs_util.set_quota_attrs(mnt_client, "0", "0", mnt_pt)
-    time.sleep(1)
-
-    new_dir = f"{mnt_pt.rstrip('/')}/subvol_metrics_test_dir"
-    try:
-        mnt_client.exec_command(sudo=True, cmd=f"mkdir -p {new_dir}")
-    except Exception as e:
-        log.error("mkdir failed for %s: %s", new_dir, e)
-        return 1
-
-    # Add small dataset (e.g. 10MB)
-    dataset_size_mb = 10
-    dd_cmd = f"dd if=/dev/zero of={new_dir}/data.bin bs=1M count={dataset_size_mb} conv=fsync 2>/dev/null"
-    mnt_client.exec_command(sudo=True, cmd=dd_cmd)
-    time.sleep(2)
-
-    quota_bytes_new = 50 * 1024 * 1024  # 50MB
-    fs_util.set_quota_attrs(mnt_client, "1000", quota_bytes_new, new_dir)
-    time.sleep(1)
-
     out, _ = mnt_client.exec_command(
         sudo=True,
         cmd=f"ceph fs subvolume getpath {entry['vol_name']} {entry['sv']} {entry['svg']}",
     )
     subvol_path = (out or "").strip()
-    result = _get_quota_and_used_from_metrics(
-        helper, mnt_client, entry["vol_name"], subvol_path, ranks
-    )
-    if result is None:
-        log.error("Step 3: No subvolume metrics after adding dir")
-        test_status = 1
-    else:
+    # Remove existing quota on mount path before creating new dir and applying quota
+    log.info("Removing existing quota on mount path %s", mnt_pt)
+    fs_util.set_quota_attrs(mnt_client, "0", "0", mnt_pt)
+    time.sleep(1)
+
+    rand_str = "".join(random.choices(string.ascii_letters + string.digits, k=3))
+    # Existing dataset is ~10GB, so new quota is 50GB considering new IOs post upgrade
+    quota_bytes_new = 50 * 1024 * 1024 * 1024  # 50GB
+    fs_util.set_quota_attrs(mnt_client, "1000", quota_bytes_new, mnt_pt)
+    time.sleep(2)
+    dd_cmd = f"dd if=/dev/urandom of={mnt_pt}/data_{rand_str}.bin bs=1M count=10 conv=fsync 2>/dev/null"
+    mnt_client.exec_command(sudo=True, cmd=dd_cmd)
+    retry_count = 0
+    test_fail = 0
+    while retry_count < 5:
+        test_fail = 0
+        result = _get_quota_and_used_from_metrics(
+            helper, mnt_client, entry["vol_name"], subvol_path, ranks
+        )
+        if result is None:
+            log.error("Step 3: No subvolume metrics after setting new quota")
+            retry_count += 1
+            test_fail += 1
+            time.sleep(5)
+            continue
+
         metrics_quota, metrics_used = result
-        du_mount = _get_du_bytes(mnt_client, mnt_pt)
-        if du_mount is None:
-            test_status = 1
-        elif metrics_used != du_mount:
+        expected_used_bytes = _get_expected_used_bytes(
+            mnt_client, entry["vol_name"], entry["sv"], entry["svg"]
+        )
+        if metrics_used != expected_used_bytes:
             log.error(
-                "Step 3: used_bytes mismatch with du -sb mount: metrics=%s du=%s",
+                "Step 3: new used_bytes mismatch: expected %s got %s",
+                expected_used_bytes,
                 metrics_used,
-                du_mount,
             )
-            test_status = 1
-        # New dir: verify get_quota_attrs and du -sb on the dir
-        try:
-            dir_quota_attrs = fs_util.get_quota_attrs(mnt_client, new_dir)
-            dir_quota_bytes = int(dir_quota_attrs.get("bytes", 0))
-            dir_du_bytes = _get_du_bytes(mnt_client, new_dir)
-            if dir_du_bytes is None:
-                test_status = 1
-            elif dir_quota_bytes != quota_bytes_new:
-                log.error(
-                    "Step 3: new dir quota mismatch: expected %s got %s",
-                    quota_bytes_new,
-                    dir_quota_bytes,
-                )
-                test_status = 1
-            elif dir_du_bytes != dataset_size_mb * 1024 * 1024:
-                log.error(
-                    "Step 3: new dir du mismatch: expected %s got %s",
-                    dataset_size_mb * 1024 * 1024,
-                    dir_du_bytes,
-                )
-                test_status = 1
-        except Exception as e:
-            log.error("Step 3: get_quota_attrs or du for new dir failed: %s", e)
-            test_status = 1
+            test_fail += 1
+        else:
+            log.info(
+                "Step 3: new used_bytes matched: expected %s got %s",
+                expected_used_bytes,
+                metrics_used,
+            )
 
-    try:
-        mnt_client.exec_command(sudo=True, cmd=f"rm -rf {new_dir}")
-    except Exception:
-        pass
+        # New dir: verify get_quota_attrs
 
-    return test_status
+        expected_quota_attrs = fs_util.get_quota_attrs(mnt_client, mnt_pt)
+        expected_quota_bytes = int(expected_quota_attrs.get("bytes", 0))
+
+        if expected_quota_bytes != metrics_quota:
+            log.error(
+                "Step 3: new quota mismatch: expected %s got %s",
+                expected_quota_bytes,
+                metrics_quota,
+            )
+            test_fail += 1
+        else:
+            log.info(
+                "Step 3: new quota matched: expected %s got %s",
+                expected_quota_bytes,
+                metrics_quota,
+            )
+        if test_fail == 0:
+            log.info(
+                "Subvolume %s/%s: quota_bytes=%s used_bytes=%s (match get_quota_attrs and expected_used_bytes)",
+                entry["svg"],
+                entry["sv"],
+                metrics_quota,
+                metrics_used,
+            )
+            break
+        else:
+            retry_count += 1
+            time.sleep(5)
+    if test_fail != 0:
+        log.error(
+            "Failed to validate subvolume metrics for %s/%s", entry["svg"], entry["sv"]
+        )
+        return 1
+    return 0
 
 
 def run(ceph_cluster, **kw):
@@ -404,6 +432,7 @@ def run(ceph_cluster, **kw):
     Test Details:
     1. Toggle Snapshot Visibility :
         CEPH-83621389 : Verify CLI option default behavior and option modify on existing subvolume, new subvolume
+    2. Validate 9.1 subvolume metrics quota_bytes and used_bytes post-upgrade.
 
     """
     try:


### PR DESCRIPTION
# Description

Jira: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-24002

Subvol metrics post upgrade test was failing because used_bytes was being compared with du -sb output which was incorrect.
Fix:
compare metrics used_bytes with subvol info used_bytes with retries for metrics 
Also change new quota to a higher value as there is existing dataset

Failed logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-E98403
Fixed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-437JAN
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
