### PR TITLE
Fix A signature was required, but no signature exists eroor in 10.2

### DIFF
--- a/conf/inventory/ibm-eu-rhel-10.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2.yaml
@@ -85,6 +85,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+            - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser

--- a/conf/inventory/ibm-eu-rhel-9.8.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8.yaml
@@ -85,6 +85,41 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+            - content: |
+          PermitRootLogin yes
+        path: /etc/ssh/sshd_config.d/50-cephci.conf
+        owner: root:root
+        permissions: '0644'
+            - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser


### PR DESCRIPTION
# Description

Fixes the issue with Upgrades:

`Trying to pull registry.redhat.io/rhceph/rhceph-7-rhel9:latest...
Error: unable to copy from source docker://registry.redhat.io/rhceph/rhceph-7-rhel9:latest: Source image rejected: A signature was required, but no signature exists
 and code 125`
