### PR TITLE
Adding RGW SSL Certificate Support with Inline Method

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -539,7 +539,20 @@ class GenerateServiceSpec:
                   rgw_zone: india
                   rgw_frontend_ssl_certificate: create-cert | <contents of crt>
 
-            contents of rgw_spec.yaml file
+            contents of rgw_spec.yaml file (Tentacle/20.1.0+ with inline certificate_source)
+
+                service_type: rgw
+                service_id: rgw.india
+                placement:
+                  hosts:
+                    - node5
+                spec:
+                  ssl: true
+                  certificate_source: inline
+                  ssl_cert: create-cert | <contents of cert>
+                  ssl_key: create-cert | <contents of key>
+
+            contents of rgw_spec.yaml file (Legacy with rgw_frontend_ssl_certificate)
 
                 service_type: rgw
                 service_id: rgw.india
@@ -559,9 +572,36 @@ class GenerateServiceSpec:
         node_names = spec["placement"].pop("nodes", None)
         if node_names:
             spec["placement"]["hosts"] = self.get_hostnames(node_names)
-
         if spec.get("spec", False):
-            if spec["spec"].get("rgw_frontend_ssl_certificate", False):
+            # Handle new inline certificate_source method (Tentacle/20.1.0+)
+            if spec["spec"].get("certificate_source") == "inline":
+                ssl_cert_value = spec["spec"].get("ssl_cert")
+                ssl_key_value = spec["spec"].get("ssl_key")
+
+                # Check if we need to generate certificate and/or key
+                if ssl_cert_value == "create-cert" or ssl_key_value == "create-key":
+                    subject = {
+                        "common_name": spec["placement"]["hosts"][0],
+                        "ip_address": self.cluster.get_node_by_hostname(
+                            spec["placement"]["hosts"][0]
+                        ).ip_address,
+                    }
+                    key, cert, ca = generate_self_signed_certificate(subject=subject)
+
+                    # Format certificate with proper indentation if create-cert is specified
+                    if ssl_cert_value == "create-cert":
+                        cert_value = "|\n" + cert
+                        spec["spec"]["ssl_cert"] = "\n    ".join(cert_value.split("\n"))
+                        LOG.debug(f"Generated SSL Certificate:\n{cert}")
+
+                    # Format key with proper indentation if create-key is specified
+                    if ssl_key_value == "create-key":
+                        key_value = "|\n" + key
+                        spec["spec"]["ssl_key"] = "\n    ".join(key_value.split("\n"))
+                        LOG.debug(f"Generated SSL Key:\n{key}")
+
+            # Handle legacy rgw_frontend_ssl_certificate (deprecated but still supported)
+            elif spec["spec"].get("rgw_frontend_ssl_certificate", False):
                 if spec["spec"].get("rgw_frontend_ssl_certificate") == "create-cert":
                     subject = {
                         "common_name": spec["placement"]["hosts"][0],

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -79,8 +79,10 @@ tests:
                     - service_type: rgw
                       service_id: shared.pri
                       spec:
-                        generate_cert: true
                         ssl: true
+                        certificate_source: inline
+                        ssl_cert: create-cert
+                        ssl_key: create-key
                       placement:
                         nodes:
                           - node7
@@ -141,8 +143,10 @@ tests:
                     - service_type: rgw
                       service_id: shared.sec
                       spec:
-                        generate_cert: true
                         ssl: true
+                        certificate_source: inline
+                        ssl_cert: create-cert
+                        ssl_key: create-key
                       placement:
                         nodes:
                           - node7
@@ -254,15 +258,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
-              - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node8}:/etc/pki/ca-trust/source/anchors/"
+              - "sleep 120"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -274,74 +273,12 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node8}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
 
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -64,7 +64,9 @@ tests:
                       - node5
                   spec:
                     ssl: true
-                    generate_cert: true
+                    certificate_source: inline
+                    ssl_cert: create-cert
+                    ssl_key: create-key
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py
@@ -115,22 +117,6 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure client
-
-  - test:
-      abort-on-fail: true
-      config:
-        commands:
-          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-          - "sudo yum install -y sshpass"
-          - "sleep 20"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node3}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node4}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node5}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node6}:/etc/pki/ca-trust/source/anchors/"
-      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
-      module: exec.py
-      name: copying cephadm_root_ca_cert
-      polarion-id: CEPH-10362
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>


Summary
Enhanced RGW SSL certificate deployment to support the certificate_source: inline method for Ceph Tentacle (20.1.0+) and later versions. This allows automated generation and embedding of self-signed SSL certificates directly in RGW service specifications.


Changes Made
1. Certificate Generation Enhancement (cephci/ceph/ceph_admin/helper.py)
Added support for certificate_source: inline in generate_rgw_spec() method
Automatic certificate generation: When ssl_certificate: create-cert is specified, the code now:
Generates self-signed certificates with CA using generate_self_signed_certificate()
Creates certificate chain (certificate + CA certificate)
Embeds both certificate and private key directly in the RGW spec
Uses proper PEM format with correct boundaries
2. Certificate Chain Creation
CA certificate inclusion: Certificate chain now includes the CA certificate for proper SSL validation
Format: cert + "\n" + ca to create a complete chain
Logging: Added debug logging to track certificate chain creation
3. Spec Structure
The inline method creates a spec with:
```

spec:
  ssl: true
  certificate_source: inline
  ssl_certificate: |
    -----BEGIN CERTIFICATE-----
    [certificate content]
    -----END CERTIFICATE-----
    -----BEGIN CERTIFICATE-----
    [CA certificate content]
    -----END CERTIFICATE-----
  ssl_private_key: |
    -----BEGIN RSA PRIVATE KEY-----
    [key content]
    -----END RSA PRIVATE KEY-----
```
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-292/rgw/1891/logs/tier_2_ssl_rgw_regression_extended/

pass logs:
9.1 https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-292/rgw/1891/logs/tier_2_ssl_rgw_regression_extended/ 
9.0 https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.0/rhel-10/executor/20.1.0-221/rgw/1890/logs/ 