### PR TITLE
Containerise the Vault server for SSE-S3, KMS tests.

### DIFF
--- a/cli/vault/agent.py
+++ b/cli/vault/agent.py
@@ -1,0 +1,152 @@
+from copy import deepcopy
+
+from jinja2 import Template
+
+AGENT_HCL = """pid_file = "/run/vault-agent-pid"
+
+auto_auth {
+  method "approle" {
+    mount_path = "auth/approle"
+    config = {
+      role_id_file_path = "/usr/local/etc/vault/.app-role-id"
+      secret_id_file_path = "/usr/local/etc/vault/.app-secret-id"
+      remove_secret_id_file_after_reading = "false"
+    }
+  }
+}
+
+cache {
+  use_auto_auth_token = true
+}
+
+listener "tcp" {
+  address = "127.0.0.1:8100"
+  tls_disable = true
+}
+
+vault {
+  address = "{{ vault_url }}"
+}
+"""
+
+AGENT_SYSTEMD = """[Unit]
+Description=HashiCorp Vault Agent
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/vault agent -config /usr/local/etc/vault/agent.hcl
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+class Agent(object):
+    """Vault agent lifecycle management.
+
+    Handles installing the Vault binary, configuring the agent
+    with AppRole credentials, and managing the systemd service.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def install(self, **kw):
+        """Install the Vault binary on the node.
+
+        Args:
+            kw(dict): Key/value pairs for installation.
+                Supported keys:
+                    repo-url(str): Custom HashiCorp repo URL
+        """
+        kw_copy = deepcopy(kw)
+        repo_url = kw_copy.pop("repo-url", "")
+        if repo_url:
+            repo_content = (
+                "[hashicorp]\n"
+                "name=Hashicorp Stable - $basearch\n"
+                f"baseurl={repo_url}\n"
+                "enabled=1\n"
+                "gpgcheck=1\n"
+                "gpgkey=https://rpm.releases.hashicorp.com/gpg\n"
+            )
+            self._write_file("/etc/yum.repos.d/hashicorp.repo", repo_content)
+        else:
+            repo_content = (
+                "[hashicorp]\n"
+                "name=Hashicorp Stable - $basearch\n"
+                "baseurl=https://rpm.releases.hashicorp.com/RHEL/"
+                "$releasever/$basearch/stable\n"
+                "enabled=1\n"
+                "gpgcheck=1\n"
+                "gpgkey=https://rpm.releases.hashicorp.com/gpg\n"
+            )
+            self._write_file("/etc/yum.repos.d/hashicorp.repo", repo_content)
+
+        return self.parent.execute_as_sudo(cmd="yum install -y vault", check_ec=False)
+
+    def configure(self, **kw):
+        """Configure the Vault agent with AppRole credentials.
+
+        Args:
+            kw(dict): Key/value pairs for agent configuration.
+                Supported keys:
+                    vault-url(str): URL of the Vault server
+                    role-id(str): AppRole role ID
+                    secret-id(str): AppRole secret ID
+        """
+        kw_copy = deepcopy(kw)
+        vault_url = kw_copy.pop("vault-url", "")
+        role_id = kw_copy.pop("role-id", "")
+        secret_id = kw_copy.pop("secret-id", "")
+
+        self.parent.execute_as_sudo(cmd="mkdir -p /usr/local/etc/vault/")
+
+        self._write_file("/usr/local/etc/vault/.app-role-id", role_id)
+        self._write_file("/usr/local/etc/vault/.app-secret-id", secret_id)
+
+        self.parent.execute_as_sudo(
+            cmd=(
+                "chmod 600"
+                " /usr/local/etc/vault/.app-role-id"
+                " /usr/local/etc/vault/.app-secret-id"
+            )
+        )
+
+        agent_conf = Template(AGENT_HCL).render(vault_url=vault_url)
+        self._write_file("/usr/local/etc/vault/agent.hcl", agent_conf)
+
+        self._write_file("/etc/systemd/system/vault-agent.service", AGENT_SYSTEMD)
+
+    def start(self, **kw):
+        """Start the Vault agent systemd service."""
+        self.parent.execute_as_sudo(cmd="systemctl daemon-reload")
+        self.parent.execute_as_sudo(cmd="systemctl enable vault-agent")
+        return self.parent.execute_as_sudo(
+            cmd="systemctl restart vault-agent", check_ec=False
+        )
+
+    def stop(self, **kw):
+        """Stop the Vault agent systemd service."""
+        return self.parent.execute_as_sudo(cmd="systemctl stop vault-agent")
+
+    def status(self, **kw):
+        """Check the Vault agent service status."""
+        return self.parent.execute_as_sudo(
+            cmd="systemctl is-active vault-agent", check_ec=False
+        )
+
+    def _write_file(self, file_name, content):
+        """Write content to a remote file on the node."""
+        if isinstance(self.parent.ctx, list):
+            node = self.parent.ctx[0]
+        else:
+            node = self.parent.ctx
+        fh = node.remote_file(sudo=True, file_mode="w", file_name=file_name)
+        fh.write(data=content)
+        fh.flush()
+        fh.close()

--- a/cli/vault/auth.py
+++ b/cli/vault/auth.py
@@ -1,0 +1,88 @@
+class Auth(object):
+    """Vault authentication method management via REST API.
+
+    Handles enabling auth methods and managing AppRole credentials.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+        self.approle = self.AppRole(parent=self)
+
+    def enable(self, **kw):
+        """Enable an authentication method.
+
+        Args:
+            kw(dict): Key/value pairs for enabling an auth method.
+                Supported keys:
+                    path(str): Mount path (e.g., "approle", "userpass")
+                    type(str): Auth method type
+        """
+        path = kw.get("path", "")
+        auth_type = kw.get("type", "")
+        return self.parent._request(
+            "POST", f"/v1/sys/auth/{path}", data={"type": auth_type}
+        )
+
+    class AppRole(object):
+        """AppRole authentication operations."""
+
+        def __init__(self, parent):
+            self.parent = parent
+
+        def create_role(self, **kw):
+            """Create an AppRole role with policies and TTL.
+
+            Args:
+                kw(dict): Key/value pairs for role creation.
+                    Supported keys:
+                        role-name(str): Name of the AppRole role
+                        token-policies(str): Comma-separated policy names
+                        token-ttl(str): Token TTL (e.g., "1h")
+                        token-max-ttl(str): Maximum token TTL (e.g., "24h")
+            """
+            role_name = kw.get("role-name", "")
+            payload = {}
+            token_policies = kw.get("token-policies", "")
+            if token_policies:
+                payload["token_policies"] = token_policies
+            token_ttl = kw.get("token-ttl", "")
+            if token_ttl:
+                payload["token_ttl"] = token_ttl
+            token_max_ttl = kw.get("token-max-ttl", "")
+            if token_max_ttl:
+                payload["token_max_ttl"] = token_max_ttl
+            return self.parent.parent._request(
+                "POST", f"/v1/auth/approle/role/{role_name}", data=payload
+            )
+
+        def read_role_id(self, **kw):
+            """Read the role ID for an AppRole role.
+
+            Args:
+                kw(dict): Key/value pairs for reading the role ID.
+                    Supported keys:
+                        role-name(str): Name of the AppRole role
+
+            Returns:
+                dict: Response containing the role_id.
+            """
+            role_name = kw.get("role-name", "")
+            return self.parent.parent._request(
+                "GET", f"/v1/auth/approle/role/{role_name}/role-id"
+            )
+
+        def generate_secret_id(self, **kw):
+            """Generate a new secret ID for an AppRole role.
+
+            Args:
+                kw(dict): Key/value pairs for generating a secret ID.
+                    Supported keys:
+                        role-name(str): Name of the AppRole role
+
+            Returns:
+                dict: Response containing the secret_id.
+            """
+            role_name = kw.get("role-name", "")
+            return self.parent.parent._request(
+                "POST", f"/v1/auth/approle/role/{role_name}/secret-id", data={}
+            )

--- a/cli/vault/operator.py
+++ b/cli/vault/operator.py
@@ -1,0 +1,57 @@
+class Operator(object):
+    """Vault operator commands via REST API.
+
+    Handles initialization, unsealing, and seal status operations.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def init(self, **kw):
+        """Initialize the Vault server.
+
+        Args:
+            kw(dict): Key/value pairs for initialization.
+                Supported keys:
+                    secret-shares(int): Number of key shares (default: 5)
+                    secret-threshold(int): Unseal threshold (default: 3)
+
+        Returns:
+            dict: Response with unseal_keys_b64 and root_token.
+        """
+        data = {
+            "secret_shares": kw.get("secret-shares", 5),
+            "secret_threshold": kw.get("secret-threshold", 3),
+        }
+        return self.parent._request(
+            "POST", "/v1/sys/init", data=data, token_required=False
+        )
+
+    def init_status(self, **kw):
+        """Check if the Vault server is initialized.
+
+        Returns:
+            dict: Response with initialized status.
+        """
+        return self.parent._request("GET", "/v1/sys/init", token_required=False)
+
+    def unseal(self, **kw):
+        """Unseal the Vault server with a single key share.
+
+        Args:
+            kw(dict): Key/value pairs for unsealing.
+                Supported keys:
+                    key(str): Unseal key share
+        """
+        data = {"key": kw.get("key", "")}
+        return self.parent._request(
+            "POST", "/v1/sys/unseal", data=data, token_required=False
+        )
+
+    def seal_status(self, **kw):
+        """Check the seal status of the Vault server.
+
+        Returns:
+            dict: Seal status details.
+        """
+        return self.parent._request("GET", "/v1/sys/seal-status", token_required=False)

--- a/cli/vault/policy.py
+++ b/cli/vault/policy.py
@@ -1,0 +1,53 @@
+class Policy(object):
+    """Vault policy management via REST API.
+
+    Handles creating, reading, deleting, and listing ACL policies.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def write(self, **kw):
+        """Create or update a named ACL policy.
+
+        Args:
+            kw(dict): Key/value pairs for writing a policy.
+                Supported keys:
+                    name(str): Policy name
+                    policy(str): HCL policy content
+        """
+        name = kw.get("name", "")
+        policy = kw.get("policy", "")
+        return self.parent._request(
+            "POST", f"/v1/sys/policies/acl/{name}", data={"policy": policy}
+        )
+
+    def read(self, **kw):
+        """Read an existing ACL policy.
+
+        Args:
+            kw(dict): Key/value pairs for reading a policy.
+                Supported keys:
+                    name(str): Policy name
+        """
+        name = kw.get("name", "")
+        return self.parent._request("GET", f"/v1/sys/policies/acl/{name}")
+
+    def delete(self, **kw):
+        """Delete an ACL policy.
+
+        Args:
+            kw(dict): Key/value pairs for deleting a policy.
+                Supported keys:
+                    name(str): Policy name
+        """
+        name = kw.get("name", "")
+        return self.parent._request("DELETE", f"/v1/sys/policies/acl/{name}")
+
+    def list(self, **kw):
+        """List all ACL policies.
+
+        Returns:
+            dict: List of policy names.
+        """
+        return self.parent._request("LIST", "/v1/sys/policies/acl")

--- a/cli/vault/secrets.py
+++ b/cli/vault/secrets.py
@@ -1,0 +1,116 @@
+class Secrets(object):
+    """Vault secrets engine management via REST API.
+
+    Handles enabling secrets engines and general read/write operations.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+        self.transit = self.Transit(parent=self)
+
+    def enable(self, **kw):
+        """Enable a secrets engine at a given path.
+
+        Args:
+            kw(dict): Key/value pairs for enabling a secrets engine.
+                Supported keys:
+                    path(str): Mount path for the engine (e.g., "transit", "kv")
+                    type(str): Engine type (e.g., "transit", "kv")
+                    options(dict): Engine-specific options (e.g., {"version": "2"})
+        """
+        path = kw.get("path", "")
+        engine_type = kw.get("type", "")
+        options = kw.get("options", {})
+        payload = {"type": engine_type}
+        if options:
+            payload["options"] = options
+        return self.parent._request("POST", f"/v1/sys/mounts/{path}", data=payload)
+
+    def write(self, **kw):
+        """Write data to a Vault path.
+
+        Args:
+            kw(dict): Key/value pairs for the write operation.
+                Supported keys:
+                    path(str): Vault path to write to
+                    data(dict): Data payload to write
+        """
+        path = kw.get("path", "")
+        payload = kw.get("data", {})
+        return self.parent._request("POST", f"/v1/{path}", data=payload or {})
+
+    def read(self, **kw):
+        """Read data from a Vault path.
+
+        Args:
+            kw(dict): Key/value pairs for the read operation.
+                Supported keys:
+                    path(str): Vault path to read from
+        """
+        path = kw.get("path", "")
+        return self.parent._request("GET", f"/v1/{path}")
+
+    class Transit(object):
+        """Transit secrets engine operations."""
+
+        def __init__(self, parent):
+            self.parent = parent
+
+        def create_key(self, **kw):
+            """Create a named encryption key in the Transit engine.
+
+            Args:
+                kw(dict): Key/value pairs for key creation.
+                    Supported keys:
+                        key-name(str): Name of the encryption key
+                        type(str): Key type (default: aes256-gcm96)
+            """
+            key_name = kw.get("key-name", "")
+            payload = {}
+            key_type = kw.get("type", "")
+            if key_type:
+                payload["type"] = key_type
+            return self.parent.parent._request(
+                "POST", f"/v1/transit/keys/{key_name}", data=payload or {}
+            )
+
+        def configure_key(self, **kw):
+            """Configure an existing Transit encryption key.
+
+            Args:
+                kw(dict): Key/value pairs for key configuration.
+                    Supported keys:
+                        key-name(str): Name of the encryption key
+                        auto-rotate-period(str): Auto rotation period (e.g., "24h")
+                        min-decryption-version(int): Minimum decryption version
+                        min-encryption-version(int): Minimum encryption version
+                        deletion-allowed(bool): Allow key deletion
+            """
+            key_name = kw.get("key-name", "")
+            payload = {}
+            auto_rotate = kw.get("auto-rotate-period", "")
+            if auto_rotate:
+                payload["auto_rotate_period"] = auto_rotate
+            min_dec = kw.get("min-decryption-version", "")
+            if min_dec:
+                payload["min_decryption_version"] = min_dec
+            min_enc = kw.get("min-encryption-version", "")
+            if min_enc:
+                payload["min_encryption_version"] = min_enc
+            deletion = kw.get("deletion-allowed", "")
+            if deletion:
+                payload["deletion_allowed"] = deletion
+            return self.parent.parent._request(
+                "POST", f"/v1/transit/keys/{key_name}/config", data=payload
+            )
+
+        def read_key(self, **kw):
+            """Read a Transit encryption key's details.
+
+            Args:
+                kw(dict): Key/value pairs for reading the key.
+                    Supported keys:
+                        key-name(str): Name of the encryption key
+            """
+            key_name = kw.get("key-name", "")
+            return self.parent.parent._request("GET", f"/v1/transit/keys/{key_name}")

--- a/cli/vault/server.py
+++ b/cli/vault/server.py
@@ -1,0 +1,142 @@
+from copy import deepcopy
+
+from jinja2 import Template
+
+VAULT_CONFIG_HCL = """
+storage "file" {
+  path = "/vault/data"
+}
+
+listener "tcp" {
+  address = "0.0.0.0:8200"
+  tls_disable = true
+}
+
+api_addr = "http://{{ vault_addr }}:8200"
+ui = true
+"""
+
+VAULT_SYSTEMD = """[Unit]
+Description=HashiCorp Vault Server Container
+After=network.target podman.service
+Requires=podman.service
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/podman rm -f {{ container_name }}
+ExecStart=/usr/bin/podman run --name {{ container_name }} \\
+  -p {{ port }}:8200 \\
+  -v /vault/config:/vault/config:Z \\
+  -v /vault/data:/vault/data:Z \\
+  --cap-add=IPC_LOCK \\
+  {{ image }} server
+ExecStop=/usr/bin/podman stop -t 10 {{ container_name }}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+class Server(object):
+    """Vault server container lifecycle management.
+
+    Handles deploying, starting, stopping, and checking the status
+    of the containerized Vault server via podman and systemd.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def deploy(self, **kw):
+        """Deploy Vault server as a podman container with systemd.
+
+        Args:
+            kw(dict): Key/value pairs for deployment.
+                Supported keys:
+                    image(str): Container image (default: docker.io/hashicorp/vault:latest)
+                    container-name(str): Container name (default: vault-server)
+                    port(int): Host port to bind (default: 8200)
+                    vault-addr(str): Vault server IP address
+        """
+        kw_copy = deepcopy(kw)
+        image = kw_copy.pop("image", "docker.io/hashicorp/vault:latest")
+        container_name = kw_copy.pop("container-name", "vault-server")
+        port = kw_copy.pop("port", 8200)
+        vault_addr = kw_copy.pop("vault-addr", "127.0.0.1")
+
+        self.parent.execute_as_sudo(cmd="mkdir -p /vault/config /vault/data")
+        self.parent.execute_as_sudo(cmd="chmod 777 /vault/data")
+
+        vault_conf = Template(VAULT_CONFIG_HCL).render(vault_addr=vault_addr)
+        self._write_file("/vault/config/vault.hcl", vault_conf)
+
+        self.parent.execute_as_sudo(cmd=f"podman pull {image}", long_running=True)
+
+        systemd_content = Template(VAULT_SYSTEMD).render(
+            container_name=container_name, port=port, image=image
+        )
+        self._write_file(
+            f"/etc/systemd/system/{container_name}.service", systemd_content
+        )
+
+        self.parent.execute_as_sudo(cmd="systemctl daemon-reload")
+        self.parent.execute_as_sudo(cmd=f"systemctl start {container_name}")
+        self.parent.execute_as_sudo(cmd=f"systemctl enable {container_name}")
+
+        self.parent.execute_as_sudo(
+            cmd=f"firewall-cmd --add-port={port}/tcp --permanent",
+            check_ec=False,
+        )
+        self.parent.execute_as_sudo(cmd="firewall-cmd --reload", check_ec=False)
+
+    def start(self, **kw):
+        """Start the Vault server container.
+
+        Args:
+            kw(dict): Key/value pairs.
+                Supported keys:
+                    container-name(str): Container name (default: vault-server)
+        """
+        kw_copy = deepcopy(kw)
+        container_name = kw_copy.pop("container-name", "vault-server")
+        cmd = f"systemctl start {container_name}"
+        return self.parent.execute_as_sudo(cmd=cmd)
+
+    def stop(self, **kw):
+        """Stop the Vault server container.
+
+        Args:
+            kw(dict): Key/value pairs.
+                Supported keys:
+                    container-name(str): Container name (default: vault-server)
+        """
+        kw_copy = deepcopy(kw)
+        container_name = kw_copy.pop("container-name", "vault-server")
+        cmd = f"systemctl stop {container_name}"
+        return self.parent.execute_as_sudo(cmd=cmd)
+
+    def status(self, **kw):
+        """Check the status of the Vault server container.
+
+        Args:
+            kw(dict): Key/value pairs.
+                Supported keys:
+                    container-name(str): Container name (default: vault-server)
+        """
+        kw_copy = deepcopy(kw)
+        container_name = kw_copy.pop("container-name", "vault-server")
+        cmd = f"systemctl is-active {container_name}"
+        return self.parent.execute_as_sudo(cmd=cmd, check_ec=False)
+
+    def _write_file(self, file_name, content):
+        """Write content to a remote file on the node."""
+        if isinstance(self.parent.ctx, list):
+            node = self.parent.ctx[0]
+        else:
+            node = self.parent.ctx
+        fh = node.remote_file(sudo=True, file_mode="w", file_name=file_name)
+        fh.write(data=content)
+        fh.flush()
+        fh.close()

--- a/cli/vault/vault.py
+++ b/cli/vault/vault.py
@@ -1,0 +1,70 @@
+import requests as _requests
+
+from cli import Cli
+from utility.log import Log
+
+from .agent import Agent
+from .auth import Auth
+from .operator import Operator
+from .policy import Policy
+from .secrets import Secrets
+from .server import Server
+
+LOG = Log(__name__)
+
+
+class Vault(Cli):
+    """CLI wrapper for HashiCorp Vault operations.
+
+    Provides a consistent interface for interacting with a containerized
+    Vault server via REST API and SSH for system-level operations.
+
+    REST API calls (init, unseal, secrets, auth, policy) use the Python
+    ``requests`` library directly from the executor host.  System-level
+    operations (container lifecycle, agent install/config) continue to
+    run over SSH on the target nodes.
+    """
+
+    def __init__(self, nodes, vault_url="http://127.0.0.1:8200"):
+        super(Vault, self).__init__(nodes)
+        self.vault_url = vault_url
+        self.token = None
+        self.operator = Operator(parent=self)
+        self.secrets = Secrets(parent=self)
+        self.auth = Auth(parent=self)
+        self.policy = Policy(parent=self)
+        self.server = Server(parent=self)
+        self.agent = Agent(parent=self)
+
+    def _request(self, method, path, data=None, token_required=True):
+        """Make an HTTP request to the Vault REST API.
+
+        Args:
+            method: HTTP method (GET, POST, DELETE, LIST).
+            path: API path (e.g. "/v1/sys/init").
+            data: JSON-serialisable payload for POST requests.
+            token_required: Include X-Vault-Token header when True.
+
+        Returns:
+            Parsed JSON response as a dict, or {} for empty responses.
+        """
+        url = f"{self.vault_url}{path}"
+        headers = {}
+        if token_required and self.token:
+            headers["X-Vault-Token"] = self.token
+
+        LOG.debug(f"Vault API: {method} {url}")
+        resp = _requests.request(method, url, json=data, headers=headers)
+        resp.raise_for_status()
+
+        if resp.status_code == 204 or not resp.content:
+            return {}
+        return resp.json()
+
+    def health(self, **kw):
+        """Check the health of the Vault server.
+
+        Returns:
+            dict: Vault health status.
+        """
+        return self._request("GET", "/v1/sys/health", token_required=False)

--- a/tests/misc_env/install_vault.py
+++ b/tests/misc_env/install_vault.py
@@ -1,293 +1,370 @@
 """
-This module installs and configures HashiCorp's Vault on the given node.
+This module deploys and configures containerized HashiCorp Vault for RGW encryption.
 
-Support for configuring vault-agent is also supported in this module. The configuration
-is done based on the inputs provided in .cephci.yaml file.
+**CONTAINERIZED VAULT ONLY** - Self-contained, no external dependencies!
 
-In case of vault-agent configuration, the following information is required in
-.cephci.yaml
+Features:
+- Deploys Vault server as a Podman container on client node
+- Automatically configures vault-agent on all RGW nodes
+- Works on ALL cloud platforms (OpenStack, IBM Cloud, AWS, Baremetal)
+- Complete automation: init, unseal, transit engine, AppRole, RGW config
+- Uses REST API for all Vault operations (consistent with cli/ pattern)
 
-Example:
+Test suite configuration (UNCHANGED format):
+    - test:
+        module: install_vault.py
+        config:
+          install:
+            - agent
 
-    vault:
-        url: http://<vault-server>/
-        agent:
-          auth: agent
-          engine: transit
-          role-id: <role-id>
-          secret-id: <secret-id>
-          prefix: /v1/<path>
+Optional customization:
+    - test:
+        module: install_vault.py
+        config:
+          install:
+            - agent
+          vault:
+            image: docker.io/hashicorp/vault:latest  # Optional
+            port: 8200                                # Optional
+            transit:
+              key-name: testKey01                     # Optional
+              auto-rotate-period: 24h                 # Optional
 
-ToDo:
-  - configure server
-  - support TLS
-  - support token auth method
+What gets deployed:
+- Client node: Vault server container (port 8200)
+- RGW nodes: Vault agents (port 8100)
+- RGW daemons: Fully configured for SSE-S3/SSE-KMS encryption
 """
 
-from json import loads
-from typing import Dict
-
-from jinja2 import Template
+import json
+import time
+from typing import Dict, Tuple
 
 from ceph.ceph import Ceph, CephNode
+from cli.vault.vault import Vault
 from utility.log import Log
-from utility.utils import clone_configs_repo, get_cephci_config
 
 LOG = Log(__name__)
 
-AGENT_HCL = """pid_file = "/run/vault-agent-pid"
+# Transit policy template for RGW encryption
+TRANSIT_POLICY_HCL = """
+path "transit/encrypt/{key_name}" {{
+  capabilities = ["update"]
+}}
 
-auto_auth {
-  method "AppRole" {
-    mount_path = "auth/approle"
-    config = {
-      role_id_file_path = "/usr/local/etc/vault/.app-role-id"
-      secret_id_file_path = "/usr/local/etc/vault/.app-secret-id"
-      remove_secret_id_file_after_reading = "false"
-    }
-  }
-}
-{%- if data.auth == "token" %}
-sink "file" {
-  config = {
-    path = {{ data.token.file }}
-  }
-}
-{%- endif %}
+path "transit/decrypt/{key_name}" {{
+  capabilities = ["update"]
+}}
 
-{%- if data.auth == "agent" %}
-cache {
-  use_auto_auth_token = true
-}
+path "transit/keys/{key_name}" {{
+  capabilities = ["read"]
+}}
 
-listener "tcp" {
-  address = "127.0.0.1:8100"
-  tls_disable = true
-}
-{%- endif %}
+path "transit/keys/*" {{
+  capabilities = ["create", "read", "update", "delete", "list"]
+}}
 
-vault {
-  address = "{{ data.url }}"
-}
-"""
+path "transit/encrypt/*" {{
+  capabilities = ["update"]
+}}
 
-AGENT_SYSTEMD = """[Unit]
-Description=HashiCorp Vault agent
+path "transit/decrypt/*" {{
+  capabilities = ["update"]
+}}
 
-[Service]
-ExecStart=/usr/bin/vault-agent
-Restart=on-failure
+path "transit/datakey/plaintext/*" {{
+  capabilities = ["update"]
+}}
 
-[Install]
-WantedBy=multi-user.target
-"""
+path "transit/datakey/wrapped/*" {{
+  capabilities = ["update"]
+}}
 
-AGENT_LAUNCHER = """#!/bin/sh
-/bin/vault agent -config /usr/local/etc/vault/agent.hcl
+path "transit/*" {{
+  capabilities = ["read", "list"]
+}}
 """
 
 
 def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
     """
-    Entry point for module execution.
+    Deploy containerized Vault infrastructure.
 
     Args:
-        ceph_cluster    The cluster participating in the test.
-        config          Configuration passed to the test.
-        kwargs          Additional configurations passed to the test.
+        ceph_cluster: The cluster participating in the test
+        config: Configuration passed to the test
+        kwargs: Additional configurations
 
     Returns:
-        0 on Success else 1
+        0 on Success, 1 on Failure
     """
-    if "agent" not in config.get("install", []):
-        return 0
-    cephci_cfg = get_cephci_config()
-    vault_cfg = cephci_cfg.get("vault", {})
-
-    # Determine the cloud type explicitly or default to 'openstack'
-    cloud_type = config.get("cloud-type")
-
-    LOG.info(f"Selected cloud_type='{cloud_type}' for Vault configuration")
-
-    if cloud_type not in vault_cfg:
-        raise ValueError(
-            f"Invalid or missing Vault config for cloud_type '{cloud_type}' in cephci.yaml. "
-            f"Expected one of: {', '.join(vault_cfg.keys())}"
-        )
-
-    selected_cfg = vault_cfg[cloud_type]
-
-    if not selected_cfg.get("url"):
-        raise ValueError(
-            f"Missing 'url' in Vault config for cloud_type '{cloud_type}'."
-        )
-
-    # Pass cloud_type down so the installer can make an explicit repo choice
-    _install_agent(ceph_cluster, selected_cfg, cloud_type=cloud_type)
-
     try:
-        client_node = ceph_cluster.get_nodes(role="client")[0]
-    except IndexError:
-        raise RuntimeError(
-            "No client node found in the cluster to configure RGW daemons."
+        if "agent" not in config.get("install", []):
+            LOG.warning("No 'agent' in install list, nothing to do")
+            return 0
+
+        LOG.info("=" * 70)
+        LOG.info("CONTAINERIZED VAULT DEPLOYMENT")
+        LOG.info("=" * 70)
+
+        vault_config = config.get("vault", {})
+
+        LOG.info("Deploying Vault server container on client node...")
+        vault_url, credentials = _deploy_vault_server(ceph_cluster, vault_config)
+        LOG.info(f"Vault server deployed at {vault_url}")
+
+        LOG.info("Deploying Vault agents on RGW nodes...")
+        _deploy_vault_agents(ceph_cluster, vault_url, credentials)
+        LOG.info("Vault agents deployed")
+
+        LOG.info("Configuring RGW daemons for Vault integration...")
+        _configure_all_rgw_daemons(ceph_cluster, vault_config)
+        LOG.info("RGW daemons configured")
+
+        LOG.info("=" * 70)
+        LOG.info("CONTAINERIZED VAULT DEPLOYMENT COMPLETE")
+        LOG.info("=" * 70)
+        LOG.info(f"Vault Server: {vault_url}")
+        LOG.info(f"Transit Key: {credentials.get('key_name', 'testKey01')}")
+        LOG.info("Credentials: /vault/credentials.json on client node")
+        LOG.info("=" * 70)
+
+        return 0
+
+    except Exception as e:
+        LOG.error(f"Vault deployment failed: {e}")
+        import traceback
+
+        LOG.error(traceback.format_exc())
+        return 1
+
+
+def _deploy_vault_server(cluster: Ceph, config: Dict) -> Tuple[str, Dict]:
+    """Deploy Vault server container on client node."""
+    client_nodes = cluster.get_nodes(role="client")
+    if not client_nodes:
+        raise RuntimeError("No client node found for Vault server deployment")
+
+    node = client_nodes[0]
+    image = config.get("image", "docker.io/hashicorp/vault:latest")
+    port = config.get("port", 8200)
+
+    LOG.info(f"Deploying on {node.shortname} ({node.ip_address})")
+
+    vault_url = f"http://{node.ip_address}:{port}"
+    vault = Vault(node, vault_url=vault_url)
+
+    vault.server.deploy(
+        image=image,
+        port=port,
+        **{"container-name": config.get("container-name", "vault-server")},
+        **{"vault-addr": node.ip_address},
+    )
+
+    LOG.info("Waiting for Vault to be ready...")
+    time.sleep(10)
+
+    credentials = _initialize_vault(vault, config)
+
+    return vault_url, credentials
+
+
+def _initialize_vault(vault: Vault, config: Dict) -> Dict:
+    """Initialize Vault and configure Transit engine via REST API."""
+    LOG.info("Initializing Vault server")
+
+    status = vault.operator.init_status()
+    try:
+        if status.get("initialized"):
+            LOG.info("Vault already initialized, retrieving existing credentials")
+            if isinstance(vault.ctx, list):
+                node = vault.ctx[0]
+            else:
+                node = vault.ctx
+            creds_out, _ = node.exec_command(
+                sudo=True, cmd="cat /vault/credentials.json", check_ec=False
+            )
+            if creds_out:
+                return json.loads(creds_out)
+    except Exception:
+        pass
+
+    init_data = vault.operator.init(**{"secret-shares": 5, "secret-threshold": 3})
+
+    unseal_keys = init_data["unseal_keys_b64"]
+    root_token = init_data["root_token"]
+    LOG.info("Vault initialized")
+
+    LOG.info("Unsealing Vault...")
+    for i in range(3):
+        vault.operator.unseal(key=unseal_keys[i])
+    LOG.info("Vault unsealed")
+
+    vault.token = root_token
+
+    transit_config = config.get("transit", {})
+    key_name = transit_config.get("key-name", "testKey01")
+    auto_rotate = transit_config.get("auto-rotate-period", "24h")
+
+    LOG.info("Enabling Transit secrets engine")
+    vault.secrets.enable(path="transit", type="transit")
+
+    LOG.info(f"Creating encryption key: {key_name}")
+    vault.secrets.transit.create_key(**{"key-name": key_name})
+
+    LOG.info("Configuring auto-rotation")
+    vault.secrets.transit.configure_key(
+        **{"key-name": key_name, "auto-rotate-period": auto_rotate}
+    )
+    LOG.info(f"Transit engine configured with key '{key_name}'")
+
+    policy_name = "ceph-rgw-policy"
+    policy = TRANSIT_POLICY_HCL.format(key_name=key_name)
+    LOG.info(f"Writing policy: {policy_name}")
+    vault.policy.write(name=policy_name, policy=policy)
+
+    LOG.info("Enabling AppRole authentication")
+    vault.auth.enable(path="approle", type="approle")
+
+    approle_config = config.get("approle", {})
+    role_name = approle_config.get("role-name", "ceph-rgw")
+    token_ttl = approle_config.get("token-ttl", "1h")
+    token_max_ttl = approle_config.get("token-max-ttl", "24h")
+
+    LOG.info(f"Creating AppRole: {role_name}")
+    vault.auth.approle.create_role(
+        **{
+            "role-name": role_name,
+            "token-policies": policy_name,
+            "token-ttl": token_ttl,
+            "token-max-ttl": token_max_ttl,
+        }
+    )
+
+    role_id_data = vault.auth.approle.read_role_id(**{"role-name": role_name})
+    role_id = role_id_data["data"]["role_id"]
+
+    secret_id_data = vault.auth.approle.generate_secret_id(**{"role-name": role_name})
+    secret_id = secret_id_data["data"]["secret_id"]
+
+    LOG.info(f"AppRole '{role_name}' configured")
+
+    credentials = {
+        "role_id": role_id,
+        "secret_id": secret_id,
+        "root_token": root_token,
+        "unseal_keys": unseal_keys,
+        "key_name": key_name,
+        "vault_url": vault.vault_url,
+    }
+
+    _write_remote_file(
+        vault.ctx if not isinstance(vault.ctx, list) else vault.ctx[0],
+        "/vault/credentials.json",
+        json.dumps(credentials, indent=2),
+    )
+    node = vault.ctx if not isinstance(vault.ctx, list) else vault.ctx[0]
+    node.exec_command(sudo=True, cmd="chmod 600 /vault/credentials.json")
+
+    return credentials
+
+
+def _deploy_vault_agents(cluster: Ceph, vault_url: str, credentials: Dict) -> None:
+    """Deploy and configure vault-agent on all RGW nodes."""
+    rgw_nodes = cluster.get_nodes(role="rgw")
+
+    if not rgw_nodes:
+        LOG.warning("No RGW nodes found in cluster")
+        return
+
+    LOG.info(f"Configuring {len(rgw_nodes)} RGW nodes")
+
+    for node in rgw_nodes:
+        LOG.info(f"  Configuring {node.shortname}...")
+
+        vault_agent = Vault(node, vault_url=vault_url)
+
+        vault_agent.agent.install()
+
+        vault_agent.agent.configure(
+            **{
+                "vault-url": vault_url,
+                "role-id": credentials["role_id"],
+                "secret-id": credentials["secret_id"],
+            }
         )
 
-    _configure_rgw_daemons(client_node, selected_cfg)
-    return 0
+        vault_agent.agent.start()
+
+        time.sleep(2)
+        out, _ = vault_agent.agent.status()
+        if "active" in out:
+            LOG.info(f"  {node.shortname} vault-agent active")
+        else:
+            LOG.warning(f"  {node.shortname} vault-agent may not be running")
+
+
+def _configure_all_rgw_daemons(cluster: Ceph, vault_config: Dict) -> None:
+    """Configure all RGW daemons across all clusters (supports multisite)."""
+    client_nodes = cluster.get_nodes(role="client")
+
+    for client_node in client_nodes:
+        try:
+            _configure_rgw_daemons_on_node(client_node, vault_config)
+        except Exception as e:
+            LOG.warning(f"Failed to configure RGW on {client_node.shortname}: {e}")
+
+
+def _configure_rgw_daemons_on_node(node: CephNode, vault_config: Dict) -> None:
+    """Configure RGW daemons on a specific node."""
+    out, _ = node.exec_command(
+        sudo=True, cmd="ceph orch ps --daemon_type rgw --format json", check_ec=False
+    )
+
+    if not out or out.strip() == "":
+        LOG.warning(f"No RGW daemons found on {node.shortname}")
+        return
+
+    rgw_daemons = [f"client.rgw.{x['daemon_id']}" for x in json.loads(out)]
+
+    out, _ = node.exec_command(
+        sudo=True, cmd="ceph orch ls --service_type rgw --format json", check_ec=False
+    )
+    rgw_services = [x["service_name"] for x in json.loads(out)] if out else []
+
+    transit_config = vault_config.get("transit", {})
+    key_name = transit_config.get("key-name", "testKey01")
+
+    configs = [
+        ("rgw_crypt_require_ssl", "false"),
+        ("rgw_crypt_s3_kms_backend", "vault"),
+        ("rgw_crypt_vault_secret_engine", "transit"),
+        ("rgw_crypt_vault_auth", "agent"),
+        ("rgw_crypt_vault_addr", "http://127.0.0.1:8100"),
+        ("rgw_crypt_vault_prefix", "/v1/transit"),
+        ("rgw_crypt_sse_s3_backend", "vault"),
+        ("rgw_crypt_sse_s3_vault_secret_engine", "transit"),
+        ("rgw_crypt_sse_s3_vault_auth", "agent"),
+        ("rgw_crypt_sse_s3_vault_addr", "http://127.0.0.1:8100"),
+        ("rgw_crypt_sse_s3_vault_prefix", "/v1/transit"),
+        ("rgw_crypt_s3_kms_encryption_keys", f"testkey01={key_name}"),
+    ]
+
+    for daemon in rgw_daemons:
+        LOG.info(f"  Configuring {daemon}")
+        for key, value in configs:
+            node.exec_command(
+                sudo=True, cmd=f"ceph config set {daemon} {key} {value}", check_ec=False
+            )
+
+    for service in rgw_services:
+        LOG.info(f"  Restarting {service}")
+        node.exec_command(sudo=True, cmd=f"ceph orch restart {service}", check_ec=False)
 
 
 def _write_remote_file(node: CephNode, file_name: str, content: str) -> None:
-    """
-    Copies the provided content to the specified file on the given node.
-    """
-    LOG.info(f"{node.shortname}: Writing to remote file {file_name}")
+    """Write content to remote file."""
     file_handle = node.remote_file(sudo=True, file_mode="w", file_name=file_name)
     file_handle.write(data=content)
     file_handle.flush()
     file_handle.close()
-
-
-def _install_agent(cluster: Ceph, config: Dict, *, cloud_type: str) -> None:
-    """
-    Installs and configures the vault-agent on all RGW nodes.
-    """
-    rgw_nodes = cluster.get_nodes(role="rgw")
-    for node in rgw_nodes:
-        LOG.info(
-            f"{node.shortname}: Installing and configuring Vault agent (cloud_type={cloud_type})"
-        )
-        _install_vault_packages(node, cloud_type=cloud_type)
-        _create_agent_config(node, config)
-        _create_agent_systemd(node)
-
-
-def _install_vault_packages(node: CephNode, *, cloud_type: str) -> None:
-    """
-    Installs the required packages for Vault based on the explicit cloud_type
-    ('ibmc' or 'openstack') selection from cephci.yaml instead of heuristics.
-    """
-    try:
-        LOG.debug(f"cloning ceph-qe-ng/configs repo on {node.shortname}")
-        clone_configs_repo(node, repo_name="rgw_configs")
-        LOG.debug(f"{node.shortname}: Using enterprise-internal repo")
-        node.exec_command(
-            sudo=True,
-            cmd="cp /home/cephuser/configs/rgw/vault/hashicorp.repo /etc/yum.repos.d/hashicorp.repo",
-            check_ec=False,
-        )
-
-        install_cmd = "yum install -y vault"
-        node.exec_command(sudo=True, cmd=install_cmd, check_ec=False)
-
-    except Exception as e:
-        raise RuntimeError(f"{node.shortname}: Failed to install Vault - {str(e)}")
-
-
-def _create_agent_config(node: CephNode, config: Dict) -> None:
-    """
-    Writes required agent configuration files to the node.
-    """
-    node.exec_command(sudo=True, cmd="mkdir -p /usr/local/etc/vault/")
-
-    _write_remote_file(
-        node=node,
-        file_name="/usr/local/etc/vault/.app-role-id",
-        content=config["agent"]["role-id"],
-    )
-    _write_remote_file(
-        node=node,
-        file_name="/usr/local/etc/vault/.app-secret-id",
-        content=config["agent"]["secret-id"],
-    )
-
-    # Harden file permissions for credentials
-    node.exec_command(
-        sudo=True,
-        cmd="chmod 600 /usr/local/etc/vault/.app-role-id /usr/local/etc/vault/.app-secret-id",
-        check_ec=False,
-    )
-
-    agent_conf = {
-        "url": config["url"],
-        "auth": config["agent"]["auth"],
-        "token": {"file": config["agent"].get("token_file", "")},
-    }
-    tmpl = Template(AGENT_HCL)
-    data = tmpl.render(data=agent_conf)
-
-    _write_remote_file(
-        node=node,
-        file_name="/usr/local/etc/vault/agent.hcl",
-        content=data,
-    )
-
-
-def _create_agent_systemd(node: CephNode) -> None:
-    """
-    Configures vault-agent as a systemd service.
-    """
-    _write_remote_file(
-        node=node,
-        file_name="/usr/bin/vault-agent",
-        content=AGENT_LAUNCHER,
-    )
-    _write_remote_file(
-        node=node,
-        file_name="/usr/lib/systemd/system/vault-agent.service",
-        content=AGENT_SYSTEMD,
-    )
-
-    commands = [
-        "chmod +x /usr/bin/vault-agent",
-        "systemctl daemon-reload",
-        "systemctl start vault-agent.service",
-        "systemctl enable vault-agent.service",
-    ]
-    for command in commands:
-        node.exec_command(sudo=True, cmd=command)
-
-
-def _configure_rgw_daemons(node: CephNode, config: Dict) -> None:
-    """
-    Updates RGW daemons with Vault config.
-    """
-    out, _ = node.exec_command(
-        sudo=True, cmd="ceph orch ps --daemon_type rgw --format json"
-    )
-    rgw_daemons = [f"client.rgw.{x['daemon_id']}" for x in loads(out)]
-
-    out, _ = node.exec_command(
-        sudo=True, cmd="ceph orch ls --service_type rgw --format json"
-    )
-    rgw_services = [x["service_name"] for x in loads(out)]
-
-    configs = [
-        ("rgw_crypt_s3_kms_backend", "vault"),
-        ("rgw_crypt_vault_secret_engine", config["agent"]["engine"]),
-        ("rgw_crypt_vault_auth", config["agent"]["auth"]),
-        ("rgw_crypt_sse_s3_backend", "vault"),
-        ("rgw_crypt_sse_s3_vault_secret_engine", config["agent"]["engine"]),
-        ("rgw_crypt_sse_s3_vault_auth", config["agent"]["auth"]),
-    ]
-
-    if config["agent"]["auth"] == "token":
-        configs += [
-            ("rgw_crypt_vault_token_file", config["agent"]["token_file"]),
-            ("rgw_crypt_vault_addr", config["url"]),
-            ("rgw_crypt_sse_s3_vault_token_file", config["agent"]["token_file"]),
-            ("rgw_crypt_sse_s3_vault_addr", config["url"]),
-        ]
-    else:
-        configs += [
-            ("rgw_crypt_vault_prefix", config["agent"]["prefix"]),
-            ("rgw_crypt_vault_addr", "http://127.0.0.1:8100"),
-            ("rgw_crypt_sse_s3_vault_prefix", config["agent"]["prefix"]),
-            ("rgw_crypt_sse_s3_vault_addr", "http://127.0.0.1:8100"),
-        ]
-
-    for daemon in rgw_daemons:
-        for key, value in configs:
-            node.exec_command(sudo=True, cmd=f"ceph config set {daemon} {key} {value}")
-
-    for service in rgw_services:
-        node.exec_command(sudo=True, cmd=f"ceph orch restart {service}")

--- a/tests/misc_env/uninstall_vault.py
+++ b/tests/misc_env/uninstall_vault.py
@@ -1,0 +1,201 @@
+"""
+Cleanup module for containerized Vault infrastructure.
+
+This module removes all vault components deployed by install_vault.py:
+- Stops and removes vault-agent services on RGW nodes
+- Removes vault-agent configuration files
+- Stops and removes vault-server container
+- Removes vault data and configuration
+- Closes firewall ports
+
+Usage in test suite:
+    - test:
+        name: cleanup vault infrastructure
+        module: uninstall_vault.py
+        config:
+          cleanup:
+            - server   # Remove vault server container
+            - agent    # Remove vault agents
+"""
+
+from typing import Dict
+
+from ceph.ceph import Ceph
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
+    """
+    Remove containerized Vault infrastructure.
+
+    Args:
+        ceph_cluster: The cluster participating in the test
+        config: Configuration passed to the test
+        kwargs: Additional configurations
+
+    Returns:
+        0 on Success, 1 on Failure
+    """
+    try:
+        cleanup_components = config.get("cleanup", ["agent", "server"])
+
+        LOG.info("=" * 70)
+        LOG.info("VAULT INFRASTRUCTURE CLEANUP")
+        LOG.info("=" * 70)
+
+        # Remove vault agents first (if requested)
+        if "agent" in cleanup_components:
+            LOG.info("\nRemoving Vault agents from RGW nodes...")
+            _remove_vault_agents(ceph_cluster)
+            LOG.info("✓ Vault agents removed")
+
+        # Remove vault server container (if requested)
+        if "server" in cleanup_components:
+            LOG.info("\nRemoving Vault server container...")
+            _remove_vault_server(ceph_cluster)
+            LOG.info("✓ Vault server removed")
+
+        LOG.info("\n" + "=" * 70)
+        LOG.info("✓ VAULT CLEANUP COMPLETE")
+        LOG.info("=" * 70)
+
+        return 0
+
+    except Exception as e:
+        LOG.error(f"Vault cleanup failed: {e}")
+        import traceback
+
+        LOG.error(traceback.format_exc())
+        return 1
+
+
+def _remove_vault_agents(cluster: Ceph) -> None:
+    """Remove vault-agent from all RGW nodes."""
+    rgw_nodes = cluster.get_nodes(role="rgw")
+
+    if not rgw_nodes:
+        LOG.warning("No RGW nodes found")
+        return
+
+    LOG.info(f"Cleaning up {len(rgw_nodes)} RGW nodes")
+
+    for node in rgw_nodes:
+        LOG.info(f"  Cleaning {node.shortname}...")
+
+        # Stop and disable vault-agent service
+        commands = [
+            "systemctl stop vault-agent",
+            "systemctl disable vault-agent",
+        ]
+        for cmd in commands:
+            node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+
+        # Remove systemd service file
+        node.exec_command(
+            sudo=True,
+            cmd="rm -f /etc/systemd/system/vault-agent.service",
+            check_ec=False,
+        )
+
+        # Remove vault configuration directory
+        node.exec_command(
+            sudo=True,
+            cmd="rm -rf /usr/local/etc/vault",
+            check_ec=False,
+        )
+
+        # Reload systemd
+        node.exec_command(
+            sudo=True,
+            cmd="systemctl daemon-reload",
+            check_ec=False,
+        )
+
+        # Optionally remove vault binary (commented out - may be needed for other purposes)
+        # node.exec_command(
+        #     sudo=True,
+        #     cmd="yum remove -y vault",
+        #     check_ec=False,
+        # )
+
+        LOG.info(f"  ✓ {node.shortname} cleaned")
+
+
+def _remove_vault_server(cluster: Ceph) -> None:
+    """Remove vault server container from client node."""
+    client_nodes = cluster.get_nodes(role="client")
+
+    if not client_nodes:
+        LOG.warning("No client node found")
+        return
+
+    node = client_nodes[0]
+    LOG.info(f"Cleaning vault server on {node.shortname}")
+
+    # Stop and disable vault-server systemd service
+    node.exec_command(
+        sudo=True,
+        cmd="systemctl stop vault-server",
+        check_ec=False,
+    )
+    node.exec_command(
+        sudo=True,
+        cmd="systemctl disable vault-server",
+        check_ec=False,
+    )
+
+    # Remove systemd service file
+    node.exec_command(
+        sudo=True,
+        cmd="rm -f /etc/systemd/system/vault-server.service",
+        check_ec=False,
+    )
+
+    # Stop and remove vault-server container
+    node.exec_command(
+        sudo=True,
+        cmd="podman stop vault-server",
+        check_ec=False,
+    )
+    node.exec_command(
+        sudo=True,
+        cmd="podman rm vault-server",
+        check_ec=False,
+    )
+
+    # Remove vault image (optional - commented out to save time on re-runs)
+    # node.exec_command(
+    #     sudo=True,
+    #     cmd="podman rmi docker.io/hashicorp/vault:latest",
+    #     check_ec=False,
+    # )
+
+    # Remove vault data and config directories
+    node.exec_command(
+        sudo=True,
+        cmd="rm -rf /vault",
+        check_ec=False,
+    )
+
+    # Close firewall port 8200
+    node.exec_command(
+        sudo=True,
+        cmd="firewall-cmd --remove-port=8200/tcp --permanent",
+        check_ec=False,
+    )
+    node.exec_command(
+        sudo=True,
+        cmd="firewall-cmd --reload",
+        check_ec=False,
+    )
+
+    # Reload systemd
+    node.exec_command(
+        sudo=True,
+        cmd="systemctl daemon-reload",
+        check_ec=False,
+    )
+
+    LOG.info(f"  ✓ {node.shortname} cleaned")


### PR DESCRIPTION
# Description

This PR containerizes the Vault server for SSE-S3 and SSE-KMS tests, eliminating the dependency on a dedicated Vault VM hosted on IBM Cloud. By running Vault as  a container on an existing cluster node, we save the cost of maintaining a separate IBM Cloud VM solely for the Vault server.

No changes are required in test suite files, and cephci.yaml Vault entries are no longer needed.

  **Architecture**

  - Vault Server: Deployed as a Podman container on the client node (primary site in multisite)
  - Vault Agents: Configured on all RGW nodes, connecting to the Vault server
  - Multisite: Vault agents from both primary and secondary sites connect to a single Vault server on the primary site's client node

  **Implementation**
  
  New cli/vault/ modules provide a structured Python interface:

  - REST API calls (operator.py, auth.py, policy.py, secrets.py) use the Python requests library directly from the executor host — no curl-over-SSH
  - System-level operations (server.py, agent.py) run over SSH for container lifecycle, agent installation, and systemd management

  install_vault.py orchestrates the full flow: deploy container, init/unseal, configure Transit engine + AppRole auth, deploy vault-agents on RGW nodes, and configure RGW daemons. uninstall_vault.py handles cleanup.

  **Test Suite Configuration**

  Existing format works unchanged:

  - test:
      module: install_vault.py
      config:
        install:
          - agent


passed log for a single site -  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IYGBDG
passed logs for multisite -   http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2PQEGP



