### PR TITLE
fix(inventory): add podman container policy to fix cephadm bootstrap on eu-de RHEL 9.8 and 10.2

### DIFF
--- a/conf/inventory/ibm-eu-rhel-10.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2.yaml
@@ -85,6 +85,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser

--- a/conf/inventory/ibm-eu-rhel-9.8.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8.yaml
@@ -85,6 +85,36 @@ instance:
         path: /etc/ssh/sshd_config.d/50-cephci.conf
         owner: root:root
         permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
 
     groups:
       - cephuser


### PR DESCRIPTION
`Summary`
Bootstrap on IBM eu-de lab VMs using RHEL 9.8 and RHEL 10.2 inventory can fail during cephadm bootstrap even when registry credentials are correct. Podman rejects pulls from registry.redhat.io because fresh nodes do not have container image signature trust configured:

Error: unable to copy from source docker://registry.redhat.io/rhceph/rhceph-7-rhel9:7.1-1:
Source image rejected: A signature was required, but no signature exists
This PR adds /etc/containers/policy.json via cloud-init in the 9.8 and 10.2 eu-de inventory files, matching the policy already used on 9.7 and other IBM eu-de images.

Note: please refer previously merged [PR](https://github.com/red-hat-storage/cephci/pull/5679) which was added to same issue with rhel-10.1 and 9.7

Test Log: https://149.81.216.83/job/tentacle-dmfg-upgrade-ci/61/
