### PR TITLE
[TFA] fixing bucket_notification test failures in rgw upgrade suite

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
@@ -174,6 +174,7 @@ tests:
           - jdk
         git_clone_configs_repo: true
         install_start_kafka: true
+        configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
 
@@ -220,7 +221,6 @@ tests:
       polarion-id: CEPH-83575407
       config:
         run-on-rgw: true
-        configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
 

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
@@ -158,6 +158,7 @@ tests:
           - jdk
         git_clone_configs_repo: true
         install_start_kafka: true
+        configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
 
@@ -232,7 +233,6 @@ tests:
       polarion-id: CEPH-83575407
       config:
         run-on-rgw: true
-        configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
 


### PR DESCRIPTION
this PR is to fix the bucket_notifications testcase failure in upgrade suite. the issue was because the configure-kafka-security config not added in the pre-upgrade test, because of which one of rgw ceph config not set, and the test failed with topic creation error (topic config containing passwords as plaintext)

pipeline fail log: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/8.1/rhel-9/extended_regression/19.2.1-363/rgw/2/logs/Tier_1rgw_upgrade_71GA_to_8x_latest/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
