### PR TITLE
Extend crash detection to MDS, NFS, and RGW with MGR false-positive fix

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -5291,7 +5291,15 @@ EOF"""
         )["summary"]["total_kb"]
         return total_size_osd
 
-    def check_crash_status(self, check_logs=True, start_time=None, end_time=None):
+    def check_crash_status(
+        self,
+        check_logs=True,
+        start_time=None,
+        end_time=None,
+        check_mds=False,
+        check_nfs=False,
+        check_rgw=False,
+    ):
         """
         Module to check crashes on the cluster using multiple methods:
         1. Standard crash detection via 'ceph crash ls' command
@@ -5304,6 +5312,10 @@ EOF"""
                        (requires both start_time and end_time to be provided)
             start_time: Start time for log analysis
             end_time: End time for log analysis
+            check_mds: If True, also scan MDS daemon logs for crash patterns
+            check_nfs: If True, also scan NFS-Ganesha daemon logs for crash
+                       patterns (via cephadm logs / journalctl)
+            check_rgw: If True, also scan RGW daemon logs for crash patterns
 
         Returns:
             True -> crash detected (in either crash ls or log scan)
@@ -5334,8 +5346,18 @@ EOF"""
         # Method 2: Scan daemon logs for crash patterns (if requested and timestamps provided)
         if check_logs and start_time and end_time:
             try:
+                daemon_types = ["mon", "mgr", "osd"]
+                if check_mds:
+                    daemon_types.append("mds")
+                if check_nfs:
+                    daemon_types.append("nfs")
+                if check_rgw:
+                    daemon_types.append("rgw")
+
                 crash_report = self.scan_daemon_logs_for_crashes(
-                    start_time=start_time, end_time=end_time
+                    start_time=start_time,
+                    end_time=end_time,
+                    daemon_types=daemon_types,
                 )
                 if crash_report.get("crashes_found", False):
                     crash_detected = True
@@ -6129,6 +6151,20 @@ EOF"""
         # Compile all patterns into a single regex for efficiency
         combined_pattern = "|".join(crash_patterns)
 
+        # NFS-Ganesha specific crash/fatal patterns (separate from generic)
+        # Used only inside _scan_nfs_daemon() to avoid false positives in
+        # OSD/MON/MGR/MDS/RGW logs
+        nfs_crash_patterns = [
+            r"Fatal signal",
+            r"ganesha_exit",
+            r"FSAL.*FATAL",
+            r"NFS STARTUP.*FATAL",
+            r":MAIN :FATAL",
+            r"Server is about to die",
+            r"Shutting down on signal",
+        ]
+        nfs_combined_pattern = "|".join(crash_patterns + nfs_crash_patterns)
+
         # Initialize result with daemon_crashes keys for all requested daemon types
         result = {
             "crashes_found": False,
@@ -6212,9 +6248,16 @@ EOF"""
 
                     if daemon_id and daemon_host:
                         # Build log path based on daemon type
-                        log_path = (
-                            f"/var/log/ceph/{fsid}/ceph-{daemon_type}.{daemon_id}.log"
-                        )
+                        if daemon_type == "rgw":
+                            log_path = (
+                                f"/var/log/ceph/{fsid}/ceph-client"
+                                f".rgw.{daemon_id}.log"
+                            )
+                        else:
+                            log_path = (
+                                f"/var/log/ceph/{fsid}/ceph-"
+                                f"{daemon_type}.{daemon_id}.log"
+                            )
                         daemons_to_scan.append(
                             {
                                 "type": daemon_type,
@@ -6382,6 +6425,10 @@ EOF"""
                         if not journal_timestamp_pattern.match(line):
                             continue
 
+                        # Skip MGR crash-store KV writes (false positives)
+                        if d_type == "mgr" and "set mgr/crash/crash/" in line:
+                            continue
+
                         # Check if this line matches a crash pattern
                         matched_keyword = None
                         for pattern in crash_patterns:
@@ -6435,6 +6482,126 @@ EOF"""
 
             return scan_result
 
+        # Helper function to scan NFS daemon logs via cephadm logs
+        def _scan_nfs_daemon(daemon_info: dict) -> dict:
+            """
+            Scan NFS daemon logs via 'cephadm logs' (primary) or journalctl
+            (fallback). NFS-Ganesha does not write to /var/log/ceph/{fsid}/.
+
+            Uses 'cephadm logs --name nfs.{id} -- --since --until --no-pager'
+            which passes journalctl args through for native time filtering.
+
+            Args:
+                daemon_info: Dict with type, id, host, log_path
+
+            Returns:
+                Dict with daemon_type, daemon_id, host, crash_events
+            """
+            d_type = daemon_info["type"]
+            d_id = daemon_info["id"]
+            d_host = daemon_info["host"]
+
+            scan_result = {
+                "daemon_type": d_type,
+                "daemon_id": d_id,
+                "host": d_host,
+                "crash_events": [],
+            }
+
+            host_obj = host_cache.get(d_host)
+            if not host_obj:
+                return scan_result
+
+            service_name = f"nfs.{d_id}"
+            grep_pattern_escaped = nfs_combined_pattern.replace("'", "'\\''")
+            stack_context = context_lines * 3
+            max_events = 50
+
+            cephadm_cmd = f"""
+            cephadm logs --name {service_name} -- \
+              --since "{journal_start}" \
+              --until "{journal_end}" \
+              --no-pager 2>/dev/null | \
+            grep -E '{grep_pattern_escaped}' \
+              -B {stack_context} -A {stack_context} 2>/dev/null | \
+            head -n 1000 || true
+            """
+
+            try:
+                crash_output, _ = host_obj.exec_command(
+                    cmd=cephadm_cmd, sudo=True, check_ec=False
+                )
+
+                if crash_output and crash_output.strip():
+                    raw_lines = crash_output.strip().split("\n")
+                    crash_events = []
+                    seen_timestamps = set()
+
+                    blocks = []
+                    current_block = []
+                    for line in raw_lines:
+                        if line.strip() == "--":
+                            if current_block:
+                                blocks.append(current_block)
+                            current_block = []
+                        else:
+                            current_block.append(line)
+                    if current_block:
+                        blocks.append(current_block)
+
+                    all_patterns = crash_patterns + nfs_crash_patterns
+                    for block in blocks:
+                        for line in block:
+                            if not journal_timestamp_pattern.match(line):
+                                continue
+                            matched_keyword = None
+                            for pattern in all_patterns:
+                                if re.search(pattern, line, re.IGNORECASE):
+                                    matched_keyword = (
+                                        pattern.replace("\\", "")
+                                        .replace("[", "")
+                                        .replace("]", "")
+                                        .replace("(", "")
+                                        .replace(")", "")
+                                    )
+                                    break
+
+                            if matched_keyword:
+                                ts_match = journal_timestamp_pattern.match(line)
+                                timestamp_key = (
+                                    ts_match.group(0) if ts_match else line[:20]
+                                )
+                                if timestamp_key in seen_timestamps:
+                                    continue
+                                seen_timestamps.add(timestamp_key)
+                                crash_events.append(
+                                    {
+                                        "keyword": matched_keyword,
+                                        "line_number": 0,
+                                        "line": line,
+                                        "context": list(block),
+                                        "source": "cephadm_logs",
+                                    }
+                                )
+                                if len(crash_events) >= max_events:
+                                    break
+                        if len(crash_events) >= max_events:
+                            break
+
+                    scan_result["crash_events"] = crash_events
+                    if crash_events:
+                        log.info(
+                            f"Found {len(crash_events)} crash event(s) via "
+                            f"cephadm logs for {d_type}.{d_id}"
+                        )
+                    return scan_result
+
+            except Exception as e:
+                log.warning(f"cephadm logs failed for {service_name}: {e}")
+
+            log.info(f"Falling back to journalctl for {d_type}.{d_id}")
+            return _scan_daemon_via_journalctl(daemon_info)
+
         # Helper function to scan a single daemon's logs (for parallel execution)
         def _scan_single_daemon(daemon_info: dict) -> dict:
             """
@@ -6450,6 +6617,10 @@ EOF"""
             # If journalctl-only mode is enabled, skip file scanning entirely
             if use_journalctl_only:
                 return _scan_daemon_via_journalctl(daemon_info)
+
+            # NFS daemons have no log files; use dedicated scanner
+            if daemon_info["type"] == "nfs":
+                return _scan_nfs_daemon(daemon_info)
 
             d_type = daemon_info["type"]
             d_id = daemon_info["id"]
@@ -6587,6 +6758,12 @@ EOF"""
 
                     # Validate line number is numeric (grep -n output format)
                     if not line_num_str.isdigit():
+                        continue
+
+                    # Skip MGR lines that are storing crash data from other
+                    # daemons via the crash module KV store — not actual MGR
+                    # crashes (avoids false positives from OSD crash payloads)
+                    if d_type == "mgr" and "set mgr/crash/crash/" in line_content:
                         continue
 
                     # Deduplicate: skip if we've seen similar content
@@ -7087,6 +7264,8 @@ EOF"""
 
         log.info(f"Creating CephFS with {pool_type} data pool: {fs_name}")
 
+        self.run_ceph_command(cmd="ceph fs flag set enable_multiple true")
+
         self.create_cephfs_pools(
             client_node,
             fs_name,
@@ -7172,6 +7351,7 @@ EOF"""
 
         # Step 1: Create CephFS filesystem for NFS
         log.info(f"Creating CephFS filesystem for NFS: {nfs_fs_name}")
+        self.run_ceph_command(cmd="ceph fs flag set enable_multiple true")
         self.create_cephfs_pools(
             client_node=client_node,
             fs_name=nfs_fs_name,

--- a/tests/rados/test_osd_thrashing.py
+++ b/tests/rados/test_osd_thrashing.py
@@ -120,6 +120,7 @@ from tests.rados.monitor_configurations import MonConfigMethods, MonElectionStra
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_four_node_ecpool import create_comprehensive_test_objects
 from utility.log import Log
+from utility.utils import extract_ceph_version
 
 log = Log(__name__)
 
@@ -127,51 +128,31 @@ log = Log(__name__)
 def _has_inconsistent_obj_fix(rados_obj) -> bool:
     """Check if the running ceph build contains the IBMCEPH-12717 fix.
 
-    The fix is present in builds with version > 20.1.0-149 but NOT in the
-    20.2.1.X line. Returns True if the fix is present and inconsistent
-    object detection should cause test failure.
+    The fix is NOT present in the 20.2.1.X line (Ceph 9.1). All other versions
+    are assumed to have the fix.
+    Returns True if the fix is present and inconsistent object
+    detection should cause test failure.
     """
-    import re
-
     try:
         out, _ = rados_obj.client.exec_command(cmd="ceph version", sudo=True)
-        # Expected: "ceph version 20.2.1-280.el9cp (...) tentacle"
-        version_str = out.strip().split()[2]  # e.g. "20.2.1-280.el9cp"
-        log.info(f"IBMCEPH-12717 fix check: ceph version = {version_str}")
+        version = extract_ceph_version(out)
+        log.info(f"IBMCEPH-12717 fix check: ceph version = {version}")
 
-        # Parse "MAJOR.MINOR.PATCH-BUILD.suffix"
-        match = re.match(r"(\d+)\.(\d+)\.(\d+)(?:-(\d+))?", version_str)
-        if not match:
-            log.warning(
-                f"Could not parse ceph version '{version_str}', "
-                f"assuming fix is present"
-            )
+        if not version:
+            log.warning("Could not parse ceph version, assuming fix is present")
             return True
 
-        major = int(match.group(1))
-        minor = int(match.group(2))
-        patch = int(match.group(3))
-        build_num = int(match.group(4)) if match.group(4) else 0
+        parts = version.split(".")
+        major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
 
-        # 20.2.1.X line does NOT have the fix
-        if (major, minor, patch) == (20, 2, 1):
+        if (major, minor, patch) <= (20, 2, 1):
             log.info(
-                f"Ceph version {version_str}: 20.2.1.X does not have "
-                f"IBMCEPH-12717 fix, disabling inconsistent_object_fail"
+                f"Ceph version {version} does not have IBMCEPH-12717 fix,"
+                f" disabling inconsistent_object_fail"
             )
             return False
 
-        # Fix is present in builds > 20.1.0-149
-        if (major, minor, patch) > (20, 1, 0):
-            return True
-        if (major, minor, patch) == (20, 1, 0) and build_num > 149:
-            return True
-
-        log.info(
-            f"Ceph version {version_str}: build does not have "
-            f"IBMCEPH-12717 fix, disabling inconsistent_object_fail"
-        )
-        return False
+        return True
     except Exception as e:
         log.warning(f"Failed to determine ceph version for fix check: {e}")
         return True
@@ -1409,6 +1390,23 @@ def run(ceph_cluster, **kw):
             except Exception as e:
                 log.warning(f"Failed to restore election strategy: {e}")
 
+        test_end_time = get_cluster_timestamp(rados_obj.node)
+        log.debug(f"Test completed. Start: {start_time}, End: {test_end_time}")
+
+        try:
+            if rados_obj.check_crash_status(
+                start_time=start_time,
+                end_time=test_end_time,
+                check_mds=enable_mds_thrashing,
+                check_nfs=enable_nfs_thrashing,
+                check_rgw=enable_rgw_thrashing,
+            ):
+                log.error("Test failed due to crash detected")
+                test_failed = True
+        except Exception as e:
+            log.error(f"Crash check failed: {e}")
+            test_failed = True
+
         if config.get("cleanup_pools", True):
             log.debug("Cleaning up test resources...")
 
@@ -1511,19 +1509,6 @@ def run(ceph_cluster, **kw):
             log.info("Pool cleanup completed")
         else:
             log.info("Skipping cleanup (cleanup_pools=False)")
-
-        test_end_time = get_cluster_timestamp(rados_obj.node)
-        log.debug(f"Test completed. Start: {start_time}, End: {test_end_time}")
-
-        try:
-            if rados_obj.check_crash_status(
-                start_time=start_time, end_time=test_end_time
-            ):
-                log.error("Test failed due to crash detected")
-                test_failed = True
-        except Exception as e:
-            log.error(f"Crash check failed: {e}")
-            test_failed = True
 
         if enable_debug_logs:
             log.info("Forcing log rotation on OSD nodes...")


### PR DESCRIPTION
Add optional check_mds, check_nfs, and check_rgw parameters to check_crash_status() to scan additional daemon types for crash patterns.

MDS: Uses existing log file scanning (ceph-mds.{daemon_id}.log). RGW: Adds log path special-case (ceph-client.rgw.{daemon_id}.log). NFS: Implements dedicated _scan_nfs_daemon() using cephadm logs with journalctl passthrough args for time filtering, since NFS-Ganesha has no log files in /var/log/ceph/{fsid}/. Includes isolated NFS-specific crash patterns to avoid contaminating generic daemon scanning.

Also fixes a false-positive where MGR crash-module KV store writes (set mgr/crash/crash/) containing OSD crash payloads were incorrectly flagged as MGR crashes.


Co-Authored-by: Cursor
