### PR TITLE
fix(bootstrap): align registry credentials with image registry host

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -31,6 +31,17 @@ __DEFAULT_KEYRING_PATH = "/etc/ceph/ceph.client.admin.keyring"
 __DEFAULT_SSH_PATH = "/etc/ceph/ceph.pub"
 
 
+def _detect_registry_tier(registry: str, build_type: str) -> str:
+    """Return credential tier (cdn/stage) from registry host, else from build_type."""
+    if not registry:
+        return "cdn" if build_type in ("released", "cdn") else "stage"
+    if "registry.redhat.io" in registry or "cp.icr.io" in registry:
+        return "cdn"
+    if "registry.stage.redhat.io" in registry or "cp.stg.icr.io" in registry:
+        return "stage"
+    return "cdn" if build_type in ("released", "cdn") else "stage"
+
+
 def construct_registry(
     cls,
     registry: str,
@@ -48,6 +59,9 @@ def construct_registry(
         ibm_build: flag to fetch IBM registry creds
         build_type: CLI build type (released|cdn|stage|nightly etc.)
 
+    Registry tier is chosen from the registry hostname when it matches a known
+    RH/IBM host; otherwise build_type is used (released/cdn -> cdn, else stage).
+
     Example::
 
         json_file:
@@ -61,9 +75,15 @@ def construct_registry(
     _vendor = "ibm" if ibm_build else "rh"
 
     _config = get_cephci_config()
-
-    # Determine the registry tier: "cdn" for released/cdn builds, "stage" otherwise
-    _tier = "cdn" if build_type in ("released", "cdn") else "stage"
+    _reg = registry if registry else ""
+    _tier = _detect_registry_tier(_reg, build_type)
+    logger.debug(
+        "Registry tier selection: registry=%r tier=%r build_type=%r vendor=%r",
+        _reg,
+        _tier,
+        build_type,
+        _vendor,
+    )
 
     # Prefer the nested credentials.registry.<vendor>.<tier> path which
     # carries separate entries for cdn (cp.icr.io) vs stage (cp.stg.icr.io).
@@ -77,7 +97,7 @@ def construct_registry(
             f"{_vendor}_registry_credentials", _config["cdn_credentials"]
         )
     reg_args = {
-        "registry-url": cdn_cred.get("registry", registry),
+        "registry-url": registry or cdn_cred.get("registry"),
         "registry-username": cdn_cred.get("username"),
         "registry-password": cdn_cred.get("password"),
     }
@@ -321,7 +341,6 @@ class BootstrapMixin:
             else:
                 image_registry = self.config["container_image"].split("/")[0]
 
-            # If using stage or production registry, auto-add credentials
             if (
                 "registry.stage.redhat.io" in image_registry
                 or "registry.redhat.io" in image_registry


### PR DESCRIPTION
<h2 class="mt-6 [mb-2](https://redhat.atlassian.net/browse/mb-2) font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; --tw-font-weight: 600; font-weight: 590; line-height: 1.42; font-size: 1.428em; margin-top: 16px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When bootstrap uses a custom image from a container registry,<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">construct_registry()</code><span> </span>should use credentials for<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">that</span><span> </span>registry (CDN vs stage), not only from the job’s<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">build_type</code>.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Previously, tier selection used<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">build_type</code><span> </span>(<code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">released</code><span> </span>/<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cdn</code><span> </span>→ CDN, else → stage), and<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">--registry-url</code><span> </span>could come from config instead of the registry parsed from the image. That breaks whenever the image registry and job<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">build_type</code><span> </span>disagree—for example baseline deploys with<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">rhcs-version</code><span> </span>+<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">release: rc|released</code><span> </span>while the job runs as nightly/upgrade/stable, or any suite that passes a CDN image with a non-released<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">build_type</code>.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This change picks the credential tier from the registry hostname when it is a known RH/IBM registry, and prefers the image-derived registry for<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">--registry-url</code>.</p><hr class="my-6 border-border" data-streamdown="horizontal-rule" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 16px 0px; border-right: none; border-bottom: none; border-left: none; border-image: initial; border-top: 1px solid color(srgb 0.894118 0.894118 0.894118 / 0.0737255); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 class="mt-6 [mb-2](https://redhat.atlassian.net/browse/mb-2) font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; --tw-font-weight: 600; font-weight: 590; line-height: 1.42; font-size: 1.428em; margin-top: 16px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Bootstrap could run with mismatched image and credentials:</p><div class="ui-scroll-area" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; --scroll-area-scroll-padding: 4px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain auto; scrollbar-width: none !important;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
Source | Example
-- | --
Image | registry.redhat.io/rhceph/rhceph-7-rhel9:7.1-1
--registry-url | registry.stage.redhat.io (from config)
Credential tier | stage (from build_type)

</div></div></div><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Result:<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">podman pull</code><span> </span>against<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-filename">registry.redhat.io</span></code><span> </span>with stage auth / wrong<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">--registry-url</code>.</p><hr class="my-6 border-border" data-streamdown="horizontal-rule" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 16px 0px; border-right: none; border-bottom: none; border-left: none; border-image: initial; border-top: 1px solid color(srgb 0.894118 0.894118 0.894118 / 0.0737255); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 class="mt-6 [mb-2](https://redhat.atlassian.net/browse/mb-2) font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; --tw-font-weight: 600; font-weight: 590; line-height: 1.42; font-size: 1.428em; margin-top: 16px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">construct_registry()</code></span></p><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: disc; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Derive<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cdn</code><span> </span>vs<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">stage</code><span> </span>from the registry host when it matches known RH/IBM registries; otherwise keep the existing<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">build_type</code><span> </span>fallback.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Set<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">--registry-url</code><span> </span>to the registry passed in (e.g. from image auto-detect), not the config default when both are present.</li></ul><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">bootstrap()</code></span></p><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: disc; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Existing behavior unchanged: auto-detect registry via<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">image.split("/")[0]</code><span> </span>for Red Hat registries and pass it into<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); color: color(srgb 0.894118 0.894118 0.894118 / 0.866275); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">construct_registry()</code>.</li></ul>