### PR TITLE
interop: default BUILD_TYPE to rc for OpenStack certification runs

### DIFF
--- a/pipeline/scripts/interop/test-ceph-features.sh
+++ b/pipeline/scripts/interop/test-ceph-features.sh
@@ -13,7 +13,7 @@ PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
 OSP_CRED_FILE=${OSP_CRED_FILE:-}
 REPO_FILE=${REPO_FILE:-}
 VM_SPEC=${VM_SPEC:-}
-BUILD_TYPE=${BUILD_TYPE:-"released"}
+BUILD_TYPE=${BUILD_TYPE:-"rc"}
 RHCS_VERSION=${RHCS_VERSION:-}
 
 echo "Red Hat Ceph Storage sanity test suite execution."


### PR DESCRIPTION
The interop pipeline uses --skip-subscription, which is incompatible with --build released bootstrap on OpenStack. Use rc to install the same GA compose without enabling RH CDN tool repos via subscription-manager.