### PR TITLE
extending support for gklm tests on single site

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -56,6 +56,7 @@ import os
 
 import yaml
 
+from ceph.ceph_admin.helper import check_service_exists
 from utility import utils
 from utility.log import Log
 from utility.utils import (
@@ -64,6 +65,7 @@ from utility.utils import (
     get_cephci_config,
     install_start_kafka,
     setup_cluster_access,
+    setup_gklm_prereq,
 )
 
 log = Log(__name__)
@@ -104,6 +106,8 @@ def run(ceph_cluster, **kw):
     install_keystone_ldap = config.get("install_keystone_ldap")
     cloud_type = config.get("cloud-type")
     log.info(f"Cloud Type is {cloud_type}")
+    test_data = kw.get("test_data")
+    custom_config = test_data.get("custom-config", {})
     test_config = {"config": config.get("test-config", {})}
     rgw_node = rgw_ceph_object.node
     client_node = client_ceph_object.node
@@ -178,6 +182,18 @@ def run(ceph_cluster, **kw):
         install_start_kafka(rgw_node, cloud_type)
     if configure_kafka_broker_security:
         configure_kafka_security(rgw_node, cloud_type)
+
+    setup_gklm_prerequisites = config.get("setup_gklm_prerequisites")
+    if setup_gklm_prerequisites:
+        setup_gklm_prereq(ceph_cluster, cloud_type, custom_config)
+        rgw_status = check_service_exists(
+            ceph_cluster.get_nodes(role="installer")[0],
+            service_type="rgw",
+            interval=10,
+            timeout=180,
+        )
+        if not rgw_status:
+            raise Exception("rgw service restart failed")
 
     if install_keystone_ldap:
         config_keystone_ldap(rgw_node, cloud_type)

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2846,10 +2846,6 @@ def setup_gklm_prereq(ceph_cluster, cloud_type, custom_config):
         raise GKLMSetupError(
             "gklm-auth-cert-path not passed as custom-config which is required for gklm tests prerequisites"
         )
-    if gklm_endpoint_openstack is None or gklm_endpoint_ibmc is None:
-        raise GKLMSetupError(
-            "gklm-endpoint not passed as custom-config which is required for gklm tests prerequisites"
-        )
 
     for rgw_node_obj in rgw_nodes:
         rgw_node = rgw_node_obj.node


### PR DESCRIPTION
this PR is to extend support for GKLM tests to run on single site as well.
changes are incorporated in sanity_rgw.py as well for GKLM prerequisites support.

also removed the check for gklm-endpoint required both custom-configs in utils.py setup_gklm_prerequisites.
only one endpoint is sufficient, if it is openstack env, then ` gklm-endpoint-openstack` is required, if it is an ibmc env then ` gklm-endpoint-ibmc` custom-config needs to be passed. but both are not needed to be passed. 
the check for the respective env custom-configs are present later in the code anyways, so removed the unnecessary check for both custom-configs

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/gklm_single_site_support/cephci-run-8AO0KY/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
