### PR TITLE
[RADOS] Add sanity test suite and pre-req support for Crimson-OSD

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -7544,3 +7544,40 @@ EOF"""
         ]
 
         return mount_path, device_path, created_pools
+
+    def setup_crimson_pre_req(self, **kwargs) -> None:
+        """
+        Setup Crimson pre-requisites for the cluster.
+
+        This method enables experimental Crimson features, allows Crimson OSD usage,
+        sets the default pool type to Crimson, and configures Crimson-specific thread settings.
+
+        Args:
+            crimson_seastar_num_threads (int, optional): Number of threads for Crimson Seastar.
+            crimson_alien_op_num_threads (int, optional): Number of threads for Crimson alienized objectstore.
+        """
+        crimson_seastar_num_threads = kwargs.get("crimson_seastar_num_threads", 1)
+        crimson_alien_op_num_threads = kwargs.get("crimson_alien_op_num_threads", 6)
+
+        log.info(
+            "Setting up Crimson pre-requisites for the cluster with the following parameters:"
+        )
+        log.info("Crimson Seastar number of threads: %s", crimson_seastar_num_threads)
+        log.info(
+            "Crimson Alien operation number of threads: %s",
+            crimson_alien_op_num_threads,
+        )
+
+        exp_cmds = [
+            "ceph config set global 'enable_experimental_unrecoverable_data_corrupting_features' crimson",
+            "ceph osd set-allow-crimson --yes-i-really-mean-it",
+            "ceph config set mon osd_pool_default_crimson true",
+        ]
+        cfg_cmds = [
+            f"ceph config set osd crimson_seastar_num_threads {crimson_seastar_num_threads}",
+            f"ceph config set osd crimson_alien_op_num_threads {crimson_alien_op_num_threads}",
+        ]
+        for cmd in exp_cmds + cfg_cmds:
+            self.node.shell([cmd])
+
+        log.info("Crimson pre-requisites setup completed.")

--- a/cephci/utils/build_info.py
+++ b/cephci/utils/build_info.py
@@ -29,6 +29,7 @@ class CephTestManifest:
         build_type: str,
         platform: str,
         datacenter: Optional[str] = None,
+        crimson: Optional[bool] = None,
     ) -> None:
         """Instance initialization.
 
@@ -38,6 +39,7 @@ class CephTestManifest:
             build_type  Refers to section in the manifest file to be read.
             platform    The base operating system.
             datacenter  The location where the tests are being executed.
+            crimson     Whether to use crimson osd image
         """
         if product not in self.SUPPORTED_PRODUCTS:
             raise RuntimeError("Unsupported product")
@@ -46,7 +48,7 @@ class CephTestManifest:
         self._release: str = release
         self._build_type: str = build_type
         self._platform: str = platform
-
+        self._crimson: bool = crimson or False
         if datacenter is None:
             # Retrieve from config
             try:
@@ -125,16 +127,22 @@ class CephTestManifest:
         return self.build_info["images"]["ceph-base"]
 
     @property
+    def crimson_image(self) -> str:
+        return self.images.get("crimson_image", "")
+
+    @property
     def ceph_image_dtr(self) -> str:
         return self.ceph_image.split("/")[0]
 
     @property
     def ceph_image_tag(self) -> str:
+        if self._crimson:
+            return self.crimson_image.split(":")[-1]
         return self.ceph_image.split(":")[-1]
 
     @property
     def ceph_image_path(self) -> str:
-        _image_fqdn = self.ceph_image
+        _image_fqdn = self.crimson_image if self._crimson else self.ceph_image
         _image_without_dtr = _image_fqdn.split("/", 1)[1]
         return _image_without_dtr.split(":")[0]
 

--- a/run.py
+++ b/run.py
@@ -623,6 +623,7 @@ def run(args):
     ibm_build = False
     # disable coredump collection by default
     collect_coredump = False
+    crimson = False
 
     # Custom or override configurations
     kernel_repo = args.get("--kernel-repo")
@@ -646,6 +647,9 @@ def run(args):
 
             product = "ibm"
 
+    if "crimson" in custom_config_dict.keys():
+        crimson = bool(custom_config_dict["crimson"])
+
     # Setting to released by default is not right as there is case wherein it
     # would be unavailable. Hence switching accordingly to released or nightly.
     if build == "released":
@@ -657,7 +661,9 @@ def run(args):
             build = "nightly"
 
     # Now handle the manifest. At this point we are allowing failures
-    ctm: CephTestManifest = CephTestManifest(product, release, build, platform)
+    ctm: CephTestManifest = CephTestManifest(
+        product, release, build, platform, crimson=crimson
+    )
 
     base_url = args.get("--rhs-ceph-repo")
     docker_registry = args.get("--docker-registry")

--- a/suites/tentacle/rados/tier-2_rados_crimson_sanity.yaml
+++ b/suites/tentacle/rados/tier-2_rados_crimson_sanity.yaml
@@ -1,0 +1,292 @@
+# Suite contains basic tier-2 rados tests for Crimson sanity
+# conf - conf/tentacle/rados/4-node-ec-cluster-1-client.yaml
+# RHOS-d run duration:
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: Setup Crimson pre-requisites
+      module: rados_prep.py
+      config:
+        setup-crimson-pre-req: true
+      desc: Setup Crimson pre-requisites for the cluster
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  # TODO: Uncomment this test when the bug is fixed
+  # Bug:
+  # - test:
+  #     name: OSD Fragmentation tests
+  #     polarion-id: CEPH-83607852
+  #     module: test_fragmentation_warnings.py
+  #     desc: Generate Fragmentation on OSDs and verify health warning + logs
+
+  # TODO: Uncomment this test when the bug is fixed
+  # Bug:
+  # - test:
+  #     name: OSD addition on an unavailable disk
+  #     desc: Add new OSD on an pre-occupied OSD disk
+  #     module: test_add_new_osd.py
+  #     polarion-id: CEPH-83574780
+
+  # TODO: Uncomment this test when the bug is fixed
+  # Bug:
+  # - test:
+  #     name: replacement of OSD
+  #     module: test_osd_replacement.py
+  #     polarion-id: CEPH-83572702
+  #     desc: Replace an OSD by retaining its ID
+
+  - test:
+      name: Test ceph osd command arguments
+      desc: Provide invalid values as argument to different ceph osd commands
+      module: test_osd_args.py
+      polarion-id: CEPH-10417
+      config:
+        cmd_list:
+          - "reweight-by-pg"
+          - "reweight-by-utilization"
+          - "test-reweight-by-pg"
+          - "test-reweight-by-utilization"
+
+  - test:
+      name: Verify Ceph df MAX_AVAIL
+      desc: MAX_AVAIL value should not change to 0 upon addition of OSD with weight 0
+      module: test_cephdf.py
+      polarion-id: CEPH-10312
+      config:
+        verify_cephdf_max_avail:
+          create_pool: true
+          pool_name: test-max-avail
+          obj_nums: 5
+          delete_pool: true
+
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 300
+          rados_read_duration: 10
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571671
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 300
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 300
+          rados_read_duration: 10
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.

--- a/tests/rados/rados_prep.py
+++ b/tests/rados/rados_prep.py
@@ -295,5 +295,8 @@ def run(ceph_cluster, **kw):
             f"Completed check of fragmentation & min-alloc scores on OSDs : {pg_set}. Pass"
         )
 
+    if config.get("setup-crimson-pre-req"):
+        rados_obj.setup_crimson_pre_req(**config)
+
     log.info("All the test cases have been completed. Pass")
     return 0


### PR DESCRIPTION
Included a new test suite specifically for Crimson automated testing.

Introduces a new method to handle Crimson pre-requisite steps necessary for smoother OSD installation until seastar OSD backend is released with Ceph 10.x

Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3YSS60

Signed-off-by: Harsh Kumar <hakumar@redhat.com>