### PR TITLE
Fix Deploy multiple nfs ganesha servers concurrently and veriify test…

### DIFF
--- a/tests/nfs/test_deploy_multiple_nfs_ganesha_concurrently.py
+++ b/tests/nfs/test_deploy_multiple_nfs_ganesha_concurrently.py
@@ -52,8 +52,8 @@ def run(ceph_cluster, **kw):
     try:
         # Find 12 free ports (6 services * 2 ports each)
         all_nfs_nodes = ceph_cluster.get_nodes("nfs")
-        needed_ports = nfs_instance_number * 2
-        free_ports = get_free_ports(all_nfs_nodes, needed_ports, 50200)
+        needed_ports = nfs_instance_number * 3
+        free_ports = get_free_ports(all_nfs_nodes, needed_ports, 52000)
 
         if len(free_ports) < needed_ports:
             raise ConfigError(f"Could not find {needed_ports} free ports on NFS nodes")
@@ -62,6 +62,7 @@ def run(ceph_cluster, **kw):
         for i in range(nfs_instance_number):
             nfs_port = free_ports[i * 2]
             mon_port = free_ports[i * 2 + 1]
+            cQoS_port = free_ports[i * 2 + 2]
 
             new_object = {
                 "service_type": original_config["service_type"],
@@ -70,6 +71,7 @@ def run(ceph_cluster, **kw):
                 "spec": {
                     "port": nfs_port,
                     "monitoring_port": mon_port,
+                    "cluster_qos_port": cQoS_port,
                 },
             }
             new_objects.append(new_object)


### PR DESCRIPTION
Multiple  instances with default CQOS port was causing conflict 
Added Custom CQoS port for multiple deployments

Pass logs:
https://10.8.128.2/cephci-jenkins/ibm-cos//RH/9.1/rhel-10/executor/20.2.1-280/nfs/1673/logs/tier1_nfs_ganesha_test/