### PR TITLE
[9.1][SMB][Automation]Per Share Quota and Capacity Test Scenarios

### DIFF
--- a/suites/tentacle/smb/tier-1-smb-share-quota-capacity.yaml
+++ b/suites/tentacle/smb/tier-1-smb-share-quota-capacity.yaml
@@ -1,0 +1,298 @@
+tests:
+  - test:
+      name: setup pre-requisites
+      desc: Install software pre-requisites for cluster deployment
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Deploy cluster using cephadm
+      desc: Bootstrap and deploy services
+      module: test_cephadm.py
+      polarion-id: CEPH-83573713
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: configure client
+      desc: Configure client system
+      module: test_client.py
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - samba-client
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Test set and retrieve quota and capacity on subvolume
+      desc: Test set and retrieve quota and capacity on subvolume
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632299
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes/smb/sv1
+        quota: 1000000000
+        quota_operation: set_and_get_quota
+        path: "/"
+
+  - test:
+      name: Test write operation on share within quota limit on subvolume.
+      desc: Test write operation on share within quota limit on subvolume.
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632303
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes/smb/sv1
+        quota: 1000000000
+        quota_operation: write_within_quota
+        path: "/"
+
+  - test:
+      name: Test write operation on share above quota limit on subvolume.
+      desc: Test write operation on share above quota limit on subvolume.
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632303
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes/smb/sv1
+        quota: 1000000000
+        quota_operation: write_above_quota
+        path: "/"
+
+  - test:
+      name: Test set and retrieve quota and capacity on volume
+      desc: Test set and retrieve quota and capacity on volume
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632300
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes/smb/sv1
+        quota: 1000000000
+        quota_operation: set_and_get_quota
+        path: "/"
+
+  - test:
+      name: Test write operation on share within quota limit on volume.
+      desc: Test write operation on share within quota limit on volume.
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632302
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes
+        quota: 1000000000
+        quota_operation: write_within_quota
+        path: "/"
+
+  - test:
+      name: Test write operation on share above quota limit on volume.
+      desc: Test write operation on share above quota limit on volume.
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632302
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes
+        quota: 1000000000
+        quota_operation: write_above_quota
+        path: "/"
+
+  - test:
+      name: Test write operation on multiple shares within quota limit on volume.
+      desc: Test write operation on multiple shares within quota limit on volume.
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632303
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1, sv2 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1, share2 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes
+        quota: 1000000000
+        quota_operation: multiple_shares_quota
+        path: "/"
+
+  - test:
+      name: Test write operation on multiple shares within quota limit on subvolume.
+      desc: Test write operation on multiple shares within quota limit on subvolume.
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632303
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1, sv2 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1, share2 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes/smb/sv1
+        quota: 1000000000
+        quota_operation: multiple_shares_quota
+        path: "/"
+
+  - test:
+      name: Test delete quota and capacity on subvolume
+      desc: Test delete quota and capacity on subvolume
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632301
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes/smb/sv1
+        quota: 1000000000
+        quota_operation: delete_quota
+        path: "/"
+
+  - test:
+      name: Test delete quota and capacity on volume
+      desc: Test delete quota and capacity on volume
+      module: smb_per_share_quota_capacity_setup.py
+      polarion-id: CEPH-83632301
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [ sv1 ]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [ share1 ]
+        mount_point: /mnt/mount
+        cifs_mount_point: /mnt/smb
+        sub_dir: /volumes
+        quota: 1000000000
+        quota_operation: delete_quota
+        smb_cluster_cleanup: true
+        path: "/"

--- a/tests/smb/smb_per_share_quota_capacity_operations.py
+++ b/tests/smb/smb_per_share_quota_capacity_operations.py
@@ -1,0 +1,221 @@
+from ceph.ceph import CommandFailed
+from cli.exceptions import OperationFailedError
+from smb_operations import (
+    check_smb_cluster,
+    get_smb_shares,
+    smb_cifs_mount,
+    smb_cleanup,
+    verify_smb_service,
+)
+
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def samba_kernel_mount(samba_client, mount_point, mon_node_ip, sub_dir):
+    """
+    Mounts the sub volume or volume using kernel mount
+    Args:
+        samba_client:
+        mount_point:
+        mon_node_ip:
+        sub_dir: specific directory subvolume or volume
+    Returns:
+
+    Exceptions:
+        assertion error will occur if the device is not mounted
+    """
+    log.info("Creating mounting dir:")
+    samba_client.exec_command(sudo=True, cmd=f"mkdir -p %{mount_point}")
+    samba_client.exec_command(
+        sudo=True,
+        cmd=f"ceph auth get-key client.admin -o "
+            f"/etc/ceph/{samba_client.hostname}.secret",
+    )
+    cmd = (
+        f"mount -t ceph {mon_node_ip}:{sub_dir} {mount_point} "
+        f"-o name=admin,"
+        f"secretfile=/etc/ceph/{samba_client.hostname}.secret,"
+        f"noshare"
+    )
+    cmd_rc = samba_client.exec_command(sudo=True, cmd=cmd, long_running=True)
+
+    if cmd_rc:
+        raise CommandFailed(
+            f"Ceph Kernel Command failed with error: {cmd_rc}"
+        )
+    return cmd_rc
+
+
+def set_quota_and_capacity(samba_client, mount_point, quota):
+    """
+    Set quota and capacity on subvolume or volume
+    Args:
+        samba_client:
+        mount_point:
+        quota:
+
+    """
+    log.info("Setting quota and capacity of {} bytes".format(quota))
+    out = samba_client.exec_command(sudo=True, cmd=f"setfattr -n ceph.quota.max_bytes -v {quota} {mount_point}")
+    if out:
+        raise CommandFailed(
+            f"Set quota and capacity failed with error: {out}"
+        )
+
+
+def get_quota_and_capacity(samba_client, mount_point, quota):
+    """
+    get quota and capacity on subvolume or volume
+    Args:
+        samba_client:
+        mount_point:
+        quota:
+
+    """
+    out, _ = out = samba_client.exec_command(
+        sudo=True,
+        cmd=f"getfattr -n ceph.quota.max_bytes {mount_point} | awk -F'\"' '/ceph.quota.max_bytes/{{print $2}}'"
+    )
+    if not out:
+        raise CommandFailed(
+            f"Get quota and capacity failed with error: {out}"
+        )
+    log.info("quota and capacity is set to {} bytes".format(out))
+
+
+def run(ceph_cluster, **kw):
+    """Deploy samba with auth_mode 'user' using imperative style(CLI Commands)
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    # Get config
+    config = kw.get("config")
+
+    # Get installer node
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
+
+    # Get smb nodes
+    smb_nodes = ceph_cluster.get_nodes("smb")
+
+    # Get client node
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    # Get smb cluster id
+    smb_cluster_id = config.get("smb_cluster_id")
+
+    # Check smb cluster
+    check_smb_cluster(installer_node, smb_cluster_id)
+
+    # Check smb service
+    verify_smb_service(installer_node, service_name="smb")
+
+    # Get smb shares
+    smb_shares = get_smb_shares(installer_node, smb_cluster_id)
+    log.info("smb_shares: {}".format(smb_shares))
+    print(type(smb_shares))
+
+    # Get auth_mode
+    auth_mode = config.get("auth_mode", "user")
+
+    # Get domain_realm
+    domain_realm = config.get("domain_realm", None)
+
+    # Get smb user name
+    smb_user_name = config.get("smb_user_name", "user1")
+
+    # Get smb user password
+    smb_user_password = config.get("smb_user_password", "passwd")
+
+    # Get quota operations to perform
+    quota_operation = config.get("quota_operation")
+
+    # Get kernel mount point
+    mount_point = config.get("mount_point", "/mnt/mount")
+
+    # Get CIFS mount point
+    cifs_mount_point = config.get("mount_point", "/mnt/smb")
+
+    # Get sub directory path
+    sub_dir = config.get("sub_dir", "/volumes/smb/sv1")
+
+    # Get quota
+    quota = config.get("quota", "1000000")
+
+    # Get cleanup value, True if cleanup has to be done, False by default
+    smb_cluster_cleanup = config.get("smb_cluster_cleanup", False)
+
+    try:
+
+        # Mount smb share with cifs
+        smb_cifs_mount(
+            smb_nodes[0],
+            client,
+            smb_shares[0],
+            smb_user_name,
+            smb_user_password,
+            auth_mode,
+            domain_realm,
+            cifs_mount_point,
+        )
+
+        log.info("mount subvolume using kernel mount")
+        rc = samba_kernel_mount(client, mount_point, installer_node.ip_address, sub_dir)
+
+        if quota_operation == "set_and_get_quota":
+            log.info("Set quota and capacity on {}".format(mount_point))
+            set_quota_and_capacity(client, mount_point, quota)
+            log.info("Get quota and capacity on {}".format(mount_point))
+            get_quota_and_capacity(client, mount_point, quota)
+
+        elif quota_operation == "write_within_quota":
+            rc, err = client.exec_command(
+                sudo=True,
+                cmd=f"dd if=/dev/zero of={cifs_mount_point}/file1 bs=100M count=5",
+            )
+            if err:
+                raise OperationFailedError(
+                    f"Ceph Kernel Command failed with error: {err}"
+                )
+
+            log.info("Print Samba and container Info Samba Control")
+        elif quota_operation == "write_above_quota":
+            rc, err = client.exec_command(
+                sudo=True,
+                cmd=f"dd if=/dev/zero of={cifs_mount_point}/file1 bs=100M count=10",
+            )
+            if not err:
+                raise OperationFailedError(
+                    f"Ceph Kernel Command failed with error"
+                )
+
+            log.info("Print Samba and container Info Samba Control ")
+        elif quota_operation == "multiple_shares_quota":
+
+            log.info("Print Samba and container Info Samba Control ")
+        elif quota_operation == "delete_quota":
+
+            log.info("Print Samba and container Info Samba Control ")
+
+    except Exception as e:
+        log.error(f"Failed to perform quota operations {quota_operation} : {e}")
+        return 1
+    finally:
+        if smb_cluster_cleanup:
+            smb_cleanup(installer_node, smb_shares, smb_cluster_id)
+            client.exec_command(
+                sudo=True,
+                cmd=f"umount {cifs_mount_point}",
+            )
+            client.exec_command(sudo=True, cmd=f"rm -rf {cifs_mount_point}")
+
+        client.exec_command(
+            sudo=True,
+            cmd=f"umount {mount_point}",
+        )
+        client.exec_command(sudo=True, cmd=f"rm -rf {mount_point}")
+
+        return 0
+
+

--- a/tests/smb/smb_per_share_quota_capacity_setup.py
+++ b/tests/smb/smb_per_share_quota_capacity_setup.py
@@ -1,0 +1,108 @@
+import time
+
+from ceph.ceph import CommandFailed
+from cli.exceptions import OperationFailedError
+from smb_operations import (
+    deploy_smb_service_imperative,
+    smb_cleanup,
+    smb_cifs_mount, smbclient_check_shares,
+)
+
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+def run(ceph_cluster, **kw):
+    """Deploy samba with auth_mode 'user' using imperative style(CLI Commands)
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    # Get config
+    config = kw.get("config")
+
+    # Get cephadm obj
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+
+    # Get cephfs volume
+    cephfs_vol = config.get("cephfs_volume", "cephfs")
+
+    # Get smb subvloume group
+    smb_subvol_group = config.get("smb_subvolume_group", "smb")
+
+    # Get smb subvloumes
+    smb_subvols = config.get("smb_subvolumes", ["sv1", "sv2"])
+
+    # Get smb subvolume mode
+    smb_subvolume_mode = config.get("smb_subvolume_mode", "0777")
+
+    # Get smb cluster id
+    smb_cluster_id = config.get("smb_cluster_id", "smb1")
+
+    # Get auth_mode
+    auth_mode = config.get("auth_mode", "user")
+
+    # Get domain_realm
+    domain_realm = config.get("domain_realm", None)
+
+    # Get custom_dns
+    custom_dns = config.get("custom_dns", None)
+
+    # Get smb user name
+    smb_user_name = config.get("smb_user_name", "user1")
+
+    # Get smb user password
+    smb_user_password = config.get("smb_user_password", "passwd")
+
+    # Get smb shares
+    smb_shares = config.get("smb_shares", ["share1", "share2"])
+
+    # Get smb path
+    path = config.get("path", "/")
+
+    # Get installer node
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+
+    # Get smb nodes
+    smb_nodes = ceph_cluster.get_nodes("smb")
+
+    # get client node
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    # Check ctdb clustering
+    clustering = config.get("clustering", "default")
+
+    try:
+        # deploy smb services
+        deploy_smb_service_imperative(
+            installer,
+            cephfs_vol,
+            smb_subvol_group,
+            smb_subvols,
+            smb_subvolume_mode,
+            smb_cluster_id,
+            auth_mode,
+            smb_user_name,
+            smb_user_password,
+            smb_shares,
+            path,
+            domain_realm,
+            custom_dns,
+            clustering,
+        )
+        # Check smb share using smbclient
+        smbclient_check_shares(
+            smb_nodes,
+            client,
+            smb_shares,
+            smb_user_name,
+            smb_user_password,
+            auth_mode,
+            domain_realm,
+        )
+        log.info("Samba service is ready to test quota operations.")
+
+    except Exception as e:
+        log.error(f"Failed to deploy samba with auth_mode {auth_mode} : {e}")
+        return 1
+    return 0


### PR DESCRIPTION
# Description
Added new Testcases for Per Share Quota and Capacity
 
Test retrieve quota and capacity on volume when no quota is added.
Test set and retrieve quota and capacity on subvolume
Test write operation on share within quota limit on subvolume.
Test write operation on share above quota limit on subvolume.
Test set and retrieve quota and capacity on volume
Test write operation on share within quota limit on volume.
Test write operation on share above quota limit on volume.
Test write operation on multiple shares within quota limit on volume.
Test write operation on multiple shares within quota limit on subvolume.
Test delete quota and capacity on subvolume
Test delete quota and capacity on volume
