### PR TITLE
Fixes for TLS tests on RHEL 10.2

### DIFF
--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -234,7 +234,7 @@ def setup_tls_client(client_node, ca_cert):
     Package(client_node).install("ktls-utils")
 
     log.info("Configuring tlshd on client node %s", client_node.hostname)
-    cert_dir = "/cert/tls"
+    cert_dir = "/etc/pki/ca-trust/source/anchors"
     cert_path = f"{cert_dir}/tls_ca_cert.pem"
     client_node.exec_command(sudo=True, cmd=f"mkdir -p {cert_dir}")
 
@@ -259,9 +259,13 @@ def setup_tls_client(client_node, ca_cert):
     client_node.exec_command(
         sudo=True, cmd="sed -i '/x509.truststore/d' /etc/tlshd.conf", check_ec=False
     )
-    tlshd_conf_adds = f"\n[authenticate.client]\nx509.truststore= {cert_path}\n"
+    # keep strict formatting for tlshd parser: no leading spaces around '='
+    tlshd_conf_adds = f"\n[authenticate.client]\nx509.truststore={cert_path}\n"
     client_node.exec_command(
         sudo=True, cmd=f"echo '{tlshd_conf_adds}' >> /etc/tlshd.conf"
+    )
+    client_node.exec_command(
+        sudo=True, cmd=f"restorecon -Rv {cert_dir}", check_ec=False
     )
 
     log.info("Restarting tlshd on %s", client_node.hostname)


### PR DESCRIPTION
## Summary
This PR fixes TLS client truststore handling for NFS TLS tests on RHEL 10.2.
### What changed
- Updated TLS CA truststore path in `setup_tls_client()`:
  - from `/cert/tls/tls_ca_cert.pem`
  - to `/etc/pki/ca-trust/source/anchors/tls_ca_cert.pem`
- Fixed `tlshd.conf` formatting to avoid parser issues:
  - from `x509.truststore= /path`
  - to `x509.truststore=/path`
- Added SELinux relabel step after writing the CA file:
  - `restorecon -Rv /etc/pki/ca-trust/source/anchors` (best-effort)
  
  Pass Logs: 
  https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-280/nfs/1689/logs/tier1_nfs_ganesha/