### PR TITLE
NFS Ganesha TLS wire encryption verification using fio I/O and tcpdump (CEPH-83629170)

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
@@ -515,3 +515,23 @@ tests:
         nfs_cluster_name: cephfs-nfs-tls
         operation: tls_logs_openssl_probe
         redeploy_cluster_min_tls12: false
+
+  - test:
+      name: TLS mount fio IO with tcpdump encryption verification
+      module: security.test_tls_feature.py
+      desc: >
+        Phase 1: plain NFS cluster/export, fio write/read, tcpdump- fio buffer
+        pattern must appear in cleartext on the wire. Phase 2: TLS cluster/export,
+        same fio pattern must not appear; TLS wire traffic verified encrypted.
+      abort-on-fail: false
+      polarion-id: CEPH-83629170
+      config:
+        nfs_version: 4.2
+        clients: 1
+        nfs_cluster_name: cephfs-nfs-tls
+        plain_nfs_cluster_name: cephfs-nfs-plain
+        operation: tls_io_tcpdump_encryption
+        fio_size: 100M
+        fio_bs: 4k
+        fio_runtime: 300
+        timeout: 7200

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -1,4 +1,6 @@
 import json
+import shlex
+import time
 
 from ceph.ceph import CommandFailed
 from ceph.waiter import WaitUntil
@@ -16,6 +18,8 @@ TLS_TEST_MOUNT_CANDIDATES = [
     "/mnt/plain_tc2",
     "/mnt/tls_tc2",
     "/mnt/tls_tc1_0",
+    "/mnt/plain_tc4_0",
+    "/mnt/tls_tc4_0",
 ]
 
 
@@ -424,6 +428,466 @@ def probe_tls_handshake_with_openssl(
     except Exception as ex:
         log.warning("openssl probe skipped/failed: %s", ex)
         return False, str(ex)
+
+
+def _quote_shell_path(path):
+    """Return ``path`` safely escaped for use in remote shell commands."""
+    return shlex.quote(str(path))
+
+
+def _validate_max_packets(max_packets):
+    if not isinstance(max_packets, int) or max_packets < 0:
+        raise OperationFailedError(
+            f"max_packets must be a non-negative integer, got {max_packets!r}"
+        )
+
+
+def _wait_for_pcap_closed(client_node, pcap_path, max_wait=5):
+    """Wait until no tcpdump process holds ``pcap_path`` open."""
+    quoted = _quote_shell_path(pcap_path)
+    for _ in range(max_wait):
+        out, _ = client_node.exec_command(
+            sudo=True,
+            cmd=f"lsof {quoted} 2>/dev/null",
+            check_ec=False,
+        )
+        if not out or "tcpdump" not in str(out):
+            return
+        time.sleep(1)
+    log.warning("pcap file %s still open after %ss", pcap_path, max_wait)
+
+
+def normalize_fio_buffer_pattern(pattern):
+    """
+    Return a fio-compatible ``--buffer_pattern`` value.
+
+    fio 3.x requires a hex literal (e.g. ``0xCEFACEFE``); plain ASCII strings
+    fail with "failed parsing buffer_pattern".
+    """
+    raw = str(pattern).strip()
+    if raw.lower().startswith("0x"):
+        hex_body = raw[2:]
+    else:
+        hex_body = raw
+    if not hex_body or len(hex_body) % 2:
+        raise OperationFailedError(
+            f"fio buffer_pattern must be even-length hex (e.g. 0xCEFACEFE), got {pattern!r}"
+        )
+    try:
+        int(hex_body, 16)
+    except ValueError as err:
+        raise OperationFailedError(
+            f"Invalid fio buffer_pattern hex {pattern!r}: {err}"
+        ) from err
+    return f"0x{hex_body.lower()}"
+
+
+def fio_pattern_to_pcap_hex_substring(pattern):
+    """Map fio ``--buffer_pattern`` bytes to a spaced hex substring for tcpdump -xx."""
+    normalized = normalize_fio_buffer_pattern(pattern)
+    byte_pairs = [normalized[i : i + 2] for i in range(2, len(normalized), 2)]
+    return " ".join(byte_pairs)
+
+
+def fio_pattern_to_binary_grep_literal(pattern):
+    """Return a bash ``$'\\x..\\x..'` literal for ``grep -a -F`` on a pcap file."""
+    normalized = normalize_fio_buffer_pattern(pattern)
+    byte_pairs = [normalized[i : i + 2] for i in range(2, len(normalized), 2)]
+    return "".join(f"\\x{b}" for b in byte_pairs)
+
+
+def _pcap_count_tls_records(client_node, pcap_path, tls_regex, max_packets, timeout):
+    """Count TLS record headers in the first ``max_packets`` of a pcap via on-node grep."""
+    _validate_max_packets(max_packets)
+    quoted_pcap = _quote_shell_path(pcap_path)
+    cmd = (
+        f"timeout {timeout} tcpdump -r {quoted_pcap} -xx -n -c {max_packets} "
+        f"2>/dev/null | grep -cE '{tls_regex}' || true"
+    )
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=cmd,
+        check_ec=False,
+        timeout=timeout + 5,
+    )
+    try:
+        return int(str(out).strip() or "0")
+    except ValueError:
+        return 0
+
+
+def _pcap_count_binary_byte_pattern(client_node, pcap_path, bash_literal, timeout):
+    """Count occurrences of a raw byte pattern anywhere in a pcap via ``grep -a -o``."""
+    quoted_pcap = _quote_shell_path(pcap_path)
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=(
+            f"timeout {timeout} grep -a -o $'{bash_literal}' {quoted_pcap} "
+            f"2>/dev/null | wc -l"
+        ),
+        check_ec=False,
+        timeout=timeout + 5,
+    )
+    try:
+        return int(str(out).strip() or "0")
+    except ValueError:
+        return 0
+
+
+def ensure_package_installed(client_node, package_name, manager="yum"):
+    """Install ``package_name`` when ``rpm -q`` reports it is missing."""
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=f"rpm -q {package_name}",
+        check_ec=False,
+    )
+    if out and "is not installed" not in out.lower():
+        log.info("%s already installed on %s", package_name, client_node.hostname)
+        return
+    log.info("Installing %s on %s", package_name, client_node.hostname)
+    Package(client_node, manager=manager).install(package_name)
+
+
+def start_tcpdump_capture(client_node, server_host, port, pcap_path, snaplen=512):
+    """
+    Start ``tcpdump`` in the background on ``client_node`` for NFS TLS traffic.
+
+    Returns the background shell pid printed by ``nohup ... & echo $!``.
+    """
+    pid = None
+    quoted_pcap = _quote_shell_path(pcap_path)
+    try:
+        ensure_package_installed(client_node, "tcpdump")
+        client_node.exec_command(
+            sudo=True, cmd="mkdir -p /tmp/tls_pcap", check_ec=False
+        )
+        client_node.exec_command(
+            sudo=True,
+            cmd=f"pkill -f 'tcpdump.*{quoted_pcap}'",
+            check_ec=False,
+        )
+        bpf = f"host {server_host} and tcp port {port}"
+        log_name = pcap_path.rsplit("/", 1)[-1]
+        cmd = (
+            f"nohup tcpdump -i any -s {snaplen} -w {quoted_pcap} '{bpf}' "
+            f">/tmp/tcpdump_{log_name}.log 2>&1 & echo $!"
+        )
+        out, _ = client_node.exec_command(sudo=True, cmd=cmd, timeout=30)
+        pid = (out or "").strip().splitlines()[-1].strip()
+        if not pid or not pid.isdigit():
+            raise OperationFailedError(f"Failed to start tcpdump: invalid pid {pid!r}")
+        time.sleep(2)
+        log.info(
+            "tcpdump capture started on %s (pid=%s, bpf=%r, pcap=%s, snaplen=%s)",
+            client_node.hostname,
+            pid,
+            bpf,
+            pcap_path,
+            snaplen,
+        )
+        return pid
+    except Exception:
+        if pid and pid.isdigit():
+            stop_tcpdump_capture(client_node, pcap_path, pid=pid)
+        else:
+            client_node.exec_command(
+                sudo=True,
+                cmd=f"pkill -f 'tcpdump.*{quoted_pcap}'",
+                check_ec=False,
+            )
+        raise
+
+
+def stop_tcpdump_capture(client_node, pcap_path, pid=None):
+    """Stop a background ``tcpdump`` and wait briefly for the pcap to flush."""
+    quoted_pcap = _quote_shell_path(pcap_path)
+    if pid:
+        log.info("Stopping tcpdump pid=%s", pid)
+        client_node.exec_command(
+            sudo=True,
+            cmd=f"kill -TERM {pid}",
+            check_ec=False,
+        )
+        time.sleep(1)
+        out, _ = client_node.exec_command(
+            sudo=True,
+            cmd=f"ps -p {pid} -o comm=",
+            check_ec=False,
+        )
+        if out and "tcpdump" in str(out):
+            log.warning("tcpdump %s did not stop with TERM, using KILL", pid)
+            client_node.exec_command(
+                sudo=True,
+                cmd=f"kill -KILL {pid}",
+                check_ec=False,
+            )
+    client_node.exec_command(
+        sudo=True,
+        cmd=f"pkill -9 -f 'tcpdump.*{quoted_pcap}'",
+        check_ec=False,
+    )
+    _wait_for_pcap_closed(client_node, pcap_path)
+    time.sleep(1)
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=f"test -s {quoted_pcap} && echo exists || echo missing",
+        check_ec=False,
+    )
+    if "missing" in str(out or ""):
+        log.warning("pcap file %s is missing or empty after capture", pcap_path)
+
+
+def analyze_pcap_traffic(
+    client_node,
+    pcap_path,
+    cleartext_marker,
+    min_total_packets=10,
+    min_tls_app_records=5,
+    max_packets_to_analyze=10000,
+    pcap_analyze_timeout=300,
+):
+    """
+    Analyze a pcap for TLS record headers and an optional fio cleartext marker.
+
+    Returns a dict with packet_count, tls/binary TLS hit counts, cleartext_marker_hits,
+    cleartext_marker_found, and tls_record_signal.
+    """
+    quoted_pcap = _quote_shell_path(pcap_path)
+    _wait_for_pcap_closed(client_node, pcap_path)
+    size_out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=f"test -s {quoted_pcap} && wc -c < {quoted_pcap}",
+        check_ec=False,
+    )
+    if not size_out or not str(size_out).strip().isdigit():
+        raise OperationFailedError(f"Capture file missing or empty: {pcap_path}")
+
+    pcap_bytes = int(str(size_out).strip())
+    log.info("pcap %s size=%s bytes", pcap_path, pcap_bytes)
+
+    pkt_out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=(
+            f"timeout {pcap_analyze_timeout} tcpdump -r {quoted_pcap} -n "
+            f"2>/dev/null | wc -l"
+        ),
+        check_ec=False,
+        timeout=pcap_analyze_timeout + 5,
+    )
+    packet_count = int(str(pkt_out).strip().splitlines()[-1].strip() or "0")
+    if packet_count < min_total_packets:
+        raise OperationFailedError(
+            f"Expected at least {min_total_packets} packets in {pcap_path}, "
+            f"got {packet_count}"
+        )
+
+    tls_handshake_hits = _pcap_count_tls_records(
+        client_node,
+        pcap_path,
+        r" 16 03 0[34] ",
+        max_packets_to_analyze,
+        pcap_analyze_timeout,
+    )
+    tls_app_data_hits = _pcap_count_tls_records(
+        client_node,
+        pcap_path,
+        r" 17 03 0[34] ",
+        max_packets_to_analyze,
+        pcap_analyze_timeout,
+    )
+    binary_tls_handshake_hits = _pcap_count_binary_byte_pattern(
+        client_node, pcap_path, r"\x16\x03", pcap_analyze_timeout
+    )
+    binary_tls_app_hits = _pcap_count_binary_byte_pattern(
+        client_node, pcap_path, r"\x17\x03", pcap_analyze_timeout
+    )
+
+    cleartext_marker_hits = 0
+    marker_hex_substring = ""
+    if cleartext_marker:
+        marker_hex_substring = fio_pattern_to_pcap_hex_substring(cleartext_marker)
+        grep_literal = fio_pattern_to_binary_grep_literal(cleartext_marker)
+        leak_out, _ = client_node.exec_command(
+            sudo=True,
+            cmd=(
+                f"timeout {pcap_analyze_timeout} grep -a -F $'{grep_literal}' "
+                f"{quoted_pcap} 2>/dev/null | wc -l"
+            ),
+            check_ec=False,
+            timeout=pcap_analyze_timeout + 5,
+        )
+        cleartext_marker_hits = int(str(leak_out).strip() or "0")
+
+    cleartext_marker_found = cleartext_marker_hits > 0
+    has_tls_record_signal = (
+        tls_handshake_hits >= 1
+        or tls_app_data_hits >= min_tls_app_records
+        or binary_tls_handshake_hits >= 1
+        or binary_tls_app_hits >= min_tls_app_records
+    )
+
+    log.info(
+        "pcap analysis for %s: packets=%s analyzed_packets<=%s "
+        "handshake_tls_records=%s app_data_tls_records=%s "
+        "binary_handshake_hits=%s binary_app_hits=%s "
+        "cleartext_marker_hex=%r cleartext_marker_hits=%s "
+        "cleartext_marker_found=%s tls_record_signal=%s",
+        pcap_path,
+        packet_count,
+        max_packets_to_analyze,
+        tls_handshake_hits,
+        tls_app_data_hits,
+        binary_tls_handshake_hits,
+        binary_tls_app_hits,
+        marker_hex_substring,
+        cleartext_marker_hits,
+        cleartext_marker_found,
+        has_tls_record_signal,
+    )
+
+    return {
+        "pcap_bytes": pcap_bytes,
+        "packet_count": packet_count,
+        "tls_handshake_hits": tls_handshake_hits,
+        "tls_app_data_hits": tls_app_data_hits,
+        "binary_tls_handshake_hits": binary_tls_handshake_hits,
+        "binary_tls_app_hits": binary_tls_app_hits,
+        "cleartext_marker_hits": cleartext_marker_hits,
+        "cleartext_marker_found": cleartext_marker_found,
+        "tls_record_signal": has_tls_record_signal,
+    }
+
+
+def verify_cleartext_traffic_in_pcap(
+    client_node,
+    pcap_path,
+    cleartext_marker,
+    min_total_packets=10,
+    min_cleartext_marker_hits=1,
+    max_packets_to_analyze=10000,
+    pcap_analyze_timeout=300,
+):
+    """
+    Verify a plain (non-TLS) NFS capture exposes the fio buffer pattern on the wire.
+
+    Used as a control baseline before the TLS capture phase: sustained fio I/O with
+    ``--buffer_pattern`` must leave that byte sequence visible in the pcap when NFS is
+    not encrypted.
+    """
+    analysis = analyze_pcap_traffic(
+        client_node,
+        pcap_path,
+        cleartext_marker,
+        min_total_packets=min_total_packets,
+        max_packets_to_analyze=max_packets_to_analyze,
+        pcap_analyze_timeout=pcap_analyze_timeout,
+    )
+    if analysis["cleartext_marker_hits"] < min_cleartext_marker_hits:
+        raise OperationFailedError(
+            f"Plain NFS control capture did not show fio cleartext marker "
+            f"{cleartext_marker!r} on the wire (hits={analysis['cleartext_marker_hits']}, "
+            f"expected>={min_cleartext_marker_hits}); cannot confirm unencrypted baseline."
+        )
+    if analysis["tls_record_signal"]:
+        log.warning(
+            "TLS record headers present in plain NFS capture (unexpected); "
+            "cleartext marker was still observed."
+        )
+    log.info(
+        "Plain NFS control confirmed: fio pattern visible in cleartext "
+        "(marker_hits=%s, packets=%s)",
+        analysis["cleartext_marker_hits"],
+        analysis["packet_count"],
+    )
+    return analysis
+
+
+def verify_tls_encrypted_traffic_in_pcap(
+    client_node,
+    pcap_path,
+    cleartext_marker,
+    min_total_packets=10,
+    min_tls_app_records=5,
+    max_packets_to_analyze=10000,
+    pcap_analyze_timeout=300,
+    max_cleartext_marker_hits=50,
+    plain_cleartext_marker_hits=None,
+    max_cleartext_leak_ratio=0.0001,
+):
+    """
+    Verify a pcap captured during NFS-over-TLS I/O shows encrypted wire traffic.
+
+    Primary pass criterion: the fio ``--buffer_pattern`` must not appear at the
+    same rate as the plain-NFS control capture. A small number of grep hits can
+    occur by chance in large pcaps (encrypted ciphertext may contain the byte
+    sequence), so when ``plain_cleartext_marker_hits`` is provided the allowed
+    TLS hit count scales with that baseline.
+
+    TLS record headers (``\\x16\\x03`` handshake, ``\\x17\\x03`` application data) are
+    counted for positive signal. With kernel TLS (kTLS), post-handshake traffic may not
+    expose TLS record framing on the wire, so missing headers does not fail the test
+    when cleartext leakage is below threshold and enough packets were captured.
+    """
+    analysis = analyze_pcap_traffic(
+        client_node,
+        pcap_path,
+        cleartext_marker,
+        min_total_packets=min_total_packets,
+        min_tls_app_records=min_tls_app_records,
+        max_packets_to_analyze=max_packets_to_analyze,
+        pcap_analyze_timeout=pcap_analyze_timeout,
+    )
+
+    tls_hits = analysis["cleartext_marker_hits"]
+    allowed_hits = max_cleartext_marker_hits
+    if plain_cleartext_marker_hits is not None and plain_cleartext_marker_hits > 0:
+        ratio_cap = int(plain_cleartext_marker_hits * max_cleartext_leak_ratio)
+        allowed_hits = max(allowed_hits, ratio_cap)
+
+    cleartext_leak = tls_hits > allowed_hits
+    analysis["cleartext_marker_found"] = cleartext_leak
+    analysis["allowed_cleartext_marker_hits"] = allowed_hits
+
+    if cleartext_leak:
+        raise OperationFailedError(
+            f"Cleartext marker {cleartext_marker!r} visible in TLS capture "
+            f"(hits={tls_hits}, allowed<={allowed_hits}, "
+            f"plain_baseline={plain_cleartext_marker_hits}); "
+            "NFS payload was not encrypted on the wire."
+        )
+
+    if tls_hits > 0:
+        log.warning(
+            "TLS capture had %s cleartext marker hit(s) within allowed threshold "
+            "(allowed<=%s, plain_baseline=%s); treating as grep false-positive",
+            tls_hits,
+            allowed_hits,
+            plain_cleartext_marker_hits,
+        )
+
+    if not analysis["tls_record_signal"]:
+        log.warning(
+            "No TLS record headers in capture (kTLS may omit TLS framing on wire); "
+            "encryption verified via low fio cleartext marker hits (%s) during %s packets",
+            tls_hits,
+            analysis["packet_count"],
+        )
+
+    return analysis
+
+
+def setup_plain_nfs_cluster(installer_node, nfs_node, nfs_name):
+    """Deploy a non-TLS NFS-Ganesha cluster (no ssl / xprtsec on the service)."""
+    nfs_spec = {
+        "service_type": "nfs",
+        "service_id": nfs_name,
+        "placement": {"hosts": [nfs_node.hostname]},
+        "spec": {},
+    }
+    log.info("Deploying plain (non-TLS) NFS cluster %s via spec file", nfs_name)
+    if not create_nfs_via_file_and_verify(installer_node, [nfs_spec], timeout=300):
+        raise OperationFailedError(f"Failed to create plain NFS cluster {nfs_name}")
+    log.info("Successfully deployed plain NFS cluster %s", nfs_name)
 
 
 def setup_tls_nfs_cluster(

--- a/tests/nfs/security/test_tls_feature.py
+++ b/tests/nfs/security/test_tls_feature.py
@@ -1,16 +1,31 @@
+import json
+import re
 import traceback
+from time import sleep
 
 from cli.ceph.ceph import Ceph
 from cli.exceptions import OperationFailedError
 from cli.utilities.filesys import Mount, MountFailedError, Unmount
+from tests.nfs.nfs_operations import (
+    _get_client_specific_mount_versions,
+    exports_mounts_perclient,
+    mount_retry,
+)
 from tests.nfs.security.security_utils import (
     check_mount_fails,
+    ensure_package_installed,
     full_tls_stack_cleanup,
+    normalize_fio_buffer_pattern,
     probe_tls_handshake_with_openssl,
+    setup_plain_nfs_cluster,
     setup_tls_client,
     setup_tls_nfs_cluster,
+    start_tcpdump_capture,
+    stop_tcpdump_capture,
     tls_config_get,
     verify_ceph_orch_nfs_running,
+    verify_cleartext_traffic_in_pcap,
+    verify_tls_encrypted_traffic_in_pcap,
     verify_tls_strings_in_nfs_logs,
     wait_for_tls_strings_in_nfs_logs,
     wait_until_ceph_orch_nfs_ps_ready,
@@ -32,17 +47,57 @@ from utility.log import Log
 log = Log(__name__)
 
 DEFAULT_NFS_TLS_CLUSTER = "cephfs-nfs-tls"
+DEFAULT_NFS_PLAIN_CLUSTER = "cephfs-nfs-plain"
 
 # Single-operation names and the combined workflow
 OP_TLS_DEPLOY_MOUNT_VERIFY = "tls_deploy_mount_verify"
 OP_TLS_EXPORT_ENFORCEMENT = "tls_export_enforcement"
 OP_TLS_LOGS_OPENSSL_PROBE = "tls_logs_openssl_probe"
+OP_TLS_IO_TCPDUMP_ENCRYPTION = "tls_io_tcpdump_encryption"
 OP_TLS_FULL_WORKFLOW = "tls_full_workflow"
 _TLS_FULL_SEQUENCE = [
     OP_TLS_DEPLOY_MOUNT_VERIFY,
     OP_TLS_EXPORT_ENFORCEMENT,
     OP_TLS_LOGS_OPENSSL_PROBE,
 ]
+_TLS_STANDALONE_OPERATIONS = _TLS_FULL_SEQUENCE + [OP_TLS_IO_TCPDUMP_ENCRYPTION]
+# fio --buffer_pattern requires hex (e.g. 0xCEFACEFE), not ASCII strings.
+DEFAULT_TLS_IO_MARKER = "0xCEFACEFE"
+_FIO_SIZE_RE = re.compile(r"^\d+[kKmMgGtT]?$")
+
+
+def _validate_fio_config(fio_size, fio_bs, fio_runtime):
+    if not _FIO_SIZE_RE.match(str(fio_size)):
+        raise OperationFailedError(
+            f"Invalid fio_size format: {fio_size!r}. Expected format: 32M, 1G, etc."
+        )
+    if not _FIO_SIZE_RE.match(str(fio_bs)):
+        raise OperationFailedError(
+            f"Invalid fio_bs format: {fio_bs!r}. Expected format: 64k, 4M, etc."
+        )
+    if fio_runtime <= 0:
+        raise OperationFailedError(f"fio_runtime must be positive, got {fio_runtime}")
+
+
+def _fio_timeout_from_config(config, fio_runtime):
+    fio_timeout_buffer = int(
+        tls_config_get(
+            config, "fio_timeout_buffer", "tc_04_fio_timeout_buffer", default=120
+        )
+    )
+    fio_min_timeout = int(
+        tls_config_get(config, "fio_min_timeout", "tc_04_fio_min_timeout", default=600)
+    )
+    # Each phase runs write then read; allow up to ~2x runtime plus buffer per command.
+    fio_timeout = max((fio_runtime * 2) + fio_timeout_buffer, fio_min_timeout)
+    log.info(
+        "fio timeout set to %ss (2*runtime=%ss + buffer=%ss, min=%ss)",
+        fio_timeout,
+        fio_runtime * 2,
+        fio_timeout_buffer,
+        fio_min_timeout,
+    )
+    return fio_timeout
 
 
 def _normalize_operation(name):
@@ -61,17 +116,142 @@ def _operations_to_run(config):
         raise OperationFailedError(
             "config.operation is required. Use one of: "
             f"{OP_TLS_DEPLOY_MOUNT_VERIFY}, {OP_TLS_EXPORT_ENFORCEMENT}, "
-            f"{OP_TLS_LOGS_OPENSSL_PROBE}, {OP_TLS_FULL_WORKFLOW} (or tls_all_in_one)."
+            f"{OP_TLS_LOGS_OPENSSL_PROBE}, {OP_TLS_IO_TCPDUMP_ENCRYPTION}, "
+            f"{OP_TLS_FULL_WORKFLOW} (or tls_all_in_one)."
         )
     op = _normalize_operation(raw)
     if op in (OP_TLS_FULL_WORKFLOW, "tls_all_in_one", "tls_full"):
         return list(_TLS_FULL_SEQUENCE)
-    if op in _TLS_FULL_SEQUENCE:
+    if op in _TLS_STANDALONE_OPERATIONS:
         return [op]
     raise OperationFailedError(
-        f"Unknown operation {raw!r}. Expected one of: {', '.join(_TLS_FULL_SEQUENCE)} "
+        f"Unknown operation {raw!r}. Expected one of: {', '.join(_TLS_STANDALONE_OPERATIONS)} "
         f"or {OP_TLS_FULL_WORKFLOW}."
     )
+
+
+def _parse_fio_json(fio_stdout, rw_type):
+    """Return (bandwidth_mib_per_sec, iops) from fio JSON output."""
+    raw = str(fio_stdout).strip()
+    try:
+        data = json.loads(raw)
+        rw_stats = data["jobs"][0][rw_type]
+    except (json.JSONDecodeError, KeyError, IndexError) as err:
+        raise OperationFailedError(
+            f"Could not parse fio {rw_type} JSON output: {err}\n"
+            f"Raw (first 500 chars): {raw[:500]}"
+        ) from err
+    return rw_stats["bw"] / 1024.0, rw_stats["iops"]
+
+
+def _run_fio_write_read_on_mount(client_node, mount_path, config):
+    """Run sequential fio write/read on ``mount_path``; return combined stats dict."""
+    ensure_package_installed(client_node, "fio")
+    fio_size = tls_config_get(config, "fio_size", "tc_04_fio_size", default="32M")
+    fio_bs = tls_config_get(config, "fio_bs", "tc_04_fio_bs", default="64k")
+    fio_runtime = int(
+        tls_config_get(config, "fio_runtime", "tc_04_fio_runtime", default=20)
+    )
+    _validate_fio_config(fio_size, fio_bs, fio_runtime)
+    log.info(
+        "fio config: size=%s, bs=%s, runtime=%ss",
+        fio_size,
+        fio_bs,
+        fio_runtime,
+    )
+    marker = normalize_fio_buffer_pattern(
+        tls_config_get(
+            config,
+            "fio_cleartext_marker",
+            "tc_04_cleartext_marker",
+            default=DEFAULT_TLS_IO_MARKER,
+        )
+    )
+    fio_timeout = _fio_timeout_from_config(config, fio_runtime)
+    base_args = (
+        f"--filename={mount_path}/tls_fio_encrypt.dat "
+        f"--bs={fio_bs} --size={fio_size} --runtime={fio_runtime} "
+        f"--time_based --direct=1 --ioengine=libaio "
+        f"--group_reporting --output-format=json "
+        f"--buffer_pattern={marker}"
+    )
+
+    write_cmd = f"fio --name=tls_encrypt_verify --rw=write {base_args}"
+    log.info("Running fio WRITE command: %s", write_cmd)
+    write_out, write_err = client_node.exec_command(
+        sudo=True,
+        cmd=write_cmd,
+        timeout=fio_timeout,
+    )
+    if write_err:
+        log.warning("fio write stderr: %s", write_err)
+    if not write_out:
+        raise OperationFailedError(
+            f"fio write produced no output. Command: {write_cmd}\nStderr: {write_err}"
+        )
+    try:
+        write_mbps, write_iops = _parse_fio_json(write_out, "write")
+    except Exception as err:
+        log.error("Failed to parse fio write output. Command: %s", write_cmd)
+        log.error("fio stdout (first 500 chars): %s", str(write_out)[:500])
+        log.error("fio stderr: %s", write_err)
+        raise OperationFailedError(f"fio write parsing failed: {err}") from err
+    log.info(
+        "fio write completed: %.1f MiB/s, %.0f IOPS",
+        write_mbps,
+        write_iops,
+    )
+
+    client_node.exec_command(
+        sudo=True, cmd="echo 3 > /proc/sys/vm/drop_caches", check_ec=False
+    )
+
+    read_cmd = f"fio --name=tls_encrypt_verify --rw=read {base_args}"
+    log.info("Running fio READ command: %s", read_cmd)
+    read_out, read_err = client_node.exec_command(
+        sudo=True,
+        cmd=read_cmd,
+        timeout=fio_timeout,
+    )
+    if read_err:
+        log.warning("fio read stderr: %s", read_err)
+    if not read_out:
+        raise OperationFailedError(
+            f"fio read produced no output. Command: {read_cmd}\nStderr: {read_err}"
+        )
+    try:
+        read_mbps, read_iops = _parse_fio_json(read_out, "read")
+    except Exception as err:
+        log.error("Failed to parse fio read output. Command: %s", read_cmd)
+        log.error("fio stdout (first 500 chars): %s", str(read_out)[:500])
+        log.error("fio stderr: %s", read_err)
+        raise OperationFailedError(f"fio read parsing failed: {err}") from err
+    log.info(
+        "fio read completed: %.1f MiB/s, %.0f IOPS",
+        read_mbps,
+        read_iops,
+    )
+
+    client_node.exec_command(
+        sudo=True,
+        cmd=f"rm -f {mount_path}/tls_fio_encrypt.dat",
+        check_ec=False,
+    )
+    log.info(
+        "fio on TLS mount succeeded: write=%.3f MiB/s (%.1f IOPS), "
+        "read=%.3f MiB/s (%.1f IOPS)",
+        write_mbps,
+        write_iops,
+        read_mbps,
+        read_iops,
+    )
+    return {
+        "write_mbps": write_mbps,
+        "write_iops": write_iops,
+        "read_mbps": read_mbps,
+        "read_iops": read_iops,
+        "cleartext_marker": marker,
+    }
 
 
 def op_tls_deploy_mount_verify(client_node, nfs_node, config, nfs_name):
@@ -318,6 +498,351 @@ def op_tls_logs_openssl_probe(installer_node, client_node, nfs_node, config, nfs
     log.info("tls_logs_openssl_probe completed.")
 
 
+def _setup_tls_io_capture_prerequisites(client_node):
+    """Install packages required for tcpdump capture and fio I/O on the client."""
+    log.info("=== Setup: install tcpdump and fio on NFS TLS client ===")
+    ensure_package_installed(client_node, "tcpdump")
+    ensure_package_installed(client_node, "fio")
+    log.info(
+        "Client %s ready for TLS I/O capture (tcpdump + fio installed)",
+        client_node.hostname,
+    )
+
+
+def _create_nfs_export_for_capture(
+    client_node, fs_name, nfs_name, export_name, mount_name, xprtsec=None
+):
+    """Create export (subvolume + export) without mounting — mount follows capture start."""
+    client_export_mount_dict = exports_mounts_perclient(
+        [client_node], export_name, mount_name, 1
+    )
+    export_path = client_export_mount_dict[client_node]["export"][0]
+    mount_path = client_export_mount_dict[client_node]["mount"][0]
+    export_kwargs = {"xprtsec": xprtsec} if xprtsec else {}
+    Ceph(client_node).nfs.export.create(
+        fs_name=fs_name,
+        nfs_name=nfs_name,
+        nfs_export=export_path,
+        fs=fs_name,
+        **export_kwargs,
+    )
+    wait_until_nfs_export_visible(client_node, nfs_name, export_path)
+    return export_path, mount_path
+
+
+def _mount_export_for_capture(
+    client_node, nfs_node, export_path, mount_path, version, port, xprtsec=None
+):
+    """Mount an export after tcpdump has started (TLS handshake included when xprtsec=tls)."""
+    mount_versions = _get_client_specific_mount_versions(version, [client_node])
+    mount_kwargs = {"xprtsec": xprtsec} if xprtsec else {}
+    for mount_version, clients in mount_versions.items():
+        clients[0].create_dirs(dir_path=mount_path, sudo=True)
+        if not mount_retry(
+            client=clients[0],
+            mount_name=mount_path,
+            version=mount_version,
+            port=port,
+            nfs_server=nfs_node.hostname,
+            export_name=export_path,
+            **mount_kwargs,
+        ):
+            label = "TLS" if xprtsec else "plain"
+            raise OperationFailedError(
+                f"Failed to mount {label} export {export_path} on {client_node.hostname}"
+            )
+        sleep(1)
+    log.info(
+        "%s mount succeeded on %s at %s",
+        "TLS" if xprtsec else "Plain",
+        client_node.hostname,
+        mount_path,
+    )
+
+
+def _pcap_analysis_kwargs(config):
+    """Shared pcap verification options from suite config."""
+    return {
+        "min_total_packets": int(
+            tls_config_get(
+                config, "min_capture_packets", "tc_04_min_capture_packets", default=10
+            )
+        ),
+        "max_packets_to_analyze": int(
+            tls_config_get(
+                config,
+                "max_pcap_packets_to_analyze",
+                "tc_04_max_pcap_packets",
+                default=10000,
+            )
+        ),
+        "pcap_analyze_timeout": int(
+            tls_config_get(
+                config,
+                "pcap_analyze_timeout_sec",
+                "tc_04_pcap_analyze_timeout_sec",
+                default=300,
+            )
+        ),
+    }
+
+
+def _run_capture_fio_phase(
+    client_node,
+    nfs_node,
+    export_path,
+    mount_path,
+    version,
+    port,
+    server_host,
+    pcap_path,
+    snaplen,
+    config,
+    xprtsec=None,
+):
+    """Start tcpdump, mount, run fio write/read, stop capture, and lazy-umount."""
+    capture_pid = None
+    mount_created = False
+    try:
+        capture_pid = start_tcpdump_capture(
+            client_node,
+            server_host=server_host,
+            port=port,
+            pcap_path=pcap_path,
+            snaplen=snaplen,
+        )
+        _mount_export_for_capture(
+            client_node,
+            nfs_node,
+            export_path,
+            mount_path,
+            version,
+            port,
+            xprtsec=xprtsec,
+        )
+        mount_created = True
+        return _run_fio_write_read_on_mount(client_node, mount_path, config)
+    finally:
+        if capture_pid:
+            try:
+                stop_tcpdump_capture(client_node, pcap_path, pid=capture_pid)
+            except Exception as err:
+                log.error("Failed to stop tcpdump: %s", err)
+        if mount_created:
+            try:
+                client_node.exec_command(
+                    sudo=True,
+                    cmd=f"umount -l {mount_path}",
+                    check_ec=False,
+                )
+                log.info("Unmounted %s", mount_path)
+            except Exception as err:
+                log.error("Failed to unmount %s: %s", mount_path, err)
+        try:
+            client_node.exec_command(
+                sudo=True,
+                cmd=f"rm -f {mount_path}/tls_fio_encrypt.dat",
+                check_ec=False,
+            )
+        except Exception as err:
+            log.error("Failed to cleanup temp files on %s: %s", mount_path, err)
+
+
+def op_tls_io_tcpdump_encryption(
+    installer_node, client_node, nfs_node, config, nfs_name
+):
+    """
+    Two-phase wire encryption test:
+
+    1. Plain NFS cluster + export: fio with known buffer pattern; pcap must show
+       the pattern in cleartext (unencrypted control baseline).
+    2. TLS NFS cluster + export: same fio; pcap must not show the pattern
+       (encrypted traffic).
+    """
+    log.info("=== Operation: tls_io_tcpdump_encryption ===")
+    _setup_tls_io_capture_prerequisites(client_node)
+    fs_name = config.get("fs_name", "cephfs")
+    plain_nfs_name = tls_config_get(
+        config,
+        "plain_nfs_cluster_name",
+        "tc_04_plain_cluster",
+        default=DEFAULT_NFS_PLAIN_CLUSTER,
+    )
+    tls_nfs_name = nfs_name or config.get("nfs_cluster_name", DEFAULT_NFS_TLS_CLUSTER)
+    plain_export_name = tls_config_get(
+        config,
+        "plain_nfs_export",
+        "tc_04_plain_export",
+        default="/plain_export_tc4",
+    )
+    plain_mount_name = tls_config_get(
+        config,
+        "plain_export_mount",
+        "tc_04_plain_mount",
+        default="/mnt/plain_tc4",
+    )
+    tls_export_name = tls_config_get(
+        config, "tls_export_path", "tc_04_export", default="/tls_export_tc4"
+    )
+    tls_mount_name = tls_config_get(
+        config, "tls_client_mount", "tc_04_mount", default="/mnt/tls_tc4"
+    )
+    plain_pcap_path = tls_config_get(
+        config,
+        "plain_tcpdump_pcap_path",
+        "tc_04_plain_pcap_path",
+        default="/tmp/tls_pcap/tc04_plain.pcap",
+    )
+    tls_pcap_path = tls_config_get(
+        config,
+        "tcpdump_pcap_path",
+        "tc_04_pcap_path",
+        default="/tmp/tls_pcap/tc04.pcap",
+    )
+    version = config.get("nfs_version", "4.2")
+    port = int(config.get("port", 2049))
+    server_host = nfs_node.ip_address or nfs_node.hostname
+    snaplen = int(
+        tls_config_get(config, "tcpdump_snaplen", "tc_04_tcpdump_snaplen", default=512)
+    )
+    pcap_kwargs = _pcap_analysis_kwargs(config)
+    min_tls_app_records = int(
+        tls_config_get(
+            config,
+            "min_tls_app_records",
+            "tc_04_min_tls_app_records",
+            default=5,
+        )
+    )
+
+    # --- Phase 1: plain NFS control (expect cleartext fio pattern on wire) ---
+    log.info(
+        "=== Phase 1: plain NFS baseline (non-TLS cluster, expect cleartext pattern) ==="
+    )
+    setup_plain_nfs_cluster(installer_node, nfs_node, plain_nfs_name)
+    ok, _ = verify_ceph_orch_nfs_running(client_node, plain_nfs_name)
+    if not ok:
+        raise OperationFailedError(
+            f"Plain NFS service {plain_nfs_name} not reported in ceph orch ps"
+        )
+
+    plain_export_path, plain_mount_path = _create_nfs_export_for_capture(
+        client_node, fs_name, plain_nfs_name, plain_export_name, plain_mount_name
+    )
+    plain_fio_stats = _run_capture_fio_phase(
+        client_node,
+        nfs_node,
+        plain_export_path,
+        plain_mount_path,
+        version,
+        port,
+        server_host,
+        plain_pcap_path,
+        snaplen,
+        config,
+        xprtsec=None,
+    )
+    plain_analysis = verify_cleartext_traffic_in_pcap(
+        client_node,
+        plain_pcap_path,
+        cleartext_marker=plain_fio_stats["cleartext_marker"],
+        min_cleartext_marker_hits=int(
+            tls_config_get(
+                config,
+                "min_plain_cleartext_hits",
+                "tc_04_min_plain_cleartext_hits",
+                default=1,
+            )
+        ),
+        **pcap_kwargs,
+    )
+    log.info(
+        "Phase 1 plain baseline ok: marker_hits=%s packets=%s (traffic not encrypted)",
+        plain_analysis["cleartext_marker_hits"],
+        plain_analysis["packet_count"],
+    )
+
+    log.info("Tearing down plain NFS cluster before TLS deploy")
+    full_tls_stack_cleanup(
+        client_node,
+        plain_nfs_name,
+        mount_candidates=[plain_mount_path],
+        fs_name=fs_name,
+    )
+
+    # --- Phase 2: TLS NFS (expect encrypted wire, no cleartext pattern) ---
+    log.info("=== Phase 2: TLS NFS (TLS cluster + export, expect encrypted wire) ===")
+    ca_cert = setup_tls_nfs_cluster(
+        installer_node,
+        nfs_node,
+        tls_nfs_name,
+        tls_min_version=config.get("tls_min_version", "TLSv1.3"),
+        tls_ciphers=config.get("tls_ciphers", "ALL"),
+        tls_ktls=config.get("tls_ktls", True),
+        tls_debug=config.get("tls_debug", True),
+    )
+    setup_tls_client(client_node, ca_cert)
+
+    ok, _ = verify_ceph_orch_nfs_running(client_node, tls_nfs_name)
+    if not ok:
+        raise OperationFailedError("TLS NFS service not reported in ceph orch ps")
+
+    tls_export_path, tls_mount_path = _create_nfs_export_for_capture(
+        client_node,
+        fs_name,
+        tls_nfs_name,
+        tls_export_name,
+        tls_mount_name,
+        xprtsec="tls",
+    )
+    tls_fio_stats = _run_capture_fio_phase(
+        client_node,
+        nfs_node,
+        tls_export_path,
+        tls_mount_path,
+        version,
+        port,
+        server_host,
+        tls_pcap_path,
+        snaplen,
+        config,
+        xprtsec="tls",
+    )
+    tls_analysis = verify_tls_encrypted_traffic_in_pcap(
+        client_node,
+        tls_pcap_path,
+        cleartext_marker=tls_fio_stats["cleartext_marker"],
+        min_tls_app_records=min_tls_app_records,
+        max_cleartext_marker_hits=int(
+            tls_config_get(
+                config,
+                "max_tls_cleartext_hits",
+                "tc_04_max_tls_cleartext_hits",
+                default=50,
+            )
+        ),
+        plain_cleartext_marker_hits=plain_analysis["cleartext_marker_hits"],
+        max_cleartext_leak_ratio=float(
+            tls_config_get(
+                config,
+                "max_tls_cleartext_leak_ratio",
+                "tc_04_max_tls_cleartext_leak_ratio",
+                default=0.0001,
+            )
+        ),
+        **pcap_kwargs,
+    )
+    log.info(
+        "tls_io_tcpdump_encryption completed: plain cleartext_hits=%s, "
+        "TLS cleartext_hits=%s (allowed<=%s) tls_record_signal=%s (packets=%s)",
+        plain_analysis["cleartext_marker_hits"],
+        tls_analysis["cleartext_marker_hits"],
+        tls_analysis["allowed_cleartext_marker_hits"],
+        tls_analysis["tls_record_signal"],
+        tls_analysis["packet_count"],
+    )
+
+
 _OP_DISPATCH = {
     OP_TLS_DEPLOY_MOUNT_VERIFY: lambda inst, c, n, cfg, name: op_tls_deploy_mount_verify(
         c, n, cfg, name
@@ -328,6 +853,9 @@ _OP_DISPATCH = {
     OP_TLS_LOGS_OPENSSL_PROBE: lambda inst, c, n, cfg, name: op_tls_logs_openssl_probe(
         inst, c, n, cfg, name
     ),
+    OP_TLS_IO_TCPDUMP_ENCRYPTION: lambda inst, c, n, cfg, name: op_tls_io_tcpdump_encryption(
+        inst, c, n, cfg, name
+    ),
 }
 
 
@@ -336,7 +864,8 @@ def run(ceph_cluster, **kw):
     Each invocation is independent: deploy TLS NFS + tlshd, run config.operation, full cleanup.
 
     config.operation: tls_deploy_mount_verify | tls_export_enforcement |
-        tls_logs_openssl_probe | tls_full_workflow (or tls_all_in_one)
+        tls_logs_openssl_probe | tls_io_tcpdump_encryption |
+        tls_full_workflow (or tls_all_in_one)
     """
     log.info("Starting NFS TLS feature tests (independent mode)")
     config = kw.get("config", {})
@@ -355,19 +884,27 @@ def run(ceph_cluster, **kw):
 
     nfs_node = nfs_nodes[0]
     nfs_name = config.get("nfs_cluster_name", DEFAULT_NFS_TLS_CLUSTER)
+    plain_nfs_name = tls_config_get(
+        config,
+        "plain_nfs_cluster_name",
+        "tc_04_plain_cluster",
+        default=DEFAULT_NFS_PLAIN_CLUSTER,
+    )
     fs_name = config.get("fs_name", "cephfs")
+    tcpdump_self_contained = steps == [OP_TLS_IO_TCPDUMP_ENCRYPTION]
 
     try:
-        ca_cert = setup_tls_nfs_cluster(
-            installer_node=installer,
-            nfs_node=nfs_node,
-            nfs_name=nfs_name,
-            tls_min_version=config.get("tls_min_version", "TLSv1.3"),
-            tls_ciphers=config.get("tls_ciphers", "ALL"),
-            tls_ktls=config.get("tls_ktls", True),
-            tls_debug=config.get("tls_debug", True),
-        )
-        setup_tls_client(client_node, ca_cert)
+        if not tcpdump_self_contained:
+            ca_cert = setup_tls_nfs_cluster(
+                installer_node=installer,
+                nfs_node=nfs_node,
+                nfs_name=nfs_name,
+                tls_min_version=config.get("tls_min_version", "TLSv1.3"),
+                tls_ciphers=config.get("tls_ciphers", "ALL"),
+                tls_ktls=config.get("tls_ktls", True),
+                tls_debug=config.get("tls_debug", True),
+            )
+            setup_tls_client(client_node, ca_cert)
 
         for step in steps:
             _OP_DISPATCH[step](installer, client_node, nfs_node, config, nfs_name)
@@ -382,6 +919,8 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Full TLS stack cleanup (umount, exports, cluster, subvolumes)")
         try:
+            if tcpdump_self_contained:
+                full_tls_stack_cleanup(client_node, plain_nfs_name, fs_name=fs_name)
             full_tls_stack_cleanup(client_node, nfs_name, fs_name=fs_name)
         except Exception as ex:
             log.error("Cleanup failed: %s", ex)


### PR DESCRIPTION
**Description**
This automation validates that NFS-over-TLS encrypts data on the network between the client and the Ganesha server. It uses a two-phase compare approach. 

In the first phase, a plain (non-TLS) Ganesha cluster is deployed, sustained fio I/O is run with a known buffer pattern, and traffic is captured with tcpdump. The test confirms that the fio pattern appears in cleartext on the wire, establishing that the capture and detection method works. 

In the second phase, a TLS-enabled Ganesha cluster and TLS export are deployed, the same fio workload is run under tcpdump, and the test confirms that the same pattern does not appear in the capture while TLS-framed traffic is present. Together, this proves the control baseline (plain NFS leaks the pattern) and that TLS actually protects payload data on the wire.

**Summary**

This change adds a new test operation tls_io_tcpdump_encryption to security.test_tls_feature.py and registers it in suites/tentacle/nfs/tier1-nfs-ganesha.yaml under Polarion ID CEPH-83629170. Supporting helpers were added in security_utils.py for deploying a plain NFS cluster without SSL, starting and stopping tcpdump capture on the client, running fio with a normalized hex buffer pattern, and analyzing pcaps on the client node.

The test deploys a plain NFS Ganesha cluster named cephfs-nfs-plain and a separate TLS cluster named cephfs-nfs-tls with inline certificates, TLSv1.3, and kTLS enabled. On the client, ktls-utils and tlshd are configured with the server CA for TLS mounts. Plain and TLS exports are created on CephFS, and NFS port 2049 traffic is captured with tcpdump during mount and fio I/O. The fio workload uses 100M file size, 4k block size, 300 second runtime for both write and read, and a buffer pattern of 0xcefacefe so that cleartext leakage can be detected by searching the raw pcap for those bytes.

Pcap verification runs on the client without transferring large capture files back to cephci. For the plain NFS control phase, the test passes when the fio pattern is found in the pcap, confirming unencrypted traffic. For the TLS phase, the test passes when the same pattern is not found in the pcap, indicating encrypted wire traffic. TLS record byte patterns are also counted as supporting evidence. The test performs full cleanup of mounts, exports, both NFS clusters, and CephFS subvolumes when complete.

**Test Steps**

The automation begins by installing tcpdump and fio on the NFS client. 
In **Phase 1**, it deploys a plain Ganesha cluster on the NFS node without TLS, verifies the service is running in ceph orch, creates a CephFS subvolume and plain export without xprtsec tls, and starts tcpdump on the client filtering traffic to the NFS server on port 2049. It then mounts the plain export on the client using NFSv4.2 without xprtsec tls, runs fio write for 300 seconds with the known buffer pattern, drops caches, runs fio read for 300 seconds, stops tcpdump, and unmounts. The plain pcap is analyzed and the test passes if the cleartext fio pattern appears in the capture. The plain cluster, export, and subvolume are then torn down before the TLS phase begins.

In **Phase 2**, a self-signed certificate is generated and a TLS-enabled Ganesha cluster is deployed with ssl enabled. The client is configured with tlshd and the server CA. A TLS export is created with xprtsec tls, tcpdump is started on the client, and the export is mounted with xprtsec tls so the TLS handshake is included in the capture. The same fio write and read workload runs for 300 seconds each. After stopping tcpdump and unmounting, the TLS pcap is analyzed. The test passes if the fio cleartext pattern is not found in the capture and TLS record traffic is present. Finally, all TLS resources are cleaned up including the cluster, exports, subvolumes, and mount paths.


**Pass Criteria**
The test passes when fio write and read complete successfully on both plain and TLS mounts, the plain NFS capture shows the fio buffer pattern in cleartext on the wire, and the TLS capture does not show that pattern while sustained I/O runs over the encrypted connection. 
