### PR TITLE
Fix versioned client installation for IBM cloud

### DIFF
--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -126,7 +126,7 @@ def add(cls, config: Dict) -> None:
                     enabled_repos.append(repo)
             log.debug(f"Enabled repos on the system are : {enabled_repos}")
 
-            if rhcs_version != "default":
+            if rhcs_version != "default" and not _manifest_section:
                 try:
                     # Disabling all the repos and enabling the ones we need to install the ceph client
                     for cmd in disable_all:


### PR DESCRIPTION
For versioned client installation in IBM cloud executions, subscription-manager commands need to be executed. Subscription manager is not setup in IBM cloud deployments.

Follow up for PR https://github.com/red-hat-storage/cephci/pull/5786 where the conditional check was changed.

Failure in CI runs -
```
2026-05-24 07:21:33,192 - cephci - ceph:2004 - INFO - Execute subscription-manager repos --list-enabled | grep -i "Repo ID" on ceph-rados-29-k9oi-7ipx25-node7 [10.243.14.208]
2026-05-24 07:21:34,197 - cephci - ceph:2039 - INFO - Execution of subscription-manager repos --list-enabled | grep -i "Repo ID" took 1.004606 seconds on ceph-rados-29-k9oi-7ipx25-node7 by user root [10.243.14.208]
2026-05-24 07:21:34,198 - cephci - test_client:127 - DEBUG - Enabled repos on the system are : []
2026-05-24 07:21:34,200 - cephci - ceph:2004 - INFO - Execute subscription-manager repos --disable=* on ceph-rados-29-k9oi-7ipx25-node7 [10.243.14.208]
2026-05-24 07:21:35,205 - cephci - ceph:2039 - INFO - Execution of subscription-manager repos --disable=* took 1.004654 seconds on ceph-rados-29-k9oi-7ipx25-node7 by user root [10.243.14.208]
2026-05-24 07:21:35,205 - cephci - test_client:135 - ERROR - Failed to disable the repos enabled on the host: ceph-rados-29-k9oi-7ipx25-node7Error : subscription-manager repos --disable=* returned  and code 1 on ceph-rados-29-k9oi-7ipx25-node7 [10.243.14.208]. Continuing without the repos disabled.
2026-05-24 07:21:35,207 - cephci - ceph:2004 - INFO - Execute subscription-manager repos --enable=rhel-9-for-x86_64-appstream-rpms on ceph-rados-29-k9oi-7ipx25-node7 [10.243.14.208]
2026-05-24 07:21:36,212 - cephci - ceph:2039 - INFO - Execution of subscription-manager repos --enable=rhel-9-for-x86_64-appstream-rpms took 1.004856 seconds on ceph-rados-29-k9oi-7ipx25-node7 by user root [10.243.14.208]
2026-05-24 07:21:54,148 - cephci - run:1094 - ERROR - subscription-manager repos --enable=rhel-9-for-x86_64-appstream-rpms returned  and code 1 on ceph-rados-29-k9oi-7ipx25-node7 [10.243.14.208]
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/cephci/run.py", line 1079, in run
    rc = test_mod.run(
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/cephci/tests/cephadm/test_client.py", line 290, in run
    method(orch, config)
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/cephci/tests/cephadm/test_client.py", line 205, in add
    time.sleep(20)
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/cephci/ceph/parallel.py", line 141, in __exit__
    self._results.append(_f.result())
  File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/lib64/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/cephci/tests/cephadm/test_client.py", line 141, in setup
    _node.exec_command(sudo=True, cmd=f"{enable_cmd}{repos}")
  File "/data/jenkins/ceph-builds/IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/cephci/ceph/ceph.py", line 2135, in exec_command
    raise CommandFailed(
ceph.ceph.CommandFailed: subscription-manager repos --enable=rhel-9-for-x86_64-appstream-rpms returned  and code 1 on ceph-rados-29-k9oi-7ipx25-node7 [10.243.14.208]
```

Failure log - https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.0/rhel-9/upgrade/20.1.0-210/rados/29/logs/RADOS_Test___EC_Pool_Recovery/Configure_client_admin_0.log

Pass log -
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.0/rhel-9/upgrade/20.1.0-215/rados/37/logs/

https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-9/upgrade/20.2.1-273/rados/36/logs/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>