### PR TITLE
NFS - Delegation - Including system and scale tests

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml
@@ -587,7 +587,22 @@ tests:
   - test:
       name: NFSv4 delegation revoke and recall multi-client
       module: nfs_verify_delegation_revoke_recall.py
-      desc: Multi-client read-read (no recall), write-write and write-read (recall); validate Ganesha delegation recall logs.
+      desc: >-
+        Multi-client recall (read/read, write/write, write-then-read) and revoke
+      polarion-id: CEPH-83632377
+      abort-on-fail: false
+      config:
+        nfs_name: cephfs-nfs
+        auto_create_nfs_cluster: true
+        clients: 2
+        delegation_exit_wait_seconds: 120
+        delegation_log_settle_seconds: 90
+        delegation_return_wait_seconds: 15
+
+  - test:
+      name: NFSv4 delegation conflict recall multi-client
+      module: nfs_verify_delegation_conflict_scenarios.py
+      desc: READ/WRITE delegation recalled on SETATTR, REMOVE, RENAME, and cross-mode write conflicts.
       polarion-id: CEPH-83632377
       abort-on-fail: false
       config:
@@ -598,14 +613,39 @@ tests:
         delegation_log_settle_seconds: 90
 
   - test:
-      name: NFSv4 delegation conflict recall multi-client
-      module: nfs_verify_delegation_conflict_scenarios.py
-      desc: READ/WRITE delegation recalled on SETATTR, REMOVE, RENAME, and cross-mode write conflicts; validate Ganesha recall logs.
-      polarion-id: CEPH-83632377
+      name: NFSv4 delegation file operations under delegation
+      module: nfs_verify_delegation_file_operations.py
+      desc: >-
+        Open/close cycles, read-write IO with recall, lock/unlock, and
+        setattr/truncate while NFSv4 delegations are held.
+      polarion-id: CEPH-83632379
       abort-on-fail: false
       config:
         nfs_name: cephfs-nfs
         auto_create_nfs_cluster: true
         clients: 2
+        hold_mode: write
+        delegation_exit_wait_seconds: 120
+        delegation_hold_ready_seconds: 8
+        delegation_log_settle_seconds: 90
+        open_close_cycles: 5
+        lock_wait_seconds: 15
+
+  - test:
+      name: NFSv4 delegation stress and scale scenarios
+      module: nfs_verify_delegation_stress_scenarios.py
+      desc: >-
+        Up to 4 clients and 5 mounts per client run mixed read/write IO; cross-client
+        writes on a shared file trigger recalls.
+      polarion-id: CEPH-83632381
+      abort-on-fail: false
+      config:
+        nfs_name: cephfs-nfs
+        auto_create_nfs_cluster: true
+        clients: 4
+        mounts_per_client: 5
+        workload_duration_seconds: 180
+        conflict_interval_seconds: 45
+        strict_log_validation: false
         delegation_exit_wait_seconds: 120
         delegation_log_settle_seconds: 90

--- a/tests/nfs/nfs_delegation_operations.py
+++ b/tests/nfs/nfs_delegation_operations.py
@@ -17,7 +17,17 @@ import json
 import os
 import re
 import time
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from nfs_operations import setup_nfs_cluster, verify_nfs_ganesha_service
 
@@ -70,6 +80,8 @@ SUPPORTED_DELEGATIONS = frozenset({"rw", "ro", "none"})
 # Ganesha log validation (compiled once; used by scenario test modules).
 RE_DELEGATION_RECALLING = re.compile(r"Recalling", re.I)
 RE_DELEGATION_RECALLED = re.compile(r"successfully recalled", re.I)
+RE_DELEGATION_REVOKING = re.compile(r"Revoking", re.I)
+RE_DELEGATION_DELEGRETURN = re.compile(r"DELEGRETURN|OP_DELEGRETURN", re.I)
 RE_DELEGATION_ATTEMPT_GRANT = re.compile(r"Attempting to grant delegation", re.I)
 RE_DELEGATION_TYPE_NOT_SUPPORTED = re.compile(r"Delegation type not supported", re.I)
 RE_DELEGATION_TYPE_VALUE = re.compile(r"delegation_type\s+(\d+)", re.I)
@@ -96,12 +108,186 @@ DELEGATION_EXIT_WAIT_SECONDS_DEFAULT = 120
 DELEGATION_HOLD_SECONDS_DEFAULT = 120
 # After starting the hold OPEN, before peer IO, so grant can complete asynchronously.
 DELEGATION_HOLD_READY_SECONDS_DEFAULT = 8
+# After client A returns a delegation, before peer conflict IO (revoke scenarios).
+DELEGATION_RETURN_WAIT_SECONDS_DEFAULT = 15
 # After scenario IO: wait for recall/grant lines in the filtered ganesha.log capture.
 DELEGATION_LOG_SETTLE_SECONDS_DEFAULT = 90
 # clamp_delegation_log_settle_seconds() bounds when callers use that helper.
 DELEGATION_LOG_SETTLE_SECONDS_CLAMP_LO = 75
 DELEGATION_LOG_SETTLE_SECONDS_CLAMP_HI = 90
 DELEGATION_LOG_SETTLE_FALLBACK_DEFAULT = 82
+# Poll attempts when waiting for a seeded file to appear on an NFS mount.
+DELEGATION_PATH_WAIT_RETRIES_DEFAULT = 40
+
+# Loose stress capture: grant-ish and recall/return-ish line patterns.
+RE_DELEGATION_STRESS_GRANT_ACTIVITY = re.compile(
+    r"Attempting to grant delegation|delegation_type|do_delegation", re.I
+)
+RE_DELEGATION_STRESS_RECALL_ACTIVITY = re.compile(
+    r"Recalling|successfully recalled|DELEGRETURN|OP_DELEGRETURN|Revoking", re.I
+)
+
+
+class DelegationTiming(NamedTuple):
+    """Unified delegation timing values parsed from a suite config mapping."""
+
+    exit_wait_seconds: int
+    hold_seconds: int
+    hold_ready_seconds: int
+    return_wait_seconds: int
+    log_settle_seconds: int
+    path_wait_retries: int
+
+
+def delegation_timing_from_config(config: Mapping[str, Any]) -> DelegationTiming:
+    """
+    Parse common delegation timing keys from a cephci suite ``config`` mapping.
+
+    Keys: ``delegation_exit_wait_seconds``, ``delegation_hold_seconds``,
+    ``delegation_hold_ready_seconds``, ``delegation_return_wait_seconds``,
+    ``delegation_log_settle_seconds``, ``path_wait_retries``.
+    """
+    cfg = config or {}
+    timing = DelegationTiming(
+        exit_wait_seconds=int(
+            cfg.get(
+                "delegation_exit_wait_seconds", DELEGATION_EXIT_WAIT_SECONDS_DEFAULT
+            )
+        ),
+        hold_seconds=int(
+            cfg.get("delegation_hold_seconds", DELEGATION_HOLD_SECONDS_DEFAULT)
+        ),
+        hold_ready_seconds=int(
+            cfg.get(
+                "delegation_hold_ready_seconds",
+                DELEGATION_HOLD_READY_SECONDS_DEFAULT,
+            )
+        ),
+        return_wait_seconds=int(
+            cfg.get(
+                "delegation_return_wait_seconds",
+                DELEGATION_RETURN_WAIT_SECONDS_DEFAULT,
+            )
+        ),
+        log_settle_seconds=int(
+            cfg.get(
+                "delegation_log_settle_seconds", DELEGATION_LOG_SETTLE_SECONDS_DEFAULT
+            )
+        ),
+        path_wait_retries=int(
+            cfg.get("path_wait_retries", DELEGATION_PATH_WAIT_RETRIES_DEFAULT)
+        ),
+    )
+    log.info(
+        "delegation timing: exit_wait=%ss hold=%ss ready=%ss return_wait=%ss "
+        "settle=%ss path_retries=%s",
+        timing.exit_wait_seconds,
+        timing.hold_seconds,
+        timing.hold_ready_seconds,
+        timing.return_wait_seconds,
+        timing.log_settle_seconds,
+        timing.path_wait_retries,
+    )
+    return timing
+
+
+def q_delegation_shell(s: str) -> str:
+    """Quote *s* for embedding in remote ``bash -c '...'`` commands."""
+    return s.replace("'", "'\"'\"'")
+
+
+def write_delegation_file(
+    client: CephNode, path: str, content: str, append: bool = False
+) -> None:
+    """
+    Write *content* to *path* on *client* using remote python3.
+
+    Avoids shell ``echo`` interpolation of user-controlled text.
+    """
+    mode = "a" if append else "w"
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "python3 <<'PY'\n"
+            "path = %r\n"
+            "content = %r\n"
+            "with open(path, '%s') as f:\n"
+            "    f.write(content)\n"
+            "import os\n"
+            "os.sync()\n"
+            "PY" % (path, content, mode)
+        ),
+    )
+    log.info(
+        "wrote delegation file %s on %s (append=%s, bytes=%d)",
+        path,
+        getattr(client, "hostname", client),
+        append,
+        len(content),
+    )
+
+
+def delegation_path_exists(client: CephNode, path: str) -> bool:
+    """Return True if *path* exists as a regular file on *client*."""
+    client.exec_command(sudo=True, cmd="test -f %s" % path, check_ec=False)
+    return int(getattr(client, "exit_status", 1)) == 0
+
+
+def wait_for_delegation_path(
+    client: CephNode, path: str, label: str, retries: Optional[int] = None
+) -> None:
+    """
+    Poll until *path* is visible on *client*.
+
+    Raises:
+        OperationFailedError: if *path* is not visible after *retries* attempts.
+    """
+    if retries is None:
+        retries = DELEGATION_PATH_WAIT_RETRIES_DEFAULT
+    parent = path.rsplit("/", 1)[0] or "/"
+    for n in range(1, int(retries) + 1):
+        client.exec_command(sudo=True, cmd="ls -la %s" % parent, check_ec=False)
+        if delegation_path_exists(client, path):
+            log.info("%s: %s visible (attempt %d)", label, path, n)
+            return
+        time.sleep(1)
+    raise OperationFailedError(
+        "%s: %s not visible on %s" % (label, path, client.hostname)
+    )
+
+
+def validate_delegation_stress_loose_capture(hits: Iterable[str]) -> None:
+    """
+    Validate post-IO capture contains delegation grant and recall/return markers.
+
+    Used by stress/scale tests when ``strict_log_validation`` is false.
+    """
+    text = "\n".join(hits or [])
+    if not text.strip():
+        raise OperationFailedError("empty ganesha tail capture after stress IO")
+    if not RE_DELEGATION_STRESS_GRANT_ACTIVITY.search(text):
+        raise OperationFailedError(
+            "no delegation grant activity in ganesha capture after IO"
+        )
+    if not RE_DELEGATION_STRESS_RECALL_ACTIVITY.search(text):
+        raise OperationFailedError(
+            "no recall/return activity in ganesha capture after IO"
+        )
+    log.info("stress capture: grant and recall/return activity present")
+
+
+def validate_delegation_stress_strict_capture(
+    hits: Iterable[str], hold_mode: str = "write"
+) -> None:
+    """
+    Strict stress validation: write/read grant plus completed recall in capture.
+
+    Used when suite config sets ``strict_log_validation: true``.
+    """
+    hit_list = list(hits or [])
+    validate_delegation_grant_capture("delegation_stress", hit_list, hold_mode)
+    validate_delegation_recall_ganesha_capture("delegation_stress", hit_list, True)
+    log.info("stress capture: strict grant and recall validation passed")
 
 
 def parse_nfs4_open_delegation_types(window_text):
@@ -135,6 +321,113 @@ def validate_delegation_recall_ganesha_capture(scenario_name, hits, expect_recal
         raise OperationFailedError(
             "Scenario %s: unexpected recall in ganesha.log" % scenario_name
         )
+
+
+def _hits_after_last_delegreturn(hits):
+    """Return capture lines following the last DELEGRETURN/OP_DELEGRETURN marker."""
+    last_idx = -1
+    for idx, ln in enumerate(hits or []):
+        if RE_DELEGATION_DELEGRETURN.search(ln):
+            last_idx = idx
+    if last_idx < 0:
+        return hits or []
+    return (hits or [])[last_idx + 1 :]
+
+
+def count_nfs4_open_end_markers(hits):
+    """Count ``END OF nfs4_op_open`` lines in a log capture."""
+    return sum(1 for ln in (hits or []) if NFS4_OP_OPEN_END_MARKER in ln)
+
+
+def validate_delegation_grant_capture(scenario_name, hits, hold_mode="write"):
+    """Assert a read/write delegation was granted in *hits*."""
+    if not hits:
+        raise OperationFailedError("Scenario %s: empty tail -f capture" % scenario_name)
+    text = "\n".join(hits)
+    if not RE_DELEGATION_ATTEMPT_GRANT.search(text):
+        raise OperationFailedError(
+            "Scenario %s: missing 'Attempting to grant delegation'" % scenario_name
+        )
+    expected = 5 if hold_mode == "write" else 4
+    types = parse_nfs4_open_delegation_types(text)
+    if expected not in types:
+        raise OperationFailedError(
+            "Scenario %s: expected delegation_type %s, parsed %r"
+            % (scenario_name, expected, types)
+        )
+
+
+def validate_delegation_open_close_cycles_capture(
+    scenario_name, hits, open_close_cycles, hold_mode="write"
+):
+    """Delegation held; extra OPEN RPCs stay bounded during local open/close cycles."""
+    validate_delegation_grant_capture(scenario_name, hits, hold_mode)
+    opens = count_nfs4_open_end_markers(hits)
+    max_allowed = int(open_close_cycles) + 2
+    if opens > max_allowed:
+        raise OperationFailedError(
+            "Scenario %s: saw %d nfs4_op_open END lines (expected <= %d for %d local cycles)"
+            % (scenario_name, opens, max_allowed, open_close_cycles)
+        )
+
+
+def validate_delegation_rw_io_recall_capture(scenario_name, hits, hold_mode="write"):
+    """Delegated IO on client A, recall from client B, grant on delegated path."""
+    validate_delegation_recall_ganesha_capture(scenario_name, hits, True)
+    validate_delegation_grant_capture(scenario_name, hits, hold_mode)
+
+
+def validate_delegation_lock_capture(scenario_name, hits, hold_mode="write"):
+    """Delegation grant with locks; optional recall if peer IO follows lock conflict."""
+    validate_delegation_grant_capture(scenario_name, hits, hold_mode)
+    text = "\n".join(hits or [])
+    if RE_DELEGATION_RECALLING.search(text):
+        validate_delegation_recall_ganesha_capture(scenario_name, hits, True)
+
+
+def validate_delegation_setattr_capture(scenario_name, hits, hold_mode="write"):
+    """Delegation grant during setattr/truncate metadata operations."""
+    validate_delegation_grant_capture(scenario_name, hits, hold_mode)
+
+
+def validate_delegation_revoke_ganesha_capture(
+    scenario_name, hits, expect_revoke, require_delegreturn=True
+):
+    """Validate revoke path in tail -f capture."""
+    if not hits:
+        raise OperationFailedError("Scenario %s: empty tail -f capture" % scenario_name)
+    text = "\n".join(hits)
+    if expect_revoke:
+        if not RE_DELEGATION_RECALLING.search(text):
+            raise OperationFailedError(
+                "Scenario %s: missing 'Recalling' in capture (revoke path)"
+                % scenario_name
+            )
+        if not (
+            RE_DELEGATION_REVOKING.search(text) or RE_DELEGATION_RECALLED.search(text)
+        ):
+            raise OperationFailedError(
+                "Scenario %s: missing 'Revoking' or 'successfully recalled' "
+                "(delegation not revoked after unresponsive client)" % scenario_name
+            )
+    else:
+        if require_delegreturn and not RE_DELEGATION_DELEGRETURN.search(text):
+            raise OperationFailedError(
+                "Scenario %s: missing DELEGRETURN before peer IO" % scenario_name
+            )
+        peer_hits = (
+            _hits_after_last_delegreturn(hits) if require_delegreturn else (hits or [])
+        )
+        peer_text = "\n".join(peer_hits)
+        if (
+            RE_DELEGATION_RECALLING.search(peer_text)
+            or RE_DELEGATION_REVOKING.search(peer_text)
+            or RE_DELEGATION_RECALLED.search(peer_text)
+        ):
+            raise OperationFailedError(
+                "Scenario %s: unexpected recall/revoke after DELEGRETURN "
+                "(delegation should have been returned before conflict)" % scenario_name
+            )
 
 
 def validate_delegation_ganesha_window(delegation_mode, window_text):
@@ -381,7 +674,7 @@ def _delegation_hold_pidfile(client: CephNode) -> str:
 
 
 def _q_delegation_hold_path(path: str) -> str:
-    return path.replace("'", "'\"'\"'")
+    return q_delegation_shell(path)
 
 
 def hold_delegation_open(client: CephNode, path: str, mode: str, seconds: int) -> None:
@@ -412,6 +705,38 @@ def kill_delegation_holds(client: CephNode) -> None:
         % (pidfile, pidfile, pidfile),
         check_ec=False,
     )
+
+
+def release_delegation_hold_gracefully(
+    client: CephNode, term_wait_seconds: int = 5
+) -> None:
+    """SIGTERM hold OPEN processes so NFS CLOSE/DELEGRETURN can complete."""
+    pidfile = _delegation_hold_pidfile(client)
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "if [ -f %s ]; then while read -r pid; do "
+            '[ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null || true; '
+            "done < %s; fi"
+        )
+        % (pidfile, pidfile),
+        check_ec=False,
+    )
+    time.sleep(int(term_wait_seconds))
+    kill_delegation_holds(client)
+
+
+def wait_for_delegreturn_in_ganesha_capture(
+    nfs_node, container_id, timeout_seconds: int = 45
+) -> bool:
+    """Poll filtered tail capture until DELEGRETURN appears or *timeout_seconds* elapses."""
+    deadline = time.time() + int(timeout_seconds)
+    while time.time() < deadline:
+        hits = read_ganesha_delegation_tailf_capture(nfs_node, container_id)
+        if RE_DELEGATION_DELEGRETURN.search("\n".join(hits or [])):
+            return True
+        time.sleep(2)
+    return False
 
 
 def ensure_nfs_cluster_for_delegation_test(
@@ -589,6 +914,61 @@ def set_cluster_delegation(cmd_host, delegation):
     )
 
 
+def wait_for_nfs_cluster_daemons_running(
+    cephadm,
+    nfs_clusters: Sequence[str],
+    timeout_seconds: int = 300,
+    interval: int = 5,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Poll `ceph orch ps` until every nfs daemon is running with a container_id.
+
+    `verify_nfs_ganesha_service` uses aggregate `orch ls` counts, which can
+    report success while individual daemons are still in `starting` state.
+    """
+    deadline = time.time() + int(timeout_seconds)
+    results: Dict[str, List[Dict[str, Any]]] = {}
+    while time.time() < deadline:
+        all_ready = True
+        results = {}
+        for cluster_name in nfs_clusters:
+            service = "nfs.%s" % cluster_name
+            raw = cephadm.orch.ps(service_name=service, format="json")
+            daemons = json.loads(raw) if raw else []
+            results[cluster_name] = daemons
+            if not daemons:
+                all_ready = False
+                log.info("Waiting for %s: orch ps returned no daemons", service)
+                break
+            pending = [
+                d
+                for d in daemons
+                if str(d.get("status_desc", "")).strip().lower() != "running"
+                or not d.get("container_id")
+            ]
+            if pending:
+                all_ready = False
+                for daemon in pending:
+                    log.info(
+                        "Waiting for %s daemon on %s: status=%s container_id=%s",
+                        service,
+                        daemon.get("hostname"),
+                        daemon.get("status_desc"),
+                        daemon.get("container_id") or "none",
+                    )
+        if all_ready:
+            log.info(
+                "All NFS daemons running with container ids for: %s",
+                ", ".join(nfs_clusters),
+            )
+            return results
+        time.sleep(interval)
+    raise OperationFailedError(
+        "Timed out after %ss waiting for NFS daemons to reach running state "
+        "with container ids for %s" % (timeout_seconds, ", ".join(nfs_clusters))
+    )
+
+
 def redeploy_nfs_clusters(
     cephadm, nfs_clusters, installer, redeploy_wait, service_wait_timeout
 ):
@@ -596,6 +976,9 @@ def redeploy_nfs_clusters(
         cephadm.orch.redeploy("nfs.%s" % cluster_name)
     time.sleep(redeploy_wait)
     verify_nfs_ganesha_service(node=installer, timeout=service_wait_timeout)
+    wait_for_nfs_cluster_daemons_running(
+        cephadm, nfs_clusters, timeout_seconds=service_wait_timeout
+    )
 
 
 def _expect_delegation(conf, label, expected):
@@ -614,10 +997,14 @@ def verify_container_delegation(nfs_nodes, daemons, nfs_name, delegation):
     by_short = {(d.get("hostname") or "").split(".")[0]: d for d in daemons}
     for node in nfs_nodes:
         short = node.hostname.split(".")[0]
-        cid = by_short.get(short, {}).get("container_id")
+        daemon = by_short.get(short, {})
+        cid = daemon.get("container_id")
         if not cid:
+            status = daemon.get("status_desc", "missing")
             raise OperationFailedError(
-                "No nfs daemon on %s for nfs.%s" % (node.hostname, nfs_name)
+                "No running nfs daemon container on %s for nfs.%s "
+                "(status=%s; wait for redeploy to finish)"
+                % (node.hostname, nfs_name, status)
             )
         conf, _ = node.exec_command(
             sudo=True, cmd="podman exec %s cat /etc/ganesha/ganesha.conf" % cid

--- a/tests/nfs/nfs_verify_delegation_conflict_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_conflict_scenarios.py
@@ -8,11 +8,8 @@ conflicting NFS operations (SETATTR, REMOVE, RENAME, WRITE).
 import time
 
 from nfs_delegation_operations import (
-    DELEGATION_EXIT_WAIT_SECONDS_DEFAULT,
-    DELEGATION_HOLD_READY_SECONDS_DEFAULT,
-    DELEGATION_HOLD_SECONDS_DEFAULT,
-    DELEGATION_LOG_SETTLE_SECONDS_DEFAULT,
     create_delegation_exports,
+    delegation_timing_from_config,
     enable_cluster_delegation_and_debug_logging,
     ensure_ceph_conf_and_admin_keyring_on_hosts,
     ensure_nfs_cluster_for_delegation_test,
@@ -27,6 +24,8 @@ from nfs_delegation_operations import (
     truncate_ganesha_container_log,
     unmount_delegation_export,
     validate_delegation_recall_ganesha_capture,
+    wait_for_delegation_path,
+    write_delegation_file,
 )
 from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
 
@@ -49,28 +48,6 @@ CONFLICT_SCENARIOS = (
 CONFLICT_TEST_FILES = [row[2] for row in CONFLICT_SCENARIOS]
 
 
-def _q(s):
-    return s.replace("'", "'\"'\"'")
-
-
-def _path_exists(client, path):
-    client.exec_command(sudo=True, cmd="test -e %s" % path, check_ec=False)
-    return int(getattr(client, "exit_status", 1)) == 0
-
-
-def _wait_path(client, path, label, retries=20):
-    parent = path.rsplit("/", 1)[0] or "/"
-    for n in range(1, retries + 1):
-        client.exec_command(sudo=True, cmd="ls -la %s" % parent, check_ec=False)
-        if _path_exists(client, path):
-            log.info("%s: %s visible (attempt %d)", label, path, n)
-            return
-        time.sleep(1)
-    raise OperationFailedError(
-        "%s: %s not visible on %s" % (label, path, client.hostname)
-    )
-
-
 def _cleanup_paths(client_a, client_b, path_a, path_b, extra_paths=()):
     for c in (client_a, client_b):
         kill_delegation_holds(c)
@@ -80,27 +57,23 @@ def _cleanup_paths(client_a, client_b, path_a, path_b, extra_paths=()):
             c.exec_command(sudo=True, cmd="rm -f %s" % p, check_ec=False)
 
 
-def _seed_clients(client_a, client_b, path_a, path_b, scenario):
-    payload = "seed-%s" % scenario
+def _seed_clients(client_a, client_b, path_a, path_b, scenario, path_wait_retries):
+    payload = "seed-%s\n" % scenario
     for client, path, tag in ((client_a, path_a, "A"), (client_b, path_b, "B")):
-        client.exec_command(
-            sudo=True,
-            cmd="bash -c 'echo %s > %s && sync'" % (_q(payload), path),
+        write_delegation_file(client, path, payload)
+        wait_for_delegation_path(
+            client, path, "client %s after seed" % tag, retries=path_wait_retries
         )
-        _wait_path(client, path, "client %s after seed" % tag)
 
 
 def _establish_delegation_hold(client_a, path_a, hold_mode, hold_s, ready_s):
     if hold_mode == "read":
         client_a.exec_command(sudo=True, cmd="cat %s" % path_a)
-        _wait_path(client_a, path_a, "client A pre read-hold")
+        wait_for_delegation_path(client_a, path_a, "client A pre read-hold")
         hold_delegation_open(client_a, path_a, "rb", hold_s)
     elif hold_mode == "write":
-        _wait_path(client_a, path_a, "client A pre write-hold")
-        client_a.exec_command(
-            sudo=True,
-            cmd="bash -c 'echo hold-write > %s && sync'" % path_a,
-        )
+        wait_for_delegation_path(client_a, path_a, "client A pre write-hold")
+        write_delegation_file(client_a, path_a, "hold-write\n")
         hold_delegation_open(client_a, path_a, "r+b", hold_s)
     else:
         raise ConfigError("Unknown hold_mode %r" % hold_mode)
@@ -108,7 +81,7 @@ def _establish_delegation_hold(client_a, path_a, hold_mode, hold_s, ready_s):
 
 
 def _run_conflict_io(name, client_b, path_b):
-    _wait_path(client_b, path_b, "client B pre-conflict")
+    wait_for_delegation_path(client_b, path_b, "client B pre-conflict")
 
     if name == "read_setattr_recall":
         client_b.exec_command(sudo=True, cmd="chmod 600 %s" % path_b)
@@ -121,10 +94,7 @@ def _run_conflict_io(name, client_b, path_b):
         client_b.exec_command(sudo=True, cmd="mv %s %s" % (path_b, renamed))
         return (renamed,)
     if name == "read_write_recall":
-        client_b.exec_command(
-            sudo=True,
-            cmd="bash -c 'echo client-b-write >> %s && sync'" % path_b,
-        )
+        write_delegation_file(client_b, path_b, "client-b-write\n", append=True)
         return ()
     if name == "write_setattr_recall":
         client_b.exec_command(sudo=True, cmd="chmod 644 %s" % path_b)
@@ -156,20 +126,12 @@ def run(ceph_cluster, **kw):
     export_rw = config.get("conflict_export", "/deleg_conflict_rw")
     mount_a = config.get("client_a_mount", "/mnt/deleg_conflict_c0")
     mount_b = config.get("client_b_mount", "/mnt/deleg_conflict_c1")
-    hold_s = int(config.get("delegation_hold_seconds", DELEGATION_HOLD_SECONDS_DEFAULT))
-    ready_s = int(
-        config.get(
-            "delegation_hold_ready_seconds", DELEGATION_HOLD_READY_SECONDS_DEFAULT
-        )
-    )
-    exit_wait = int(
-        config.get("delegation_exit_wait_seconds", DELEGATION_EXIT_WAIT_SECONDS_DEFAULT)
-    )
-    settle_s = int(
-        config.get(
-            "delegation_log_settle_seconds", DELEGATION_LOG_SETTLE_SECONDS_DEFAULT
-        )
-    )
+    timing = delegation_timing_from_config(config)
+    hold_s = timing.hold_seconds
+    ready_s = timing.hold_ready_seconds
+    exit_wait = timing.exit_wait_seconds
+    settle_s = timing.log_settle_seconds
+    path_wait_retries = timing.path_wait_retries
     redeploy_wait = int(config.get("redeploy_wait", 30))
     service_wait = int(config.get("service_wait_timeout", 300))
     subvol_group = config.get("subvolume_group", "delegconflictgrp")
@@ -234,7 +196,9 @@ def run(ceph_cluster, **kw):
             )
 
             truncate_ganesha_container_log(nfs_node, container_id)
-            _seed_clients(client_a, client_b, path_a, path_b, scenario)
+            _seed_clients(
+                client_a, client_b, path_a, path_b, scenario, path_wait_retries
+            )
             log.info("Waiting %s s after seed for delegations to exit", exit_wait)
             time.sleep(exit_wait)
 

--- a/tests/nfs/nfs_verify_delegation_file_operations.py
+++ b/tests/nfs/nfs_verify_delegation_file_operations.py
@@ -1,0 +1,425 @@
+"""
+NFSv4 delegation file operations (CEPH-83632379).
+
+Scenarios: open/close cycles, read-write IO with recall, lock/unlock, setattr/truncate.
+"""
+
+import time
+
+from nfs_delegation_operations import (
+    create_delegation_exports,
+    delegation_timing_from_config,
+    enable_cluster_delegation_and_debug_logging,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    ensure_nfs_cluster_for_delegation_test,
+    hold_delegation_open,
+    kill_delegation_holds,
+    mount_delegation_export,
+    read_ganesha_delegation_tailf_capture,
+    restore_delegation_ganesha_templates,
+    start_ganesha_delegation_tailf_follow,
+    stop_ganesha_delegation_tailf_follow,
+    teardown_delegation_exports,
+    truncate_ganesha_container_log,
+    unmount_delegation_export,
+    validate_delegation_lock_capture,
+    validate_delegation_open_close_cycles_capture,
+    validate_delegation_rw_io_recall_capture,
+    validate_delegation_setattr_capture,
+    wait_for_delegation_path,
+    write_delegation_file,
+)
+from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+# (scenario_name, min_clients, test_file, validator)
+FILE_OP_SCENARIOS = (
+    ("open_close_cycles", 1, "deleg_fops_open_close.txt", "open_close"),
+    ("read_write_io_recall", 2, "deleg_fops_rw_recall.txt", "rw_recall"),
+    ("lock_unlock", 2, "deleg_fops_lock.txt", "lock"),
+    ("setattr_truncate", 1, "deleg_fops_setattr.txt", "setattr"),
+)
+SCENARIO_TEST_FILES = [row[2] for row in FILE_OP_SCENARIOS]
+
+
+def _seed_file(client, path, scenario, path_wait_retries):
+    write_delegation_file(client, path, "seed-%s\n" % scenario)
+    wait_for_delegation_path(client, path, "seed", retries=path_wait_retries)
+
+
+def _prime_delegation_hold(client, path, hold_mode):
+    if hold_mode == "read":
+        client.exec_command(sudo=True, cmd="cat %s" % path)
+    else:
+        write_delegation_file(client, path, "hold-prime\n", append=True)
+
+
+def _run_open_close_cycles(client, path, cycles):
+    """Local OPEN/read/CLOSE loops while a background hold keeps the delegation active."""
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "python3 <<'PY'\n"
+            "path = %r\n"
+            "for _ in range(%d):\n"
+            "    f = open(path, 'rb')\n"
+            "    f.read(1)\n"
+            "    f.close()\n"
+            "PY" % (path, int(cycles))
+        ),
+    )
+
+
+def _run_sequential_random_rw(client, path, rounds):
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "bash -c 'for i in $(seq 1 %d); do "
+            "echo rw-$i >> %s; head -c 32 %s >/dev/null; "
+            "dd if=%s of=/dev/null bs=1 skip=$((i%%8)) count=1 2>/dev/null; "
+            "done && sync'" % (int(rounds), path, path, path)
+        ),
+    )
+    out, _ = client.exec_command(sudo=True, cmd="cat %s" % path)
+    if not (out or "").strip():
+        raise OperationFailedError("read/write IO: empty readback from %s" % path)
+
+
+def _run_lock_holder(client, path, hold_s):
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "nohup python3 <<'PY' >/dev/null 2>&1 &\n"
+            "import fcntl, time\n"
+            "path = %r\n"
+            "f = open(path, 'r+b')\n"
+            "fcntl.lockf(f, fcntl.LOCK_EX)\n"
+            "time.sleep(%d)\n"
+            "fcntl.lockf(f, fcntl.LOCK_UN)\n"
+            "f.close()\n"
+            "PY" % (path, int(hold_s))
+        ),
+        check_ec=False,
+    )
+
+
+def _expect_peer_lock_blocked(client, path, wait_s):
+    out, err = client.exec_command(
+        sudo=True,
+        cmd=(
+            "python3 <<'PY'\n"
+            "import fcntl, sys, time\n"
+            "path = %r\n"
+            "deadline = time.time() + %d\n"
+            "blocked = False\n"
+            "with open(path, 'r+b') as f:\n"
+            "    while time.time() < deadline:\n"
+            "        try:\n"
+            "            fcntl.lockf(f, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+            "            print('UNEXPECTED_OK')\n"
+            "            sys.exit(2)\n"
+            "        except BlockingIOError:\n"
+            "            blocked = True\n"
+            "            time.sleep(1)\n"
+            "print('LOCK_BLOCKED' if blocked else 'NO_BLOCK')\n"
+            "PY" % (path, int(wait_s))
+        ),
+        check_ec=False,
+    )
+    if "LOCK_BLOCKED" not in (out or ""):
+        host = client.hostname
+        exit_code = getattr(client, "exit_status", "?")
+        raise OperationFailedError(
+            "lock_unlock: client %s did not observe blocking lock on %s "
+            "(out=%r, err=%r, exit=%s)" % (host, path, out, err, exit_code)
+        )
+    log.info("lock_unlock: peer lock attempt blocked on %s", path)
+
+
+def _run_setattr_truncate_ops(client, path):
+    client.exec_command(sudo=True, cmd="chmod 640 %s" % path, check_ec=False)
+    client.exec_command(sudo=True, cmd="chown root:root %s" % path, check_ec=False)
+    client.exec_command(sudo=True, cmd="truncate -s 4096 %s" % path, check_ec=False)
+    client.exec_command(sudo=True, cmd="touch %s" % path, check_ec=False)
+    client.exec_command(
+        sudo=True,
+        cmd="setfattr -n user.deleg_test -v fops %s" % path,
+        check_ec=False,
+    )
+    out, _ = client.exec_command(
+        sudo=True,
+        cmd="getfattr -n user.deleg_test --only-values %s" % path,
+        check_ec=False,
+    )
+    if "fops" not in (out or ""):
+        log.warning(
+            "setfattr/getfattr not confirmed on %s (xattr may be unsupported)", path
+        )
+    size_out, _ = client.exec_command(
+        sudo=True, cmd="stat -c %%s %s" % path, check_ec=False
+    )
+    try:
+        if int((size_out or "0").strip()) < 4096:
+            raise OperationFailedError(
+                "setattr_truncate: truncate did not reach 4096 bytes on %s" % path
+            )
+    except ValueError:
+        log.warning("setattr_truncate: could not parse stat size: %r", size_out)
+    log.info("setattr_truncate: metadata and size checks completed on %s", path)
+
+
+def _validate_capture(scenario, validator, hits, hold_mode, open_close_cycles):
+    if validator == "open_close":
+        validate_delegation_open_close_cycles_capture(
+            scenario, hits, open_close_cycles, hold_mode
+        )
+    elif validator == "rw_recall":
+        validate_delegation_rw_io_recall_capture(scenario, hits, hold_mode)
+    elif validator == "lock":
+        validate_delegation_lock_capture(scenario, hits, hold_mode)
+    elif validator == "setattr":
+        validate_delegation_setattr_capture(scenario, hits, hold_mode)
+    else:
+        raise ConfigError("Unknown file-op validator %r" % validator)
+
+
+def _run_scenario_io(
+    name,
+    client_a,
+    client_b,
+    path_a,
+    path_b,
+    hold_mode,
+    hold_s,
+    ready_s,
+    open_close_cycles,
+    lock_wait_s,
+    path_wait_retries=40,
+):
+    open_mode = "r+b" if hold_mode == "write" else "rb"
+
+    _prime_delegation_hold(client_a, path_a, hold_mode)
+
+    if name == "open_close_cycles":
+        hold_delegation_open(client_a, path_a, open_mode, hold_s)
+        time.sleep(ready_s)
+        _run_open_close_cycles(client_a, path_a, open_close_cycles)
+        return
+
+    if name == "read_write_io_recall":
+        hold_delegation_open(client_a, path_a, open_mode, hold_s)
+        time.sleep(ready_s)
+        _run_sequential_random_rw(client_a, path_a, open_close_cycles)
+        wait_for_delegation_path(
+            client_b, path_b, "client B pre-conflict", retries=path_wait_retries
+        )
+        write_delegation_file(client_b, path_b, "peer-recall\n", append=True)
+        _run_sequential_random_rw(client_a, path_a, 4)
+        return
+
+    if name == "lock_unlock":
+        # Delegation hold OPEN, then a second OPEN with an exclusive lock on client A.
+        hold_delegation_open(client_a, path_a, open_mode, hold_s)
+        time.sleep(ready_s)
+        _run_lock_holder(client_a, path_a, hold_s)
+        time.sleep(5)
+        _expect_peer_lock_blocked(client_b, path_b, lock_wait_s)
+        write_delegation_file(client_b, path_b, "peer-lock-io\n", append=True)
+        return
+
+    if name == "setattr_truncate":
+        hold_delegation_open(client_a, path_a, open_mode, hold_s)
+        time.sleep(ready_s)
+        _run_setattr_truncate_ops(client_a, path_a)
+        return
+
+    raise ConfigError("Unknown file operations scenario %r" % name)
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    installers = ceph_cluster.get_nodes("installer")
+    if not clients:
+        raise ConfigError("This test requires at least one client node")
+    if not nfs_nodes or not installers:
+        raise ConfigError("This test requires nfs and installer nodes")
+
+    client_a = clients[0]
+    client_b = clients[1] if len(clients) > 1 else None
+    installer, nfs_node = installers[0], nfs_nodes[0]
+    cephadm = CephAdm(installer).ceph
+    nfs_cmd_host = nfs_node
+
+    fs_name = config.get("fs_name", "cephfs")
+    nfs_name = config.get("nfs_name", "cephfs-nfs")
+    export_rw = config.get("fops_export", "/deleg_fops_rw")
+    mount_a = config.get("client_a_mount", "/mnt/deleg_fops_c0")
+    mount_b = config.get("client_b_mount", "/mnt/deleg_fops_c1")
+    hold_mode = str(config.get("hold_mode", "write")).strip().lower()
+    if hold_mode not in ("read", "write"):
+        raise ConfigError("hold_mode accepts only read or write")
+
+    timing = delegation_timing_from_config(config)
+    hold_s = timing.hold_seconds
+    ready_s = timing.hold_ready_seconds
+    exit_wait = timing.exit_wait_seconds
+    settle_s = timing.log_settle_seconds
+    path_wait_retries = timing.path_wait_retries
+    open_close_cycles = int(config.get("open_close_cycles", 5))
+    lock_wait_s = int(config.get("lock_wait_seconds", 15))
+    redeploy_wait = int(config.get("redeploy_wait", 30))
+    service_wait = int(config.get("service_wait_timeout", 300))
+    subvol_group = config.get("subvolume_group", "delegfopsgrp")
+    nfs_mount = config.get("nfs_mount", "/mnt/delegation_bootstrap")
+    bootstrap_export = config.get("bootstrap_export", "/export_delegation_boot")
+
+    delegation_template_backup = logging_template_backup = False
+    created_cluster = False
+    subvol_names, container_id = [], None
+
+    cephfs_utils = CephFSCommonUtils(ceph_cluster)
+    if not cephfs_utils.get_fs_info(client_a, fs_name):
+        cephfs_utils.create_fs(client_a, fs_name)
+    ensure_ceph_conf_and_admin_keyring_on_hosts(installer, nfs_nodes)
+
+    try:
+        nfs_clusters, created_cluster = ensure_nfs_cluster_for_delegation_test(
+            cephadm,
+            nfs_name,
+            config,
+            client=client_a,
+            nfs_nodes=nfs_nodes,
+            installer=installer,
+            ceph_cluster=ceph_cluster,
+        )
+
+        delegation_template_backup, logging_template_backup = (
+            enable_cluster_delegation_and_debug_logging(
+                nfs_cmd_host,
+                cephadm,
+                nfs_clusters,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        )
+        subvol_names = create_delegation_exports(
+            nfs_cmd_host, fs_name, nfs_name, subvol_group, [(export_rw, "rw")]
+        )
+        _, info = get_ganesha_info_from_container(installer, nfs_name, nfs_node)
+        container_id = (info or {}).get("container_id")
+        if not container_id:
+            raise OperationFailedError("No Ganesha container for nfs.%s" % nfs_name)
+
+        nfs_ver = config.get("nfs_version", "4.2")
+        port = str(config.get("port", "2049"))
+        server = nfs_node.hostname
+        mount_delegation_export(client_a, mount_a, nfs_ver, port, server, export_rw)
+        if client_b:
+            mount_delegation_export(client_b, mount_b, nfs_ver, port, server, export_rw)
+
+        for scenario, min_clients, test_file, validator in FILE_OP_SCENARIOS:
+            if len(clients) < min_clients:
+                raise ConfigError(
+                    "Scenario %s requires %d clients" % (scenario, min_clients)
+                )
+            if min_clients > 1 and client_b is None:
+                raise ConfigError("Scenario %s requires a second client" % scenario)
+
+            path_a = "%s/%s" % (mount_a, test_file)
+            path_b = "%s/%s" % (mount_b, test_file) if min_clients > 1 else path_a
+            log.info("Scenario %s (%s) validator=%s", scenario, test_file, validator)
+
+            truncate_ganesha_container_log(nfs_node, container_id)
+            _seed_file(client_a, path_a, scenario, path_wait_retries)
+            if min_clients > 1:
+                _seed_file(client_b, path_b, scenario, path_wait_retries)
+            log.info("Waiting %s s after seed for delegations to exit", exit_wait)
+            time.sleep(exit_wait)
+
+            start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+            _run_scenario_io(
+                scenario,
+                client_a,
+                client_b,
+                path_a,
+                path_b,
+                hold_mode,
+                hold_s,
+                ready_s,
+                open_close_cycles,
+                lock_wait_s,
+                path_wait_retries,
+            )
+            time.sleep(settle_s)
+            stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+            _validate_capture(
+                scenario,
+                validator,
+                read_ganesha_delegation_tailf_capture(nfs_node, container_id),
+                hold_mode,
+                open_close_cycles,
+            )
+            kill_delegation_holds(client_a)
+            if client_b:
+                kill_delegation_holds(client_b)
+
+        return 0
+    except Exception as err:
+        log.error("Delegation file operations test failed: %s", err)
+        return 1
+    finally:
+        kill_delegation_holds(client_a)
+        if client_b:
+            kill_delegation_holds(client_b)
+        unmount_delegation_export(
+            client_a,
+            mount_a,
+            remove_mount_dir=True,
+            test_files=SCENARIO_TEST_FILES,
+        )
+        if client_b:
+            unmount_delegation_export(
+                client_b,
+                mount_b,
+                remove_mount_dir=True,
+                test_files=SCENARIO_TEST_FILES,
+            )
+        if subvol_names:
+            teardown_delegation_exports(
+                nfs_cmd_host, fs_name, nfs_name, subvol_group, [export_rw], subvol_names
+            )
+        try:
+            if container_id:
+                stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                truncate_ganesha_container_log(nfs_node, container_id)
+        except Exception as err:
+            log.warning("Ganesha log cleanup failed: %s", err)
+        try:
+            restore_delegation_ganesha_templates(
+                nfs_cmd_host,
+                delegation_template_backup,
+                logging_template_backup,
+                cephadm,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        except Exception as err:
+            log.warning("Template restore failed: %s", err)
+        if created_cluster:
+            cleanup_cluster(
+                clients=[client_a],
+                nfs_mount=nfs_mount,
+                nfs_name=nfs_name,
+                nfs_export=bootstrap_export,
+                nfs_nodes=nfs_nodes,
+            )

--- a/tests/nfs/nfs_verify_delegation_revoke_recall.py
+++ b/tests/nfs/nfs_verify_delegation_revoke_recall.py
@@ -1,19 +1,19 @@
 """
-NFSv4 delegation recall (2 clients, shared rw export).
+NFSv4 delegation recall and revoke (2 clients, shared rw export).
 
-Per scenario: seed file, wait delegation_exit_wait_seconds, tail -f, IO.
-Timing defaults are defined in nfs_delegation_operations (lease + log-capture margin).
-Files: deleg_recall_read_read.txt, deleg_recall_write_write.txt, deleg_recall_write_then_read.txt
+Recall: read/read (no recall), write/write, write-then-read.
+Revoke: client returns delegation before peer IO (no revoke); peer write while
+client A still holds an open write delegation (recall then revoke/reclaim path).
+
+Note: ``revoke_after_recall_on_conflict`` keeps client A's hold OPEN during peer
+write; it does not simulate a client that ignores DELEGRECALL until lease expiry.
 """
 
 import time
 
 from nfs_delegation_operations import (
-    DELEGATION_EXIT_WAIT_SECONDS_DEFAULT,
-    DELEGATION_HOLD_READY_SECONDS_DEFAULT,
-    DELEGATION_HOLD_SECONDS_DEFAULT,
-    DELEGATION_LOG_SETTLE_SECONDS_DEFAULT,
     create_delegation_exports,
+    delegation_timing_from_config,
     enable_cluster_delegation_and_debug_logging,
     ensure_ceph_conf_and_admin_keyring_on_hosts,
     ensure_nfs_cluster_for_delegation_test,
@@ -21,6 +21,7 @@ from nfs_delegation_operations import (
     kill_delegation_holds,
     mount_delegation_export,
     read_ganesha_delegation_tailf_capture,
+    release_delegation_hold_gracefully,
     restore_delegation_ganesha_templates,
     start_ganesha_delegation_tailf_follow,
     stop_ganesha_delegation_tailf_follow,
@@ -28,6 +29,10 @@ from nfs_delegation_operations import (
     truncate_ganesha_container_log,
     unmount_delegation_export,
     validate_delegation_recall_ganesha_capture,
+    validate_delegation_revoke_ganesha_capture,
+    wait_for_delegation_path,
+    wait_for_delegreturn_in_ganesha_capture,
+    write_delegation_file,
 )
 from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
 
@@ -38,34 +43,24 @@ from utility.log import Log
 
 log = Log(__name__)
 
-RECALL_SCENARIOS = (
-    ("read_read_no_recall", False, "deleg_recall_read_read.txt"),
-    ("write_write_recall", True, "deleg_recall_write_write.txt"),
-    ("rw_read_after_write_recall", True, "deleg_recall_write_then_read.txt"),
+RECALL_REVOKE_SCENARIOS = (
+    ("read_read_no_recall", "recall", False, "deleg_recall_read_read.txt"),
+    ("write_write_recall", "recall", True, "deleg_recall_write_write.txt"),
+    ("rw_read_after_write_recall", "recall", True, "deleg_recall_write_then_read.txt"),
+    (
+        "revoke_io_completes_before_timeout",
+        "revoke",
+        False,
+        "deleg_revoke_io_done.txt",
+    ),
+    (
+        "revoke_after_recall_on_conflict",
+        "revoke",
+        True,
+        "deleg_revoke_after_recall.txt",
+    ),
 )
-RECALL_TEST_FILES = [row[2] for row in RECALL_SCENARIOS]
-
-
-def _q(s):
-    return s.replace("'", "'\"'\"'")
-
-
-def _path_exists(client, path):
-    client.exec_command(sudo=True, cmd="test -f %s" % path, check_ec=False)
-    return int(getattr(client, "exit_status", 1)) == 0
-
-
-def _wait_path(client, path, label, retries=20):
-    parent = path.rsplit("/", 1)[0] or "/"
-    for n in range(1, retries + 1):
-        client.exec_command(sudo=True, cmd="ls -la %s" % parent, check_ec=False)
-        if _path_exists(client, path):
-            log.info("%s: %s visible (attempt %d)", label, path, n)
-            return
-        time.sleep(1)
-    raise OperationFailedError(
-        "%s: %s not visible on %s" % (label, path, client.hostname)
-    )
+SCENARIO_TEST_FILES = [row[3] for row in RECALL_REVOKE_SCENARIOS]
 
 
 def _cleanup_paths(client_a, client_b, path_a, path_b):
@@ -76,42 +71,128 @@ def _cleanup_paths(client_a, client_b, path_a, path_b):
     client_b.exec_command(sudo=True, cmd="rm -f %s" % path_b, check_ec=False)
 
 
-def _seed_clients(client_a, client_b, path_a, path_b, scenario):
-    payload = "seed-%s" % scenario
+def _seed_clients(client_a, client_b, path_a, path_b, scenario, path_wait_retries):
+    payload = "seed-%s\n" % scenario
     for client, path, tag in ((client_a, path_a, "A"), (client_b, path_b, "B")):
-        client.exec_command(
-            sudo=True,
-            cmd="bash -c 'echo %s > %s && sync'" % (_q(payload), path),
+        write_delegation_file(client, path, payload)
+        wait_for_delegation_path(
+            client, path, "client %s after seed" % tag, retries=path_wait_retries
         )
-        _wait_path(client, path, "client %s after seed" % tag)
+
+
+def _client_a_hold_write_then_return_delegation(client_a, path_a, ready_s, hold_s):
+    write_delegation_file(client_a, path_a, "deleg-hold\n")
+    hold_duration = max(int(hold_s), int(ready_s) + 20)
+    hold_delegation_open(client_a, path_a, "r+b", hold_duration)
+    time.sleep(ready_s)
+    release_delegation_hold_gracefully(client_a, term_wait_seconds=5)
+
+
+def _run_revoke_io_completes_before_timeout(
+    client_a,
+    client_b,
+    path_a,
+    path_b,
+    nfs_node,
+    container_id,
+    ready_s,
+    hold_s,
+    return_wait,
+    settle_s,
+):
+    wait_for_delegation_path(client_a, path_a, "client A pre write-hold")
+    start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+    _client_a_hold_write_then_return_delegation(client_a, path_a, ready_s, hold_s)
+    if not wait_for_delegreturn_in_ganesha_capture(
+        nfs_node, container_id, timeout_seconds=return_wait + 30
+    ):
+        stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+        raise OperationFailedError(
+            "revoke_io_completes_before_timeout: DELEGRETURN not seen after client A close"
+        )
+    time.sleep(2)
+    stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+
+    truncate_ganesha_container_log(nfs_node, container_id)
+    start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+    time.sleep(return_wait)
+    wait_for_delegation_path(client_b, path_b, "client B pre-conflict write")
+    write_delegation_file(client_b, path_b, "peer-after-deleg-return\n", append=True)
+    time.sleep(settle_s)
+    stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+    validate_delegation_revoke_ganesha_capture(
+        "revoke_io_completes_before_timeout",
+        read_ganesha_delegation_tailf_capture(nfs_node, container_id),
+        False,
+        require_delegreturn=False,
+    )
+
+
+def _hold_write_delegation_on_a(client_a, path_a, hold_s, ready_s, pre_hold_label):
+    wait_for_delegation_path(client_a, path_a, pre_hold_label)
+    write_delegation_file(client_a, path_a, "hold-write\n")
+    hold_delegation_open(client_a, path_a, "r+b", hold_s)
+    time.sleep(ready_s)
+
+
+def _io_read_read_no_recall(client_a, client_b, path_a, path_b, hold_s, ready_s):
+    client_a.exec_command(sudo=True, cmd="cat %s" % path_a)
+    wait_for_delegation_path(client_a, path_a, "client A pre read-hold")
+    hold_delegation_open(client_a, path_a, "rb", hold_s)
+    time.sleep(ready_s)
+    wait_for_delegation_path(client_b, path_b, "client B pre-IO")
+    client_b.exec_command(sudo=True, cmd="cat %s && stat %s" % (path_b, path_b))
+
+
+def _io_write_write_recall(client_a, client_b, path_a, path_b, hold_s, ready_s):
+    _hold_write_delegation_on_a(
+        client_a, path_a, hold_s, ready_s, "client A pre write-hold"
+    )
+    wait_for_delegation_path(client_b, path_b, "client B pre-IO")
+    write_delegation_file(client_b, path_b, "client-b-write\n", append=True)
+
+
+def _io_rw_read_after_write_recall(client_a, client_b, path_a, path_b, hold_s, ready_s):
+    _hold_write_delegation_on_a(
+        client_a, path_a, hold_s, ready_s, "client A pre write-hold"
+    )
+    wait_for_delegation_path(client_b, path_b, "client B pre-IO")
+    client_b.exec_command(sudo=True, cmd="cat %s" % path_b)
+
+
+def _io_revoke_after_recall_on_conflict(
+    client_a, client_b, path_a, path_b, hold_s, ready_s
+):
+    wait_for_delegation_path(
+        client_a, path_a, "client A pre write-hold (recall on conflict)"
+    )
+    write_delegation_file(client_a, path_a, "hold-unresponsive\n")
+    hold_delegation_open(client_a, path_a, "r+b", hold_s)
+    time.sleep(ready_s)
+    wait_for_delegation_path(client_b, path_b, "client B pre-conflict write")
+    write_delegation_file(client_b, path_b, "client-b-write\n", append=True)
+
+
+SCENARIO_IO_HANDLERS = {
+    "read_read_no_recall": _io_read_read_no_recall,
+    "write_write_recall": _io_write_write_recall,
+    "rw_read_after_write_recall": _io_rw_read_after_write_recall,
+    "revoke_after_recall_on_conflict": _io_revoke_after_recall_on_conflict,
+}
 
 
 def _run_scenario_io(name, client_a, client_b, path_a, path_b, hold_s, ready_s):
-    if name == "read_read_no_recall":
-        client_a.exec_command(sudo=True, cmd="cat %s" % path_a)
-        _wait_path(client_a, path_a, "client A pre read-hold")
-        hold_delegation_open(client_a, path_a, "rb", hold_s)
-        time.sleep(ready_s)
-        _wait_path(client_b, path_b, "client B pre-IO")
-        client_b.exec_command(sudo=True, cmd="cat %s && stat %s" % (path_b, path_b))
-        return
-    if name not in ("write_write_recall", "rw_read_after_write_recall"):
-        raise ConfigError("Unknown recall scenario %r" % name)
-    _wait_path(client_a, path_a, "client A pre write-hold")
-    client_a.exec_command(
-        sudo=True,
-        cmd="bash -c 'echo hold-write > %s && sync'" % path_a,
-    )
-    hold_delegation_open(client_a, path_a, "r+b", hold_s)
-    time.sleep(ready_s)
-    _wait_path(client_b, path_b, "client B pre-IO")
-    if name == "write_write_recall":
-        client_b.exec_command(
-            sudo=True,
-            cmd="bash -c 'echo client-b-write >> %s && sync'" % path_b,
-        )
+    handler = SCENARIO_IO_HANDLERS.get(name)
+    if not handler:
+        raise ConfigError("Unknown recall/revoke scenario %r" % name)
+    handler(client_a, client_b, path_a, path_b, hold_s, ready_s)
+
+
+def _validate_scenario_capture(scenario, kind, expect_positive, hits):
+    if kind == "recall":
+        validate_delegation_recall_ganesha_capture(scenario, hits, expect_positive)
     else:
-        client_b.exec_command(sudo=True, cmd="cat %s" % path_b)
+        validate_delegation_revoke_ganesha_capture(scenario, hits, expect_positive)
 
 
 def run(ceph_cluster, **kw):
@@ -134,20 +215,13 @@ def run(ceph_cluster, **kw):
     export_rw = config.get("recall_export", "/deleg_recall_rw")
     mount_a = config.get("client_a_mount", "/mnt/deleg_recall_c0")
     mount_b = config.get("client_b_mount", "/mnt/deleg_recall_c1")
-    hold_s = int(config.get("delegation_hold_seconds", DELEGATION_HOLD_SECONDS_DEFAULT))
-    ready_s = int(
-        config.get(
-            "delegation_hold_ready_seconds", DELEGATION_HOLD_READY_SECONDS_DEFAULT
-        )
-    )
-    exit_wait = int(
-        config.get("delegation_exit_wait_seconds", DELEGATION_EXIT_WAIT_SECONDS_DEFAULT)
-    )
-    settle_s = int(
-        config.get(
-            "delegation_log_settle_seconds", DELEGATION_LOG_SETTLE_SECONDS_DEFAULT
-        )
-    )
+    timing = delegation_timing_from_config(config)
+    hold_s = timing.hold_seconds
+    ready_s = timing.hold_ready_seconds
+    return_wait = timing.return_wait_seconds
+    exit_wait = timing.exit_wait_seconds
+    settle_s = timing.log_settle_seconds
+    path_wait_retries = timing.path_wait_retries
     redeploy_wait = int(config.get("redeploy_wait", 30))
     service_wait = int(config.get("service_wait_timeout", 300))
     subvol_group = config.get("subvolume_group", "delegrecallgrp")
@@ -198,41 +272,62 @@ def run(ceph_cluster, **kw):
         for client, mp in ((client_a, mount_a), (client_b, mount_b)):
             mount_delegation_export(client, mp, nfs_ver, port, server, export_rw)
 
-        for scenario, expect_recall, test_file in RECALL_SCENARIOS:
+        for scenario, kind, expect_positive, test_file in RECALL_REVOKE_SCENARIOS:
             path_a, path_b = "%s/%s" % (mount_a, test_file), "%s/%s" % (
                 mount_b,
                 test_file,
             )
             log.info(
-                "Scenario %s (%s) expect_recall=%s", scenario, test_file, expect_recall
+                "Scenario %s (%s) kind=%s expect_positive=%s",
+                scenario,
+                test_file,
+                kind,
+                expect_positive,
             )
 
             truncate_ganesha_container_log(nfs_node, container_id)
-            _seed_clients(client_a, client_b, path_a, path_b, scenario)
+            _seed_clients(
+                client_a, client_b, path_a, path_b, scenario, path_wait_retries
+            )
             log.info("Waiting %s s after seed for delegations to exit", exit_wait)
             time.sleep(exit_wait)
 
-            start_ganesha_delegation_tailf_follow(nfs_node, container_id)
-            _run_scenario_io(
-                scenario, client_a, client_b, path_a, path_b, hold_s, ready_s
-            )
-            time.sleep(settle_s)
-            stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
-            validate_delegation_recall_ganesha_capture(
-                scenario,
-                read_ganesha_delegation_tailf_capture(nfs_node, container_id),
-                expect_recall,
-            )
+            if scenario == "revoke_io_completes_before_timeout":
+                _run_revoke_io_completes_before_timeout(
+                    client_a,
+                    client_b,
+                    path_a,
+                    path_b,
+                    nfs_node,
+                    container_id,
+                    ready_s,
+                    hold_s,
+                    return_wait,
+                    settle_s,
+                )
+            else:
+                start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                _run_scenario_io(
+                    scenario, client_a, client_b, path_a, path_b, hold_s, ready_s
+                )
+                time.sleep(settle_s)
+                stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                _validate_scenario_capture(
+                    scenario,
+                    kind,
+                    expect_positive,
+                    read_ganesha_delegation_tailf_capture(nfs_node, container_id),
+                )
             _cleanup_paths(client_a, client_b, path_a, path_b)
 
         return 0
     except Exception as err:
-        log.error("Delegation recall test failed: %s", err)
+        log.error("Delegation recall/revoke test failed: %s", err)
         return 1
     finally:
         for client, mp in ((client_a, mount_a), (client_b, mount_b)):
             unmount_delegation_export(
-                client, mp, remove_mount_dir=True, test_files=RECALL_TEST_FILES
+                client, mp, remove_mount_dir=True, test_files=SCENARIO_TEST_FILES
             )
             kill_delegation_holds(client)
 

--- a/tests/nfs/nfs_verify_delegation_stress_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_stress_scenarios.py
@@ -1,0 +1,357 @@
+"""
+NFSv4 delegation stress: multi-client, multi-mount mixed IO.
+
+Mounts the export on up to 4 clients (5 mounts per client), runs background read/write
+workloads, triggers occasional cross-client writes on a shared file, then checks the
+filtered Ganesha tail -f capture for delegation activity after IO stops.
+
+Set ``strict_log_validation: true`` in suite config for grant-type and recall validation;
+default is a loose grant/recall activity check only.
+"""
+
+import time
+
+from nfs_delegation_operations import (
+    create_delegation_exports,
+    delegation_timing_from_config,
+    enable_cluster_delegation_and_debug_logging,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    ensure_nfs_cluster_for_delegation_test,
+    mount_delegation_export,
+    q_delegation_shell,
+    read_ganesha_delegation_tailf_capture,
+    restore_delegation_ganesha_templates,
+    start_ganesha_delegation_tailf_follow,
+    stop_ganesha_delegation_tailf_follow,
+    teardown_delegation_exports,
+    truncate_ganesha_container_log,
+    unmount_delegation_export,
+    validate_delegation_stress_loose_capture,
+    validate_delegation_stress_strict_capture,
+    wait_for_delegation_path,
+    write_delegation_file,
+)
+from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+CONFLICT_FILE = "deleg_stress_conflict.dat"
+WORKLOAD_KINDS = ("seq_read", "rand_read", "seq_write", "rand_write")
+MOUNTS_PER_CLIENT_MAX = 5
+
+
+def _workload_pidfile(client):
+    host = str(getattr(client, "hostname", "client")).replace("/", "_")
+    return "/tmp/ganesha_delegation_workload_%s.pids" % host
+
+
+def _kill_workloads(client):
+    pidfile = _workload_pidfile(client)
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "if [ -f %s ]; then while read -r pid; do "
+            '[ -n "$pid" ] && kill "$pid" 2>/dev/null || true; '
+            "done < %s; rm -f %s; fi"
+        )
+        % (pidfile, pidfile, pidfile),
+        check_ec=False,
+    )
+
+
+def _resolve_container_id(installer, nfs_name, nfs_node):
+    _, info = get_ganesha_info_from_container(installer, nfs_name, nfs_node)
+    container_id = (info or {}).get("container_id")
+    if not container_id:
+        raise OperationFailedError("No Ganesha container for nfs.%s" % nfs_name)
+    return container_id
+
+
+def _mount_point(client_idx, mount_idx):
+    return "/mnt/deleg_stress_c%s_m%s" % (client_idx, mount_idx)
+
+
+def _setup_client_mounts(clients, mounts_per_client, nfs_ver, port, server, export_rw):
+    specs = []
+    for ci, client in enumerate(clients):
+        for mi in range(mounts_per_client):
+            mp = _mount_point(ci, mi)
+            mount_delegation_export(client, mp, nfs_ver, port, server, export_rw)
+            specs.append((client, mp, WORKLOAD_KINDS[(ci + mi) % len(WORKLOAD_KINDS)]))
+    return specs
+
+
+def _teardown_client_mounts(clients, mounts_per_client):
+    for ci, client in enumerate(clients):
+        for mi in range(mounts_per_client):
+            unmount_delegation_export(
+                client, _mount_point(ci, mi), remove_mount_dir=True
+            )
+
+
+def _first_mount_per_client(mount_roots):
+    first = {}
+    for client, mp, _kind in mount_roots:
+        if client not in first:
+            first[client] = mp
+    return first
+
+
+def _seed_workload_files(mount_roots, path_wait_retries):
+    seeded = []
+    for client, mp, kind in mount_roots:
+        host = getattr(client, "hostname", "client").replace(".", "_")
+        path = "%s/stress_%s.dat" % (mp, host)
+        write_delegation_file(client, path, "seed-%s\n" % host)
+        wait_for_delegation_path(
+            client, path, "seed %s" % path, retries=path_wait_retries
+        )
+        seeded.append((client, path, kind))
+    return seeded
+
+
+def _seed_conflict_file(clients, mount_roots, path_wait_retries):
+    mounts = _first_mount_per_client(mount_roots)
+    seed_client = clients[0]
+    seed_path = "%s/%s" % (mounts[seed_client], CONFLICT_FILE)
+    write_delegation_file(seed_client, seed_path, "conflict-seed\n")
+    paths = {}
+    for client in clients:
+        path = "%s/%s" % (mounts[client], CONFLICT_FILE)
+        wait_for_delegation_path(
+            client,
+            path,
+            "conflict seed on %s" % client.hostname,
+            retries=path_wait_retries,
+        )
+        paths[client] = path
+    return paths
+
+
+def _start_mixed_workload(client, path, kind, duration_s):
+    safe = q_delegation_shell(path)
+    pidfile = _workload_pidfile(client)
+    if kind == "seq_read":
+        body = "while [ $(date +%%s) -lt $end ]; do cat '%s' >/dev/null; done" % safe
+    elif kind == "rand_read":
+        body = (
+            "while [ $(date +%%s) -lt $end ]; do "
+            "dd if='%s' of=/dev/null bs=4096 count=1 skip=$((RANDOM%%32)) 2>/dev/null; "
+            "done"
+        ) % safe
+    elif kind == "seq_write":
+        body = (
+            "while [ $(date +%%s) -lt $end ]; do "
+            "echo seq-write-$(date +%%s) >> '%s'; sync; done"
+        ) % safe
+    else:
+        body = (
+            "while [ $(date +%%s) -lt $end ]; do "
+            "echo rand-$RANDOM >> '%s'; sync; done"
+        ) % safe
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "bash -c 'end=$(( $(date +%%s) + %s )); %s' >/dev/null 2>&1 & echo $! >> %s"
+            % (int(duration_s), body, pidfile)
+        ),
+        check_ec=False,
+    )
+
+
+def _cross_client_conflict_write(writer, conflict_path, tag):
+    content = "conflict-%s-%s\n" % (tag, getattr(writer, "hostname", "w"))
+    write_delegation_file(writer, conflict_path, content, append=True)
+
+
+def _validate_stress_capture(hits, strict_validation, hold_mode):
+    if strict_validation:
+        validate_delegation_stress_strict_capture(hits, hold_mode)
+    else:
+        validate_delegation_stress_loose_capture(hits)
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    installers = ceph_cluster.get_nodes("installer")
+    if not clients:
+        raise ConfigError("This test requires at least one client node")
+    if not nfs_nodes or not installers:
+        raise ConfigError("This test requires nfs and installer nodes")
+
+    num_clients = min(int(config.get("clients", 4)), len(clients), 4)
+    clients = clients[:num_clients]
+    mounts_per_client = min(
+        int(config.get("mounts_per_client", 3)), MOUNTS_PER_CLIENT_MAX
+    )
+
+    installer, nfs_node = installers[0], nfs_nodes[0]
+    cephadm = CephAdm(installer).ceph
+    nfs_cmd_host = nfs_node
+
+    fs_name = config.get("fs_name", "cephfs")
+    nfs_name = config.get("nfs_name", "cephfs-nfs")
+    export_rw = config.get("stress_export", "/deleg_stress_rw")
+    timing = delegation_timing_from_config(config)
+    strict_validation = bool(config.get("strict_log_validation", False))
+    hold_mode = str(config.get("hold_mode", "write")).strip().lower()
+    if hold_mode not in ("read", "write"):
+        raise ConfigError("hold_mode accepts only read or write")
+
+    workload_duration = int(config.get("workload_duration_seconds", 180))
+    conflict_interval = int(config.get("conflict_interval_seconds", 45))
+    redeploy_wait = int(config.get("redeploy_wait", 30))
+    service_wait = int(config.get("service_wait_timeout", 300))
+    subvol_group = config.get("subvolume_group", "delegstressgrp")
+    nfs_mount = config.get("nfs_mount", "/mnt/delegation_bootstrap")
+    bootstrap_export = config.get("bootstrap_export", "/export_delegation_boot")
+
+    delegation_template_backup = logging_template_backup = False
+    created_cluster = False
+    subvol_names, container_id = [], None
+    mount_roots = []
+
+    log.info(
+        "Stress config: clients=%d mounts_per_client=%d strict_validation=%s hold_mode=%s",
+        num_clients,
+        mounts_per_client,
+        strict_validation,
+        hold_mode,
+    )
+
+    cephfs_utils = CephFSCommonUtils(ceph_cluster)
+    if not cephfs_utils.get_fs_info(clients[0], fs_name):
+        cephfs_utils.create_fs(clients[0], fs_name)
+    ensure_ceph_conf_and_admin_keyring_on_hosts(installer, nfs_nodes)
+
+    try:
+        nfs_clusters, created_cluster = ensure_nfs_cluster_for_delegation_test(
+            cephadm,
+            nfs_name,
+            config,
+            client=clients[0],
+            nfs_nodes=nfs_nodes,
+            installer=installer,
+            ceph_cluster=ceph_cluster,
+        )
+
+        delegation_template_backup, logging_template_backup = (
+            enable_cluster_delegation_and_debug_logging(
+                nfs_cmd_host,
+                cephadm,
+                nfs_clusters,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        )
+        subvol_names = create_delegation_exports(
+            nfs_cmd_host, fs_name, nfs_name, subvol_group, [(export_rw, "rw")]
+        )
+        container_id = _resolve_container_id(installer, nfs_name, nfs_node)
+
+        nfs_ver = config.get("nfs_version", "4.2")
+        port = str(config.get("port", "2049"))
+        server = nfs_node.hostname
+        mount_roots = _setup_client_mounts(
+            clients, mounts_per_client, nfs_ver, port, server, export_rw
+        )
+        workload_specs = _seed_workload_files(mount_roots, timing.path_wait_retries)
+        conflict_paths = _seed_conflict_file(
+            clients, mount_roots, timing.path_wait_retries
+        )
+
+        log.info(
+            "Waiting %s s after seed for delegations to exit", timing.exit_wait_seconds
+        )
+        time.sleep(timing.exit_wait_seconds)
+
+        truncate_ganesha_container_log(nfs_node, container_id)
+        start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+
+        for client, path, kind in workload_specs:
+            log.info(
+                "Starting %s workload on %s path=%s duration=%ss",
+                kind,
+                getattr(client, "hostname", client),
+                path,
+                workload_duration,
+            )
+            _start_mixed_workload(client, path, kind, workload_duration)
+
+        end_at = time.time() + workload_duration
+        next_conflict = time.time() + conflict_interval
+        round_num = 0
+        while time.time() < end_at:
+            if conflict_interval > 0 and time.time() >= next_conflict:
+                writer = clients[round_num % len(clients)]
+                log.info(
+                    "Cross-client conflict write round %d from %s",
+                    round_num,
+                    getattr(writer, "hostname", writer),
+                )
+                _cross_client_conflict_write(
+                    writer, conflict_paths[writer], "r%d" % round_num
+                )
+                round_num += 1
+                next_conflict = time.time() + conflict_interval
+            time.sleep(5)
+
+        for client in clients:
+            _kill_workloads(client)
+
+        log.info(
+            "Waiting %s s for delegation log lines to settle",
+            timing.log_settle_seconds,
+        )
+        time.sleep(timing.log_settle_seconds)
+        stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+        hits = read_ganesha_delegation_tailf_capture(nfs_node, container_id)
+        _validate_stress_capture(hits, strict_validation, hold_mode)
+
+        return 0
+    except Exception as err:
+        log.error("Delegation stress IO test failed: %s", err)
+        return 1
+    finally:
+        for client in clients:
+            _kill_workloads(client)
+        if mount_roots:
+            _teardown_client_mounts(clients, mounts_per_client)
+        if subvol_names:
+            teardown_delegation_exports(
+                nfs_cmd_host, fs_name, nfs_name, subvol_group, [export_rw], subvol_names
+            )
+        try:
+            if container_id:
+                stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                truncate_ganesha_container_log(nfs_node, container_id)
+        except Exception as err:
+            log.warning("Ganesha log cleanup failed: %s", err)
+        try:
+            restore_delegation_ganesha_templates(
+                nfs_cmd_host,
+                delegation_template_backup,
+                logging_template_backup,
+                cephadm,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        except Exception as err:
+            log.warning("Template restore failed: %s", err)
+        if created_cluster:
+            cleanup_cluster(
+                clients=clients[:1],
+                nfs_mount=nfs_mount,
+                nfs_name=nfs_name,
+                nfs_export=bootstrap_export,
+                nfs_nodes=nfs_nodes,
+            )


### PR DESCRIPTION
# Description

Summary : 
Adds NFSv4 delegation automation for revoke/recall (extended), file operations under delegation, and multi-client stress/scale. Extends nfs_delegation_operations.py with shared revoke and file-op log validators.

Changes - 
Revoke/recall — 5 scenarios: 3 recall + 2 revoke (return before peer IO; recall/revoke on write conflict). Existing suite entry updated in place with delegation_return_wait_seconds.
File operations — open/close, rw+recall, lock/unlock, setattr/truncate (CEPH-83632379).
Stress/scale — up to 4 clients × 5 mounts, mixed IO, cross-client conflict writes, loose grant/recall log check (CEPH-83632381).

Logs : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2190P0/ 


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
