### PR TITLE
Apply black formatting to NFS test files

### DIFF
--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -242,7 +242,8 @@ def run(ceph_cluster, **kw):
         c1.join()
 
         clients[0].exec_command(
-            sudo=True, cmd=f"rm -f {nfs_squash_mount}/{LOCK_READY_FILENAME}",
+            sudo=True,
+            cmd=f"rm -f {nfs_squash_mount}/{LOCK_READY_FILENAME}",
         )
 
         try:
@@ -272,7 +273,5 @@ def run(ceph_cluster, **kw):
         Ceph(clients[0]).nfs.export.delete(nfs_name, nfs_export_squash)
 
         # Cleaning up the remaining export and deleting the nfs cluster
-        cleanup_cluster(
-            clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node
-        )
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successfull")

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -132,9 +132,7 @@ def run(ceph_cluster, **kw):
                 server=nfs_server_name,
                 export=nfs_export_squash,
             ):
-                raise OperationFailedError(
-                    f"Failed to mount nfs on {cl.hostname}"
-                )
+                raise OperationFailedError(f"Failed to mount nfs on {cl.hostname}")
         log.info("Mount succeeded on all clients for squash export")
 
         # Create oprtaions on each client


### PR DESCRIPTION
Fix black --check CI failure on tests/nfs/nfs_verify_file_lock_root_squash.py and tests/nfs/nfs_verify_setuid_bit.py.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
