### PR TITLE
enabling monitoring stacks in nfs and cephfs

### DIFF
--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_7x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_7x_to_8x.yaml
@@ -19,9 +19,9 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     rhcs-version: 6.1
-                    release: rc
+                    release: released
                     orphan-initial-daemons: true
-                    skip-monitoring-stack: true
+                    skip-monitoring-stack: false
               - config:
                   command: add_hosts
                   service: host

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml
@@ -25,11 +25,11 @@ tests:
           - config:
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
               base_cmd_args:
                 verbose: true
               command: bootstrap

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml
@@ -25,11 +25,11 @@ tests:
           - config:
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
               base_cmd_args:
                 verbose: true
               command: bootstrap

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_8x_latest_to_81x_latest.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_8x_latest_to_81x_latest.yaml
@@ -25,11 +25,11 @@ tests:
           - config:
               args:
                 rhcs-version: 8.0
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
               base_cmd_args:
                 verbose: true
               command: bootstrap

--- a/suites/squid/nfs/tier1-nfs-ganesha-upgrade-7x-to-8x-latest.yaml
+++ b/suites/squid/nfs/tier1-nfs-ganesha-upgrade-7x-to-8x-latest.yaml
@@ -30,10 +30,10 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
           - config:
               command: add_hosts
               service: host

--- a/suites/squid/nfs/tier1-nfs-ganesha-upgrade-8x-to-8x-latest.yaml
+++ b/suites/squid/nfs/tier1-nfs-ganesha-upgrade-8x-to-8x-latest.yaml
@@ -30,10 +30,10 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
@@ -19,9 +19,9 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     orphan-initial-daemons: true
-                    skip-monitoring-stack: true
+                    skip-monitoring-stack: false
               - config:
                   command: add_hosts
                   service: host

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
@@ -25,11 +25,11 @@ tests:
           - config:
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
               base_cmd_args:
                 verbose: true
               command: bootstrap

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
@@ -25,11 +25,11 @@ tests:
           - config:
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
               base_cmd_args:
                 verbose: true
               command: bootstrap

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_9x_to_91x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_9x_to_91x.yaml
@@ -25,11 +25,11 @@ tests:
           - config:
               args:
                 rhcs-version: 9.0
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
               base_cmd_args:
                 verbose: true
               command: bootstrap

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7-1x-to-8.1x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7-1x-to-8.1x-to-9x-latest.yaml
@@ -32,10 +32,10 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7-1x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-7-1x-to-9x-latest.yaml
@@ -30,10 +30,10 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
@@ -30,10 +30,10 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
@@ -30,10 +30,10 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 9.0
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
+                skip-monitoring-stack: false
           - config:
               command: add_hosts
               service: host


### PR DESCRIPTION
Changes:  bootstrap for Upgrades won't skip monitoring stack .


### jobs : 
### ceph-fs :
job: https://149.81.216.83/job/tentacle-test-executor/1945/
logs:   http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/upgrades/monitoring/tier_0_cephfs_upgrade_81_to_9x/


### nfs:
job:  https://149.81.216.83/job/tentacle-test-executor/1954/stages/
logs: http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/upgrades/monitoring/tier1_nfs_ganesha_upgrade_8x_to_9x_latest/

### changing RC- > release tag

ceph-fs_logs : http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/upgrades/monitoring/released_tag/tier_0_cephfs_upgrade_81_to_9x/

nfs_logs: http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/upgrades/monitoring/released_tag/tier1_nfs_ganesha_upgrade_8x_to_9x_latest/
