### PR TITLE
Fix unboundlocal error observed with collect_ceph_logs

### DIFF
--- a/run.py
+++ b/run.py
@@ -699,8 +699,15 @@ def run(args):
     enable_eus = args.get("--enable-eus")
     skip_enabling_rhel_rpms = args.get("--skip-enabling-rhel-rpms")
     skip_sos_report = args.get("--skip-sos-report")
+
+    # Pre define the variables for coredump and logs collection.
+    # By default we don't collect any logs.
+    collect_coredump = False
+    collect_ceph_logs = False
+
     if "collect-coredump" in custom_config_dict.keys():
         collect_coredump = bool(custom_config_dict["collect-coredump"])
+
     if "collect-ceph-logs" in custom_config_dict.keys():
         collect_ceph_logs = bool(custom_config_dict["collect-ceph-logs"])
 


### PR DESCRIPTION
# Description

A recent introduction of collecting the logs or coredump variables did not have a default value. Hence, when an user does not provide them, it would cause the below traceback

```
Traceback (most recent call last):
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/regression/19.2.1-374/cephfs/18/cephci/run.py", line 1365, in <module>
    rc = run(args)
  File "/data/jenkins/ceph-builds/IBM/8.1/rhel-9/regression/19.2.1-374/cephfs/18/cephci/run.py", line 1296, in run
    if jenkins_rc or collect_ceph_logs:
UnboundLocalError: local variable 'collect_ceph_logs' referenced before assignment
script returned exit code 1
```

- [x] Review the automation design
- [x] Submit PR for code review and approve
