### PR TITLE
TFA Fix for the inconsistence objects repaired in EC pool

### DIFF
--- a/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
@@ -256,8 +256,8 @@ tests:
       desc: EC pool with Overwrites & create RBD pool
 
   - test:
-      name: Inconsistent objects in  EC pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      name: EC Case 1-Inconsistent objects verification
+      desc: Scrub on EC pool - Inconsistent objects>auto repair errors count & auto_repair is true
       module: test_osd_ecpool_inconsistency_scenario.py
       polarion-id: CEPH-83586175
       config:
@@ -274,6 +274,119 @@ tests:
         inconsistent_obj_count: 4
         delete_pool:
           - ec62_pool4
+        case_to_run:
+          - case1
+
+  - test:
+      name: EC Case 2-Inconsistent objects verification
+      desc: Scrub on EC pool - Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec62_4
+          pool_name: ec62_pool4
+          pg_num: 1
+          k: 6
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          crush-failure-domain: host
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec62_pool4
+        case_to_run:
+          - case2
+
+  - test:
+      name: EC Case 3-Inconsistent objects verification
+      desc: Scrub on EC pool - Inconsistent objects<auto repair errors count, auto_repair enabled; expect auto-repair
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec62_4
+          pool_name: ec62_pool4
+          pg_num: 1
+          k: 6
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          crush-failure-domain: host
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec62_pool4
+        case_to_run:
+          - case3
+
+  - test:
+      name: EC Case 4-Inconsistent objects verification
+      desc: Deep-scrub on EC pool - Inconsistent objects>auto repair errors count & auto_repair is true
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec62_4
+          pool_name: ec62_pool4
+          pg_num: 1
+          k: 6
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          crush-failure-domain: host
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec62_pool4
+        case_to_run:
+          - case4
+
+  - test:
+      name: EC Case 5-Inconsistent objects verification
+      desc: Deep-scrub on EC pool - Inconsistent objects<auto repair errors count & auto_repair is false
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec62_4
+          pool_name: ec62_pool4
+          pg_num: 1
+          k: 6
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          crush-failure-domain: host
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec62_pool4
+        case_to_run:
+          - case5
+
+  - test:
+      name: EC Case 6-Inconsistent objects verification
+      desc: Deep-scrub on EC pool - Inconsistent objects<auto repair errors count, auto_repair enabled
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec62_4
+          pool_name: ec62_pool4
+          pg_num: 1
+          k: 6
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          crush-failure-domain: host
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec62_pool4
+        case_to_run:
+          - case6
+
 
   - test:
       name: Compression test - EC pool

--- a/tests/rados/test_osd_ecpool_inconsistency_scenario.py
+++ b/tests/rados/test_osd_ecpool_inconsistency_scenario.py
@@ -1,22 +1,36 @@
 """
-This file contains the  methods to verify the  inconsistent object functionality during scrub/deep-scrub in EC pool.
-AS part of verification the script  perform the following tasks-
-   1. Create objects
-   2. Convert the object in to inconsistent object
-   3. Use the osd_scrub_auto_repair and osd_scrub_auto_repair_num_errors to perform the PG repair
-       osd_scrub_auto_repair_num_errors - Setting this to true will enable automatic PG repair when errors are
-                                          found by scrubs or deep-scrubs.
-       osd_scrub_auto_repair_num_errors - Auto repair will not occur if more than this many errors are found
-                                          Default value is - 5
-   3. Verifying the functionality by executing the following scenarios-
-      3.1- Inconsistent objects greater than the osd_scrub_auto_repair_num_errors count
-           Creating the n inconsistent
-           Setting the osd_scrub_auto_repair_num_errors to n-1
-           Setting the osd_scrub_auto_repair to true
-           Performing the scrub and deep-scrub on the PG
-      3.2  The inconsistent object count is less than osd_scrub_auto_repair_num_errors count
-           Setting the osd_scrub_auto_repair_num_errors to n+1
-           Performing the scrub and deep-scrub on the PG
+This file contains the methods to verify inconsistent object functionality during
+scrub/deep-scrub in an EC pool.
+
+As part of verification the script performs the following tasks:
+   1. Create objects in an EC pool
+   2. Convert the objects into inconsistent objects
+   3. Use osd_scrub_auto_repair and osd_scrub_auto_repair_num_errors to verify PG repair behavior
+       osd_scrub_auto_repair - Setting this to true enables automatic PG repair when errors are
+                               found by scrubs or deep-scrubs.
+       osd_scrub_auto_repair_num_errors - Auto repair will not occur if more than this many errors
+                                          are found. Default value is 5.
+   4. Verify the functionality by executing the following cases (config['case_to_run']):
+      case1 - Scrub: inconsistent objects > osd_scrub_auto_repair_num_errors and auto_repair is true
+              Set osd_scrub_auto_repair_num_errors to n-1 and osd_scrub_auto_repair to true.
+              Expectation: No repairs to be made.
+      case2 - Scrub: inconsistent objects < osd_scrub_auto_repair_num_errors and auto_repair is false
+              Set osd_scrub_auto_repair_num_errors to n+1 and osd_scrub_auto_repair to false.
+              Expectation: No repairs to be made.
+      case3 - Scrub: inconsistent objects < osd_scrub_auto_repair_num_errors and auto_repair is true
+              Set osd_scrub_auto_repair_num_errors to n+1 and osd_scrub_auto_repair to true.
+              Expectation: All inconsistent objects are auto-repaired.
+      case4 - Deep-scrub: inconsistent objects > osd_scrub_auto_repair_num_errors and auto_repair is true
+              Set osd_scrub_auto_repair_num_errors to n-1 and osd_scrub_auto_repair to true.
+              Expectation: No repairs to be made.
+      case5 - Deep-scrub: inconsistent objects < osd_scrub_auto_repair_num_errors and auto_repair is false
+              Set osd_scrub_auto_repair_num_errors to n+1 and osd_scrub_auto_repair to false.
+              Expectation: No repairs to be made.
+      case6 - Deep-scrub: inconsistent objects < osd_scrub_auto_repair_num_errors and auto_repair is true
+              Set osd_scrub_auto_repair_num_errors to n+1 and osd_scrub_auto_repair to true.
+              Expectation: All inconsistent objects are auto-repaired and PG repair state is cleared.
+
+      If case_to_run is not specified, all six cases are executed sequentially.
 """
 
 import time
@@ -35,10 +49,36 @@ from utility.utils import method_should_succeed
 
 log = Log(__name__)
 
+CASE_LOG_PREFIX = {
+    "case1": "CASE1",
+    "case2": "CASE2",
+    "case3": "CASE3",
+    "case4": "CASE4",
+    "case5": "CASE5",
+    "case6": "CASE6",
+}
+
 
 def run(ceph_cluster, **kw):
     """
-    Test to create an inconsistent object functionality during scrub/deep-scrub in EC pool.
+    Verify inconsistent object behavior during scrub/deep-scrub in an EC pool.
+
+    Test cases are selected via config['case_to_run']:
+      case1 - Scrub with inconsistent count > auto_repair_num_errors and auto_repair enabled.
+              Expectation: No repairs.
+      case2 - Scrub with inconsistent count < auto_repair_num_errors and auto_repair disabled.
+              Expectation: No repairs.
+      case3 - Scrub with inconsistent count < auto_repair_num_errors and auto_repair enabled.
+              Expectation: All inconsistent objects are auto-repaired.
+      case4 - Deep-scrub with inconsistent count > auto_repair_num_errors and auto_repair enabled.
+              Expectation: No repairs.
+      case5 - Deep-scrub with inconsistent count < auto_repair_num_errors and auto_repair disabled.
+              Expectation: No repairs.
+      case6 - Deep-scrub with inconsistent count < auto_repair_num_errors and auto_repair enabled.
+              Expectation: All inconsistent objects are auto-repaired and PG repair state is cleared.
+
+    If case_to_run is not specified, all six cases run sequentially.
+
     Returns:
         1 -> Fail, 0 -> Pass
     """
@@ -53,481 +93,600 @@ def run(ceph_cluster, **kw):
     client_node = ceph_cluster.get_nodes(role="client")[0]
     wait_time = 45
     start_time = get_cluster_timestamp(rados_obj.node)
-    log.debug(f"Test workflow started. Start time: {start_time}")
+    log.info(f"[SETUP] Test workflow started at cluster time: {start_time}")
     try:
-        # set global autoscaler to off
+        log.info("[SETUP] Disabling PG autoscaler for the test duration")
         rados_obj.configure_pg_autoscaler(**{"default_mode": "off"})
-        # Creating ec pool
         ec_config = config.get("ec_pool")
         pool_name = ec_config["pool_name"]
         req_no_of_objects = config.get("inconsistent_obj_count")
+        if (
+            not req_no_of_objects
+            or not isinstance(req_no_of_objects, int)
+            or req_no_of_objects <= 0
+        ):
+            log.error("[SETUP] inconsistent_obj_count must be a positive integer")
+            return 1
 
-        # Set the default values
         log.info(
-            "Reset the scrub minimum and maximum interval settings to their default values before initiating "
-            "the tests. This ensures that any custom values set by previous tests in the suite are cleared, "
-            "preventing the scrub operation from starting immediately."
+            f"[SETUP] EC pool configuration - pool: {pool_name}, "
+            f"requested inconsistent objects: {req_no_of_objects}"
+        )
+
+        log.info(
+            "[SETUP] Resetting scrub interval settings to defaults to prevent "
+            "immediate scrub from prior suite tests"
         )
         mon_obj.remove_config(section="osd", name="osd_scrub_min_interval")
         mon_obj.remove_config(section="osd", name="osd_scrub_max_interval")
         mon_obj.remove_config(section="osd", name="osd_deep_scrub_interval")
 
+        log.info("[SETUP] Setting noscrub and nodeep-scrub OSD flags")
         scrub_object.set_osd_flags("set", "nodeep-scrub")
         scrub_object.set_osd_flags("set", "noscrub")
 
         if not rados_obj.create_erasure_pool(name=pool_name, **ec_config):
-            log.error("Failed to create the EC Pool")
+            log.error(f"[SETUP] Failed to create EC pool '{pool_name}'")
             return 1
-        # Get the acting PG set
+        log.info(f"[SETUP] EC pool '{pool_name}' created successfully")
+
         acting_pg_set = rados_obj.get_pg_acting_set(pool_name=pool_name)
+        log.info(f"[SETUP] Acting PG set for pool '{pool_name}': {acting_pg_set}")
 
         if config.get("debug_enable"):
+            log.info("[SETUP] Enabling debug logging for osd and mgr")
             mon_obj.set_config(section="osd", name="debug_osd", value="20/20")
             mon_obj.set_config(section="mgr", name="debug_mgr", value="20/20")
+
+        log.info("[SETUP] Waiting for all PGs to reach clean state")
         method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        log.info("[SETUP] All PGs are in clean state")
 
         try:
+            log.info(
+                f"[SETUP] Creating {req_no_of_objects} inconsistent objects in "
+                f"pool '{pool_name}'"
+            )
             pg_info = rados_obj.create_ecpool_inconsistent_obj(
                 objectstore_obj, client_node, pool_name, req_no_of_objects
             )
-
             pg_id, no_of_inconsistent_objects = pg_info
-        except Exception as e:
-            log.error(e)
-            log.error(
-                "The inconsistent_obj_count is 0.To proceed further tests the auto_repair_param_value "
-                "should be less than Inconsistent objects count which is -1.The -1 is not acceptable to "
-                "run the tests"
-            )
-            return 1
-
-        # Check the default values of the osd_scrub_auto_repair_num_errors
-        auto_repair_num_value = mon_obj.get_config(
-            section="osd", param="osd_scrub_auto_repair_num_errors"
-        )
-        log.info(
-            f"Original value of osd_scrub_auto_repair_num_errors is {auto_repair_num_value}"
-        )
-        if int(auto_repair_num_value) != 5:
-            log.error(
-                "The default value of the osd_scrub_auto_repair_num_errors is not equal to 5"
-            )
-            return 1
-
-        # Check the default values of the osd_scrub_auto_repair
-        auto_repair_value = mon_obj.get_config(
-            section="osd", param="osd_scrub_auto_repair"
-        )
-        log.info(f"Original value of osd_scrub_auto_repair is {auto_repair_value}")
-        if auto_repair_value is True:
-            log.error("The default value of the osd_scrub_auto_repair should be false")
-            return 1
-
-        log.info("====VERIFICATION OF THE TESTS BY PERFORMING SCRUB OPERATIONS====")
-
-        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
-            log.error(
-                "Test_scenario1: The scrub operations are still in progress.Not executing the further tests"
-            )
-            return 1
-        no_of_inconsistent_objects = get_pg_inconsistent_object_count(rados_obj, pg_id)
-        auto_repair_param_value = no_of_inconsistent_objects - 1
-
-        # case 1: inconsistent objects are greater than the osd_scrub_auto_repair_num_errors count
-
-        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
-        log.info("The osd_scrub_auto_repair value is set to true")
-
-        log.info(
-            "Test scenario1:Inconsistent objects greater than the osd_scrub_auto_repair_num_errors count\n"
-            + "operation : scrub\n"
-            + "Expectation : No repairs to be made"
-        )
-        mon_obj.set_config(
-            section="osd",
-            name="osd_scrub_auto_repair_num_errors",
-            value=auto_repair_param_value,
-        )
-        log.info(
-            f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
-        )
-        scrub_object.set_osd_flags("unset", "noscrub")
-        print_parameter_messages(
-            1,
-            no_of_inconsistent_objects,
-            auto_repair_param_value,
-            auto_repair_value="True",
-            operation="scrub",
-        )
-        try:
-            obj_count = get_inconsistent_count(
-                scrub_object, mon_obj, pg_id, rados_obj, "scrub", acting_pg_set
+            log.info(
+                f"[SETUP] Created inconsistent objects in PG {pg_id}. "
+                f"Inconsistent object count: {no_of_inconsistent_objects}"
             )
         except Exception as e:
-            log.info(e)
-            return 1
-        msg_obj_count = f"Scenario-1:The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-        if obj_count == -1:
-            log.error(f"The scrub not initiated on the pg-{pg_id}")
-            rados_obj.log_cluster_health()
-            return 1
-
-        if obj_count != no_of_inconsistent_objects:
+            log.error(f"[SETUP] Failed to create inconsistent objects: {e}")
             log.error(
-                f"Scrub repaired the {no_of_inconsistent_objects - obj_count} inconsistent objects"
-            )
-            return 1
-        log.info(
-            "Test scenario1 completed:Inconsistent objects greater than the osd_scrub_auto_repair_num_errors count\n"
-            + "operation : scrub\n"
-            + "Expectation : No repairs to be made\n"
-            + f"Inconsistent count before test:{obj_count}\n"
-            + f"Inconsistent count after test:{no_of_inconsistent_objects}"
-        )
-
-        log.info(
-            "Test scenario2:Inconsistent objects less than the osd_scrub_auto_repair_num_errors count and "
-            "osd_scrub_auto_repair is false\n"
-            + "operation : scrub\n"
-            + "Expectation : No repairs to be made"
-        )
-        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
-            log.error(
-                "Test_scenario2: The scrub operations are still in progress.Not executing the further tests"
+                "[SETUP] inconsistent_obj_count must be greater than 0. "
+                "Cannot proceed when auto_repair_param_value would be invalid."
             )
             return 1
 
-        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="false")
-        no_of_inconsistent_objects = get_pg_inconsistent_object_count(rados_obj, pg_id)
-        auto_repair_param_value = no_of_inconsistent_objects + 1
-        mon_obj.set_config(
-            section="osd",
-            name="osd_scrub_auto_repair_num_errors",
-            value=auto_repair_param_value,
-        )
-
-        log.info(
-            f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
-        )
-        print_parameter_messages(
-            2,
-            no_of_inconsistent_objects,
-            auto_repair_param_value,
-            auto_repair_value="False",
-            operation="scrub",
-        )
-        try:
-            obj_count = get_inconsistent_count(
-                scrub_object, mon_obj, pg_id, rados_obj, "scrub", acting_pg_set
+        case_to_run = config.get("case_to_run")
+        if not case_to_run:
+            case_to_run = ["case1", "case2", "case3", "case4", "case5", "case6"]
+            log.info(
+                "[SETUP] case_to_run not specified; executing all cases sequentially: "
+                f"{case_to_run}"
             )
-        except Exception as e:
-            log.info(e)
-            return 1
-        # Change to high value
-        msg_obj_count = f"Scenario-2:The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-        if obj_count == -1:
-            log.error(f"The scrub not initiated on the pg-{pg_id}")
-            rados_obj.log_cluster_health()
-            return 1
-        if obj_count != no_of_inconsistent_objects:
-            log.error(
-                f"Scrub repaired the {no_of_inconsistent_objects - obj_count} inconsistent objects"
+        else:
+            log.info(f"[SETUP] Cases selected for execution: {case_to_run}")
+
+        if "case1" in case_to_run:
+            log_case_start(
+                "case1",
+                "Inconsistent objects > osd_scrub_auto_repair_num_errors, auto_repair enabled",
+                "scrub",
+                "No repairs to be made",
             )
-            return 1
-
-        log.info(
-            "Test scenario2 completed:Inconsistent objects less than the osd_scrub_auto_repair_num_errors "
-            "count and osd_scrub_auto_repair is false\n"
-            + "operation : scrub\n"
-            + "Expectation : No repairs to be made\n"
-            + f"Inconsistent count before test:{obj_count}\n"
-            + f"Inconsistent count after test:{no_of_inconsistent_objects}"
-        )
-
-        # Check the scrub/deep-scrub in sin running or not if not
-        log.info(
-            "Test scenario3:Inconsistent objects less than the osd_scrub_auto_repair_num_errors count and "
-            "osd_scrub_auto_repair is true\n"
-            + "operation : scrub\n"
-            + "Expectation : No repairs to be made"
-        )
-
-        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
-            log.error(
-                "Test_scenario3: The scrub operations are still in progress.Not executing the further tests"
+            log.info(
+                "[CASE1] Verifying default values of osd_scrub_auto_repair_num_errors "
+                "and osd_scrub_auto_repair"
             )
-            return 1
-        no_of_inconsistent_objects = get_pg_inconsistent_object_count(rados_obj, pg_id)
-        auto_repair_param_value = no_of_inconsistent_objects + 1
-        mon_obj.set_config(
-            section="osd",
-            name="osd_scrub_auto_repair_num_errors",
-            value=auto_repair_param_value,
-        )
-        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
-        print_parameter_messages(
-            3,
-            no_of_inconsistent_objects,
-            auto_repair_param_value,
-            auto_repair_value="True",
-            operation="scrub",
-        )
-        obj_count = get_inconsistent_count(
-            scrub_object, mon_obj, pg_id, rados_obj, "scrub", acting_pg_set
-        )
-        msg_obj_count = f"Scenario-3:The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-
-        if obj_count == -1:
-            log.error(f"The scrub not initiated on the pg-{pg_id}")
-            rados_obj.log_cluster_health()
-            return 1
-        if obj_count != no_of_inconsistent_objects:
-            log.error(
-                f"Scrub repaired the {no_of_inconsistent_objects - obj_count} inconsistent objects"
+            auto_repair_num_value = mon_obj.get_config(
+                section="osd", param="osd_scrub_auto_repair_num_errors"
             )
-            return 1
-
-        log.info(
-            "Test scenario3 completed:SCRUB-Inconsistent objects less than the osd_scrub_auto_repair_num_errors "
-            "count and osd_scrub_auto_repair is true\n"
-            + "operation : scrub\n"
-            + "Expectation : No repairs to be made\n"
-            + f"Inconsistent count before test:{obj_count}\n"
-            + f"Inconsistent count after test:{no_of_inconsistent_objects}"
-        )
-        scrub_object.set_osd_flags("set", "noscrub")
-        log.info("Scenario3: noscrub flag is set")
-        log.info(
-            "====VERIFICATION OF THE TESTS BY PERFORMING SCRUB OPERATIONS ARE COMPLETED===="
-        )
-        log.info(
-            "====VERIFICATION OF THE TESTS BY PERFORMING DEEP-SCRUB OPERATIONS===="
-        )
-
-        log.info(
-            "Test scenario4:Inconsistent objects greater than the osd_scrub_auto_repair_num_errors count\n"
-            + "operation : Deep-Scrub\n"
-            + "Expectation : No repairs to be made"
-        )
-        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
-            log.error(
-                "Test_scenario4: The scrub operations are still in progress.Not executing the further tests"
+            log.info(
+                f"[CASE1] Default osd_scrub_auto_repair_num_errors: {auto_repair_num_value}"
             )
-            return 1
-        no_of_inconsistent_objects = get_pg_inconsistent_object_count(rados_obj, pg_id)
-        auto_repair_param_value = no_of_inconsistent_objects - 1
-        mon_obj.set_config(
-            section="osd",
-            name="osd_scrub_auto_repair_num_errors",
-            value=auto_repair_param_value,
-        )
+            if int(auto_repair_num_value) != 5:
+                log_case_failure(
+                    "case1",
+                    "Default osd_scrub_auto_repair_num_errors is not equal to 5",
+                )
+                return 1
 
-        log.info(
-            f"The osd_scrub_auto_repair_num_errors value is set to {auto_repair_param_value}"
-        )
-        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
-        scrub_object.set_osd_flags("unset", "nodeep-scrub")
-        time.sleep(5)
-        print_parameter_messages(
-            4,
-            no_of_inconsistent_objects,
-            auto_repair_param_value,
-            auto_repair_value="True",
-            operation="deep-scrub",
-        )
-        try:
-            obj_count = get_inconsistent_count(
-                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            auto_repair_value = mon_obj.get_config(
+                section="osd", param="osd_scrub_auto_repair"
             )
-        except Exception as e:
-            log.info(e)
-            return 1
-        msg_obj_count = f"Scenario-4:The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-        if obj_count == -1:
-            log.error(f"The scrub not initiated on the pg-{pg_id}")
-            rados_obj.log_cluster_health()
-            return 1
+            log.info(f"[CASE1] Default osd_scrub_auto_repair: {auto_repair_value}")
+            if auto_repair_value == "true":
+                log_case_failure(
+                    "case1", "Default osd_scrub_auto_repair should be false"
+                )
+                return 1
 
-        if obj_count != no_of_inconsistent_objects:
-            log.error(
-                f"Scrub repaired the {no_of_inconsistent_objects - obj_count} inconsistent objects"
+            if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+                log_case_failure(
+                    "case1",
+                    "Scrub operation still in progress; cannot proceed with test",
+                )
+                return 1
+            no_of_inconsistent_objects = get_pg_inconsistent_object_count(
+                rados_obj, pg_id
             )
-            return 1
+            auto_repair_param_value = no_of_inconsistent_objects - 1
 
-        log.info(
-            "Test scenario4 completed:Inconsistent objects greater than the osd_scrub_auto_repair_num_errors count\n"
-            + "operation : Deep-scrub\n"
-            + "Expectation : No repairs to be made\n"
-            + f"Inconsistent count before test:{obj_count}\n"
-            + f"Inconsistent count after test:{no_of_inconsistent_objects}"
-        )
-
-        log.info(
-            "Test scenario5:Inconsistent objects less than the osd_scrub_auto_repair_num_errors count and "
-            "osd_scrub_auto_repair is false\n"
-            + "operation : Deep-scrub\n"
-            + "Expectation : No repairs to be made"
-        )
-        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
-            log.error(
-                "Test_scenario5: The scrub operations are still in progress.Not executing the further tests"
+            mon_obj.set_config(
+                section="osd",
+                name="osd_scrub_auto_repair_num_errors",
+                value=auto_repair_param_value,
             )
-            return 1
-        no_of_inconsistent_objects = get_pg_inconsistent_object_count(rados_obj, pg_id)
-        auto_repair_param_value = no_of_inconsistent_objects + 1
-        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="false")
-        mon_obj.set_config(
-            section="osd",
-            name="osd_scrub_auto_repair_num_errors",
-            value=auto_repair_param_value,
-        )
-        print_parameter_messages(
-            5,
-            no_of_inconsistent_objects,
-            auto_repair_param_value,
-            auto_repair_value="False",
-            operation="deep-scrub",
-        )
-        try:
-            obj_count = get_inconsistent_count(
-                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            log.info(
+                f"[CASE1] Set osd_scrub_auto_repair_num_errors to {auto_repair_param_value}"
             )
-        except Exception as e:
-            log.info(e)
-            return 1
-        msg_obj_count = f"Scenario-5:The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-        if obj_count == -1:
-            log.error(f"The scrub not initiated on the pg-{pg_id}")
-            rados_obj.log_cluster_health()
-            return 1
-        if obj_count != no_of_inconsistent_objects:
-            log.error(
-                f"Scrub repaired the {no_of_inconsistent_objects - obj_count} inconsistent objects"
+            mon_obj.set_config(
+                section="osd", name="osd_scrub_auto_repair", value="true"
             )
-            return 1
-        log.info(
-            "Test scenario5 completed:Inconsistent objects less than the osd_scrub_auto_repair_num_errors "
-            "count and osd_scrub_auto_repair is false\n"
-            + "operation : Deep-scrub\n"
-            + "Expectation : No repairs to be made\n"
-            + f"Inconsistent count before test:{obj_count}\n"
-            + f"Inconsistent count after test:{no_of_inconsistent_objects}"
-        )
-        log.info(
-            "Test scenario6:Inconsistent objects less than the osd_scrub_auto_repair_num_errors count and "
-            "osd_scrub_auto_repair is true\n"
-            + "operation : Deep-scrub\n"
-            + "Expectation : Repairs to be made"
-        )
-        if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
-            log.error(
-                "Test_scenario6: The scrub operations are still in progress.Not executing the further tests"
+            log.info("[CASE1] Set osd_scrub_auto_repair to true")
+            scrub_object.set_osd_flags("unset", "noscrub")
+            log.info("[CASE1] Unset noscrub OSD flag to allow scheduled scrub")
+            log_case_parameters(
+                "case1",
+                no_of_inconsistent_objects,
+                auto_repair_param_value,
+                "True",
+                "scrub",
             )
-            return 1
-        no_of_inconsistent_objects = get_pg_inconsistent_object_count(rados_obj, pg_id)
-        auto_repair_param_value = no_of_inconsistent_objects + 1
-        mon_obj.set_config(
-            section="osd",
-            name="osd_scrub_auto_repair_num_errors",
-            value=auto_repair_param_value,
-        )
-        mon_obj.set_config(section="osd", name="osd_scrub_auto_repair", value="true")
-        print_parameter_messages(
-            6,
-            no_of_inconsistent_objects,
-            auto_repair_param_value,
-            auto_repair_value="True",
-            operation="deep-scrub",
-        )
-        try:
-            obj_count = get_inconsistent_count(
-                scrub_object, mon_obj, pg_id, rados_obj, "deep-scrub", acting_pg_set
+            obj_count = run_scrub_operation(
+                scrub_object,
+                mon_obj,
+                pg_id,
+                rados_obj,
+                "scrub",
+                acting_pg_set,
+                "case1",
             )
-        except Exception as e:
-            log.info(e)
-            return 1
-        msg_obj_count = f"Scenario-6:The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-
-        msg_obj_count = f"The object count value is-{obj_count}"
-        log.info(msg_obj_count)
-
-        if obj_count == -1:
-            log.error(f"The scrub not initiated on the pg-{pg_id}")
-            rados_obj.log_cluster_health()
-            return 1
-
-        if obj_count != 0:
-            log.error(
-                f"Scrub repaired the {no_of_inconsistent_objects - obj_count} inconsistent objects"
+            if obj_count == -1:
+                return 1
+            if obj_count != no_of_inconsistent_objects:
+                log_case_failure(
+                    "case1",
+                    f"Scrub repaired {no_of_inconsistent_objects - obj_count} "
+                    f"inconsistent objects unexpectedly",
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log_case_complete(
+                "case1",
+                "scrub",
+                "No repairs to be made",
+                no_of_inconsistent_objects,
+                obj_count,
             )
-            rados_obj.log_cluster_health()
-            return 1
-        result = verify_pg_state(rados_obj, pg_id)
 
-        if not result:
-            log.error("The  pg state output contain repair state after deep-scrub")
-            rados_obj.log_cluster_health()
-            return 1
-        scrub_object.set_osd_flags("unset", "noscrub")
-        log.info(
-            "Test scenario6 completed:SCRUB-Inconsistent objects less than the osd_scrub_auto_repair_num_errors "
-            "count and osd_scrub_auto_repair is true\n"
-            + "operation : Deep-scrub\n"
-            + "Expectation : Repairs to be made\n"
-            + f"Inconsistent count before test:{obj_count}\n"
-            + f"Inconsistent count after test:{no_of_inconsistent_objects}"
-        )
+        if "case2" in case_to_run:
+            log_case_start(
+                "case2",
+                "Inconsistent objects < osd_scrub_auto_repair_num_errors, auto_repair disabled",
+                "scrub",
+                "No repairs to be made",
+            )
+            if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+                log_case_failure(
+                    "case2",
+                    "Scrub operation still in progress; cannot proceed with test",
+                )
+                return 1
 
-        log.info(
-            "====VERIFICATION OF THE TESTS BY PERFORMING DEEP-SCRUB OPERATIONS ARE COMPLETED===="
-        )
+            mon_obj.set_config(
+                section="osd", name="osd_scrub_auto_repair", value="false"
+            )
+            log.info("[CASE2] Set osd_scrub_auto_repair to false")
+            no_of_inconsistent_objects = get_pg_inconsistent_object_count(
+                rados_obj, pg_id
+            )
+            auto_repair_param_value = no_of_inconsistent_objects + 1
+            mon_obj.set_config(
+                section="osd",
+                name="osd_scrub_auto_repair_num_errors",
+                value=auto_repair_param_value,
+            )
+            log.info(
+                f"[CASE2] Set osd_scrub_auto_repair_num_errors to {auto_repair_param_value}"
+            )
+            scrub_object.set_osd_flags("unset", "noscrub")
+            log.info("[CASE2] Unset noscrub OSD flag to allow scheduled scrub")
+            log_case_parameters(
+                "case2",
+                no_of_inconsistent_objects,
+                auto_repair_param_value,
+                "False",
+                "scrub",
+            )
+            obj_count = run_scrub_operation(
+                scrub_object,
+                mon_obj,
+                pg_id,
+                rados_obj,
+                "scrub",
+                acting_pg_set,
+                "case2",
+            )
+            if obj_count == -1:
+                return 1
+            if obj_count != no_of_inconsistent_objects:
+                log_case_failure(
+                    "case2",
+                    f"Scrub repaired {no_of_inconsistent_objects - obj_count} "
+                    f"inconsistent objects unexpectedly",
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log_case_complete(
+                "case2",
+                "scrub",
+                "No repairs to be made",
+                no_of_inconsistent_objects,
+                obj_count,
+            )
+
+        if "case3" in case_to_run:
+            log_case_start(
+                "case3",
+                "Inconsistent objects < osd_scrub_auto_repair_num_errors, auto_repair enabled",
+                "scrub",
+                "All inconsistent objects are auto-repaired",
+            )
+            if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+                log_case_failure(
+                    "case3",
+                    "Scrub operation still in progress; cannot proceed with test",
+                )
+                return 1
+            no_of_inconsistent_objects = get_pg_inconsistent_object_count(
+                rados_obj, pg_id
+            )
+            auto_repair_param_value = no_of_inconsistent_objects + 1
+            mon_obj.set_config(
+                section="osd",
+                name="osd_scrub_auto_repair_num_errors",
+                value=auto_repair_param_value,
+            )
+            log.info(
+                f"[CASE3] Set osd_scrub_auto_repair_num_errors to {auto_repair_param_value}"
+            )
+            mon_obj.set_config(
+                section="osd", name="osd_scrub_auto_repair", value="true"
+            )
+            log.info("[CASE3] Set osd_scrub_auto_repair to true")
+            scrub_object.set_osd_flags("unset", "noscrub")
+            log.info("[CASE3] Unset noscrub OSD flag to allow scheduled scrub")
+            log_case_parameters(
+                "case3",
+                no_of_inconsistent_objects,
+                auto_repair_param_value,
+                "True",
+                "scrub",
+            )
+            obj_count = run_scrub_operation(
+                scrub_object,
+                mon_obj,
+                pg_id,
+                rados_obj,
+                "scrub",
+                acting_pg_set,
+                "case3",
+            )
+            if obj_count == -1:
+                return 1
+
+            if obj_count != 0:
+                log_case_failure(
+                    "case3",
+                    f"failed to repair {no_of_inconsistent_objects - obj_count} objects",
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log_case_complete(
+                "case3",
+                "scrub",
+                "All inconsistent objects are auto-repaired",
+                no_of_inconsistent_objects,
+                obj_count,
+            )
+            if any(case in case_to_run for case in ("case4", "case5", "case6")):
+                scrub_object.set_osd_flags("set", "noscrub")
+                log.info(
+                    "[CASE3] Set noscrub OSD flag before upcoming deep-scrub cases"
+                )
+
+        if "case4" in case_to_run:
+            log_case_start(
+                "case4",
+                "Inconsistent objects > osd_scrub_auto_repair_num_errors, auto_repair enabled",
+                "deep-scrub",
+                "No repairs to be made",
+            )
+            if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+                log_case_failure(
+                    "case4",
+                    "Scrub operation still in progress; cannot proceed with test",
+                )
+                return 1
+            no_of_inconsistent_objects = get_pg_inconsistent_object_count(
+                rados_obj, pg_id
+            )
+            auto_repair_param_value = no_of_inconsistent_objects - 1
+            mon_obj.set_config(
+                section="osd",
+                name="osd_scrub_auto_repair_num_errors",
+                value=auto_repair_param_value,
+            )
+            log.info(
+                f"[CASE4] Set osd_scrub_auto_repair_num_errors to {auto_repair_param_value}"
+            )
+            mon_obj.set_config(
+                section="osd", name="osd_scrub_auto_repair", value="true"
+            )
+            log.info("[CASE4] Set osd_scrub_auto_repair to true")
+            scrub_object.set_osd_flags("unset", "nodeep-scrub")
+            log.info(
+                "[CASE4] Unset nodeep-scrub OSD flag to allow scheduled deep-scrub"
+            )
+            log_case_parameters(
+                "case4",
+                no_of_inconsistent_objects,
+                auto_repair_param_value,
+                "True",
+                "deep-scrub",
+            )
+            obj_count = run_scrub_operation(
+                scrub_object,
+                mon_obj,
+                pg_id,
+                rados_obj,
+                "deep-scrub",
+                acting_pg_set,
+                "case4",
+            )
+            if obj_count == -1:
+                return 1
+            if obj_count != no_of_inconsistent_objects:
+                log_case_failure(
+                    "case4",
+                    f"Deep-scrub repaired {no_of_inconsistent_objects - obj_count} "
+                    f"inconsistent objects unexpectedly",
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log_case_complete(
+                "case4",
+                "deep-scrub",
+                "No repairs to be made",
+                no_of_inconsistent_objects,
+                obj_count,
+            )
+
+        if "case5" in case_to_run:
+            log_case_start(
+                "case5",
+                "Inconsistent objects < osd_scrub_auto_repair_num_errors, auto_repair disabled",
+                "deep-scrub",
+                "No repairs to be made",
+            )
+            if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+                log_case_failure(
+                    "case5",
+                    "Scrub operation still in progress; cannot proceed with test",
+                )
+                return 1
+            mon_obj.set_config(
+                section="osd", name="osd_scrub_auto_repair", value="false"
+            )
+            log.info("[CASE5] Set osd_scrub_auto_repair to false")
+            no_of_inconsistent_objects = get_pg_inconsistent_object_count(
+                rados_obj, pg_id
+            )
+            auto_repair_param_value = no_of_inconsistent_objects + 1
+            mon_obj.set_config(
+                section="osd",
+                name="osd_scrub_auto_repair_num_errors",
+                value=auto_repair_param_value,
+            )
+            log.info(
+                f"[CASE5] Set osd_scrub_auto_repair_num_errors to {auto_repair_param_value}"
+            )
+            scrub_object.set_osd_flags("unset", "nodeep-scrub")
+            log.info(
+                "[CASE5] Unset nodeep-scrub OSD flag to allow scheduled deep-scrub"
+            )
+
+            log_case_parameters(
+                "case5",
+                no_of_inconsistent_objects,
+                auto_repair_param_value,
+                "False",
+                "deep-scrub",
+            )
+            obj_count = run_scrub_operation(
+                scrub_object,
+                mon_obj,
+                pg_id,
+                rados_obj,
+                "deep-scrub",
+                acting_pg_set,
+                "case5",
+            )
+            if obj_count == -1:
+                return 1
+            if obj_count != no_of_inconsistent_objects:
+                log_case_failure(
+                    "case5",
+                    f"Deep-scrub repaired {no_of_inconsistent_objects - obj_count} "
+                    f"inconsistent objects unexpectedly",
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log_case_complete(
+                "case5",
+                "deep-scrub",
+                "No repairs to be made",
+                no_of_inconsistent_objects,
+                obj_count,
+            )
+
+        if "case6" in case_to_run:
+            log_case_start(
+                "case6",
+                "Inconsistent objects < osd_scrub_auto_repair_num_errors, auto_repair enabled",
+                "deep-scrub",
+                "All inconsistent objects are auto-repaired and PG repair state is cleared",
+            )
+            if not check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
+                log_case_failure(
+                    "case6",
+                    "Scrub operation still in progress; cannot proceed with test",
+                )
+                return 1
+            no_of_inconsistent_objects = get_pg_inconsistent_object_count(
+                rados_obj, pg_id
+            )
+            auto_repair_param_value = no_of_inconsistent_objects + 1
+            mon_obj.set_config(
+                section="osd",
+                name="osd_scrub_auto_repair_num_errors",
+                value=auto_repair_param_value,
+            )
+            log.info(
+                f"[CASE6] Set osd_scrub_auto_repair_num_errors to {auto_repair_param_value}"
+            )
+            mon_obj.set_config(
+                section="osd", name="osd_scrub_auto_repair", value="true"
+            )
+            log.info("[CASE6] Set osd_scrub_auto_repair to true")
+            scrub_object.set_osd_flags("unset", "nodeep-scrub")
+            log.info(
+                "[CASE6] Unset nodeep-scrub OSD flag to allow scheduled deep-scrub"
+            )
+
+            log_case_parameters(
+                "case6",
+                no_of_inconsistent_objects,
+                auto_repair_param_value,
+                "True",
+                "deep-scrub",
+            )
+            obj_count = run_scrub_operation(
+                scrub_object,
+                mon_obj,
+                pg_id,
+                rados_obj,
+                "deep-scrub",
+                acting_pg_set,
+                "case6",
+            )
+            if obj_count == -1:
+                return 1
+            if obj_count != 0:
+                log_case_failure(
+                    "case6",
+                    f"Deep-scrub repaired only {no_of_inconsistent_objects - obj_count} "
+                    f"of {no_of_inconsistent_objects} inconsistent objects; "
+                    f"expected all objects to be repaired",
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log.info(
+                f"[CASE6] All {no_of_inconsistent_objects} inconsistent objects "
+                "were repaired as expected"
+            )
+            result = verify_pg_state(rados_obj, pg_id)
+            if not result:
+                log_case_failure(
+                    "case6", "PG state still contains repair state after deep-scrub"
+                )
+                rados_obj.log_cluster_health()
+                return 1
+            log.info("[CASE6] PG state verified: repair state cleared after deep-scrub")
+            log_case_complete(
+                "case6",
+                "deep-scrub",
+                "All inconsistent objects are auto-repaired and PG repair state is cleared",
+                no_of_inconsistent_objects,
+                obj_count,
+            )
+
+        log.info(f"[SETUP] All selected cases completed successfully: {case_to_run}")
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(f"[SETUP] Test failed with unexpected exception: {e}")
+        log.error(traceback.format_exc())
         return 1
     finally:
-        log.info(
-            "\n\n================ Execution of finally block =======================\n\n"
-        )
+        log.info("\n\n ********* Executing finally block ******** \n\n")
+        log.info("\n[TEARDOWN] Starting test cleanup\n")
         scrub_object.set_osd_flags("unset", "nodeep-scrub")
         scrub_object.set_osd_flags("unset", "noscrub")
+        log.info("[TEARDOWN] Unset noscrub and nodeep-scrub OSD flags")
         rados_obj.configure_pg_autoscaler(**{"default_mode": "on"})
+        log.info("[TEARDOWN] Re-enabled PG autoscaler")
         if config.get("delete_pool"):
             method_should_succeed(rados_obj.delete_pool, pool_name)
-            log.info("deleted the pool successfully")
+            log.info(f"[TEARDOWN] Deleted EC pool '{pool_name}' successfully")
         set_ecpool_inconsistent_default_param_value(mon_obj, scrub_object)
         time.sleep(30)
 
         test_end_time = get_cluster_timestamp(rados_obj.node)
-        log.debug(
-            f"Test workflow completed. Start time: {start_time}, End time: {test_end_time}"
+        log.info(
+            f"[TEARDOWN] Test workflow completed. Start time: {start_time}, "
+            f"End time: {test_end_time}"
         )
         if rados_obj.check_crash_status(start_time=start_time, end_time=test_end_time):
-            log.error("Test failed due to crash at the end of test")
+            log.error("[TEARDOWN] Test failed due to OSD crash during test execution")
             return 1
-        # log cluster health
         rados_obj.log_cluster_health()
+        log.info("[TEARDOWN] Cleanup completed successfully")
     return 0
 
 
 def get_pg_inconsistent_object_count(rados_obj, pg_id):
-    chk_count = 0
-    obj_count = ""
-    while chk_count <= 10:
+    """Fetch inconsistent object count with stability check."""
+    max_attempts = 10
+    stable_threshold = 2
+
+    obj_count = 0
+    prev_count = -1
+    stable_count = 0
+
+    log.info(f"Fetching inconsistent object count for PG {pg_id}")
+
+    for attempt in range(max_attempts + 1):
         inconsistent_details = rados_obj.get_inconsistent_object_details(pg_id)
-        log.debug(
-            f"The inconsistent object details in the pg-{pg_id} is - {inconsistent_details}"
-        )
+        log.debug(f"Inconsistent object details for PG {pg_id}: {inconsistent_details}")
         obj_count = len(inconsistent_details["inconsistents"])
-        log.info(f" The inconsistent object count is --{obj_count}")
-        chk_count = chk_count + 1
-        time.sleep(30)
+        log.info(
+            f"PG {pg_id} inconsistent object count (attempt {attempt + 1}/{max_attempts + 1}): "
+            f"{obj_count}"
+        )
+
+        # Check if count has stabilized
+        if obj_count == prev_count:
+            stable_count += 1
+            if stable_count >= stable_threshold:
+                log.info(
+                    f"Count stabilized at {obj_count} after {attempt + 1} attempts"
+                )
+                break
+        else:
+            stable_count = 0
+
+        prev_count = obj_count
+
+        # Don't sleep on last iteration
+        if attempt < max_attempts:
+            time.sleep(30)
+
     return obj_count
 
 
@@ -555,7 +714,7 @@ def get_inconsistent_count(
         scrub_begin_weekday,
         scrub_end_hour,
         scrub_end_weekday,
-    ) = scrub_object.add_begin_end_hours(0, 1)
+    ) = scrub_object.add_begin_end_hours(0, 2)
     for osd_id in acting_pg_set:
         scrub_object.set_osd_configuration(
             "osd_scrub_begin_hour", scrub_begin_hour, osd_id
@@ -576,9 +735,9 @@ def get_inconsistent_count(
         scrub_object.set_osd_configuration(
             "osd_deep_scrub_interval", osd_deep_scrub_interval, osd_id
         )
-    endTime = datetime.now() + timedelta(minutes=40)
+    endtime = datetime.now() + timedelta(minutes=40)
 
-    while datetime.now() <= endTime:
+    while datetime.now() <= endtime:
         if operation == "scrub":
             log.debug(f"Running scrub on pg : {pg_id}")
             if rados_obj.start_check_scrub_complete(
@@ -590,13 +749,13 @@ def get_inconsistent_count(
         else:
             log.debug(f"Running deep-scrub on pg : {pg_id}")
             if rados_obj.start_check_deep_scrub_complete(
-                pg_id=pg_id, user_initiated=False, wait_time=2400
+                pg_id=pg_id, user_initiated=False, wait_time=3600, time_interval=5
             ):
                 log.info(f"Deep scrub completed on pg : {pg_id}")
                 time.sleep(30)
                 operation_chk_flag = True
                 break
-        log.info(f"Wating for the {operation} to complete")
+        log.info(f"Waiting for the {operation} to complete")
         time.sleep(60)
     if not operation_chk_flag:
         log.error(f"{operation} not initiated on pg-{pg_id}")
@@ -612,17 +771,17 @@ def get_inconsistent_count(
     return obj_count
 
 
-def verify_pg_state(rads_obj, pg_id):
+def verify_pg_state(rados_obj, pg_id):
     """
-    The method return if the pg state not contain repair state
-    Args:
-        rads_obj: Rados object
-        pg_id: pgid
+    Returns True if the PG state does not contain repair state.
+      Args:
+          rados_obj: Rados object
+          pg_id: pgid
 
-    Returns: True or False
+      Returns:True if repair is not in Pg state or else False
 
     """
-    pool_pg_dump = rads_obj.get_ceph_pg_dump(pg_id=pg_id)
+    pool_pg_dump = rados_obj.get_ceph_pg_dump(pg_id=pg_id)
     pg_state = pool_pg_dump["state"]
     log.info(f"The pg status is -{pg_state}")
     if "repair" not in pg_state:
@@ -678,30 +837,77 @@ def check_for_pg_scrub_state(rados_obj, pg_id, wait_time):
         except Exception as err:
             log.error(f"PGID : {pg_id} was not found, err: {err}")
             return False
-    log.info("Timeout reached, scrubbing  still  in progress.")
+    log.info("Timeout reached, scrubbing still in progress.")
     return False
 
 
-def print_parameter_messages(
-    scenario_value,
-    scrub_error_count,
-    auto_repair_param_value,
-    auto_repair_value,
-    operation,
+def log_case_start(case_id, description, operation, expectation):
+    """Log the start of a test case with operation details."""
+    prefix = CASE_LOG_PREFIX[case_id]
+    log.info(
+        f"\n{'=' * 70}\n"
+        f"[{prefix}] Starting: {description}\n"
+        f"[{prefix}] Operation: {operation}\n"
+        f"[{prefix}] Expectation: {expectation}\n"
+        f"{'=' * 70}"
+    )
+
+
+def log_case_parameters(
+    case_id, inconsistent_count, auto_repair_num_errors, auto_repair, operation
 ):
-    msg_scenario_tmp = (
-        f"===================Test scenario{scenario_value} - "
-        f"Parameter details before starting test  =========="
+    """Log test parameters configured before running scrub/deep-scrub."""
+    prefix = CASE_LOG_PREFIX[case_id]
+    log.info(
+        f"[{prefix}] Parameters - inconsistent object count: {inconsistent_count}, "
+        f"osd_scrub_auto_repair_num_errors: {auto_repair_num_errors}, "
+        f"osd_scrub_auto_repair: {auto_repair}, operation: {operation}"
     )
-    log.info(msg_scenario_tmp)
-    msg_tmp = f"The scrub error count is - {scrub_error_count}"
-    log.info(msg_tmp)
-    msg_tmp = (
-        f"The osd_scrub_auto_repair_num_errors value is - {auto_repair_param_value}"
+
+
+def log_case_complete(
+    case_id, operation, expectation, inconsistent_count_before, inconsistent_count_after
+):
+    """Log successful completion of a test case."""
+    prefix = CASE_LOG_PREFIX[case_id]
+    log.info(
+        f"[{prefix}] Completed successfully - operation: {operation}, "
+        f"expectation: {expectation}, inconsistent count before: "
+        f"{inconsistent_count_before}, after: {inconsistent_count_after}"
     )
-    log.info(msg_tmp)
-    msg_tmp = f"The osd_scrub_auto_repair value is -{auto_repair_value}"
-    log.info(msg_tmp)
-    msg_tmp = f"Operation : {operation}"
-    log.info(msg_tmp)
-    log.info(msg_scenario_tmp)
+
+
+def log_case_failure(case_id, message):
+    """Log a test case failure."""
+    log.error(f"[{CASE_LOG_PREFIX[case_id]}] Failed - {message}")
+
+
+def run_scrub_operation(
+    scrub_object, mon_obj, pg_id, rados_obj, operation, acting_pg_set, case_id
+):
+    """
+    Run scrub/deep-scrub and log the outcome.
+
+    Returns:
+        int: inconsistent object count after the operation, or -1 on failure.
+    """
+    prefix = CASE_LOG_PREFIX[case_id]
+    log.info(f"[{prefix}] Initiating scheduled {operation} on PG {pg_id}")
+    try:
+        obj_count = get_inconsistent_count(
+            scrub_object, mon_obj, pg_id, rados_obj, operation, acting_pg_set
+        )
+    except Exception:
+        log.error(f"[{prefix}] {operation} failed")
+        raise
+
+    if obj_count == -1:
+        log.error(f"[{prefix}] {operation} was not initiated on PG {pg_id}")
+        rados_obj.log_cluster_health()
+        return -1
+
+    log.info(
+        f"[{prefix}] {operation} completed on PG {pg_id}. "
+        f"Inconsistent object count: {obj_count}"
+    )
+    return obj_count


### PR DESCRIPTION
# Description
Divide the test scenario into  following cases and provided the TFA fix in Case3 and Case6-
Test cases are selected via config['case_to_run']:
      case1 - Scrub with inconsistent count > auto_repair_num_errors and auto_repair enabled.
              Expectation: No repairs.
      case2 - Scrub with inconsistent count < auto_repair_num_errors and auto_repair disabled.
              Expectation: No repairs.
      case3 - Scrub with inconsistent count < auto_repair_num_errors and auto_repair enabled.
              Expectation: All inconsistent objects are auto-repaired.
      case4 - Deep-scrub with inconsistent count > auto_repair_num_errors and auto_repair enabled.
              Expectation: No repairs.
      case5 - Deep-scrub with inconsistent count < auto_repair_num_errors and auto_repair disabled.
              Expectation: No repairs.
      case6 - Deep-scrub with inconsistent count < auto_repair_num_errors and auto_repair enabled.
              Expectation: All inconsistent objects are auto-repaired and PG repair state is cleared.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
