### PR TITLE
Add CephFS upgrade suite for 9.x latest to 9.1x latest

### DIFF
--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_9x_to_91x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_9x_to_91x.yaml
@@ -1,0 +1,281 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 9.x with below options,
+#       - rhcs-version: 9.0 in this suite, but it can be changed to 9.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                rhcs-version: 9.0
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  - test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection before upgrade"
+      polarion-id: CEPH-83575313
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+        ENABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+        daemon_dbg_level : {'mds':10,'client':10,'osd':5,'mgr':5,'mon':5}
+  - test:
+      abort-on-fail: false
+      desc: "Set size limit for log rotation"
+      name: size limit for log rotation
+      module: cephfs_logs_util.py
+      config:
+        LOG_ROTATE_SIZE : 1
+        log_size : '200M'
+  -
+    test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup : 1
+        daemon_list : ['mds','osd','mgr','mon']
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: "node8"
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check : 1
+        daemon_list : ['mds','osd','mgr','mon']
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+        DISABLE_LOGS : 1
+        daemon_list : ['mds','client','osd','mgr','mon']
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata collection After upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+  - test:
+      abort-on-fail: false
+      desc: Validates 9.1 features post upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation_ext.py
+      name: "Validates 9.1 features after upgrade"
+      polarion-id: CEPH-83621389
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+      name: cephfs_tier1_ops
+      module: cephfs_tier1_ops.py
+      polarion-id: CEPH-83573447
+      desc: cephfs tier1 operations
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+      name: Files-quota-test
+      module: quota.quota_files.py
+      polarion-id: CEPH-83573399
+      desc: Tests the file attributes on the directory
+      abort-on-fail: false
+  - test:
+      name: Bytes-quota-test
+      module: quota.quota_bytes.py
+      polarion-id: CEPH-83573399
+      desc: Tests the Byte attr
+  - test:
+      name: test cephfs subvolume metrics - functional
+      module: cephfs_subvol_metrics.test_subvol_metrics.py
+      polarion-id: CEPH-83621832
+      desc: Test fs subvolume metrics
+      abort-on-fail: false


### PR DESCRIPTION
Added 9.0 to 9.1 upgrade test coverage.
Logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-280/cephfs/1683/logs/tier_0_cephfs_upgrade_9x_to_91x/