### PR TITLE
Add CephFS mirroring upgrade suite for 7.x to 8.x to 9.x

### DIFF
--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
@@ -247,7 +247,7 @@ tests:
             polarion-id: CEPH-83575315
         - test:
             name: Upgrade ceph
-            desc: Upgrade cluster to latest version 9.0
+            desc: Upgrade cluster to latest version
             module: cephadm.test_cephadm_upgrade.py
             polarion-id: CEPH-83574638
             clusters:
@@ -257,9 +257,6 @@ tests:
                   service: upgrade
                   base_cmd_args:
                     verbose: true
-                  args:
-                    rhcs-version: 9.0
-                    release: latest
                   benchmark:
                     type: rados
                     pool_per_client: true


### PR DESCRIPTION
Need to remove rhcs-version args to consider upgrade to 9.1