### PR TITLE
nfs: fix root-squash lock marker wait on client 1

### DIFF
--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -180,7 +180,7 @@ def run(ceph_cluster, **kw):
             original_squash_value,
             new_squash_value,
         )
-        sleep(5)
+        sleep(90)  # allow Ganesha to finish grace after export apply
 
     except Exception as e:
         log.error(f"Failed to setup nfs cluster with rootsquash enabled : Error - {e}")
@@ -220,7 +220,7 @@ def run(ceph_cluster, **kw):
         c1.start()
         try:
             wait_for_lock_holder_ready(
-                clients[1], f"{nfs_squash_mount}/{LOCK_READY_FILENAME}"
+                clients[0], f"{nfs_squash_mount}/{LOCK_READY_FILENAME}"
             )
         except Exception as e:
             log.error(f"Lock setup sync failed: {e}")


### PR DESCRIPTION
nfs_verify_file_lock_root_squash.py (Nfs Verify locks over nfs mount with root_squash enabled)

The test failed with:
Lock setup sync failed: Timeout waiting for lock holder marker /mnt/nfs_squash/.cephci_nfs_lock_ready

Root cause:
Marker polled on the wrong client: The sync step waited for .cephci_nfs_lock_ready on client 2, but client 1 creates the file after taking flock. Client 2 never saw the marker within the 90s timeout even though client 1’s lock script was running.

Timing after ceph nfs export apply: Enabling rootsquash reloads NFS-Ganesha and starts an NFS grace period (Ganesha logs: NFS Server Now IN GRACE, duration 90). The lock test started too soon after export apply, while clients still used pre-reload mounts.

Fixes made:
1)Polling .cephci_nfs_lock_ready on client 1 (the lock holder) instead of client 2, so the test only checks that client 1 created the marker locally and does not rely on client 2 seeing that file over NFS.

2)Replaced sleep(5) with sleep(90) after applying the rootsquash export config, so the lock test starts after Ganesha’s grace period (logged as duration 90) following export reload.

Manual Executor logs of the run that passed:
https://10.8.128.2/cephci-jenkins/ibm-cos//RH/7.1/rhel-9/executor/18.2.1-398/nfs/121/logs/tier0_nfs_ganesha/