### PR TITLE
Fix caps quiesce test

### DIFF
--- a/tests/cephfs/clients/client_caps_update_validation.py
+++ b/tests/cephfs/clients/client_caps_update_validation.py
@@ -102,13 +102,14 @@ def test_setup(fs_util, ceph_cluster, client):
     return setup_params
 
 
-def run_io_local(fs_util, mnt_info, sv_list):
+def run_io_local(fs_util, mnt_info, sv_list, wait=True):
     """
-    This methods runs IOs in parallel on given mountpoints
+    This methods runs IOs in parallel on given mountpoints.
     mnt_info : dict type input, with below format,
     {
     sv_name:{'path' : path,'client':client}
     }
+    If wait=False, returns the list of running threads without joining.
     """
     write_procs = []
     rand_str = "".join(random.choice(string.digits) for i in range(3))
@@ -122,8 +123,10 @@ def run_io_local(fs_util, mnt_info, sv_list):
         p = Thread(target=fs_util.run_ios, args=(mnt_client, io_path, io_tools))
         p.start()
         write_procs.append(p)
-    for p in write_procs:
-        p.join()
+    if wait:
+        for p in write_procs:
+            p.join()
+    return write_procs
 
 
 def client_caps_quiesce_test(
@@ -426,11 +429,11 @@ def run(ceph_cluster, **kw):
 
         test_fail = 0
 
-        run_io_local(fs_util_v1, mnt_info, sv_list)
-
         log.info(
             "Test1:Validate Client Caps recalled when CG quiesce is run on subvolumes"
         )
+        io_threads = run_io_local(fs_util_v1, mnt_info, sv_list, wait=False)
+        time.sleep(5)
 
         sv_name = random.choice(sv_name_list)
         subvol_path = sv_path_dict[sv_name]
@@ -441,6 +444,9 @@ def run(ceph_cluster, **kw):
             == 1
         ):
             test_fail += 1
+
+        for t in io_threads:
+            t.join(timeout=300)
 
         run_io_local(fs_util_v1, mnt_info, sv_list)
 


### PR DESCRIPTION
Logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-288/cephfs/1837/logs/regression_suite_2/client_caps_update_validation_0.log

The client_caps_update_validation test was flaky on IBM Cloud (slower VMs) because run_io_local joined all IO threads before the quiesce was issued. By the time quiesce ran, IO had already completed and clients had released their write caps — leaving nothing for MDS to revoke. The test saw caps before == caps after and failed.

Fix: Added a wait parameter to run_io_local. In the quiesce test, IO threads are now started with wait=False, a short sleep lets write caps accumulate, then quiesce runs while IO is still active. Threads are joined after quiesce completes.

Before: Client Caps Before quiesce: 28, After: 28 (no change, test fails) After: Client Caps Before quiesce: 141, After: 137 (caps revoked, test passes)