### PR TITLE
Fix type mismatch in post-upgrade snapshot visibility validation

### DIFF
--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation_ext.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation_ext.py
@@ -120,7 +120,7 @@ def snap_visibility_test():
     )
     for kwargs in [sv_old, sv_new]:
         actual_snap_visibility = snap_util.snapshot_visibility(client, "get", **kwargs)
-        if actual_snap_visibility != 1:
+        if actual_snap_visibility != "1":
             str1 = f"Expected : 1,Actual:{actual_snap_visibility}"
             log.error(
                 "Snapshot Visibility on existing subvolume post upgrade is not as Expected.%s",


### PR DESCRIPTION
Changed comparison from != 1 (integer) to != "1" (string) to match the return type.

Failure Logs: https://10.8.128.2/cephci-jenkins/ibm-cos//RH/9.0/rhel-9/upgrade/20.1.0-221/cephfs/75/logs/Test_Cephfs_Upgrade_8_1x_to_9x/