### PR TITLE
fixing rgw upgrade failures

### DIFF
--- a/suites/tentacle/rgw/test_ss_upgrade_7_1_GA_to_9.x_latest.yaml
+++ b/suites/tentacle/rgw/test_ss_upgrade_7_1_GA_to_9.x_latest.yaml
@@ -19,10 +19,12 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: released
+                release: rc
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/rgw/tier-1_rgw_archive_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_archive_ms_upgrade_81GA_to_9x_latest.yaml
@@ -21,11 +21,14 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-dashboard: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -67,11 +70,14 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-dashboard: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -113,11 +119,14 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-dashboard: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_81GA_to_9x_latest.yaml
@@ -31,6 +31,8 @@ tests:
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -77,6 +79,8 @@ tests:
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_71GA_to_9x_latest.yaml
@@ -27,12 +27,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -95,6 +98,9 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_81GA_to_9x_latest.yaml
@@ -26,12 +26,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -73,12 +76,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest.yaml
@@ -23,12 +23,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -79,12 +82,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
@@ -26,12 +26,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,12 +79,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
@@ -19,10 +19,12 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: released
+                release: rc
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_81GA_to_9x_latest.yaml
@@ -19,11 +19,13 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: released
+                release: rc
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -87,13 +87,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -153,13 +155,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -26,13 +26,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -92,13 +94,15 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: released
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
@@ -19,11 +19,13 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: released
+                release: rc
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -19,11 +19,13 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: released
+                release: rc
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
@@ -33,6 +33,8 @@ tests:
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host
@@ -81,6 +83,8 @@ tests:
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
                     skip-monitoring-stack: true
+                  base_cmd_args:
+                    verbose: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
@@ -24,6 +24,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
           - config:
               command: add_hosts
               service: host


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
Without verbose: true, the upgrade fails while upgrading the OSDs. Hence, verbose: true was added.

Passing logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/upgrade/20.2.1-273/rgw/23/logs/

latest logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/executor/20.2.1-290/rgw/1843/logs/test_ss_upgrade_7_1_GA_to_9_x_latest/
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/executor/20.2.1-290/rgw/1845/logs/tier_1_rgw_ms_upgrade_71GA_to_9x_latest/
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/executor/20.2.1-290/rgw/1847/logs/tier_1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest/

Note: without these changes the osd upgrade is struck 
