### PR TITLE
Modify interop script to use the released tag by default

### DIFF
--- a/pipeline/scripts/interop/test-ceph-features.sh
+++ b/pipeline/scripts/interop/test-ceph-features.sh
@@ -13,7 +13,7 @@ PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
 OSP_CRED_FILE=${OSP_CRED_FILE:-}
 REPO_FILE=${REPO_FILE:-}
 VM_SPEC=${VM_SPEC:-}
-BUILD_TYPE=${BUILD_TYPE:-"rc"}
+BUILD_TYPE=${BUILD_TYPE:-"released"}
 RHCS_VERSION=${RHCS_VERSION:-}
 
 echo "Red Hat Ceph Storage sanity test suite execution."


### PR DESCRIPTION
# Description
Modify interop script to use the released tag by default.

Update the interop script to pick the GAed Ceph version from the
manifest using the `released` tag. This ensures the script defaults
to stable, generally available Ceph releases

