### PR TITLE
[TFA] Add fix for Grafana service state "running"/"starting"

### DIFF
--- a/tests/cephadm/test_cephadm_custom_config_support.py
+++ b/tests/cephadm/test_cephadm_custom_config_support.py
@@ -12,17 +12,18 @@ log = Log(__name__)
 
 
 def _verify_service_status(host, service_type):
-    """Verify service status is running"""
-    has_status = False
+    """Verify service status is running
+    Wait for service to reach 'running' state. Service may transition from
+    'starting' to 'running', or may already be 'running' after redeploy.
+    """
     for w in WaitUntil():
         CephAdm(host).ceph.orch.ps(refresh=True)
         conf = {"daemon_type": service_type, "format": "json-pretty"}
         service_info = loads(CephAdm(host).ceph.orch.ps(**conf))
         status_desc = [c.get("status_desc") for c in service_info][0]
         if status_desc == "starting":
-            has_status = True
-            log.info(f"{service_type} service is in starting")
-        if has_status and status_desc == "running":
+            log.info(f"{service_type} service is in starting state")
+        elif status_desc == "running":
             log.info(f"All {service_type} services are up and running")
             return True
     if w.expired:


### PR DESCRIPTION
# Description

TFA analysis -
Root Cause:
The _verify_service_status function had a logic bug where it only returned success if the service transitioned from "starting" to "running" state. When the grafana service was already in "running" state after redeploy (without going through "starting"), the test would fail with the confusing error: "expected status: running, found: running".

Fix:
Removed the has_status flag that was causing the issue
Changed the logic to return True immediately when status is "running", regardless of whether it was previously in "starting" state
Added clear documentation explaining the function handles both scenarios:
Service transitioning from "starting" to "running" 
Service already in "running" state after redeploy 
The fix ensures the test passes in both scenarios while maintaining the same wait-and-verify behavior.

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
