### PR TITLE
Fixing the monitoring service deployment failure in RH sanity

### DIFF
--- a/suites/tentacle/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_multisite.yaml
@@ -122,6 +122,19 @@ tests:
           config:
             verify_cluster_health: true
             steps:
+              # QE rh-prod mirror exposes versioned OpenShift tags (e.g. v4.13.0), not cephadm defaults (v4.15).
+              - config:
+                  command: shell
+                  args:
+                    - ceph config set mgr mgr/cephadm/container_image_prometheus registry.redhat.io/openshift4/ose-prometheus:v4.13.0
+              - config:
+                  command: shell
+                  args:
+                    - ceph config set mgr mgr/cephadm/container_image_alertmanager registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.13.0
+              - config:
+                  command: shell
+                  args:
+                    - ceph config set mgr mgr/cephadm/container_image_node_exporter registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.13.0
               - config:
                   command: apply_spec
                   service: orch
@@ -149,6 +162,18 @@ tests:
           config:
             verify_cluster_health: true
             steps:
+              - config:
+                  command: shell
+                  args:
+                    - ceph config set mgr mgr/cephadm/container_image_prometheus registry.redhat.io/openshift4/ose-prometheus:v4.13.0
+              - config:
+                  command: shell
+                  args:
+                    - ceph config set mgr mgr/cephadm/container_image_alertmanager registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.13.0
+              - config:
+                  command: shell
+                  args:
+                    - ceph config set mgr mgr/cephadm/container_image_node_exporter registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.13.0
               - config:
                   command: apply_spec
                   service: orch


### PR DESCRIPTION
RH multisite sanity fails during Monitoring Services deployment because cephadm pulls OpenShift monitoring images at v4.15, while the QE rh-prod mirror on nginx-vm-01.qe.ceph.lab does not expose that tag (manifest unknown).

This change sets mgr image overrides to v4.13.0 (prometheus, alertmanager, node-exporter) on both ceph-pri and ceph-sec immediately before the monitoring apply_spec, so cephadm uses versioned tags that are expected to be available on the mirror.