### PR TITLE
Add unified Ceph error injection framework for cephci

### DIFF
--- a/ceph/rados/ceph_error_injector.py
+++ b/ceph/rados/ceph_error_injector.py
@@ -1,0 +1,2704 @@
+"""
+ceph_error_injector.py - Unified Ceph Error Injection Framework
+
+This module provides a structured, reusable class for injecting errors into a
+running Ceph cluster during thrash/stress testing. It catalogs all known Ceph
+inject debug variables and admin socket injection commands, provides methods to
+enable/disable them on demand, and automatically tracks active injections for
+guaranteed cleanup.
+
+==============================================================================
+USAGE GUIDE
+==============================================================================
+
+1. Basic Usage (single injection):
+
+    from ceph.rados.ceph_error_injector import CephErrorInjector
+
+    injector = CephErrorInjector(rados_obj=rados_obj)
+    injector.inject_config("ms_inject_delay_probability", 0.1)
+    # ... run workload ...
+    injector.cleanup_all()
+
+2. Context Manager (automatic cleanup):
+
+    with CephErrorInjector(rados_obj=rados_obj) as injector:
+        injector.inject_config("bluestore_debug_inject_read_err", True)
+        injector.inject_ec_write_error(osd_id=3, pool="ec-pool")
+        # ... run workload ...
+    # cleanup_all() called automatically on exit
+
+3. Batch Injection:
+
+    injector.inject_config_batch({
+        "osd_debug_inject_dispatch_delay_probability": 0.2,
+        "osd_debug_inject_dispatch_delay_duration": 3,
+    })
+
+4. Chaos Profiles (predefined combinations):
+
+    injector.apply_profile("network_chaos")
+    injector.apply_profile("storage_corruption",
+        bluestore_debug_inject_csum_err_probability=0.05)
+
+5. Suite YAML Configuration:
+
+    Add an `error_injection` block under `config` in your suite YAML.
+    In your test code, call apply_from_config() to apply it:
+
+        injector = CephErrorInjector(rados_obj=rados_obj)
+        injector.apply_from_config(config.get("error_injection", {}))
+        # ... run workload ...
+        injector.cleanup_all()
+
+    Example A -- Profile only (applies all configs in the profile):
+
+        config:
+          error_injection:
+            profile: network_chaos
+
+    Example B -- Profile with overrides:
+
+        config:
+          error_injection:
+            profile: network_chaos
+            profile_overrides:
+              ms_inject_delay_probability: 0.2
+              ms_inject_delay_max: 10
+
+    Example C -- Individual configs (no profile):
+
+        config:
+          error_injection:
+            configs:
+              bluestore_debug_inject_read_err: true
+              osd_debug_inject_dispatch_delay_probability: 0.1
+              osd_debug_inject_dispatch_delay_duration: 3
+              mds_inject_health_dummy: true
+
+    Example D -- Profile + extra configs + EC write errors:
+
+        config:
+          error_injection:
+            profile: storage_corruption
+            configs:
+              osd_debug_inject_dispatch_delay_probability: 0.05
+            ec_write_errors:
+              - osd_id: 0
+                pool: ec-pool-1
+                shard: 2
+                duration: 500
+              - osd_id: 1
+                pool: ec-pool-1
+                shard: 2
+                duration: 500
+
+    Example E -- Full config with admin socket commands:
+
+        config:
+          error_injection:
+            profile: mon_instability
+            profile_overrides:
+              mon_inject_transaction_delay_probability: 0.2
+            configs:
+              bluestore_debug_inject_read_err: true
+            ec_write_errors:
+              - osd_id: 0
+                pool: ec-pool-1
+                shard: 2
+                duration: 1000
+            ec_read_errors:
+              - osd_id: 2
+                pool: ec-pool-1
+                shard: 2
+                duration: 500
+            admin_socket:
+              - command: injectfull
+                osd_id: 3
+                full_type: nearfull
+                count: 1
+              - command: injectdataerr
+                osd_id: 1
+                pool: ec-pool-1
+                objname: test-object-1
+              - command: bluefs_read_zeros
+                osd_id: 4
+              - command: injectargs
+                daemon_type: osd
+                daemon_id: "*"
+                args:
+                  ms_type: simple
+
+    Suite YAML Schema Reference:
+
+        error_injection:
+          profile: <profile_name>          # optional, predefined chaos profile
+            # Available profiles: network_chaos, network_latency,
+            #   storage_corruption, bdev_crash, mon_instability,
+            #   mon_sync_delay, mds_chaos, mds_corruption,
+            #   rgw_sync_errors, rgw_latency, rgw_multipart_errors,
+            #   osd_dispatch_delays, osd_map_corruption,
+            #   client_faults, heartbeat_failure,
+            #   bluestore_full_corruption, rgw_olh_errors,
+            #   mon_election_stress, client_session_stress,
+            #   objecter_faults, rgw_full_sync_chaos,
+            #   multi_layer_chaos
+          profile_overrides:               # optional, override profile values
+            <config_key>: <value>
+          configs:                          # optional, individual config keys
+            <config_key>: <value>
+          ec_write_errors:                  # optional, list of EC write specs
+            - osd_id: <int>                #   required
+              pool: <str>                  #   required
+              obj: <str>                   #   default: "*"
+              shard: <int>                 #   default: 2
+              err_type: <int>              #   default: 1
+              skip: <int>                  #   default: 0
+              duration: <int>              #   default: 1000
+          ec_read_errors:                   # optional, same schema as above
+            - osd_id: <int>
+              pool: <str>
+          admin_socket:                     # optional, admin socket commands
+            - command: injectfull
+              osd_id: <int>
+              full_type: <str>             # "full", "nearfull", "backfillfull"
+              count: <int>                 # default: 1
+            - command: injectdataerr
+              osd_id: <int>
+              pool: <str>
+              objname: <str>
+              shard: <int>                 # optional, for EC pools
+            - command: injectmdataerr
+              osd_id: <int>
+              pool: <str>
+              objname: <str>
+              shard: <int>                 # optional
+            - command: bluefs_read_zeros
+              osd_id: <int>
+            - command: injectargs
+              daemon_type: <str>           # osd, mon, mds, mgr
+              daemon_id: <str>             # e.g., "0", "*" for all
+              args:
+                <key>: <value>
+
+    All sections are optional. Use any combination. cleanup_all()
+    in the test's finally block removes everything automatically.
+
+==============================================================================
+INJECT VARIABLE REFERENCE
+==============================================================================
+
+All variables verified from live cluster via `ceph config help`. Every variable
+below is runtime-updatable EXCEPT `client_debug_inject_features`.
+
+--- MESSENGER / NETWORK (section: global) ---
+heartbeat_inject_failure        int    0     Skip sending heartbeats (triggers peer-down)
+ms_inject_socket_failures       uint   0     Inject socket failure every Nth operation
+ms_inject_delay_type            str    ""    Daemon type to inject delays for (osd/mon/mds)
+ms_inject_delay_max             float  1.0   Max injected message delay (seconds)
+ms_inject_delay_probability     float  0.0   Probability of delaying any message (0.0-1.0)
+ms_inject_internal_delays       float  0.0   Internal dispatch delays (seconds)
+ms_inject_network_congestion    uint   0     Simulate congestion, stuck N operations
+
+--- MON (section: mon) ---
+mon_scrub_inject_crc_mismatch           float  0.0   Probability of CRC mismatch during scrub
+mon_scrub_inject_missing_keys           float  0.0   Probability of missing keys during scrub
+mon_inject_sync_get_chunk_delay         float  0.0   Delay (seconds) fetching sync chunks
+mon_inject_transaction_delay_max        float  10.0  Max paxos transaction delay (seconds)
+mon_inject_transaction_delay_probability float  0.0  Probability of delaying paxos transaction
+mon_inject_pg_merge_bounce_probability  float  0.0   Probability of bouncing PG merge proposals
+
+--- OBJECTER (section: global) ---
+objecter_inject_no_watch_ping           bool   false  Skip watch ping (triggers timeout)
+objecter_debug_inject_relock_delay      bool   false  Add delay to relock operations
+
+--- OSD (section: osd) ---
+osd_debug_inject_dispatch_delay_probability  float  0.0   Probability of dispatch delay
+osd_debug_inject_dispatch_delay_duration     float  0.1   Duration of dispatch delay (seconds)
+osd_debug_inject_copyfrom_error              bool   false  Inject error in copy-from ops
+osd_inject_bad_map_crc_probability           float  0.0   Probability of bad OSD map CRC
+osd_inject_failure_on_pg_removal             bool   false  Force failure during PG removal
+
+--- BLUESTORE / BLOCK DEVICE (section: osd, except bluestore_debug_inject_read_err=global) ---
+bdev_inject_crash                                    int    0     Crash on Nth bdev operation
+bdev_inject_crash_flush_delay                        int    2     Delay before crash during flush
+bluestore_debug_inject_allocation_from_file_failure  float  0.0   Prob of alloc-from-file err
+bluestore_debug_inject_read_err                      bool   false  Inject read errors (global)
+bluestore_debug_inject_csum_err_probability          float  0.0   Probability of checksum error
+
+--- FILESTORE (section: osd) ---
+filestore_debug_inject_read_err  bool  false  Inject read errors
+filestore_inject_stall           int   0      Stall operations (seconds)
+
+--- RGW (section: client.rgw) ---
+rgw_mp_lock_inject_delay                           int    0     Delay after multipart lock (seconds)
+rgw_mp_lock_inject_renewal_error                   int    0     Error code for lock renewal
+rgw_sync_data_inject_err_probability               float  0.0   Probability of data sync error
+rgw_sync_meta_inject_err_probability               float  0.0   Probability of metadata sync error
+rgw_sync_data_full_inject_err_probability          float  0.0   Probability of full data sync error
+rgw_inject_delay_sec                               float  0.0   Delay at injection points (seconds)
+rgw_inject_delay_pattern                           str    ""    Pattern to match delay points
+rgw_data_sync_single_entry_inject_err_probability  float  0.0   Prob of single-entry sync err
+rgw_debug_inject_latency_bi_unlink                 uint   0     Latency before BI unlink (s)
+rgw_debug_inject_set_olh_err                       uint   0     Error code for OLH set op
+rgw_debug_inject_olh_cancel_modification_err       bool   false  Inject OLH cancel mod error
+rgw_inject_notify_timeout_probability              float  0.0   Prob of notify timeout (0-1)
+
+--- MDS (section: mds) ---
+mds_inject_rename_corrupt_dentry_first      float  0.0   Prob of corrupting dentry in rename
+mds_inject_journal_corrupt_dentry_first     float  0.0   Prob of corrupting dentry in journal
+mds_inject_health_dummy                     bool   false  Inject fake health warning
+mds_inject_skip_replaying_inotable          bool   false  Skip inotable replay on startup
+mds_inject_traceless_reply_probability      float  0.0   Probability of traceless replies
+mds_inject_migrator_session_race            bool   false  Inject subtree migration race condition
+
+--- CLIENT (section: client) ---
+client_debug_inject_tick_delay   secs  0      Delay in tick processing (seconds)
+client_debug_inject_features     str   ""     Override feature bits (NOT runtime-updatable)
+client_inject_release_failure    bool  false  Fail cap release messages
+client_inject_fixed_oldest_tid   bool  false  Fix oldest TID to stale value
+
+--- SIGNAL (section: global) ---
+inject_early_sigterm             bool  false  Send SIGTERM early in daemon startup
+
+==============================================================================
+ADMIN SOCKET COMMANDS (per-daemon, requires host resolution)
+==============================================================================
+
+injectecwriteerr <pool> <obj> <shard:int> [type:int] [when:int] [duration:int]
+    Inject write errors for objects in an EC pool.
+    - pool: target EC pool name
+    - obj: object name or '*' for all
+    - shard: shard ID (e.g., 2)
+    - type: error type (1=drop sub write, default 1)
+    - when: skip first N writes before injecting (default 0)
+    - duration: inject for N writes (default 1)
+
+injectecreaderr <pool> <obj> <shard:int> [type:int] [when:int] [duration:int]
+    Inject read errors for objects in an EC pool (same params as write).
+
+injectecclearwriteerr <pool> <obj> <shard:int> [type:int]
+    Clear previously injected EC write errors.
+
+injectecclearreaderr <pool> <obj> <shard:int> [type:int]
+    Clear previously injected EC read errors.
+
+injectdataerr <pool> <objname> [shard:int]
+    Inject data corruption on a specific object.
+
+injectmdataerr <pool> <objname> [shard:int]
+    Inject metadata corruption on a specific object.
+
+injectfull [type] [count:int]
+    Simulate disk full condition.
+    - type: "full", "nearfull", "backfillfull" (default "full")
+    - count: number of times to inject (default 1)
+
+bluefs debug_inject_read_zeros
+    Injects 8K of zeros into the next BlueFS read. Debug only.
+
+injectargs <injected_args>...
+    Inject configuration arguments into a running daemon without going
+    through the MON config database. Uses `ceph tell` mechanism.
+"""
+
+import json
+import time
+
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+# =============================================================================
+# INJECTION VARIABLE CATALOG
+# =============================================================================
+# Verified from live cluster via `ceph config ls` and `ceph config help`.
+# Each entry: key -> {section, type, default, desc}
+# All are runtime-updatable except client_debug_inject_features.
+
+MESSENGER_INJECTIONS = {
+    "heartbeat_inject_failure": {
+        "section": "global",
+        "type": "int",
+        "default": 0,
+        "desc": "Skip heartbeats for N cycles (DANGEROUS: N=duration not frequency, 0=off)",
+    },
+    "ms_inject_socket_failures": {
+        "section": "global",
+        "type": "uint",
+        "default": 0,
+        "desc": "Inject a socket failure every Nth socket operation",
+    },
+    "ms_inject_delay_type": {
+        "section": "global",
+        "type": "str",
+        "default": "",
+        "desc": "Entity type to inject delays for (osd, mon, mds, etc.)",
+    },
+    "ms_inject_delay_max": {
+        "section": "global",
+        "type": "float",
+        "default": 1.0,
+        "desc": "Max delay to inject on messages (seconds)",
+    },
+    "ms_inject_delay_probability": {
+        "section": "global",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability (0.0-1.0) of delaying any given message",
+    },
+    "ms_inject_internal_delays": {
+        "section": "global",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Inject internal delays to induce races (seconds)",
+    },
+    "ms_inject_network_congestion": {
+        "section": "global",
+        "type": "uint",
+        "default": 0,
+        "desc": "Simulate congestion stuck for N ops (DANGEROUS: N=duration)",
+    },
+}
+
+MON_INJECTIONS = {
+    "mon_scrub_inject_crc_mismatch": {
+        "section": "mon",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of injecting CRC mismatch during MON scrub",
+    },
+    "mon_scrub_inject_missing_keys": {
+        "section": "mon",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of injecting missing keys during MON scrub",
+    },
+    "mon_inject_sync_get_chunk_delay": {
+        "section": "mon",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Inject delay during MON sync chunk fetch (seconds)",
+    },
+    "mon_inject_transaction_delay_max": {
+        "section": "mon",
+        "type": "float",
+        "default": 10.0,
+        "desc": "Max duration of injected delay in paxos (seconds)",
+    },
+    "mon_inject_transaction_delay_probability": {
+        "section": "mon",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of injecting a delay in paxos transactions",
+    },
+    "mon_inject_pg_merge_bounce_probability": {
+        "section": "mon",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of failing and reverting a pg_num decrement",
+    },
+}
+
+OBJECTER_INJECTIONS = {
+    "objecter_inject_no_watch_ping": {
+        "section": "global",
+        "type": "bool",
+        "default": False,
+        "desc": "Skip watch ping, triggers watch timeout on peer",
+    },
+    "objecter_debug_inject_relock_delay": {
+        "section": "global",
+        "type": "bool",
+        "default": False,
+        "desc": "Add delay to relock operations in objecter",
+    },
+}
+
+OSD_INJECTIONS = {
+    "osd_debug_inject_dispatch_delay_probability": {
+        "section": "osd",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of adding delay to OSD op dispatch",
+    },
+    "osd_debug_inject_dispatch_delay_duration": {
+        "section": "osd",
+        "type": "float",
+        "default": 0.1,
+        "desc": "Duration of dispatch delay when triggered (seconds)",
+    },
+    "osd_debug_inject_copyfrom_error": {
+        "section": "osd",
+        "type": "bool",
+        "default": False,
+        "desc": "Inject errors in OSD copy-from operations",
+    },
+    "osd_inject_bad_map_crc_probability": {
+        "section": "osd",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of injecting bad CRC in OSD map updates",
+    },
+    "osd_inject_failure_on_pg_removal": {
+        "section": "osd",
+        "type": "bool",
+        "default": False,
+        "desc": "Force failure during PG removal",
+    },
+}
+
+BLUESTORE_INJECTIONS = {
+    "bdev_inject_crash": {
+        "section": "osd",
+        "type": "int",
+        "default": 0,
+        "desc": "Crash on Nth bdev operation (simulates SSD firmware crash)",
+    },
+    "bdev_inject_crash_flush_delay": {
+        "section": "osd",
+        "type": "int",
+        "default": 2,
+        "desc": "Delay (seconds) before crash injection during flush",
+    },
+    "bluestore_debug_inject_allocation_from_file_failure": {
+        "section": "osd",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of error restoring allocation map from file",
+    },
+    "bluestore_debug_inject_read_err": {
+        "section": "global",
+        "type": "bool",
+        "default": False,
+        "desc": "Inject read errors in BlueStore (prerequisite for EC inject)",
+    },
+    "bluestore_debug_inject_csum_err_probability": {
+        "section": "osd",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of injecting checksum errors on reads",
+    },
+}
+
+FILESTORE_INJECTIONS = {
+    "filestore_debug_inject_read_err": {
+        "section": "osd",
+        "type": "bool",
+        "default": False,
+        "desc": "Inject read errors in FileStore backend",
+    },
+    "filestore_inject_stall": {
+        "section": "osd",
+        "type": "int",
+        "default": 0,
+        "desc": "Stall FileStore operations for N seconds (simulates hung disk)",
+    },
+}
+
+RGW_INJECTIONS = {
+    "rgw_mp_lock_inject_delay": {
+        "section": "client.rgw",
+        "type": "int",
+        "default": 0,
+        "desc": "Injected delay after acquiring multipart lock (seconds)",
+    },
+    "rgw_mp_lock_inject_renewal_error": {
+        "section": "client.rgw",
+        "type": "int",
+        "default": 0,
+        "desc": "Injected error code for multipart lock renewal testing",
+    },
+    "rgw_sync_data_inject_err_probability": {
+        "section": "client.rgw",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of error during data sync between zones",
+    },
+    "rgw_sync_meta_inject_err_probability": {
+        "section": "client.rgw",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of error during metadata sync",
+    },
+    "rgw_sync_data_full_inject_err_probability": {
+        "section": "client.rgw",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of error during full data sync",
+    },
+    "rgw_inject_delay_sec": {
+        "section": "client.rgw",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Delay duration at injection points (seconds)",
+    },
+    "rgw_inject_delay_pattern": {
+        "section": "client.rgw",
+        "type": "str",
+        "default": "",
+        "desc": "Pattern to select which delay injection points are activated",
+    },
+    "rgw_data_sync_single_entry_inject_err_probability": {
+        "section": "client.rgw",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of error during single-entry data sync",
+    },
+    "rgw_debug_inject_latency_bi_unlink": {
+        "section": "client.rgw",
+        "type": "uint",
+        "default": 0,
+        "desc": "Latency before bucket index unlink (seconds)",
+    },
+    "rgw_debug_inject_set_olh_err": {
+        "section": "client.rgw",
+        "type": "uint",
+        "default": 0,
+        "desc": "Error code injected on OLH set operation (e.g., errno)",
+    },
+    "rgw_debug_inject_olh_cancel_modification_err": {
+        "section": "client.rgw",
+        "type": "bool",
+        "default": False,
+        "desc": "Inject error when canceling OLH modification",
+    },
+    "rgw_inject_notify_timeout_probability": {
+        "section": "client.rgw",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability (0.0-1.0) of ignoring cache notify messages",
+    },
+}
+
+MDS_INJECTIONS = {
+    "mds_inject_rename_corrupt_dentry_first": {
+        "section": "mds",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of corrupting first dentry during rename",
+    },
+    "mds_inject_journal_corrupt_dentry_first": {
+        "section": "mds",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of corrupting first dentry in journal",
+    },
+    "mds_inject_health_dummy": {
+        "section": "mds",
+        "type": "bool",
+        "default": False,
+        "desc": "Inject fake health warning into MDS health reports",
+    },
+    "mds_inject_skip_replaying_inotable": {
+        "section": "mds",
+        "type": "bool",
+        "default": False,
+        "desc": "Skip inotable replay on MDS startup",
+    },
+    "mds_inject_traceless_reply_probability": {
+        "section": "mds",
+        "type": "float",
+        "default": 0.0,
+        "desc": "Probability of sending replies without traces",
+    },
+    "mds_inject_migrator_session_race": {
+        "section": "mds",
+        "type": "bool",
+        "default": False,
+        "desc": "Inject race condition in subtree migration",
+    },
+}
+
+CLIENT_INJECTIONS = {
+    "client_debug_inject_tick_delay": {
+        "section": "client",
+        "type": "secs",
+        "default": 0,
+        "desc": "Delay in client tick processing (seconds)",
+    },
+    "client_debug_inject_features": {
+        "section": "client",
+        "type": "str",
+        "default": "",
+        "desc": "Override client feature bits (NOT runtime-updatable)",
+        "runtime": False,
+    },
+    "client_inject_release_failure": {
+        "section": "client",
+        "type": "bool",
+        "default": False,
+        "desc": "Fail cap release messages (tests cap revocation backoff)",
+    },
+    "client_inject_fixed_oldest_tid": {
+        "section": "client",
+        "type": "bool",
+        "default": False,
+        "desc": "Fix oldest TID to stale value (triggers session blocklist)",
+    },
+}
+
+SIGNAL_INJECTIONS = {
+    "inject_early_sigterm": {
+        "section": "global",
+        "type": "bool",
+        "default": False,
+        "desc": "Send SIGTERM early in daemon startup (tests clean shutdown)",
+    },
+}
+
+ALL_INJECTIONS = {
+    **MESSENGER_INJECTIONS,
+    **MON_INJECTIONS,
+    **OBJECTER_INJECTIONS,
+    **OSD_INJECTIONS,
+    **BLUESTORE_INJECTIONS,
+    **FILESTORE_INJECTIONS,
+    **RGW_INJECTIONS,
+    **MDS_INJECTIONS,
+    **CLIENT_INJECTIONS,
+    **SIGNAL_INJECTIONS,
+}
+
+# =============================================================================
+# CHAOS PROFILES — Predefined combinations for common fault scenarios
+# =============================================================================
+
+PROFILES = {
+    "network_chaos": {
+        "desc": "Simulate unreliable network between daemons",
+        "configs": {
+            "ms_inject_socket_failures": 500,
+            "ms_inject_delay_type": "osd",
+            "ms_inject_delay_max": 5,
+            "ms_inject_delay_probability": 0.05,
+        },
+    },
+    "network_latency": {
+        "desc": "Inject message latency without dropping connections",
+        "configs": {
+            "ms_inject_delay_type": "osd",
+            "ms_inject_delay_max": 3,
+            "ms_inject_delay_probability": 0.1,
+            "ms_inject_internal_delays": 0.5,
+        },
+    },
+    "storage_corruption": {
+        "desc": "Inject storage-layer read errors and checksum failures",
+        "configs": {
+            "bluestore_debug_inject_read_err": True,
+            "bluestore_debug_inject_csum_err_probability": 0.01,
+        },
+    },
+    "bdev_crash": {
+        "desc": "Simulate block device crashes (SSD firmware failure)",
+        "configs": {
+            "bdev_inject_crash": 10000,
+            "bdev_inject_crash_flush_delay": 5,
+        },
+    },
+    "mon_instability": {
+        "desc": "Destabilize MON quorum via paxos and scrub injection",
+        "configs": {
+            "mon_scrub_inject_crc_mismatch": 0.1,
+            "mon_scrub_inject_missing_keys": 0.05,
+            "mon_inject_transaction_delay_max": 10,
+            "mon_inject_transaction_delay_probability": 0.1,
+        },
+    },
+    "mon_sync_delay": {
+        "desc": "Slow down MON synchronization (new MON joining)",
+        "configs": {
+            "mon_inject_sync_get_chunk_delay": 5.0,
+        },
+    },
+    "mds_chaos": {
+        "desc": "Inject MDS journal corruption and migration races",
+        "configs": {
+            "mds_inject_health_dummy": True,
+            "mds_inject_traceless_reply_probability": 0.05,
+            "mds_inject_migrator_session_race": True,
+        },
+    },
+    "mds_corruption": {
+        "desc": "Inject dentry corruption in MDS rename/journal paths",
+        "configs": {
+            "mds_inject_rename_corrupt_dentry_first": 0.01,
+            "mds_inject_journal_corrupt_dentry_first": 0.01,
+        },
+    },
+    "rgw_sync_errors": {
+        "desc": "Inject errors into RGW multi-site sync paths",
+        "configs": {
+            "rgw_sync_data_inject_err_probability": 0.01,
+            "rgw_sync_meta_inject_err_probability": 0.01,
+            "rgw_data_sync_single_entry_inject_err_probability": 0.01,
+        },
+    },
+    "rgw_latency": {
+        "desc": "Inject delays at RGW injection points and OLH operations",
+        "configs": {
+            "rgw_inject_delay_sec": 2.0,
+            "rgw_inject_delay_pattern": "delay_bucket_full_sync_loop",
+            "rgw_debug_inject_latency_bi_unlink": 3,
+        },
+    },
+    "rgw_multipart_errors": {
+        "desc": "Inject multipart upload lock errors",
+        "configs": {
+            "rgw_mp_lock_inject_delay": 5,
+            "rgw_mp_lock_inject_renewal_error": -5,
+        },
+    },
+    "osd_dispatch_delays": {
+        "desc": "Slow OSD op dispatch to trigger client-side timeouts",
+        "configs": {
+            "osd_debug_inject_dispatch_delay_probability": 0.05,
+            "osd_debug_inject_dispatch_delay_duration": 2,
+        },
+    },
+    "osd_map_corruption": {
+        "desc": "Inject bad CRC in OSD maps and PG removal failures",
+        "configs": {
+            "osd_inject_bad_map_crc_probability": 0.01,
+            "osd_inject_failure_on_pg_removal": True,
+        },
+    },
+    "client_faults": {
+        "desc": "Inject client-side cap release and session failures",
+        "configs": {
+            "client_inject_release_failure": True,
+            "client_debug_inject_tick_delay": 5,
+        },
+    },
+    "heartbeat_failure": {
+        "desc": "Simulate OSD heartbeat failures causing false down reports",
+        "configs": {
+            "heartbeat_inject_failure": 500,
+        },
+    },
+    "bluestore_full_corruption": {
+        "desc": "BlueStore read errors + checksum errors + alloc failures",
+        "configs": {
+            "bluestore_debug_inject_read_err": True,
+            "bluestore_debug_inject_csum_err_probability": 0.01,
+            "bluestore_debug_inject_allocation_from_file_failure": 0.01,
+        },
+    },
+    "rgw_olh_errors": {
+        "desc": "Inject errors in RGW object versioning and OLH operations",
+        "configs": {
+            "rgw_debug_inject_set_olh_err": 5,
+            "rgw_debug_inject_olh_cancel_modification_err": True,
+            "rgw_inject_notify_timeout_probability": 0.05,
+        },
+    },
+    "mon_election_stress": {
+        "desc": "Stress MON elections with paxos delays and PG merge bounces",
+        "configs": {
+            "mon_inject_transaction_delay_probability": 0.15,
+            "mon_inject_transaction_delay_max": 5,
+            "mon_inject_pg_merge_bounce_probability": 0.1,
+        },
+    },
+    "client_session_stress": {
+        "desc": "Stress client sessions with cap failures and stale TIDs",
+        "configs": {
+            "client_inject_release_failure": True,
+            "client_inject_fixed_oldest_tid": True,
+            "client_debug_inject_tick_delay": 3,
+        },
+    },
+    "objecter_faults": {
+        "desc": "Inject objecter watch timeout and relock delays",
+        "configs": {
+            "objecter_inject_no_watch_ping": True,
+            "objecter_debug_inject_relock_delay": True,
+        },
+    },
+    "rgw_full_sync_chaos": {
+        "desc": "Inject errors across all RGW sync paths simultaneously",
+        "configs": {
+            "rgw_sync_data_inject_err_probability": 0.02,
+            "rgw_sync_meta_inject_err_probability": 0.02,
+            "rgw_sync_data_full_inject_err_probability": 0.02,
+            "rgw_data_sync_single_entry_inject_err_probability": 0.02,
+            "rgw_inject_notify_timeout_probability": 0.05,
+        },
+    },
+    "multi_layer_chaos": {
+        "desc": "Combined network delays + storage corruption + OSD dispatch",
+        "configs": {
+            "ms_inject_delay_type": "osd",
+            "ms_inject_delay_max": 2,
+            "ms_inject_delay_probability": 0.03,
+            "bluestore_debug_inject_read_err": True,
+            "osd_debug_inject_dispatch_delay_probability": 0.03,
+            "osd_debug_inject_dispatch_delay_duration": 1,
+        },
+    },
+}
+
+
+class CephErrorInjector:
+    """
+    Unified Ceph error injection framework for thrash and stress testing.
+
+    Provides a structured API to inject faults into a running Ceph cluster
+    via MON config database (persistent, cluster-wide) and admin socket
+    commands (per-daemon, runtime-only). Tracks all active injections for
+    guaranteed cleanup.
+
+    Initialization:
+        injector = CephErrorInjector(rados_obj=rados_obj)
+
+    The class follows the same composition pattern as MonConfigMethods --
+    it takes a RadosOrchestrator instance and delegates cluster commands
+    through it.
+
+    Suite YAML Integration — Two Approaches:
+
+    1. Embedded (inside test config):
+        Pass an `error_injection` dict directly in a test's config block:
+
+            - test:
+                module: test_osd_thrashing.py
+                config:
+                  error_injection:
+                    profile: network_chaos
+
+    2. Standalone (separate inject/cleanup steps):
+        Use test_ceph_error_injection.py as suite-level steps around
+        any tests. No code changes needed in the tests themselves:
+
+            - test:
+                name: Inject errors
+                module: test_ceph_error_injection.py
+                abort-on-fail: true
+                config:
+                  action: inject
+                  error_injection:
+                    profile: mon_instability
+
+            - test:
+                name: Run any test with faults active
+                module: some_other_test.py
+                config: ...
+
+            - test:
+                name: Cleanup errors
+                module: test_ceph_error_injection.py
+                config:
+                  action: cleanup
+
+    Supported error_injection keys:
+        - profile (str): Name of a predefined chaos profile
+        - profile_overrides (dict): Override values within the profile
+        - configs (dict): Key-value pairs of inject config options
+        - ec_write_errors (list): EC write error injection specs
+        - ec_read_errors (list): EC read error injection specs
+        - admin_socket (list): Arbitrary admin socket injection commands
+    """
+
+    def __init__(self, rados_obj: RadosOrchestrator):
+        """
+        Initialize the error injector.
+
+        Args:
+            rados_obj: RadosOrchestrator instance for cluster communication
+        """
+        self.rados_obj = rados_obj
+        self.mon_obj = MonConfigMethods(rados_obj=rados_obj)
+        self._active_config_injections = []
+        self._active_daemon_injections = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup_all()
+        return False
+
+    # =========================================================================
+    # CONFIG-BASED INJECTION (cluster-wide via MON config DB)
+    # =========================================================================
+
+    def inject_config(self, name: str, value, section: str = None) -> bool:
+        """
+        Set a single inject config variable in the MON config database.
+
+        The variable is validated against the known catalog. Section is
+        auto-resolved from the catalog if not provided.
+
+        Args:
+            name: Config key name (must be in ALL_INJECTIONS catalog)
+            value: Value to set (type validated against catalog)
+            section: Override target section (default: from catalog)
+
+        Returns:
+            True if successfully set, False otherwise
+
+        Raises:
+            ValueError: If name is not in the catalog
+        """
+        if name not in ALL_INJECTIONS:
+            raise ValueError(
+                f"Unknown inject variable: '{name}'. "
+                f"Use CephErrorInjector.list_available() to see all options."
+            )
+
+        meta = ALL_INJECTIONS[name]
+
+        if meta.get("runtime") is False:
+            log.warning(
+                f"Config '{name}' is NOT runtime-updatable. "
+                "It requires daemon restart or client remount to take effect."
+            )
+
+        if meta["type"] == "float" and name.endswith("_probability"):
+            try:
+                fval = float(value)
+                if fval < 0.0 or fval > 1.0:
+                    log.warning(
+                        f"Config '{name}' is a probability but value "
+                        f"{fval} is outside 0.0-1.0 range. "
+                        f"Did you mean {fval / 100.0}?"
+                    )
+            except (TypeError, ValueError):
+                pass
+
+        # Safety check: some "every Nth operation" configs with very
+        # low values (e.g., 1) will break cluster connectivity entirely
+        # because every messenger/heartbeat/dispatch operation fails.
+        # Configs where N = duration of fault (ANY non-zero is risky)
+        _DURATION_DANGER = {
+            "ms_inject_network_congestion",
+        }
+        # Configs where low int/uint values are dangerous (every-Nth)
+        _LOW_VALUE_DANGER = {
+            "ms_inject_socket_failures": 100,
+            "heartbeat_inject_failure": 100,
+            "bdev_inject_crash": 1000,
+        }
+        # Configs where high float/int values are dangerous (durations)
+        _HIGH_VALUE_DANGER = {
+            "osd_debug_inject_dispatch_delay_duration": 30,
+            "ms_inject_delay_max": 30,
+            "mon_inject_transaction_delay_max": 60,
+            "filestore_inject_stall": 60,
+            "client_debug_inject_tick_delay": 60,
+            "rgw_mp_lock_inject_delay": 60,
+        }
+        try:
+            num_val = float(value)
+            if name in _DURATION_DANGER and num_val > 0:
+                log.warning(
+                    f"SAFETY: Config '{name}' set to {num_val}. "
+                    f"N = how long the fault lasts (in operations), "
+                    f"NOT frequency. Any non-zero value is risky."
+                )
+            elif name in _LOW_VALUE_DANGER:
+                min_safe = _LOW_VALUE_DANGER[name]
+                if 0 < num_val < min_safe:
+                    log.warning(
+                        f"SAFETY: Config '{name}' set to {num_val} is "
+                        f"dangerously aggressive (min safe ~{min_safe})."
+                    )
+            elif name in _HIGH_VALUE_DANGER:
+                max_safe = _HIGH_VALUE_DANGER[name]
+                if num_val > max_safe:
+                    log.warning(
+                        f"SAFETY: Config '{name}' set to {num_val}s "
+                        f"exceeds safe threshold ({max_safe}s). "
+                        f"This may cause command timeouts."
+                    )
+        except (TypeError, ValueError):
+            pass
+
+        target_section = section or meta["section"]
+        str_value = self._convert_value(value, meta["type"])
+
+        log.info(
+            f"Injecting config: ceph config set {target_section} " f"{name} {str_value}"
+        )
+
+        # Run ceph config set directly instead of going through MonConfigMethods.set_config()
+        cmd = f"ceph config set {target_section} {name} {str_value}"
+        try:
+            self.rados_obj.node.shell([cmd])
+        except Exception as e:
+            log.error(f"Failed to run ceph config set for {name}: {e}")
+            return False
+
+        # Verify the config was actually applied using float-aware
+        # comparison against ceph config dump
+        if not self._verify_config_set(target_section, name, str_value):
+            log.warning(
+                f"Config {name} may not have been set correctly, "
+                f"but proceeding with tracking for cleanup"
+            )
+
+        self._active_config_injections.append({"name": name, "section": target_section})
+        log.info(f"Injection active: {name} = {str_value} [{target_section}]")
+        return True
+
+    def inject_config_batch(self, injections: dict) -> dict:
+        """
+        Apply multiple config injections at once.
+
+        Args:
+            injections: Dict of {config_key: value} pairs.
+                        Keys must be in ALL_INJECTIONS catalog.
+
+        Returns:
+            Dict of {config_key: bool} indicating success/failure per key
+
+        Example:
+            results = injector.inject_config_batch({
+                "ms_inject_delay_probability": 0.1,
+                "ms_inject_delay_max": 5,
+                "osd_debug_inject_dispatch_delay_probability": 0.2,
+            })
+        """
+        results = {}
+        for name, value in injections.items():
+            try:
+                results[name] = self.inject_config(name, value)
+            except ValueError as e:
+                log.error(str(e))
+                results[name] = False
+        return results
+
+    def remove_config_injection(self, name: str, section: str = None) -> bool:
+        """
+        Remove a single inject config variable from the MON config database.
+
+        Args:
+            name: Config key name
+            section: Override target section (default: from catalog)
+
+        Returns:
+            True if successfully removed, False otherwise
+        """
+        if name not in ALL_INJECTIONS:
+            log.warning(f"Unknown inject variable: '{name}', attempting removal anyway")
+            target_section = section or "global"
+        else:
+            target_section = section or ALL_INJECTIONS[name]["section"]
+
+        log.info(f"Removing injection: {name} from [{target_section}]")
+        result = self.mon_obj.remove_config(
+            section=target_section, name=name, verify_rm=False
+        )
+
+        self._active_config_injections = [
+            inj
+            for inj in self._active_config_injections
+            if not (inj["name"] == name and inj["section"] == target_section)
+        ]
+
+        return result
+
+    # =========================================================================
+    # ADMIN SOCKET INJECTION (per-daemon, requires host resolution)
+    # =========================================================================
+
+    def inject_ec_write_error(
+        self,
+        osd_id: int,
+        pool: str,
+        obj: str = "*",
+        shard: int = 2,
+        err_type: int = 1,
+        skip: int = 0,
+        duration: int = 1000,
+    ) -> bool:
+        """
+        Inject write errors for objects in an EC pool via OSD admin socket.
+
+        Runs: ceph daemon osd.{id} injectecwriteerr <pool> <obj> <shard>
+              <type> <skip> <duration>
+
+        Args:
+            osd_id: Target OSD ID
+            pool: EC pool name
+            obj: Object name or '*' for all objects
+            shard: Shard ID to inject on (default 2)
+            err_type: Error type (1=drop sub write, default 1)
+            skip: Number of writes to skip before injecting (default 0)
+            duration: Number of writes to inject errors on (default 1000)
+
+        Returns:
+            True if injection command succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectecwriteerr "
+            f"{pool} '{obj}' {shard} {err_type} {skip} {duration}"
+        )
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections.append(
+                {
+                    "type": "ec_write",
+                    "osd_id": osd_id,
+                    "pool": pool,
+                    "obj": obj,
+                    "shard": shard,
+                    "err_type": err_type,
+                }
+            )
+
+        return result
+
+    def inject_ec_read_error(
+        self,
+        osd_id: int,
+        pool: str,
+        obj: str = "*",
+        shard: int = 2,
+        err_type: int = 1,
+        skip: int = 0,
+        duration: int = 1000,
+    ) -> bool:
+        """
+        Inject read errors for objects in an EC pool via OSD admin socket.
+
+        Runs: ceph daemon osd.{id} injectecreaderr <pool> <obj> <shard>
+              <type> <skip> <duration>
+
+        Args:
+            osd_id: Target OSD ID
+            pool: EC pool name
+            obj: Object name or '*' for all objects
+            shard: Shard ID to inject on (default 2)
+            err_type: Error type (default 1)
+            skip: Number of reads to skip before injecting (default 0)
+            duration: Number of reads to inject errors on (default 1000)
+
+        Returns:
+            True if injection command succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectecreaderr "
+            f"{pool} '{obj}' {shard} {err_type} {skip} {duration}"
+        )
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections.append(
+                {
+                    "type": "ec_read",
+                    "osd_id": osd_id,
+                    "pool": pool,
+                    "obj": obj,
+                    "shard": shard,
+                    "err_type": err_type,
+                }
+            )
+
+        return result
+
+    def clear_ec_write_error(
+        self,
+        osd_id: int,
+        pool: str,
+        obj: str = "*",
+        shard: int = 2,
+        err_type: int = 1,
+    ) -> bool:
+        """
+        Clear previously injected EC write errors.
+
+        Runs: ceph daemon osd.{id} injectecclearwriteerr <pool> <obj>
+              <shard> <type>
+
+        Args:
+            osd_id: Target OSD ID
+            pool: EC pool name
+            obj: Object name or '*'
+            shard: Shard ID
+            err_type: Error type to clear
+
+        Returns:
+            True if clear command succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectecclearwriteerr "
+            f"{pool} '{obj}' {shard} {err_type}"
+        )
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections = [
+                inj
+                for inj in self._active_daemon_injections
+                if not (
+                    inj.get("type") == "ec_write"
+                    and inj.get("osd_id") == osd_id
+                    and inj.get("pool") == pool
+                    and inj.get("shard") == shard
+                )
+            ]
+
+        return result
+
+    def clear_ec_read_error(
+        self,
+        osd_id: int,
+        pool: str,
+        obj: str = "*",
+        shard: int = 2,
+        err_type: int = 1,
+    ) -> bool:
+        """
+        Clear previously injected EC read errors.
+
+        Runs: ceph daemon osd.{id} injectecclearreaderr <pool> <obj>
+              <shard> <type>
+
+        Args:
+            osd_id: Target OSD ID
+            pool: EC pool name
+            obj: Object name or '*'
+            shard: Shard ID
+            err_type: Error type to clear
+
+        Returns:
+            True if clear command succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectecclearreaderr "
+            f"{pool} '{obj}' {shard} {err_type}"
+        )
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections = [
+                inj
+                for inj in self._active_daemon_injections
+                if not (
+                    inj.get("type") == "ec_read"
+                    and inj.get("osd_id") == osd_id
+                    and inj.get("pool") == pool
+                    and inj.get("shard") == shard
+                )
+            ]
+
+        return result
+
+    def inject_data_error(
+        self, osd_id: int, pool: str, objname: str, shard: int = None
+    ) -> bool:
+        """
+        Inject data corruption on a specific object.
+
+        Runs: ceph daemon osd.{id} injectdataerr <pool> <objname> [shard]
+
+        Args:
+            osd_id: Target OSD ID
+            pool: Pool name
+            objname: Object name
+            shard: Optional shard ID for EC pools
+
+        Returns:
+            True if injection succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectdataerr "
+            f"{pool} {objname}"
+        )
+        if shard is not None:
+            cmd += f" {shard}"
+
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections.append(
+                {
+                    "type": "data_err",
+                    "osd_id": osd_id,
+                    "pool": pool,
+                    "obj": objname,
+                    "shard": shard,
+                }
+            )
+
+        return result
+
+    def inject_metadata_error(
+        self, osd_id: int, pool: str, objname: str, shard: int = None
+    ) -> bool:
+        """
+        Inject metadata corruption on a specific object.
+
+        Runs: ceph daemon osd.{id} injectmdataerr <pool> <objname> [shard]
+
+        Args:
+            osd_id: Target OSD ID
+            pool: Pool name
+            objname: Object name
+            shard: Optional shard ID for EC pools
+
+        Returns:
+            True if injection succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectmdataerr "
+            f"{pool} {objname}"
+        )
+        if shard is not None:
+            cmd += f" {shard}"
+
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections.append(
+                {
+                    "type": "mdata_err",
+                    "osd_id": osd_id,
+                    "pool": pool,
+                    "obj": objname,
+                    "shard": shard,
+                }
+            )
+
+        return result
+
+    def inject_full(self, osd_id: int, full_type: str = "full", count: int = 1) -> bool:
+        """
+        Simulate disk full condition on an OSD.
+
+        Runs: ceph daemon osd.{id} injectfull [type] [count]
+
+        Args:
+            osd_id: Target OSD ID
+            full_type: Type of full condition
+                       ("full", "nearfull", "backfillfull")
+            count: Number of times to inject (default 1)
+
+        Returns:
+            True if injection succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} injectfull "
+            f"{full_type} {count}"
+        )
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections.append(
+                {
+                    "type": "full",
+                    "osd_id": osd_id,
+                    "full_type": full_type,
+                }
+            )
+
+        return result
+
+    def inject_bluefs_read_zeros(self, osd_id: int) -> bool:
+        """
+        Inject 8K of zeros into the next BlueFS read.
+
+        Runs: ceph daemon osd.{id} bluefs debug_inject_read_zeros
+
+        Args:
+            osd_id: Target OSD ID
+
+        Returns:
+            True if injection succeeded, False otherwise
+        """
+        cmd = (
+            f"cephadm shell -- ceph daemon osd.{osd_id} "
+            f"bluefs debug_inject_read_zeros"
+        )
+        result = self._run_on_osd_host(osd_id, cmd)
+
+        if result:
+            self._active_daemon_injections.append(
+                {"type": "bluefs_zeros", "osd_id": osd_id}
+            )
+
+        return result
+
+    def inject_args(self, daemon_type: str, daemon_id: str, args: dict) -> bool:
+        """
+        Inject configuration arguments into a running daemon via ceph tell.
+
+        This bypasses the MON config database entirely -- the args are
+        applied directly to the daemon's runtime config and do NOT persist
+        across restarts.
+
+        Runs: ceph tell {daemon_type}.{daemon_id} injectargs --key value ...
+
+        Args:
+            daemon_type: Daemon type (osd, mon, mds, mgr)
+            daemon_id: Daemon ID (e.g., "0", "*" for all)
+            args: Dict of {config_key: value} to inject
+
+        Returns:
+            True if injection succeeded, False otherwise
+        """
+        args_str = " ".join(f"--{k} {v}" for k, v in args.items())
+        cmd = f"ceph tell {daemon_type}.{daemon_id} injectargs {args_str}"
+
+        log.info(f"Injecting args: {cmd}")
+        try:
+            self.rados_obj.node.shell([cmd])
+            log.info(f"Successfully injected args on {daemon_type}.{daemon_id}")
+            self._active_daemon_injections.append(
+                {
+                    "type": "injectargs",
+                    "daemon_type": daemon_type,
+                    "daemon_id": daemon_id,
+                    "args": args,
+                }
+            )
+            return True
+        except Exception as e:
+            log.error(f"Failed to inject args on {daemon_type}.{daemon_id}: {e}")
+            return False
+
+    # =========================================================================
+    # CHAOS PROFILES
+    # =========================================================================
+
+    def apply_profile(self, profile_name: str, **overrides) -> dict:
+        """
+        Apply a predefined chaos profile (batch of related injections).
+
+        Profiles are predefined combinations of inject variables that
+        simulate common failure scenarios. Override individual values
+        within a profile by passing them as keyword arguments.
+
+        Args:
+            profile_name: Name of the profile (see PROFILES dict)
+            **overrides: Override specific values within the profile
+
+        Returns:
+            Dict of {config_key: bool} indicating success/failure per key
+
+        Raises:
+            ValueError: If profile_name is not found
+
+        Example:
+            injector.apply_profile("network_chaos")
+            injector.apply_profile("storage_corruption",
+                bluestore_debug_inject_csum_err_probability=0.05)
+
+        Available profiles:
+            - network_chaos: Unreliable network (socket failures + delays)
+            - network_latency: Message latency without drops
+            - storage_corruption: BlueStore read/checksum errors
+            - bdev_crash: Block device crash simulation
+            - mon_instability: MON scrub + paxos delays
+            - mon_sync_delay: Slow MON synchronization
+            - mds_chaos: MDS health + migration races
+            - mds_corruption: MDS dentry corruption
+            - rgw_sync_errors: RGW multi-site sync failures
+            - rgw_latency: RGW delay injection points
+            - rgw_multipart_errors: Multipart upload lock errors
+            - osd_dispatch_delays: OSD op dispatch delays
+            - osd_map_corruption: OSD map CRC + PG removal failures
+            - client_faults: Client cap release + tick delays
+            - heartbeat_failure: OSD heartbeat injection
+            - bluestore_full_corruption: Read + checksum + alloc errors
+            - rgw_olh_errors: OLH versioning errors + notify timeout
+            - mon_election_stress: Paxos delays + PG merge bounces
+            - client_session_stress: Cap failures + stale TIDs
+            - objecter_faults: Watch timeout + relock delays
+            - rgw_full_sync_chaos: All RGW sync error paths
+            - multi_layer_chaos: Network + storage + dispatch combined
+        """
+        if profile_name not in PROFILES:
+            available = ", ".join(sorted(PROFILES.keys()))
+            raise ValueError(
+                f"Unknown profile: '{profile_name}'. " f"Available: {available}"
+            )
+
+        profile = PROFILES[profile_name]
+        configs = dict(profile["configs"])
+        configs.update(overrides)
+
+        log.info(
+            f"Applying chaos profile '{profile_name}': {profile['desc']} "
+            f"({len(configs)} configs)"
+        )
+
+        return self.inject_config_batch(configs)
+
+    # =========================================================================
+    # SUITE YAML CONFIGURATION
+    # =========================================================================
+
+    def validate_config(self, error_injection_config: dict) -> dict:
+        """
+        Dry-run validation of a suite YAML error_injection config dict.
+
+        Checks for typos, invalid keys, unknown profiles, and malformed
+        specs WITHOUT actually applying anything. Call this before
+        apply_from_config() to catch configuration errors early.
+
+        Args:
+            error_injection_config: Dict with the same schema as
+                                    apply_from_config() accepts.
+
+        Returns:
+            Dict with validation results:
+            {
+                "valid": bool,
+                "errors": list of error strings,
+                "warnings": list of warning strings,
+            }
+
+        Example:
+            result = injector.validate_config(config.get("error_injection"))
+            if not result["valid"]:
+                for err in result["errors"]:
+                    log.error(f"Config error: {err}")
+                return 1
+        """
+        errors = []
+        warnings = []
+
+        if not error_injection_config:
+            return {"valid": True, "errors": [], "warnings": []}
+
+        valid_top_keys = {
+            "profile",
+            "profile_overrides",
+            "configs",
+            "ec_write_errors",
+            "ec_read_errors",
+            "admin_socket",
+        }
+        for key in error_injection_config:
+            if key not in valid_top_keys:
+                errors.append(
+                    f"Unknown top-level key '{key}'. "
+                    f"Valid keys: {sorted(valid_top_keys)}"
+                )
+
+        # Validate profile
+        profile_name = error_injection_config.get("profile")
+        if profile_name and profile_name not in PROFILES:
+            available = ", ".join(sorted(PROFILES.keys()))
+            errors.append(f"Unknown profile '{profile_name}'. Available: {available}")
+
+        # Validate profile_overrides keys
+        for key in error_injection_config.get("profile_overrides", {}):
+            if key not in ALL_INJECTIONS:
+                errors.append(f"Unknown inject variable in profile_overrides: '{key}'")
+
+        # Validate individual configs
+        for key in error_injection_config.get("configs", {}):
+            if key not in ALL_INJECTIONS:
+                errors.append(f"Unknown inject variable in configs: '{key}'")
+            elif ALL_INJECTIONS[key].get("runtime") is False:
+                warnings.append(
+                    f"Config '{key}' is NOT runtime-updatable. "
+                    "Requires daemon restart or client remount."
+                )
+
+        # Validate EC write error specs
+        for i, spec in enumerate(error_injection_config.get("ec_write_errors", [])):
+            if not isinstance(spec, dict):
+                errors.append(f"ec_write_errors[{i}]: must be a dict")
+                continue
+            if "osd_id" not in spec:
+                errors.append(f"ec_write_errors[{i}]: missing 'osd_id'")
+            if "pool" not in spec:
+                errors.append(f"ec_write_errors[{i}]: missing 'pool'")
+
+        # Validate EC read error specs
+        for i, spec in enumerate(error_injection_config.get("ec_read_errors", [])):
+            if not isinstance(spec, dict):
+                errors.append(f"ec_read_errors[{i}]: must be a dict")
+                continue
+            if "osd_id" not in spec:
+                errors.append(f"ec_read_errors[{i}]: missing 'osd_id'")
+            if "pool" not in spec:
+                errors.append(f"ec_read_errors[{i}]: missing 'pool'")
+
+        # Validate admin socket specs
+        valid_asok_cmds = {
+            "injectfull",
+            "injectdataerr",
+            "injectmdataerr",
+            "bluefs_read_zeros",
+            "injectargs",
+        }
+        for i, spec in enumerate(error_injection_config.get("admin_socket", [])):
+            if not isinstance(spec, dict):
+                errors.append(f"admin_socket[{i}]: must be a dict")
+                continue
+            command = spec.get("command")
+            if not command:
+                errors.append(f"admin_socket[{i}]: missing 'command'")
+            elif command not in valid_asok_cmds:
+                errors.append(
+                    f"admin_socket[{i}]: unknown command '{command}'. "
+                    f"Valid: {sorted(valid_asok_cmds)}"
+                )
+            if command in ("injectfull", "bluefs_read_zeros"):
+                if "osd_id" not in spec:
+                    errors.append(f"admin_socket[{i}]: '{command}' requires 'osd_id'")
+            elif command in ("injectdataerr", "injectmdataerr"):
+                for req in ("osd_id", "pool", "objname"):
+                    if req not in spec:
+                        errors.append(
+                            f"admin_socket[{i}]: '{command}' " f"requires '{req}'"
+                        )
+            elif command == "injectargs":
+                for req in ("daemon_type", "daemon_id", "args"):
+                    if req not in spec:
+                        errors.append(
+                            f"admin_socket[{i}]: '{command}' " f"requires '{req}'"
+                        )
+
+        is_valid = len(errors) == 0
+
+        if errors:
+            log.error(
+                f"Error injection config validation failed with "
+                f"{len(errors)} error(s):"
+            )
+            for err in errors:
+                log.error(f"  - {err}")
+        if warnings:
+            for warn in warnings:
+                log.warning(f"  - {warn}")
+        if is_valid:
+            log.info("Error injection config validation passed")
+
+        return {"valid": is_valid, "errors": errors, "warnings": warnings}
+
+    def apply_from_config(self, error_injection_config: dict) -> dict:
+        """
+        Apply error injections from a suite YAML config dict.
+
+        This method is the primary integration point for suite-driven
+        injection. It reads a structured dict (typically from
+        config["error_injection"]) and applies all specified injections.
+
+        Args:
+            error_injection_config: Dict with optional keys:
+                - profile (str): Chaos profile name to apply
+                - profile_overrides (dict): Overrides for the profile
+                - configs (dict): Additional individual config injections
+                - ec_write_errors (list): EC write error specs
+                - ec_read_errors (list): EC read error specs
+                - admin_socket (list): Admin socket command specs
+
+        Returns:
+            Dict summarizing what was applied:
+            {
+                "profile": str or None,
+                "configs_applied": int,
+                "configs_failed": int,
+                "ec_errors_injected": int,
+                "admin_commands_run": int,
+            }
+
+        Suite YAML example:
+            config:
+              error_injection:
+                profile: network_chaos
+                profile_overrides:
+                  ms_inject_delay_probability: 0.2
+                configs:
+                  osd_debug_inject_dispatch_delay_probability: 0.1
+                  mds_inject_health_dummy: true
+                ec_write_errors:
+                  - osd_id: 0
+                    pool: my-ec-pool
+                    shard: 2
+                    duration: 500
+                admin_socket:
+                  - command: injectfull
+                    osd_id: 2
+                    full_type: nearfull
+                    count: 1
+        """
+        if not error_injection_config:
+            log.debug("No error_injection config provided, skipping")
+            return {
+                "profile": None,
+                "configs_applied": 0,
+                "configs_failed": 0,
+                "ec_errors_injected": 0,
+                "admin_commands_run": 0,
+            }
+
+        # Validate before applying to catch typos early
+        validation = self.validate_config(error_injection_config)
+        if not validation["valid"]:
+            log.error(
+                "Error injection config has validation errors. "
+                "Proceeding with best-effort application."
+            )
+
+        summary = {
+            "profile": None,
+            "configs_applied": 0,
+            "configs_failed": 0,
+            "ec_errors_injected": 0,
+            "admin_commands_run": 0,
+        }
+
+        log.info(
+            f"Applying error injection from config: "
+            f"{json.dumps(error_injection_config, indent=2)}"
+        )
+
+        # 1. Apply profile if specified
+        profile_name = error_injection_config.get("profile")
+        if profile_name:
+            overrides = error_injection_config.get("profile_overrides", {})
+            results = self.apply_profile(profile_name, **overrides)
+            summary["profile"] = profile_name
+            summary["configs_applied"] += sum(1 for v in results.values() if v)
+            summary["configs_failed"] += sum(1 for v in results.values() if not v)
+
+        # 2. Apply individual config injections
+        configs = error_injection_config.get("configs", {})
+        if configs:
+            results = self.inject_config_batch(configs)
+            summary["configs_applied"] += sum(1 for v in results.values() if v)
+            summary["configs_failed"] += sum(1 for v in results.values() if not v)
+
+        # 3. Auto-enable prerequisites for EC and data/metadata error injection
+        has_ec_errors = bool(
+            error_injection_config.get("ec_write_errors")
+            or error_injection_config.get("ec_read_errors")
+        )
+        has_data_errors = any(
+            spec.get("command") in ("injectdataerr", "injectmdataerr")
+            for spec in error_injection_config.get("admin_socket", [])
+        )
+
+        if has_ec_errors or has_data_errors:
+            already_set = any(
+                inj["name"] == "bluestore_debug_inject_read_err"
+                for inj in self._active_config_injections
+            )
+            if not already_set:
+                log.info(
+                    "Auto-enabling prerequisite: "
+                    "bluestore_debug_inject_read_err=true "
+                    "(required for EC/data error injection)"
+                )
+                prereq_ok = self.inject_config("bluestore_debug_inject_read_err", True)
+                if prereq_ok:
+                    summary["configs_applied"] += 1
+                else:
+                    summary["configs_failed"] += 1
+
+        # 5. Apply EC write error injections
+        for spec in error_injection_config.get("ec_write_errors", []):
+            success = self.inject_ec_write_error(
+                osd_id=spec["osd_id"],
+                pool=spec["pool"],
+                obj=spec.get("obj", "*"),
+                shard=spec.get("shard", 2),
+                err_type=spec.get("err_type", 1),
+                skip=spec.get("skip", 0),
+                duration=spec.get("duration", 1000),
+            )
+            if success:
+                summary["ec_errors_injected"] += 1
+
+        # 6. Apply EC read error injections
+        for spec in error_injection_config.get("ec_read_errors", []):
+            success = self.inject_ec_read_error(
+                osd_id=spec["osd_id"],
+                pool=spec["pool"],
+                obj=spec.get("obj", "*"),
+                shard=spec.get("shard", 2),
+                err_type=spec.get("err_type", 1),
+                skip=spec.get("skip", 0),
+                duration=spec.get("duration", 1000),
+            )
+            if success:
+                summary["ec_errors_injected"] += 1
+
+        # 7. Apply admin socket commands
+        for spec in error_injection_config.get("admin_socket", []):
+            command = spec.get("command")
+            success = False
+            if command == "injectfull":
+                success = self.inject_full(
+                    osd_id=spec["osd_id"],
+                    full_type=spec.get("full_type", "full"),
+                    count=spec.get("count", 1),
+                )
+            elif command == "injectdataerr":
+                success = self.inject_data_error(
+                    osd_id=spec["osd_id"],
+                    pool=spec["pool"],
+                    objname=spec["objname"],
+                    shard=spec.get("shard"),
+                )
+            elif command == "injectmdataerr":
+                success = self.inject_metadata_error(
+                    osd_id=spec["osd_id"],
+                    pool=spec["pool"],
+                    objname=spec["objname"],
+                    shard=spec.get("shard"),
+                )
+            elif command == "bluefs_read_zeros":
+                success = self.inject_bluefs_read_zeros(osd_id=spec["osd_id"])
+            elif command == "injectargs":
+                success = self.inject_args(
+                    daemon_type=spec["daemon_type"],
+                    daemon_id=spec["daemon_id"],
+                    args=spec["args"],
+                )
+            else:
+                log.warning(f"Unknown admin_socket command: {command}")
+
+            if success:
+                summary["admin_commands_run"] += 1
+
+        log.info(
+            f"Error injection applied: profile={summary['profile']}, "
+            f"configs={summary['configs_applied']} ok / "
+            f"{summary['configs_failed']} failed, "
+            f"ec_errors={summary['ec_errors_injected']}, "
+            f"admin_cmds={summary['admin_commands_run']}"
+        )
+
+        return summary
+
+    # =========================================================================
+    # CLEANUP
+    # =========================================================================
+
+    def cleanup_all(self) -> dict:
+        """
+        Remove ALL active injections (config and admin socket).
+
+        This method is idempotent and safe to call multiple times. It
+        attempts to clean up every tracked injection, logging failures
+        but not raising exceptions.
+
+        Returns:
+            Dict with cleanup summary:
+            {
+                "configs_removed": int,
+                "configs_failed": int,
+                "daemon_cmds_cleared": int,
+                "daemon_cmds_failed": int,
+            }
+        """
+        summary = {
+            "configs_removed": 0,
+            "configs_failed": 0,
+            "daemon_cmds_cleared": 0,
+            "daemon_cmds_failed": 0,
+        }
+
+        if not self._active_config_injections and not self._active_daemon_injections:
+            log.debug("No active injections to clean up")
+            return summary
+
+        log.info(
+            f"Cleaning up {len(self._active_config_injections)} config "
+            f"injections and {len(self._active_daemon_injections)} daemon "
+            f"injections"
+        )
+
+        # Clean config injections
+        for inj in list(self._active_config_injections):
+            try:
+                self.mon_obj.remove_config(
+                    section=inj["section"], name=inj["name"], verify_rm=False
+                )
+                summary["configs_removed"] += 1
+                log.debug(f"Removed config: {inj['name']} [{inj['section']}]")
+            except Exception as e:
+                log.warning(f"Failed to remove config {inj['name']}: {e}")
+                summary["configs_failed"] += 1
+
+        self._active_config_injections.clear()
+
+        # Clean daemon injections
+        for inj in list(self._active_daemon_injections):
+            try:
+                cleared = self._cleanup_daemon_injection(inj)
+                if cleared:
+                    summary["daemon_cmds_cleared"] += 1
+                else:
+                    summary["daemon_cmds_failed"] += 1
+            except Exception as e:
+                log.warning(f"Failed to clear daemon injection {inj}: {e}")
+                summary["daemon_cmds_failed"] += 1
+
+        self._active_daemon_injections.clear()
+
+        log.info(
+            f"Cleanup complete: configs {summary['configs_removed']} removed / "
+            f"{summary['configs_failed']} failed, "
+            f"daemon {summary['daemon_cmds_cleared']} cleared / "
+            f"{summary['daemon_cmds_failed']} failed"
+        )
+
+        return summary
+
+    def get_active_injections(self) -> dict:
+        """
+        Get current state of all active injections for diagnostics..
+
+        Returns:
+            Dict with:
+            {
+                "config_injections": list of active config injections,
+                "daemon_injections": list of active daemon injections,
+                "total_active": int,
+            }
+        """
+        return {
+            "config_injections": list(self._active_config_injections),
+            "daemon_injections": list(self._active_daemon_injections),
+            "total_active": (
+                len(self._active_config_injections)
+                + len(self._active_daemon_injections)
+            ),
+        }
+
+    # =========================================================================
+    # DISCOVERY AND INTROSPECTION
+    # =========================================================================
+
+    @staticmethod
+    def list_available(component: str = None) -> dict:
+        """
+        List all available inject variables, optionally filtered by component.
+
+        Args:
+            component: Filter by component name. Options:
+                       messenger, mon, objecter, osd, bluestore,
+                       filestore, rgw, mds, client, signal
+                       If None, returns all.
+
+        Returns:
+            Dict of {config_key: metadata_dict}
+        """
+        component_map = {
+            "messenger": MESSENGER_INJECTIONS,
+            "mon": MON_INJECTIONS,
+            "objecter": OBJECTER_INJECTIONS,
+            "osd": OSD_INJECTIONS,
+            "bluestore": BLUESTORE_INJECTIONS,
+            "filestore": FILESTORE_INJECTIONS,
+            "rgw": RGW_INJECTIONS,
+            "mds": MDS_INJECTIONS,
+            "client": CLIENT_INJECTIONS,
+            "signal": SIGNAL_INJECTIONS,
+        }
+
+        if component:
+            component_lower = component.lower()
+            if component_lower not in component_map:
+                available = ", ".join(sorted(component_map.keys()))
+                raise ValueError(
+                    f"Unknown component: '{component}'. " f"Available: {available}"
+                )
+            return component_map[component_lower]
+
+        return ALL_INJECTIONS
+
+    @staticmethod
+    def list_profiles() -> dict:
+        """
+        List all available chaos profiles with descriptions.
+
+        Returns:
+            Dict of {profile_name: {"desc": str, "configs": dict}}
+        """
+        return PROFILES
+
+    @staticmethod
+    def get_profile_info(profile_name: str) -> dict:
+        """
+        Get detailed info about a specific chaos profile.
+
+        Args:
+            profile_name: Name of the profile
+
+        Returns:
+            Dict with profile description and config keys with their
+            metadata from the catalog
+
+        Raises:
+            ValueError: If profile_name is not found
+        """
+        if profile_name not in PROFILES:
+            available = ", ".join(sorted(PROFILES.keys()))
+            raise ValueError(
+                f"Unknown profile: '{profile_name}'. Available: {available}"
+            )
+
+        profile = PROFILES[profile_name]
+        details = {"desc": profile["desc"], "configs": {}}
+
+        for key, value in profile["configs"].items():
+            meta = ALL_INJECTIONS.get(key, {})
+            details["configs"][key] = {
+                "value_in_profile": value,
+                "section": meta.get("section", "unknown"),
+                "type": meta.get("type", "unknown"),
+                "default": meta.get("default"),
+                "desc": meta.get("desc", ""),
+            }
+
+        return details
+
+    # =========================================================================
+    # INTERNAL HELPERS
+    # =========================================================================
+
+    def _verify_config_set(self, section: str, name: str, expected_value: str) -> bool:
+        """
+        Verify a config was applied using float-aware comparison.
+
+        Ceph stores float values with full precision (e.g., "10.000000"
+        for "10.0"), which causes naive string comparison to fail.
+        This method handles that by comparing numeric values when the
+        config type is float.
+
+        Args:
+            section: Config section (mon, osd, global, etc.)
+            name: Config key name
+            expected_value: The value we set (as string)
+
+        Returns:
+            True if the config is found with the expected value
+        """
+        try:
+            cmd = "ceph config dump -f json"
+            out, _ = self.rados_obj.node.shell([cmd])
+            config_dump = json.loads(out)
+
+            for entry in config_dump:
+                if entry.get("name") == name and entry.get("section") == section:
+                    actual = entry.get("value", "")
+                    if actual == expected_value:
+                        return True
+                    try:
+                        if float(actual) == float(expected_value):
+                            return True
+                    except (ValueError, TypeError):
+                        pass
+                    log.warning(
+                        f"Config {name} value mismatch: "
+                        f"expected={expected_value}, actual={actual}"
+                    )
+                    return False
+
+            log.warning(
+                f"Config {name} not found in ceph config dump "
+                f"for section [{section}]"
+            )
+            return False
+        except Exception as e:
+            log.warning(f"Failed to verify config {name}: {e}")
+            return False
+
+    def _run_on_osd_host(self, osd_id: int, cmd: str) -> bool:
+        """
+        Resolve the host running an OSD and execute a command on it.
+
+        Args:
+            osd_id: OSD ID to resolve
+            cmd: Command to execute on the OSD host
+
+        Returns:
+            True if command succeeded, False otherwise
+        """
+        try:
+            osd_host = self.rados_obj.fetch_host_node(
+                daemon_type="osd", daemon_id=str(osd_id)
+            )
+            if not osd_host:
+                log.error(f"Could not resolve host for osd.{osd_id}")
+                return False
+
+            out, err = osd_host.exec_command(cmd=cmd, sudo=True, check_ec=False)
+            out_str = str(out).strip() if out else ""
+            err_str = str(err).strip() if err else ""
+
+            # Detect actual failures: admin_socket errors, invalid commands,
+            # or explicit failure messages. Avoid matching "error" in
+            # legitimate output like "clear read error injects".
+            failure_patterns = [
+                "admin_socket: invalid command",
+                "missing required parameter",
+                "invalid command",
+                "errno",
+                "failed to connect",
+                "no such file or directory",
+            ]
+            combined = (out_str + " " + err_str).lower()
+            for pattern in failure_patterns:
+                if pattern in combined:
+                    log.warning(
+                        f"Admin socket command failed on osd.{osd_id}: "
+                        f"matched '{pattern}' in output: "
+                        f"{out_str or err_str}"
+                    )
+                    return False
+
+            log.info(f"Admin socket command on osd.{osd_id}: {out_str or 'ok'}")
+            return True
+
+        except Exception as e:
+            log.error(f"Failed to run command on osd.{osd_id} host: {e}")
+            return False
+
+    def _cleanup_daemon_injection(self, inj: dict) -> bool:
+        """
+        Clear a single daemon injection based on its tracked metadata.
+
+        Args:
+            inj: Injection tracking dict with 'type' and parameters
+
+        Returns:
+            True if cleared, False otherwise
+        """
+        inj_type = inj.get("type")
+
+        if inj_type == "ec_write":
+            cmd = (
+                f"cephadm shell -- ceph daemon osd.{inj['osd_id']} "
+                f"injectecclearwriteerr {inj['pool']} '{inj['obj']}' "
+                f"{inj['shard']} {inj['err_type']}"
+            )
+            return self._run_on_osd_host(inj["osd_id"], cmd)
+
+        elif inj_type == "ec_read":
+            cmd = (
+                f"cephadm shell -- ceph daemon osd.{inj['osd_id']} "
+                f"injectecclearreaderr {inj['pool']} '{inj['obj']}' "
+                f"{inj['shard']} {inj['err_type']}"
+            )
+            return self._run_on_osd_host(inj["osd_id"], cmd)
+
+        elif inj_type in ("data_err", "mdata_err"):
+            log.warning(
+                f"Injection '{inj_type}' on osd.{inj.get('osd_id')} "
+                f"pool={inj.get('pool')} obj={inj.get('obj')} has no "
+                f"clear command. Object corruption persists until "
+                f"scrub + repair."
+            )
+            return True
+
+        elif inj_type in ("full", "bluefs_zeros"):
+            log.info(
+                f"Injection '{inj_type}' on osd.{inj.get('osd_id')} "
+                f"is one-shot and does not require explicit cleanup."
+            )
+            return True
+
+        elif inj_type == "injectargs":
+            log.warning(
+                f"Injected args on {inj['daemon_type']}.{inj['daemon_id']} "
+                f"bypass MON config DB and persist until daemon restart. "
+                f"Args: {inj.get('args', {})}"
+            )
+            return True
+
+        log.warning(f"Unknown injection type for cleanup: {inj_type}")
+        return False
+
+    @staticmethod
+    def _convert_value(value, value_type: str) -> str:
+        """
+        Convert a Python value to the string representation Ceph expects.
+
+        Args:
+            value: Python value (bool, int, float, str)
+            value_type: Expected Ceph type from catalog
+
+        Returns:
+            String representation suitable for `ceph config set`
+        """
+        if value_type == "bool":
+            return "true" if value else "false"
+        elif value_type in ("float",):
+            return str(float(value))
+        elif value_type in ("int", "uint", "secs"):
+            return str(int(value))
+        else:
+            return str(value)
+
+
+class CephInjectionRecovery:
+    """
+    Post-injection cluster recovery for persistent damage.
+
+    After error injection configs are removed by CephErrorInjector.cleanup_all(),
+    some injections leave persistent damage (corrupted RADOS objects, inconsistent
+    PGs, damaged MDS metadata). This class provides recovery workflows to restore
+    the cluster to HEALTH_OK.
+
+    Must be called AFTER injector.cleanup_all() -- recovery will not work
+    while inject configs are still active.
+
+    Usage:
+        injector.cleanup_all()  # Remove all inject configs first
+        recovery = CephInjectionRecovery(rados_obj, client_node)
+        result = recovery.recover_all(fs_name="cephfs-thrash")
+    """
+
+    def __init__(self, rados_obj, client_node=None):
+        self.rados_obj = rados_obj
+        self.client_node = client_node
+
+    def recover_bluestore_damage(self, timeout=600):
+        """
+        Recover from BlueStore injection damage (inconsistent PGs, unfound
+        objects, spurious read errors).
+
+        Steps:
+            1. Identify and repair inconsistent PGs
+            2. Handle unfound objects (mark lost if unrecoverable)
+            3. Deep-scrub all OSDs
+            4. Wait for active+clean PGs
+            5. Restart OSDs to clear spurious read error and repair counters
+
+        Returns:
+            dict with recovery summary
+        """
+        result = {
+            "pgs_repaired": 0,
+            "objects_lost": 0,
+            "deep_scrub_run": False,
+            "health_ok": False,
+            "summary": "",
+        }
+
+        log.info("=== BLUESTORE DAMAGE RECOVERY ===")
+
+        # Step 1: Find and repair inconsistent PGs
+        log.info("Step 1: Repairing inconsistent PGs")
+        try:
+            health_out, _ = self.rados_obj.node.shell(["ceph health detail -f json"])
+            health = json.loads(health_out)
+            checks = health.get("checks", {})
+
+            # Collect PG IDs from health detail
+            damaged_pgs = set()
+            for check_name in [
+                "PG_DAMAGED",
+                "OSD_SCRUB_ERRORS",
+                "PG_DEGRADED",
+            ]:
+                check = checks.get(check_name, {})
+                for detail in check.get("detail", []):
+                    msg = detail.get("message", "")
+                    # Extract PG ID from messages like "pg 3.a is ..."
+                    parts = msg.split()
+                    for i, p in enumerate(parts):
+                        if p == "pg" and i + 1 < len(parts):
+                            damaged_pgs.add(parts[i + 1])
+
+            # Also find via rados list-inconsistent-pg
+            pools = self.rados_obj.list_pools()
+            for pool in pools:
+                try:
+                    inc_pgs = self.rados_obj.get_inconsistent_pg_list(pool)
+                    if inc_pgs:
+                        damaged_pgs.update(str(pg) for pg in inc_pgs)
+                except Exception:
+                    pass
+
+            if damaged_pgs:
+                max_repair = 50
+                log.info(
+                    f"Found {len(damaged_pgs)} damaged PG(s), "
+                    f"repairing up to {max_repair}"
+                )
+                for pgid in list(damaged_pgs)[:max_repair]:
+                    try:
+                        self.rados_obj.run_ceph_command(f"ceph pg repair {pgid}")
+                        result["pgs_repaired"] += 1
+                        log.info(f"  Repaired PG {pgid}")
+                    except Exception as e:
+                        log.warning(f"  Failed to repair PG {pgid}: {e}")
+                time.sleep(30)
+            else:
+                log.info("No inconsistent PGs found")
+        except Exception as e:
+            log.warning(f"PG repair step failed: {e}")
+
+        # Step 2: Handle unfound objects
+        log.info("Step 2: Handling unfound objects")
+        try:
+            health_out, _ = self.rados_obj.node.shell(["ceph health detail"])
+            if "OBJECT_UNFOUND" in str(health_out):
+                # Find PGs with unfound objects
+                pg_dump = self.rados_obj.run_ceph_command("ceph pg dump_stuck unfound")
+                unfound_pgs = []
+                if isinstance(pg_dump, list):
+                    unfound_pgs = [p.get("pgid") for p in pg_dump if p.get("pgid")]
+                elif isinstance(pg_dump, dict):
+                    unfound_pgs = [
+                        p.get("pgid")
+                        for p in pg_dump.get("pg_stats", [])
+                        if "unfound" in p.get("state", "")
+                    ]
+
+                for pgid in unfound_pgs:
+                    try:
+                        self.rados_obj.node.shell(
+                            [f"ceph pg {pgid} " f"mark_unfound_lost delete"]
+                        )
+                        result["objects_lost"] += 1
+                        log.info(f"  Marked unfound objects in PG {pgid} " f"as lost")
+                    except Exception as e:
+                        log.warning(f"  Failed to handle unfound in " f"PG {pgid}: {e}")
+                time.sleep(15)
+            else:
+                log.info("No unfound objects")
+        except Exception as e:
+            log.warning(f"Unfound objects step failed: {e}")
+
+        # Step 3: Deep-scrub all OSDs
+        log.info("Step 3: Running deep-scrub on all OSDs")
+        try:
+            self.rados_obj.run_deep_scrub()
+            result["deep_scrub_run"] = True
+            log.info("Deep-scrub initiated on all OSDs")
+            time.sleep(30)
+        except Exception as e:
+            log.warning(f"Deep-scrub failed: {e}")
+
+        # Step 4: Wait for PGs to reach active+clean
+        log.info(f"Step 4: Waiting up to {timeout}s for active+clean PGs")
+        try:
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                health_out, _ = self.rados_obj.node.shell(["ceph health detail"])
+                h = str(health_out)
+                if (
+                    "PG_DAMAGED" not in h
+                    and "PG_DEGRADED" not in h
+                    and "OBJECT_UNFOUND" not in h
+                    and "OSD_SCRUB_ERRORS" not in h
+                ):
+                    result["health_ok"] = True
+                    log.info("PG damage resolved")
+                    break
+                time.sleep(30)
+            if not result["health_ok"]:
+                log.warning("PG damage not fully resolved within timeout")
+        except Exception as e:
+            log.warning(f"Health check failed: {e}")
+
+        # Step 5: Restart OSDs to clear spurious read error and repair counters
+        try:
+            if self.rados_obj.check_health_warning(
+                "BLUESTORE_SPURIOUS_READ_ERRORS"
+            ) or self.rados_obj.check_health_warning("OSD_TOO_MANY_REPAIRS"):
+                log.info(
+                    "Restarting OSD service to clear spurious read "
+                    "error and repair counters"
+                )
+                try:
+                    self.rados_obj.restart_daemon_services(daemon="osd")
+                    log.info("OSD service restart completed")
+                except Exception as e:
+                    log.warning(f"OSD service restart failed: {e}")
+        except Exception:
+            pass
+
+        result["summary"] = (
+            f"BlueStore recovery: {result['pgs_repaired']} PGs repaired, "
+            f"{result['objects_lost']} unfound objects marked lost, "
+            f"deep_scrub={'yes' if result['deep_scrub_run'] else 'no'}, "
+            f"health_ok={result['health_ok']}"
+        )
+        log.info(f"=== {result['summary']} ===")
+        return result
+
+    def recover_mds_corruption(self, fs_name, cephfs_mount_path=None, timeout=240):
+        """
+        Full customer recovery workflow for MDS corruption.
+
+        Steps: mds repaired -> damage ls -> scrub repair -> damage rm -> verify.
+        Diagnostic only -- logs results, does not affect test pass/fail.
+        """
+        mds_target = f"{fs_name}:0"
+        result = {
+            "rank_repaired": False,
+            "mds_active": False,
+            "damage_entries": [],
+            "scrub_attempted": False,
+            "damage_cleared": False,
+            "fs_accessible": False,
+            "new_crashes": 0,
+            "outcome": "NOT_STARTED",
+        }
+
+        log.info(f"=== MDS CORRUPTION REPAIR WORKFLOW for {fs_name} ===")
+        all_crashes = self.rados_obj.do_crash_ls() or []
+        pre_crashes = len(
+            [c for c in all_crashes if c.get("entity_name", "").startswith("mds.")]
+        )
+
+        # Step 1: Reset damaged rank
+        log.info("Step 1: ceph mds repaired")
+        try:
+            self.rados_obj.node.shell([f"ceph mds repaired {mds_target}"])
+            result["rank_repaired"] = True
+        except Exception as e:
+            log.warning(f"Repair command failed: {e}")
+            result["outcome"] = "REPAIR_CMD_FAILED"
+            return result
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            post_all = self.rados_obj.do_crash_ls() or []
+            post_crashes = len(
+                [c for c in post_all if c.get("entity_name", "").startswith("mds.")]
+            )
+            if post_crashes > pre_crashes:
+                result["new_crashes"] = post_crashes - pre_crashes
+                result["outcome"] = "REPAIR_FAILED_MDS_CRASHED"
+                log.warning(
+                    f"MDS crashed {result['new_crashes']}x after "
+                    f"repair -- corruption persists"
+                )
+                return result
+            try:
+                fs_data = self.rados_obj.run_ceph_command(f"ceph fs status {fs_name}")
+                for m in fs_data.get("mdsmap", []):
+                    if m.get("state") == "active":
+                        result["mds_active"] = True
+                        log.info(f"MDS {m.get('name')} active for {fs_name}")
+                        break
+                if result["mds_active"]:
+                    break
+            except Exception:
+                pass
+            time.sleep(15)
+
+        if not result["mds_active"]:
+            result["outcome"] = "REPAIR_FAILED_NO_ACTIVE"
+            log.warning(f"No MDS became active within {timeout}s")
+            return result
+
+        # Step 2: Inspect damage table
+        log.info("Step 2: damage ls")
+        try:
+            dmg = self.rados_obj.run_ceph_command(
+                f"ceph tell mds.{mds_target} damage ls"
+            )
+            result["damage_entries"] = dmg or []
+            log.info(f"Damage entries: {len(result['damage_entries'])}")
+            for e in result["damage_entries"]:
+                log.info(f"  {e}")
+        except Exception as e:
+            log.warning(f"damage ls failed: {e}")
+
+        # Step 3: Scrub + repair
+        log.info("Step 3: scrub start / recursive,repair,force")
+        try:
+            result["scrub_attempted"] = True
+            self.rados_obj.node.shell(
+                [f"ceph tell mds.{mds_target} " f"scrub start / recursive,repair,force"]
+            )
+            scrub_end = time.time() + 120
+            while time.time() < scrub_end:
+                try:
+                    st = self.rados_obj.run_ceph_command(
+                        f"ceph tell mds.{mds_target} scrub status"
+                    )
+                    s = str(st)
+                    log.debug(f"Scrub status: {s[:200]}")
+                    if "no active" in s.lower() or "0 inodes" in s:
+                        break
+                except Exception:
+                    pass
+                time.sleep(15)
+            log.info("Scrub completed or timed out")
+        except Exception as e:
+            log.warning(f"Scrub failed: {e}")
+
+        # Step 4: Check remaining damage
+        log.info("Step 4: Check remaining damage")
+        try:
+            remaining = (
+                self.rados_obj.run_ceph_command(f"ceph tell mds.{mds_target} damage ls")
+                or []
+            )
+            if not remaining:
+                result["damage_cleared"] = True
+                log.info("Damage table empty -- scrub repaired all")
+            else:
+                log.warning(f"{len(remaining)} entries remain, " f"removing manually")
+                for entry in remaining:
+                    did = entry.get("id")
+                    if did is None:
+                        did = entry.get("damage_id")
+                    if did is not None:
+                        try:
+                            self.rados_obj.node.shell(
+                                [f"ceph tell mds.{mds_target} " f"damage rm {did}"]
+                            )
+                        except Exception:
+                            pass
+                final = self.rados_obj.run_ceph_command(
+                    f"ceph tell mds.{mds_target} damage ls"
+                )
+                result["damage_cleared"] = isinstance(final, list) and len(final) == 0
+        except Exception as e:
+            log.warning(f"Damage check failed: {e}")
+
+        # Step 5: Verify recovery
+        log.info("Step 5: Verify recovery")
+        try:
+            h, _ = self.rados_obj.node.shell(["ceph health detail"])
+            h_str = str(h)
+            mds_warns = [
+                w for w in ["MDS_DAMAGE", "MDS_ALL_DOWN", "FS_DEGRADED"] if w in h_str
+            ]
+            if not mds_warns:
+                log.info("No MDS health warnings")
+            else:
+                log.warning(f"MDS health warnings remain: {mds_warns}")
+            if cephfs_mount_path and self.client_node:
+                self.client_node.exec_command(
+                    cmd=f"mkdir -p {cephfs_mount_path}",
+                    sudo=True,
+                    check_ec=False,
+                )
+                self.client_node.exec_command(
+                    cmd=f"timeout 30 mount -t ceph "
+                    f"admin@.{fs_name}=/ {cephfs_mount_path}",
+                    sudo=True,
+                    check_ec=False,
+                )
+                out, _ = self.client_node.exec_command(
+                    cmd=f"timeout 10 ls {cephfs_mount_path}",
+                    sudo=True,
+                    check_ec=False,
+                )
+                if out is not None and "Transport endpoint" not in str(out):
+                    result["fs_accessible"] = True
+                    log.info("Filesystem accessible after repair")
+                else:
+                    log.warning("Filesystem not accessible")
+                self.client_node.exec_command(
+                    cmd=f"umount -l {cephfs_mount_path}",
+                    sudo=True,
+                    check_ec=False,
+                )
+            else:
+                log.info("Skipping mount verification")
+        except Exception as e:
+            log.warning(f"Recovery verification failed: {e}")
+
+        # Determine outcome
+        if result["fs_accessible"] and result["damage_cleared"]:
+            result["outcome"] = "FULL_REPAIR_SUCCEEDED"
+        elif result["mds_active"] and result["damage_cleared"]:
+            result["outcome"] = "PARTIAL_REPAIR_FS_NOT_ACCESSIBLE"
+        elif result["mds_active"] and result["fs_accessible"]:
+            result["outcome"] = "PARTIAL_REPAIR_DAMAGE_REMAINS"
+        elif result["mds_active"]:
+            result["outcome"] = "PARTIAL_REPAIR"
+        else:
+            result["outcome"] = "REPAIR_FAILED"
+
+        log.info(
+            f"=== REPAIR OUTCOME: {result['outcome']} | "
+            f"active={result['mds_active']} "
+            f"damage_cleared={result['damage_cleared']} "
+            f"accessible={result['fs_accessible']} "
+            f"new_crashes={result['new_crashes']} ==="
+        )
+        return result
+
+    def destroy_damaged_filesystem(self, fs_name, cephfs_mount_path=None):
+        """
+        Destroy a damaged filesystem and its pools.
+        Used when MDS corruption makes the FS unrecoverable.
+        """
+        log.info(f"Destroying damaged filesystem '{fs_name}'")
+        try:
+            if cephfs_mount_path and self.client_node:
+                self.client_node.exec_command(
+                    cmd=f"umount -l {cephfs_mount_path}",
+                    sudo=True,
+                    check_ec=False,
+                )
+                time.sleep(3)
+            self.rados_obj.node.shell([f"ceph fs fail {fs_name}"])
+            time.sleep(5)
+            self.rados_obj.node.shell([f"ceph fs rm {fs_name} --yes-i-really-mean-it"])
+            time.sleep(5)
+            for pool in [
+                f"cephfs_erasure_{fs_name}_metadata",
+                f"cephfs_erasure_{fs_name}_data",
+            ]:
+                try:
+                    self.rados_obj.delete_pool(pool=pool)
+                except Exception:
+                    pass
+            self.rados_obj.node.shell(["ceph crash archive-all"])
+            log.info("Damaged filesystem and pools removed")
+            time.sleep(15)
+        except Exception as e:
+            log.warning(f"FS destruction failed: {e}")
+
+    def recover_all(self, fs_name=None, cephfs_mount_path=None):
+        """
+        Auto-detect and recover from all injection damage.
+        Checks ceph health detail and runs appropriate recovery.
+        """
+        log.info("=== AUTO-DETECT INJECTION RECOVERY ===")
+        result = {
+            "bluestore_recovery": None,
+            "mds_recovery": None,
+        }
+
+        try:
+            health_out, _ = self.rados_obj.node.shell(["ceph health detail"])
+            health = str(health_out)
+        except Exception as e:
+            log.warning(f"Cannot read cluster health: {e}")
+            return result
+
+        bs_indicators = [
+            "BLUESTORE_SPURIOUS_READ_ERRORS",
+            "OSD_SCRUB_ERRORS",
+            "PG_DAMAGED",
+            "OBJECT_UNFOUND",
+            "OSD_TOO_MANY_REPAIRS",
+        ]
+        if any(ind in health for ind in bs_indicators):
+            log.info("BlueStore damage detected, running recovery")
+            result["bluestore_recovery"] = self.recover_bluestore_damage()
+
+        mds_indicators = [
+            "MDS_DAMAGE",
+            "MDS_ALL_DOWN",
+            "FS_DEGRADED",
+        ]
+        if any(ind in health for ind in mds_indicators):
+            if fs_name:
+                log.info("MDS damage detected, running recovery")
+                result["mds_recovery"] = self.recover_mds_corruption(
+                    fs_name, cephfs_mount_path
+                )
+
+        if not result["bluestore_recovery"] and not result["mds_recovery"]:
+            log.info("No injection damage detected")
+
+        return result

--- a/suites/squid/rados/tier-3_rados_osd_thrashing_tests.yaml
+++ b/suites/squid/rados/tier-3_rados_osd_thrashing_tests.yaml
@@ -200,6 +200,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: true
         compression: true
         cleanup_pools: true
@@ -239,6 +240,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: true
         compression: false
         cleanup_pools: true
@@ -276,6 +278,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         compression: false
         cleanup_pools: true
         enable_debug_logs: true
@@ -315,6 +318,7 @@ tests:
         aggressive: false
         enable_crush_thrashing: false
         enable_pg_thrashing: false
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: false
         compression: false
         cleanup_pools: true

--- a/suites/tentacle/rados/tier-3_rados_error_injection_thrashing.yaml
+++ b/suites/tentacle/rados/tier-3_rados_error_injection_thrashing.yaml
@@ -1,0 +1,763 @@
+# =============================================================================
+# Error Injection Thrash Test Suite
+# =============================================================================
+# This suite performs component-focused thrashing with Ceph error injection
+# variables enabled via the CephErrorInjector framework. It exercises MON,
+# OSD, MGR, and MDS thrashing at three intensity tiers (light, moderate,
+# aggressive) to verify cluster resilience under injected fault conditions.
+#
+# Each test entry targets a single component with a matching chaos profile
+# from ceph/rados/ceph_error_injector.py. The error_injection config block
+# is read by test_osd_thrashing.py and applied via CephErrorInjector.
+#
+# To be run with conf: 9-node-ec-cluster-1-client.yaml
+#
+# INTENSITY TIERS:
+# ----------------
+# Light     - Low probability injection, short duration (600s)
+# Moderate  - Medium probability, layered profiles (1200s)
+# Aggressive - High probability, multiple fault domains (1800s)
+# =============================================================================
+
+tests:
+  # ===========================================================================
+  # Deployment Preamble
+  # ===========================================================================
+  - test:
+      name: Setup install prerequisites
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+            - node5
+            - node6
+            - node8
+            - node9
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id: CEPH-83573758
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node7
+        install_packages:
+          - ceph-common
+          - rbd-nbd
+          - ceph-fuse
+        copy_admin_keyring: true
+        caps:
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      desc: Install fio
+      module: exec.py
+      name: Install FIO
+      config:
+        sudo: true
+        commands:
+          - "dnf install fio -y"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  # ===========================================================================
+  # MON Error Injection Thrashing
+  # ===========================================================================
+
+  - test:
+      name: MON error injection thrashing light
+      desc: MON thrashing with low-probability paxos delays and scrub CRC mismatch injection
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 30
+        duration: 600
+        aggressive: false
+        enable_mon_thrashing: true
+        enable_election_strategy_thrash: true
+        enable_osd_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: false
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: mon_instability
+          profile_overrides:
+            mon_inject_transaction_delay_probability: 0.02
+            mon_scrub_inject_crc_mismatch: 0.01
+
+  - test:
+      name: MON error injection thrashing moderate
+      desc: MON thrashing with mon_instability profile and sync chunk delay injection
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 60
+        duration: 1200
+        aggressive: true
+        enable_mon_thrashing: true
+        enable_election_strategy_thrash: true
+        enable_osd_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: false
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: mon_instability
+          configs:
+            mon_inject_sync_get_chunk_delay: 3.0
+
+  - test:
+      name: MON error injection thrashing aggressive
+      desc: MON thrashing with high-probability paxos delays, scrub faults, and network latency
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 120
+        duration: 1800
+        aggressive: true
+        enable_mon_thrashing: true
+        enable_election_strategy_thrash: true
+        enable_osd_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: false
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: mon_instability
+          profile_overrides:
+            mon_inject_transaction_delay_probability: 0.15
+            mon_scrub_inject_crc_mismatch: 0.15
+            mon_scrub_inject_missing_keys: 0.1
+          configs:
+            ms_inject_delay_type: mon
+            ms_inject_delay_max: 3
+            ms_inject_delay_probability: 0.05
+            mon_inject_sync_get_chunk_delay: 5.0
+
+  # ===========================================================================
+  # OSD Error Injection Thrashing
+  # ===========================================================================
+
+  - test:
+      name: OSD error injection thrashing light
+      desc: OSD thrashing with low-probability dispatch delays during peering and recovery
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 30
+        duration: 600
+        aggressive: false
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: osd_dispatch_delays
+          profile_overrides:
+            osd_debug_inject_dispatch_delay_probability: 0.02
+            osd_debug_inject_dispatch_delay_duration: 0.5
+
+  - test:
+      name: OSD error injection thrashing moderate
+      desc: OSD thrashing with BlueStore read errors and EC write error injection on 2 OSDs
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: erasure
+            sample_pool_id: sample-pool-9
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 60
+        duration: 1200
+        aggressive: true
+        inject_errors: true
+        num_osds_to_inject: 2
+        num_writes_to_inject: 500
+        inconsistent_object_fail: true
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: true
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: storage_corruption
+
+  - test:
+      name: OSD error injection thrashing aggressive
+      desc: OSD thrashing with storage corruption, bdev crash, dispatch delays, and EC errors on 3 OSDs
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: erasure
+            sample_pool_id: sample-pool-9
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 120
+        duration: 1800
+        aggressive: true
+        inject_errors: true
+        num_osds_to_inject: 3
+        num_writes_to_inject: 1000
+        inconsistent_object_fail: true
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: true
+        enable_pg_thrashing: true
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: storage_corruption
+          configs:
+            bdev_inject_crash: 50000
+            bdev_inject_crash_flush_delay: 5
+            osd_debug_inject_dispatch_delay_probability: 0.05
+            osd_debug_inject_dispatch_delay_duration: 2
+            osd_inject_bad_map_crc_probability: 0.005
+
+  # ===========================================================================
+  # BlueStore Full Corruption Thrashing
+  # ===========================================================================
+
+  - test:
+      name: BlueStore corruption thrashing light
+      desc: OSD thrashing with BlueStore read errors and all client IO types
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 30
+        duration: 600
+        aggressive: false
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: true
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: storage_corruption
+
+  - test:
+      name: BlueStore corruption thrashing moderate
+      desc: OSD thrashing with full BlueStore corruption, EC errors, and all client IO
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: erasure
+            sample_pool_id: sample-pool-9
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 60
+        duration: 1200
+        aggressive: true
+        inject_errors: true
+        num_osds_to_inject: 2
+        num_writes_to_inject: 500
+        inconsistent_object_fail: true
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: true
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: true
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: bluestore_full_corruption
+
+  - test:
+      name: BlueStore corruption thrashing aggressive
+      desc: OSD thrashing with multi-layer chaos, all client IO, and maximum EC error injection
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: erasure
+            sample_pool_id: sample-pool-9
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 120
+        duration: 1800
+        aggressive: true
+        inject_errors: true
+        num_osds_to_inject: 3
+        num_writes_to_inject: 1000
+        inconsistent_object_fail: true
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: true
+        enable_pg_thrashing: true
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: true
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: multi_layer_chaos
+          configs:
+            bluestore_debug_inject_csum_err_probability: 0.01
+            bluestore_debug_inject_allocation_from_file_failure: 0.01
+
+  # ===========================================================================
+  # MGR Error Injection Thrashing
+  # ===========================================================================
+
+  - test:
+      name: MGR error injection thrashing light
+      desc: MGR thrashing with low-probability message latency injection during failover
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 30
+        duration: 600
+        aggressive: false
+        enable_mgr_thrashing: true
+        enable_osd_thrashing: false
+        enable_mon_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: false
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: network_latency
+          profile_overrides:
+            ms_inject_delay_probability: 0.02
+            ms_inject_delay_max: 1
+
+  - test:
+      name: MGR error injection thrashing moderate
+      desc: MGR thrashing with network chaos - socket failures, delays, and congestion
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 60
+        duration: 1200
+        aggressive: true
+        enable_mgr_thrashing: true
+        enable_osd_thrashing: false
+        enable_mon_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: false
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: network_chaos
+
+  - test:
+      name: MGR error injection thrashing aggressive
+      desc: MGR thrashing with full network chaos plus heartbeat failure injection
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 120
+        duration: 1800
+        aggressive: true
+        enable_mgr_thrashing: true
+        enable_osd_thrashing: false
+        enable_mon_thrashing: false
+        enable_mds_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: false
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: false
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: network_chaos
+          profile_overrides:
+            ms_inject_delay_probability: 0.1
+            ms_inject_socket_failures: 200
+          configs:
+            heartbeat_inject_failure: 500
+
+  # ===========================================================================
+  # MDS Error Injection Thrashing
+  # ===========================================================================
+
+  - test:
+      name: MDS error injection thrashing light
+      desc: MDS thrashing with low-probability traceless reply and health dummy injection
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 30
+        duration: 600
+        aggressive: false
+        enable_mds_thrashing: true
+        enable_osd_thrashing: false
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: false
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: mds_chaos
+          profile_overrides:
+            mds_inject_traceless_reply_probability: 0.01
+
+  - test:
+      name: MDS error injection thrashing moderate
+      desc: MDS thrashing with migration race, health faults, and client cap release failures
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 60
+        duration: 1200
+        aggressive: true
+        enable_mds_thrashing: true
+        enable_osd_thrashing: false
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: false
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: mds_chaos
+          configs:
+            client_inject_release_failure: true
+            client_debug_inject_tick_delay: 5
+
+  - test:
+      name: MDS error injection thrashing aggressive
+      desc: MDS thrashing with dentry corruption, client faults, and network delays
+      module: test_osd_thrashing.py
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 120
+        duration: 1800
+        aggressive: true
+        enable_mds_thrashing: true
+        enable_osd_thrashing: false
+        enable_mon_thrashing: false
+        enable_mgr_thrashing: false
+        enable_crush_thrashing: false
+        enable_pg_thrashing: false
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_fio_cephfs: true
+        enable_fio_rbd: false
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: false
+        enable_ec_snapshots: false
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        error_injection:
+          profile: mds_corruption
+          profile_overrides:
+            mds_inject_rename_corrupt_dentry_first: 0.05
+            mds_inject_journal_corrupt_dentry_first: 0.03
+          configs:
+            mds_inject_migrator_session_race: true
+            mds_inject_traceless_reply_probability: 0.05
+            client_inject_release_failure: true
+            client_debug_inject_tick_delay: 5
+            ms_inject_delay_type: mds
+            ms_inject_delay_max: 2
+            ms_inject_delay_probability: 0.03

--- a/suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml
@@ -208,6 +208,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: true
         compression: true
         cleanup_pools: true
@@ -246,6 +247,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: true
         compression: false
         cleanup_pools: true
@@ -284,6 +286,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: true
         compression: false
         cleanup_pools: true
@@ -321,6 +324,7 @@ tests:
         aggressive: true
         enable_crush_thrashing: true
         enable_pg_thrashing: true
+        enable_scrub_thrashing: true
         compression: false
         cleanup_pools: true
         enable_debug_logs: true
@@ -359,6 +363,7 @@ tests:
         aggressive: false
         enable_crush_thrashing: false
         enable_pg_thrashing: false
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: false
         compression: false
         cleanup_pools: true
@@ -401,6 +406,7 @@ tests:
         enable_esb_verification: true
         enable_crush_thrashing: true
         enable_pg_thrashing: false
+        enable_scrub_thrashing: true
         enable_rgw_thrashing: false
         compression: false
         cleanup_pools: true

--- a/tests/rados/test_ceph_error_injection.py
+++ b/tests/rados/test_ceph_error_injection.py
@@ -1,0 +1,276 @@
+"""
+test_ceph_error_injection.py - Standalone Error Injection Test Module
+
+Reusable test module that injects or cleans up Ceph error injection
+variables as a standalone suite step. Place this before other tests
+to enable fault injection, and after them to clean up. No code changes
+are needed in the tests that run between inject and cleanup.
+
+The injector state is stored in test_data["error_injector"], a shared
+dict that run.py passes to every test's run() function, so the same
+CephErrorInjector instance persists across tests in a suite run.
+
+Supported actions (set via config.action):
+    inject  - Apply error injection config and store injector in test_data
+    cleanup - Retrieve stored injector and remove all injections
+
+==============================================================================
+SUITE YAML USAGE
+==============================================================================
+
+Example 1 -- Inject before tests, cleanup after:
+
+    - test:
+        name: Inject MON instability errors
+        module: test_ceph_error_injection.py
+        abort-on-fail: true
+        config:
+          action: inject
+          error_injection:
+            profile: mon_instability
+            profile_overrides:
+              mon_inject_transaction_delay_probability: 0.1
+
+    - test:
+        name: MON thrashing under fault injection
+        module: test_osd_thrashing.py
+        config:
+          enable_mon_thrashing: true
+          duration: 1200
+
+    - test:
+        name: Cleanup error injections
+        module: test_ceph_error_injection.py
+        config:
+          action: cleanup
+
+Example 2 -- Layer multiple profiles before tests:
+
+    - test:
+        name: Inject network chaos
+        module: test_ceph_error_injection.py
+        config:
+          action: inject
+          error_injection:
+            profile: network_chaos
+
+    - test:
+        name: Layer MON instability on top
+        module: test_ceph_error_injection.py
+        config:
+          action: inject
+          error_injection:
+            profile: mon_instability
+
+    - test:
+        name: Run tests under combined faults
+        module: test_osd_thrashing.py
+        config:
+          enable_mon_thrashing: true
+          duration: 1200
+
+    - test:
+        name: Cleanup all error injections
+        module: test_ceph_error_injection.py
+        config:
+          action: cleanup
+
+Example 3 -- Individual config injection (no profile):
+
+    - test:
+        name: Inject OSD dispatch delays
+        module: test_ceph_error_injection.py
+        abort-on-fail: true
+        config:
+          action: inject
+          error_injection:
+            configs:
+              osd_debug_inject_dispatch_delay_probability: 0.1
+              osd_debug_inject_dispatch_delay_duration: 3
+              bluestore_debug_inject_read_err: true
+
+    - test:
+        name: Run CephFS tests under OSD faults
+        module: cephfs_basic_tests.py
+        config:
+          ...
+
+    - test:
+        name: Cleanup error injections
+        module: test_ceph_error_injection.py
+        config:
+          action: cleanup
+
+Example 4 -- Full config with EC errors and admin socket commands:
+
+    - test:
+        name: Inject storage corruption with EC errors
+        module: test_ceph_error_injection.py
+        abort-on-fail: true
+        config:
+          action: inject
+          error_injection:
+            profile: storage_corruption
+            configs:
+              osd_debug_inject_dispatch_delay_probability: 0.05
+            ec_write_errors:
+              - osd_id: 0
+                pool: ec-pool-1
+                shard: 2
+                duration: 500
+            admin_socket:
+              - command: injectfull
+                osd_id: 3
+                full_type: nearfull
+                count: 1
+
+    - test:
+        name: OSD thrashing under storage faults
+        module: test_osd_thrashing.py
+        config:
+          enable_osd_thrashing: true
+          duration: 1800
+
+    - test:
+        name: Cleanup error injections
+        module: test_ceph_error_injection.py
+        config:
+          action: cleanup
+
+==============================================================================
+CONFIG REFERENCE
+==============================================================================
+
+    config:
+      action: inject | cleanup       (required, default: inject)
+      error_injection:                (required for inject, ignored for cleanup)
+        profile: <profile_name>       (optional)
+        profile_overrides:            (optional)
+          <config_key>: <value>
+        configs:                      (optional)
+          <config_key>: <value>
+        ec_write_errors:              (optional)
+          - osd_id: <int>
+            pool: <str>
+            ...
+        ec_read_errors:               (optional)
+          - osd_id: <int>
+            pool: <str>
+            ...
+        admin_socket:                 (optional)
+          - command: <str>
+            ...
+
+See ceph/rados/ceph_error_injector.py for the full error_injection schema,
+available profiles, and the complete catalog of 50 inject variables.
+"""
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.ceph_error_injector import CephErrorInjector
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Standalone error injection test entry point.
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        **kw: Test kwargs including:
+            config (dict): Must contain 'action' and optionally 'error_injection'
+            test_data (dict): Shared state dict for passing injector between tests
+
+    Config keys:
+        action (str): "inject" to apply errors, "cleanup" to remove them
+        error_injection (dict): Error injection config (same schema as
+            CephErrorInjector.apply_from_config)
+
+    Returns:
+        0: Success
+        1: Failure
+    """
+    config = kw["config"]
+    test_data = kw.get("test_data", {})
+    action = config.get("action", "inject")
+
+    if action == "inject":
+        return _do_inject(ceph_cluster, config, test_data)
+    elif action == "cleanup":
+        return _do_cleanup(test_data)
+    else:
+        log.error(f"Unknown action: '{action}'. Use 'inject' or 'cleanup'.")
+        return 1
+
+
+def _do_inject(ceph_cluster, config, test_data):
+    """Apply error injection config and store injector in test_data."""
+    error_config = config.get("error_injection", {})
+    if not error_config:
+        log.error("No error_injection config provided for inject action")
+        return 1
+
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+
+    injector = test_data.get("error_injector")
+    if injector:
+        log.info(
+            "Reusing existing CephErrorInjector for layered injection "
+            f"({injector.get_active_injections()['total_active']} "
+            f"injections already active)"
+        )
+    else:
+        injector = CephErrorInjector(rados_obj=rados_obj)
+        log.info("Created new CephErrorInjector instance")
+
+    validation = injector.validate_config(error_config)
+    if not validation["valid"]:
+        log.error(
+            "Error injection config validation failed: " f"{validation['errors']}"
+        )
+        return 1
+
+    summary = injector.apply_from_config(error_config)
+    log.info(
+        f"Error injection applied -- "
+        f"profile={summary['profile']}, "
+        f"configs={summary['configs_applied']}, "
+        f"ec_errors={summary['ec_errors_injected']}, "
+        f"admin_cmds={summary['admin_commands_run']}"
+    )
+
+    active = injector.get_active_injections()
+    log.info(f"Total active injections: {active['total_active']}")
+
+    test_data["error_injector"] = injector
+    return 0
+
+
+def _do_cleanup(test_data):
+    """Retrieve stored injector and remove all injections."""
+    injector = test_data.get("error_injector")
+    if not injector:
+        log.warning("No active error injector found in test_data, nothing to clean up")
+        return 0
+
+    active = injector.get_active_injections()
+    log.info(
+        f"Cleaning up {active['total_active']} active injections "
+        f"({len(active['config_injections'])} config, "
+        f"{len(active['daemon_injections'])} daemon)"
+    )
+
+    summary = injector.cleanup_all()
+    log.info(
+        f"Cleanup complete -- "
+        f"configs removed={summary['configs_removed']}, "
+        f"configs failed={summary['configs_failed']}, "
+        f"daemon cleared={summary['daemon_cmds_cleared']}, "
+        f"daemon failed={summary['daemon_cmds_failed']}"
+    )
+
+    test_data.pop("error_injector", None)
+    return 0

--- a/tests/rados/test_osd_thrashing.py
+++ b/tests/rados/test_osd_thrashing.py
@@ -19,9 +19,13 @@ TEST WORKFLOW:
     │   ├── Enable compression (if configured)
     │   ├── Configure aggressive recovery settings
     │   ├── Enable debug logging: debug_osd=20/20 (if configured)
-    │   └── Inject EC write errors on random OSDs (if configured)
-    │       ├── bluestore_debug_inject_read_err=true
-    │       └── ceph daemon osd.$id injectecwriteerr <pool> '*' 2 1 0 1
+    │   ├── Inject EC write errors on random OSDs (if configured)
+    │   │   ├── bluestore_debug_inject_read_err=true
+    │   │   └── ceph daemon osd.$id injectecwriteerr <pool> '*' 2 1 0 1
+    │   └── Apply suite-driven error injection config (if provided)
+    │       ├── Apply chaos profile (e.g., network_chaos, storage_corruption)
+    │       ├── Apply individual config overrides
+    │       └── Detect destructive MDS injection configs
     │
     ├── THRASHING PHASE (dynamically configured parallel threads)
     │   ├── io_workload_burst: rados bench 30s write bursts (64K blocks) [always]
@@ -34,7 +38,8 @@ TEST WORKFLOW:
     │   ├── thrash_ec_pool_snapshots: RADOS-level snapshots + partial writes [if enabled]
     │   ├── thrash_osds: Mark out → orch daemon stop → wait → mark in → start [if enabled]
     │   ├── thrash_crush_weights: Reduce to 50% → restore [if enabled]
-    │   ├── thrash_pg_count: Bulk flag toggle + scrub/deep-scrub [if enabled]
+    │   ├── thrash_pg_count: Bulk flag toggle for PG split/merge [if enabled]
+    │   ├── thrash_scrubs: Periodic scrub/deep-scrub on pools/OSDs/cluster [if enabled]
     │   ├── thrash_rgw_s3: S3 PUT/GET/DELETE/multipart on RGW [if enabled]
     │   ├── thrash_mon: Leader failover, rolling restart, election strategy [if enabled]
     │   ├── thrash_mgr: Failover, rolling restart, random fail [if enabled]
@@ -45,14 +50,20 @@ TEST WORKFLOW:
     ├── VALIDATION PHASE
     │   ├── Wait for cluster stabilization (active+clean PGs)
     │   ├── Check cluster health
-    │   ├── Check for crashes (ceph crash ls-new)
-    │   └── Report findings and fail if crashes detected
+    │   ├── If destructive MDS injection:
+    │   │   ├── Validate MDS crashes match CDentry::check_corruption signature
+    │   │   ├── Attempt repair workflow (mds repaired -> damage ls -> scrub repair -> damage rm)
+    │   │   └── Log repair outcome (diagnostic only, does not affect pass/fail)
+    │   ├── Else: Check for crashes (ceph crash ls-new) and fail if detected
+    │   └── Report findings
     │
     └── CLEANUP PHASE
         ├── Reset recovery settings
         ├── Remove debug logging configs (if enabled)
-        ├── Remove error injection configs (if enabled)
-        ├── Force log rotation on all OSD hosts
+        ├── Remove error injection configs (cleanup_all)
+        ├── Restore down OSDs (mark in + restart OSD service)
+        ├── If destructive MDS injection: destroy damaged filesystem + pools
+        ├── Force log rotation on all OSD hosts (parallel)
         ├── Unmount and cleanup CephFS and RBD
         ├── Cleanup NFS clusters and exports (if enabled)
         └── Delete test pools and EC profiles
@@ -64,6 +75,7 @@ CONFIGURATION OPTIONS:
 - aggressive: Enable aggressive mode with longer waits (default: True)
 - enable_crush_thrashing: Enable CRUSH weight modifications (default: True)
 - enable_pg_thrashing: Enable PG count thrashing via bulk flag (default: True)
+- enable_scrub_thrashing: Enable independent scrub/deep-scrub cycles (default: True)
 - compression: Enable pool compression with mode=force (default: False)
 - cleanup_pools: Delete pools after test (default: True)
 - enable_debug_logs: Enable debug logging for OSD peering and BlueStore (default: False)
@@ -96,6 +108,9 @@ CONFIGURATION OPTIONS:
   Sets bluestore_elastic_shared_blobs=true, bluestore_write_v2=false, bluestore_onode_segment_size=0,
   bluestore_debug_extent_map_encode_check=true, debug_bluestore=5/5.
   Targets extent map resharding crash in EC pools with overwrites.
+- error_injection: Suite-driven error injection config (default: None).
+  Supports profiles, individual configs, EC errors, and admin socket commands.
+  See ceph/rados/ceph_error_injector.py for full schema and 22 available profiles.
 
 """
 
@@ -111,6 +126,11 @@ import yaml
 
 from ceph import utils
 from ceph.ceph_admin import CephAdmin
+from ceph.rados.ceph_error_injector import (
+    PROFILES,
+    CephErrorInjector,
+    CephInjectionRecovery,
+)
 from ceph.rados.core_workflows import NFS_RDMA_DEFAULT_BASE_PORT, RadosOrchestrator
 from ceph.rados.mgr_workflows import MgrWorkflows
 from ceph.rados.monitor_workflows import MonitorWorkflows
@@ -145,9 +165,9 @@ def _has_inconsistent_obj_fix(rados_obj) -> bool:
         parts = version.split(".")
         major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
 
-        if (major, minor, patch) <= (20, 2, 1):
+        if major == 20 and minor == 2 and patch <= 1:
             log.info(
-                f"Ceph version {version} does not have IBMCEPH-12717 fix,"
+                f"Ceph version {version} is in 20.2.1.X line (no IBMCEPH-12717 fix),"
                 f" disabling inconsistent_object_fail"
             )
             return False
@@ -158,11 +178,37 @@ def _has_inconsistent_obj_fix(rados_obj) -> bool:
         return True
 
 
-# Path to pool configurations file
-POOL_CONFIGS_FILE = "conf/tentacle/rados/test-confs/pool-configurations.yaml"
+# Version-to-release mapping for pool configuration file paths
+_VERSION_RELEASE_MAP = {
+    9: "tentacle",
+    8: "squid",
+    7: "reef",
+    6: "quincy",
+    5: "pacific",
+}
 
 # Cache for pool configurations (loaded once per module)
 _POOL_CONFIGS_CACHE = None
+
+
+def _get_pool_configs_path(rhbuild: str) -> str:
+    """Resolve the pool configurations file path based on Ceph version.
+
+    Args:
+        rhbuild: Ceph build version string (e.g., "9.2.0-123")
+
+    Returns:
+        Path to the pool-configurations.yaml for that release
+    """
+    major = int(rhbuild.split(".")[0])
+    release = _VERSION_RELEASE_MAP.get(major)
+    if not release:
+        log.warning(
+            f"Unknown major version {major} from rhbuild '{rhbuild}', "
+            f"falling back to tentacle pool configs"
+        )
+        release = "tentacle"
+    return f"conf/{release}/rados/test-confs/pool-configurations.yaml"
 
 
 def run(ceph_cluster, **kw):
@@ -199,6 +245,7 @@ def run(ceph_cluster, **kw):
         enable_rbd_snapshots (bool): Enable RBD snapshot thrashing (default: True)
         enable_ec_snapshots (bool): Enable EC pool snapshot thrashing (default: True)
         enable_osd_thrashing (bool): Enable OSD thrashing - main thrash operation (default: True)
+        enable_scrub_thrashing (bool): Enable independent scrub/deep-scrub cycles (default: True)
         enable_mon_thrashing (bool): Enable MON thrashing - leader failover/restart (default: False)
         enable_mgr_thrashing (bool): Enable MGR thrashing - failover/restart/random fail (default: False)
         enable_mds_thrashing (bool): Enable MDS thrashing - failover/restart/random fail (default: False)
@@ -215,6 +262,9 @@ def run(ceph_cluster, **kw):
         enable_nfsv3 (bool): Pass --enable-nfsv3 to ceph nfs cluster create (default: False)
         nfs_placement_label (str|None): Prefer orch hosts with this label; if no
             matches, use all orch hosts (default: None).
+        error_injection (dict): Suite-driven error injection config (default: None).
+            Supports profile, profile_overrides, configs, ec_write_errors,
+            ec_read_errors, admin_socket. See CephErrorInjector for schema.
 
     Returns:
         0: Test passed - No crashes detected, cluster remained stable
@@ -228,6 +278,7 @@ def run(ceph_cluster, **kw):
     rados_obj = RadosOrchestrator(node=cephadm)
     pool_obj = PoolFunctions(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    injector = CephErrorInjector(rados_obj=rados_obj)
     client_node = ceph_cluster.get_nodes(role="client")[0]
     mon_workflow_obj = MonitorWorkflows(node=cephadm)
     mon_election_obj = MonElectionStrategies(rados_obj=rados_obj)
@@ -267,6 +318,7 @@ def run(ceph_cluster, **kw):
     nfs_num_clusters = config.get("nfs_num_clusters", 3)
     nfs_exports_per_cluster = config.get("nfs_exports_per_cluster", 4)
     nfs_placement = config.get("nfs_placement", 1)
+    enable_scrub_thrashing = config.get("enable_scrub_thrashing", True)
     enable_cephfs_subvolume_thrashing = config.get(
         "enable_cephfs_subvolume_thrashing", False
     )
@@ -333,7 +385,8 @@ def run(ceph_cluster, **kw):
         f"  Duration: {duration}s\n"
         f"  Aggressive mode: {aggressive}\n"
         f"  CRUSH thrashing: {enable_crush_thrashing}\n"
-        f"  PG thrashing via bulk flag and scrubbing: {enable_pg_thrashing}\n"
+        f"  PG thrashing via bulk flag (split/merge): {enable_pg_thrashing}\n"
+        f"  Scrub thrashing (independent scrub/deep-scrub): {enable_scrub_thrashing}\n"
         f"  Compression (mode=force): {compression}\n"
         f"  Debug logs: {enable_debug_logs}\n"
         f"  RADOS pools from config: {len(config.get('pool_configs', []))}\n"
@@ -366,8 +419,36 @@ def run(ceph_cluster, **kw):
         f"  Fast EC config params: {enable_fast_ec_config_params}\n"
         f"  ESB verification (Bug #70390): {enable_esb_verification}\n"
         f"  Inconsistent object fail (no repair): {inconsistent_object_fail}\n"
-        f"{'=' * 60}\n"
     )
+    _ei_config = config.get("error_injection", {})
+    if _ei_config:
+        _ei_profile = _ei_config.get("profile", "none")
+        test_params += f"  Error injection profile: {_ei_profile}\n"
+        _ei_merged = {}
+        if _ei_profile and _ei_profile in PROFILES:
+            _ei_merged.update(PROFILES[_ei_profile]["configs"])
+        _ei_merged.update(_ei_config.get("profile_overrides", {}))
+        _ei_merged.update(_ei_config.get("configs", {}))
+        if _ei_merged:
+            test_params += "  Error injection configs:\n"
+            for k, v in sorted(_ei_merged.items()):
+                test_params += f"    {k}: {v}\n"
+        if _ei_config.get("ec_write_errors"):
+            test_params += (
+                f"  EC write errors: {len(_ei_config['ec_write_errors'])} spec(s)\n"
+            )
+        if _ei_config.get("ec_read_errors"):
+            test_params += (
+                f"  EC read errors: {len(_ei_config['ec_read_errors'])} spec(s)\n"
+            )
+        if _ei_config.get("admin_socket"):
+            test_params += (
+                f"  Admin socket commands: "
+                f"{len(_ei_config['admin_socket'])} command(s)\n"
+            )
+    else:
+        test_params += "  Error injection: None\n"
+    test_params += f"{'=' * 60}\n"
     log.info(test_params)
 
     log.info("Archiving existing crashes...")
@@ -378,6 +459,8 @@ def run(ceph_cluster, **kw):
 
     created_pools = []
     test_failed = False
+    _destructive_mds_injection = False
+    _bluestore_corruption_active = False
     fs_name = None
     fs_names = []  # List of all filesystems created (for MDS thrashing)
     cephfs_mount_path = None
@@ -743,45 +826,66 @@ def run(ceph_cluster, **kw):
             )
 
         if inject_errors:
-            mon_obj.set_config(
-                section="global", name="bluestore_debug_inject_read_err", value="true"
-            )
-            # Get EC pools for injection
+            injector.inject_config("bluestore_debug_inject_read_err", True)
             ec_pool_names = [
                 p["pool_name"] for p in created_pools if p.get("pool_type") == "erasure"
             ]
             if ec_pool_names:
                 for ec_pool in ec_pool_names:
                     for osd_id in inject_osds:
-                        # injectecwriteerr <pool> <obj> <shard> <type> <skip> <inject>
-                        # shard=2, type=1 (drop sub write), skip=0
-                        inject_cmd = (
-                            f"cephadm shell -- ceph daemon osd.{osd_id} injectecwriteerr "
-                            f"{ec_pool} '*' 2 1 0 {num_writes_to_inject}"
+                        injector.inject_ec_write_error(
+                            osd_id=osd_id,
+                            pool=ec_pool,
+                            shard=2,
+                            err_type=1,
+                            skip=0,
+                            duration=num_writes_to_inject,
                         )
-                        try:
-                            osd_host = rados_obj.fetch_host_node(
-                                daemon_type="osd", daemon_id=str(osd_id)
-                            )
-                            out, _ = osd_host.exec_command(
-                                cmd=inject_cmd, sudo=True, check_ec=False
-                            )
-                            if "ok" in out.lower():
-                                log.info(
-                                    f"Injected on OSD.{osd_id} for {ec_pool}: {out.strip()}"
-                                )
-                            else:
-                                log.warning(
-                                    f"Injection failed on OSD.{osd_id} for {ec_pool}: {out.strip()}"
-                                )
-                        except Exception as e:
-                            log.warning(
-                                f"Failed to inject on OSD.{osd_id} for {ec_pool}: {e}"
-                            )
                 log.info(
                     f"Injected EC write errors on {len(inject_osds)} OSDs "
                     f"for {len(ec_pool_names)} pools: "
                     f"{', '.join(str(osd) for osd in inject_osds)}"
+                )
+
+        # Apply suite-driven error injection config (if provided)
+        error_injection_config = config.get("error_injection", {})
+        if error_injection_config:
+            injector.apply_from_config(error_injection_config)
+            _destructive_mds_keys = {
+                "mds_inject_rename_corrupt_dentry_first",
+                "mds_inject_journal_corrupt_dentry_first",
+            }
+            all_injected = set(error_injection_config.get("configs", {}).keys())
+            all_injected.update(
+                error_injection_config.get("profile_overrides", {}).keys()
+            )
+            prof = error_injection_config.get("profile")
+            if prof and prof in PROFILES:
+                all_injected.update(PROFILES[prof]["configs"].keys())
+            active_destructive = _destructive_mds_keys & all_injected
+            if active_destructive:
+                merged = {}
+                if prof and prof in PROFILES:
+                    merged.update(PROFILES[prof]["configs"])
+                merged.update(error_injection_config.get("profile_overrides", {}))
+                merged.update(error_injection_config.get("configs", {}))
+                if any(float(merged.get(k, 0)) > 0 for k in active_destructive):
+                    _destructive_mds_injection = True
+                    log.warning(
+                        "DESTRUCTIVE MDS INJECTION ACTIVE: "
+                        "CephFS metadata corruption expected. "
+                        "Filesystem will be destroyed during cleanup."
+                    )
+            _bs_corruption_keys = {
+                "bluestore_debug_inject_read_err",
+                "bluestore_debug_inject_csum_err_probability",
+                "bluestore_debug_inject_allocation_from_file_failure",
+            }
+            if _bs_corruption_keys & all_injected:
+                _bluestore_corruption_active = True
+                log.info(
+                    "BlueStore corruption injection active: "
+                    "PG inconsistency expected during test."
                 )
 
         mon_obj.set_config(
@@ -810,6 +914,7 @@ def run(ceph_cluster, **kw):
         max_workers += 1 if enable_osd_thrashing else 0
         max_workers += 1 if enable_crush_thrashing else 0
         max_workers += 1 if enable_pg_thrashing else 0
+        max_workers += 1 if enable_scrub_thrashing else 0
         max_workers += 1 if enable_rgw_thrashing else 0
         max_workers += 1 if enable_mon_thrashing else 0
         max_workers += 1 if enable_mgr_thrashing else 0
@@ -975,6 +1080,20 @@ def run(ceph_cluster, **kw):
                         pool_obj=pool_obj,
                         pools=created_pools,
                         iterations=iterations // 3,
+                        stop_flag=stop_flag,
+                    )
+                )
+
+            # Scrub thrashing (default: enabled)
+            if enable_scrub_thrashing:
+                log.info("Scrub thrashing enabled (independent scrub/deep-scrub)")
+                futures.append(
+                    executor.submit(
+                        thrash_scrubs,
+                        rados_obj=rados_obj,
+                        pools=created_pools,
+                        duration=duration,
+                        aggressive=aggressive,
                         stop_flag=stop_flag,
                     )
                 )
@@ -1183,6 +1302,8 @@ def run(ceph_cluster, **kw):
                 workflow_order.append("crush_weight_thrashing")
             if enable_pg_thrashing:
                 workflow_order.append("pg_count_thrashing")
+            if enable_scrub_thrashing:
+                workflow_order.append("scrub_thrashing")
             if enable_rgw_thrashing and rgw_config:
                 workflow_order.append("rgw_s3_thrashing")
             if enable_mon_thrashing:
@@ -1226,83 +1347,85 @@ def run(ceph_cluster, **kw):
         rados_obj.log_cluster_health()
 
         # Check for inconsistent PGs across all pools and repair if found
-        log.info("Checking for inconsistent PGs across all pools...")
-        all_pools = rados_obj.list_pools()
-        inconsistent_pgs_found = []
-        for check_pool in all_pools:
-            try:
-                inconsistent_pgs = rados_obj.get_inconsistent_pg_list(check_pool)
-                if inconsistent_pgs:
-                    log.warning(
-                        f"Found {len(inconsistent_pgs)} inconsistent PG(s) in pool "
-                        f"{check_pool}: {inconsistent_pgs}"
-                    )
-                    inconsistent_pgs_found.extend(inconsistent_pgs)
-            except Exception as e:
-                log.debug(f"Error checking pool {check_pool}: {e}")
-
-        if inconsistent_pgs_found:
-            # IBMCEPH-12717: Fail immediately on inconsistent objects to catch
-            # the bug rather than silently repairing and masking the issue.
-            if inconsistent_object_fail:
-                log.error(
-                    f"Total inconsistent PGs found: {len(inconsistent_pgs_found)}. "
-                    f"Inconsistent PGs: {inconsistent_pgs_found}. "
-                    f"Failing test due to inconsistent_object_fail=True (IBMCEPH-12717)"
-                )
-                for pg_id in inconsistent_pgs_found:
-                    try:
-                        log.info(f"Capturing diagnostic info for PG: {pg_id}")
-                        client_node.exec_command(
-                            cmd=f"ceph pg {pg_id} query -f json-pretty"
-                            f" > /tmp/{pg_id}_query.txt",
-                            sudo=True,
-                        )
-                        client_node.exec_command(
-                            cmd=f"rados list-inconsistent-obj {pg_id}"
-                            f" -f json-pretty"
-                            f" > /tmp/{pg_id}_inconsistent_obj.txt",
-                            sudo=True,
-                        )
-                    except Exception as e:
-                        log.warning(
-                            f"Failed to capture diagnostics for " f"PG {pg_id}: {e}"
-                        )
-                raise Exception(
-                    f"IBMCEPH-12717: Inconsistent objects detected in "
-                    f"{len(inconsistent_pgs_found)} PG(s): "
-                    f"{inconsistent_pgs_found}"
-                )
-            else:
-                log.debug(
-                    f"Total inconsistent PGs found: {len(inconsistent_pgs_found)}. "
-                    f"Inconsistent PGs: {inconsistent_pgs_found}. "
-                    f"Initiating PG repair..."
-                )
-                for pg_id in inconsistent_pgs_found:
-                    try:
-                        client_node.exec_command(
-                            cmd=f"ceph pg {pg_id} query -f json-pretty > /tmp/{pg_id}_query.txt",
-                            sudo=True,
-                        )
-                        client_node.exec_command(
-                            cmd=f"rados list-inconsistent-obj {pg_id} -f json-pretty "
-                            f"> /tmp/{pg_id}_inconsistent_obj.txt",
-                            sudo=True,
-                        )
-                        time.sleep(5)
-                        log.info(f"Running pg repair on PG: {pg_id}")
-                        rados_obj.run_ceph_command(cmd=f"ceph pg repair {pg_id}")
-                    except Exception as e:
-                        log.error(f"Failed to repair PG {pg_id}: {e}")
-                time.sleep(30)
+        if _bluestore_corruption_active:
+            log.info(
+                "Skipping inconsistent PG check -- BlueStore corruption "
+                "injection causes expected PG inconsistency. "
+                "Recovery will handle in cleanup phase."
+            )
+            inconsistent_pgs_found = []
         else:
-            log.info("No inconsistent PGs found across all pools")
+            log.info("Checking for inconsistent PGs across all pools...")
+            all_pools = rados_obj.list_pools()
+            inconsistent_pgs_found = []
+            for check_pool in all_pools:
+                try:
+                    inconsistent_pgs = rados_obj.get_inconsistent_pg_list(check_pool)
+                    if inconsistent_pgs:
+                        log.warning(
+                            f"Found {len(inconsistent_pgs)} inconsistent "
+                            f"PG(s) in pool {check_pool}: {inconsistent_pgs}"
+                        )
+                        inconsistent_pgs_found.extend(inconsistent_pgs)
+                except Exception as e:
+                    log.debug(f"Error checking pool {check_pool}: {e}")
 
-        log.info("Waiting for PGs to reach active+clean state...")
-        if not wait_for_clean_pg_sets(rados_obj, timeout=1200, recovery_thread=False):
-            log.error("Not all PGs are active+clean")
-            raise Exception("Not all PGs are active+clean")
+            if inconsistent_pgs_found:
+                if inconsistent_object_fail:
+                    log.error(
+                        f"Total inconsistent PGs found: "
+                        f"{len(inconsistent_pgs_found)}. "
+                        f"Failing test (IBMCEPH-12717)"
+                    )
+                    for pg_id in inconsistent_pgs_found:
+                        try:
+                            log.info(f"Capturing diagnostics for PG: {pg_id}")
+                            client_node.exec_command(
+                                cmd=f"ceph pg {pg_id} query -f json-pretty"
+                                f" > /tmp/{pg_id}_query.txt",
+                                sudo=True,
+                            )
+                            client_node.exec_command(
+                                cmd=f"rados list-inconsistent-obj {pg_id}"
+                                f" -f json-pretty"
+                                f" > /tmp/{pg_id}_inconsistent_obj.txt",
+                                sudo=True,
+                            )
+                        except Exception as e:
+                            log.warning(f"Failed diagnostics for PG {pg_id}: {e}")
+                    raise Exception(
+                        f"IBMCEPH-12717: Inconsistent objects in "
+                        f"{len(inconsistent_pgs_found)} PG(s)"
+                    )
+                else:
+                    log.debug(
+                        f"Found {len(inconsistent_pgs_found)} inconsistent "
+                        f"PG(s), initiating repair..."
+                    )
+                    for pg_id in inconsistent_pgs_found:
+                        try:
+                            time.sleep(5)
+                            log.info(f"Running pg repair on PG: {pg_id}")
+                            rados_obj.run_ceph_command(cmd=f"ceph pg repair {pg_id}")
+                        except Exception as e:
+                            log.error(f"Failed to repair PG {pg_id}: {e}")
+                    time.sleep(30)
+            else:
+                log.info("No inconsistent PGs found across all pools")
+
+        if _bluestore_corruption_active:
+            log.info(
+                "Skipping wait_for_clean_pg_sets -- BlueStore corruption "
+                "injection may have caused PG inconsistency. "
+                "Recovery will run in cleanup phase."
+            )
+        else:
+            log.info("Waiting for PGs to reach active+clean state...")
+            if not wait_for_clean_pg_sets(
+                rados_obj, timeout=1200, recovery_thread=False
+            ):
+                log.error("Not all PGs are active+clean")
+                raise Exception("Not all PGs are active+clean")
 
         rados_obj.log_cluster_health()
 
@@ -1343,11 +1466,8 @@ def run(ceph_cluster, **kw):
                 mon_obj.remove_config(section="osd", name=name)
             log.info("ESB verification configs removed")
 
-        if inject_errors:
-            log.info("Removing EC write error injection config...")
-            mon_obj.remove_config(
-                section="global", name="bluestore_debug_inject_read_err"
-            )
+        log.info("Cleaning up all error injections...")
+        injector.cleanup_all()
 
         if disabled_ec_optimizations:
             log.info("Reverting osd_pool_default_flag_ec_optimizations config...")
@@ -1372,6 +1492,12 @@ def run(ceph_cluster, **kw):
             )
             if osds_to_restore:
                 _restore_osds_to_in(rados_obj, osds_to_restore)
+                log.info("Restarting OSD service to recover down daemons...")
+                try:
+                    rados_obj.restart_daemon_services(daemon="osd")
+                    log.info("OSD service restart completed")
+                except Exception as restart_err:
+                    log.warning(f"OSD service restart failed: {restart_err}")
             else:
                 log.info("All OSDs are healthy, no restoration needed")
         except Exception as e:
@@ -1394,18 +1520,83 @@ def run(ceph_cluster, **kw):
         log.debug(f"Test completed. Start: {start_time}, End: {test_end_time}")
 
         try:
-            if rados_obj.check_crash_status(
-                start_time=start_time,
-                end_time=test_end_time,
-                check_mds=enable_mds_thrashing,
-                check_nfs=enable_nfs_thrashing,
-                check_rgw=enable_rgw_thrashing,
-            ):
-                log.error("Test failed due to crash detected")
-                test_failed = True
+            if _destructive_mds_injection:
+                log.info("Validating expected MDS corruption crashes...")
+                crash_list = rados_obj.do_crash_ls() or []
+                mds_crashes = [
+                    c for c in crash_list if c.get("entity_name", "").startswith("mds.")
+                ]
+                if mds_crashes:
+                    validated = False
+                    log.info(
+                        f"Found {len(mds_crashes)} MDS crash(es), inspecting details..."
+                    )
+                    for crash in mds_crashes[:5]:
+                        try:
+                            info = rados_obj.run_ceph_command(
+                                f"ceph crash info {crash['crash_id']}",
+                                client_exec=True,
+                            )
+                            log.info(
+                                f"  Crash: {info.get('entity_name')} "
+                                f"at {info.get('timestamp')} "
+                                f"sig={str(info.get('stack_sig') or 'N/A')[:16]} "
+                                f"assert={info.get('assert_condition', 'N/A')} "
+                                f"file={info.get('assert_file', 'N/A')}"
+                            )
+                            bt = info.get("backtrace", [])
+                            if (
+                                any(
+                                    "check_corruption" in f or "CDentry" in f
+                                    for f in bt
+                                )
+                                and info.get("process_name") == "ceph-mds"
+                            ):
+                                validated = True
+                                log.info("  -> Matches CDentry corruption signature")
+                        except Exception:
+                            continue
+                    if validated:
+                        log.info(
+                            f"EXPECTED: {len(mds_crashes)} MDS crashes with "
+                            f"CDentry corruption signature. Injection validated."
+                        )
+                        mds_recovery = CephInjectionRecovery(rados_obj, client_node)
+                        repair = mds_recovery.recover_mds_corruption(
+                            fs_name=fs_name or "cephfs-thrash",
+                            cephfs_mount_path=cephfs_mount_path,
+                        )
+                        log.info(f"Repair outcome: {repair['outcome']}")
+                    else:
+                        log.error(
+                            "MDS crashes found but none match expected "
+                            "corruption signature"
+                        )
+                        test_failed = True
+                else:
+                    log.error(
+                        "No MDS crashes despite destructive injection -- "
+                        "injection may not have triggered"
+                    )
+                    test_failed = True
+            else:
+                if rados_obj.check_crash_status(
+                    start_time=start_time,
+                    end_time=test_end_time,
+                    check_mds=enable_mds_thrashing,
+                    check_nfs=enable_nfs_thrashing,
+                    check_rgw=enable_rgw_thrashing,
+                ):
+                    log.error("Test failed due to crash detected")
+                    test_failed = True
         except Exception as e:
             log.error(f"Crash check failed: {e}")
             test_failed = True
+
+        if _destructive_mds_injection:
+            _fs = fs_name or "cephfs-thrash"
+            recovery = CephInjectionRecovery(rados_obj, client_node)
+            recovery.destroy_damaged_filesystem(_fs, cephfs_mount_path)
 
         if config.get("cleanup_pools", True):
             log.debug("Cleaning up test resources...")
@@ -1413,7 +1604,7 @@ def run(ceph_cluster, **kw):
             # Phase 1: Unmount filesystems, cleanup RGW and NFS (parallel)
             cleanup_tasks = []
             with cf.ThreadPoolExecutor(max_workers=4) as cleanup_executor:
-                if enable_cephfs_pools:
+                if enable_cephfs_pools and not _destructive_mds_injection:
                     cleanup_tasks.append(
                         (
                             "CephFS",
@@ -1522,22 +1713,48 @@ def run(ceph_cluster, **kw):
                 if fsid:
                     logrotate_cmd = f"logrotate -f /etc/logrotate.d/ceph-{fsid}"
                     osd_hosts = rados_obj.get_osd_hosts()
+                    host_objs = []
                     for host in osd_hosts:
                         host_obj = utils.get_node_by_id(ceph_cluster, host)
+                        if host_obj:
+                            host_objs.append(host_obj)
+
+                    def _rotate_log(node):
                         try:
-                            host_obj.exec_command(
+                            node.exec_command(
                                 cmd=logrotate_cmd,
                                 sudo=True,
                                 check_ec=False,
                                 long_running=True,
                             )
-                            time.sleep(10)
-                            log.debug(f"Log rotation completed on {host.hostname}")
+                            log.debug(f"Log rotation completed on {node.hostname}")
                         except Exception:
                             pass
-                    log.info(f"Log rotation triggered on {len(osd_hosts)} OSD host(s)")
+
+                    with cf.ThreadPoolExecutor(max_workers=len(host_objs)) as pool:
+                        pool.map(_rotate_log, host_objs)
+                    log.info(
+                        f"Log rotation triggered on {len(host_objs)} OSD host(s) in parallel"
+                    )
             except Exception as e:
                 log.warning(f"Failed to rotate logs: {e}")
+
+        # Post-cleanup: recover any persistent injection damage
+        try:
+            post_recovery = CephInjectionRecovery(rados_obj, client_node)
+            recovery_result = post_recovery.recover_all(
+                fs_name=(
+                    None if _destructive_mds_injection else (fs_name or "cephfs-thrash")
+                ),
+                cephfs_mount_path=cephfs_mount_path,
+            )
+            if recovery_result.get("bluestore_recovery"):
+                log.info(
+                    f"BlueStore recovery: "
+                    f"{recovery_result['bluestore_recovery']['summary']}"
+                )
+        except Exception as e:
+            log.warning(f"Post-cleanup recovery failed: {e}")
 
         log.info("Cleanup phase completed")
 
@@ -1571,8 +1788,9 @@ def create_rados_pools(
 
     # Load pool configs from file (with caching)
     if _POOL_CONFIGS_CACHE is None:
-        log.debug(f"Loading pool configs from: {POOL_CONFIGS_FILE}")
-        with open(POOL_CONFIGS_FILE, "r") as f:
+        pool_configs_path = _get_pool_configs_path(rados_obj.rhbuild)
+        log.debug(f"Loading pool configs from: {pool_configs_path}")
+        with open(pool_configs_path, "r") as f:
             _POOL_CONFIGS_CACHE = yaml.safe_load(f)
         log.debug("Pool configs cached for future use")
 
@@ -2177,20 +2395,16 @@ def thrash_pg_count(
     stop_flag: Dict,
 ) -> int:
     """
-    Thrash PG count via bulk flag and trigger scrubbing to detect inconsistencies.
+    Thrash PG count via bulk flag toggle to exercise PG split and merge paths.
 
     Per iteration:
     1. Enable bulk flag on all pools (triggers PG split)
-    2. Run cluster-wide deep-scrub
-    3. Wait 90-120 seconds for splits and deep-scrub
-    4. Remove bulk flag from all pools (triggers PG merge)
-    5. Run cluster-wide scrub
-    6. Wait 90-120 seconds for merges and scrub
+    2. Wait 90-120 seconds for splits to complete
+    3. Remove bulk flag from all pools (triggers PG merge)
+    4. Wait 90-120 seconds for merges to complete
 
-    Deep-scrub and scrub operations are critical for detecting:
-    - Missing EC shard objects (from bug #74221)
-    - Data inconsistencies from incorrect clones
-    - Object mismatches between shards
+    Scrub and deep-scrub operations are handled separately by
+    thrash_scrubs() when enable_scrub_thrashing is enabled.
 
     Args:
         rados_obj: RadosOrchestrator object
@@ -2202,13 +2416,13 @@ def thrash_pg_count(
     Returns:
         Number of iterations completed
     """
-    log.info(f"Starting PG count thrashing and scrubbing (iterations: {iterations})")
+    log.info(f"Starting PG count thrashing (iterations: {iterations})")
 
     # Filter RADOS pools only (exclude CephFS and RBD pools)
     rados_pools = tuple(p for p in pools if p.get("client") not in ("cephfs", "rbd"))
 
     if not rados_pools:
-        log.info("No RADOS pools found, skipping PG count thrashing and scrubbing")
+        log.info("No RADOS pools found, skipping PG count thrashing")
         return 0
 
     log.info(f"Will thrash PG count and scrub PGs on {len(rados_pools)} RADOS pool(s)")
@@ -2233,47 +2447,39 @@ def thrash_pg_count(
                 break
 
             log.info(
-                f"Iteration {iteration + 1}/{iterations}: PG thrashing and deep scrubbing on all pools"
+                f"Iteration {iteration + 1}/{iterations}: PG thrashing on all pools"
             )
 
-            # Phase 1: Enable bulk flag on ALL pools
+            # Phase 1: Enable bulk flag on ALL pools (triggers PG split)
             for pool in rados_pools:
                 pool_name = pool["pool_name"]
                 pool_obj.set_bulk_flag(pool_name=pool_name)
                 bulk_enabled_pools.append(pool_name)
 
-            # Trigger cluster-wide deep scrub once (not per-pool)
             if bulk_enabled_pools:
-                rados_obj.run_deep_scrub()
                 pool_count = len(bulk_enabled_pools)
                 log.info(
-                    f"  Enabled bulk on {pool_count} pool(s), sleeping for PG splits and deep scrubbing..."
+                    f"  Enabled bulk on {pool_count} pool(s), "
+                    f"sleeping for PG splits..."
                 )
 
-                # Phase 2: Sleep while ALL pools split PGs simultaneously and deep scrubbing
+                # Phase 2: Sleep while ALL pools split PGs simultaneously
                 time.sleep(random.uniform(90, 120))
 
-                # Phase 3: Remove bulk flag from ALL pools
-                log.info(
-                    f"  Removing bulk from {pool_count} pool(s) and triggering scrub..."
-                )
+                # Phase 3: Remove bulk flag from ALL pools (triggers PG merge)
+                log.info(f"  Removing bulk from {pool_count} pool(s)...")
                 for pool_name in bulk_enabled_pools:
                     pool_obj.rm_bulk_flag(pool_name=pool_name)
                 bulk_enabled_pools.clear()
 
-                # Trigger cluster-wide scrub once (not per-pool)
-                rados_obj.run_scrub()
-
-                # Phase 4: Sleep for PG merges and scrubbing
-                log.info(
-                    f"  Sleeping while {pool_count} pool(s) merge PGs and scrubbing PGs..."
-                )
+                # Phase 4: Sleep for PG merges
+                log.info(f"  Sleeping while {pool_count} pool(s) merge PGs...")
                 time.sleep(random.uniform(90, 120))
 
                 completed += 1
             else:
                 log.warning(
-                    f"Iteration {iteration + 1}: No pools had bulk enabled, skipping PG thrashing and scrubbing"
+                    f"Iteration {iteration + 1}: No pools had bulk enabled, skipping PG thrashing"
                 )
     except Exception as e:
         log.error(f"Exception in thrash_pg_count: {e}")
@@ -2285,7 +2491,114 @@ def thrash_pg_count(
             for pool_name in bulk_enabled_pools:
                 pool_obj.rm_bulk_flag(pool_name=pool_name)
 
-    log.info(f"PG count thrashing and scrubbing completed: {completed} iterations")
+    log.info(f"PG count thrashing completed: {completed} iterations")
+    return completed
+
+
+def thrash_scrubs(
+    rados_obj: RadosOrchestrator,
+    pools: List[Dict],
+    duration: int,
+    aggressive: bool,
+    stop_flag: Dict,
+) -> int:
+    """
+    Run periodic scrub and deep-scrub cycles on the cluster.
+
+    Each iteration randomly picks a scrub strategy and target:
+
+    Strategy (random per iteration):
+        - scrub: Standard scrub to verify replica/shard consistency
+        - deep-scrub: Full data + metadata verification with checksum
+
+    Target (random per iteration):
+        - cluster-wide: ceph osd scrub all / deep-scrub all
+        - per-pool: ceph osd pool scrub <pool> / deep-scrub <pool>
+        - per-osd: ceph osd scrub <osd_id> / deep-scrub <osd_id>
+
+    Timing:
+        - Normal mode: 30-60s between iterations
+        - Aggressive mode: 15-30s between iterations (more frequent scrubs)
+
+    This function is independent of thrash_pg_count and does NOT perform
+    PG split/merge operations. It purely exercises the scrub subsystem.
+
+    Args:
+        rados_obj: RadosOrchestrator instance
+        pools: List of pool config dicts (for per-pool targeting)
+        duration: Total duration in seconds
+        aggressive: If True, scrub more frequently with shorter intervals
+        stop_flag: Shared dict with "stop" key for coordinated shutdown
+
+    Returns:
+        Number of scrub operations completed
+    """
+    log.info(
+        f"Starting scrub thrashing (duration: {duration}s, aggressive: {aggressive})"
+    )
+
+    pool_names = [p["pool_name"] for p in pools if p.get("pool_name")]
+
+    osd_tree = rados_obj.run_ceph_command(cmd="ceph osd tree")
+    osd_ids = [
+        node["id"]
+        for node in osd_tree.get("nodes", [])
+        if node.get("type") == "osd" and node.get("status") == "up"
+    ]
+    if not osd_ids:
+        log.warning("No up OSDs found for scrub thrashing, running cluster-wide only")
+
+    completed = 0
+    end_time = time.time() + duration
+
+    try:
+        while time.time() < end_time and not stop_flag.get("stop"):
+            scrub_type = random.choice(["scrub", "deep-scrub"])
+            target_type = random.choice(["cluster", "pool", "osd"])
+
+            try:
+                if target_type == "pool" and pool_names:
+                    target_pool = random.choice(pool_names)
+                    if scrub_type == "deep-scrub":
+                        rados_obj.run_deep_scrub(pool=target_pool)
+                    else:
+                        rados_obj.run_scrub(pool=target_pool)
+                    log.info(
+                        f"Scrub [{completed + 1}]: {scrub_type} on pool {target_pool}"
+                    )
+
+                elif target_type == "osd" and osd_ids:
+                    target_osd = random.choice(osd_ids)
+                    if scrub_type == "deep-scrub":
+                        rados_obj.run_deep_scrub(osd=target_osd)
+                    else:
+                        rados_obj.run_scrub(osd=target_osd)
+                    log.info(
+                        f"Scrub [{completed + 1}]: {scrub_type} on osd.{target_osd}"
+                    )
+
+                else:
+                    if scrub_type == "deep-scrub":
+                        rados_obj.run_deep_scrub()
+                    else:
+                        rados_obj.run_scrub()
+                    log.info(f"Scrub [{completed + 1}]: {scrub_type} cluster-wide")
+
+                completed += 1
+
+            except Exception as e:
+                log.warning(f"Scrub operation failed (non-fatal): {e}")
+
+            sleep_time = (
+                random.uniform(15, 30) if aggressive else random.uniform(30, 60)
+            )
+            time.sleep(sleep_time)
+
+    except Exception as e:
+        log.error(f"Exception in thrash_scrubs: {e}")
+        return completed
+
+    log.info(f"Scrub thrashing completed: {completed} operations")
     return completed
 
 
@@ -5172,10 +5485,13 @@ def _cleanup_cephfs(client_node, mount_path: str, fs_name: str) -> None:
         try:
             mount_path = mount_path.rstrip("/")
             client_node.exec_command(
-                cmd=f"umount {mount_path}", sudo=True, check_ec=False
+                cmd=f"umount -l {mount_path}", sudo=True, check_ec=False
             )
+            time.sleep(3)
             client_node.exec_command(
-                cmd=f"rm -rf {mount_path}", sudo=True, check_ec=False
+                cmd=f"timeout 30 rm -rf {mount_path}",
+                sudo=True,
+                check_ec=False,
             )
             log.debug(f"CephFS unmounted from {mount_path}")
         except Exception as e:
@@ -5212,7 +5528,7 @@ def _cleanup_rbd(client_node, mount_path: str, device_path: str) -> None:
         try:
             mount_path = mount_path.rstrip("/")
             client_node.exec_command(
-                cmd=f"umount {mount_path}", sudo=True, check_ec=False
+                cmd=f"umount -l {mount_path}", sudo=True, check_ec=False
             )
             if device_path:
                 client_node.exec_command(
@@ -5221,7 +5537,9 @@ def _cleanup_rbd(client_node, mount_path: str, device_path: str) -> None:
                     check_ec=False,
                 )
             client_node.exec_command(
-                cmd=f"rm -rf {mount_path}", sudo=True, check_ec=False
+                cmd=f"timeout 30 rm -rf {mount_path}",
+                sudo=True,
+                check_ec=False,
             )
             log.debug(f"RBD unmounted from {mount_path}")
         except Exception as e:


### PR DESCRIPTION
Introduces CephErrorInjector class and supporting test infrastructure
to centralize and standardize error injection across thrash and stress
tests. All 50 inject config keys and 9 admin socket commands verified
against a live cluster.

New files:
- ceph/rados/ceph_error_injector.py: Unified injection framework with
  catalog of 50 config keys across 10 component groups, 21 chaos
  profiles, suite YAML config support, automatic tracking and cleanup,
  context manager support, float-aware config verification, safety
  checks for dangerous values, and auto-prerequisite enablement for
  EC error injection.
- tests/rados/test_ceph_error_injection.py: Standalone inject/cleanup
  test module usable as suite-level steps around any existing tests
  without code changes (action: inject | cleanup via test_data).
- suites/tentacle/rados/tier-3_rados_error_injection_thrashing.yaml:
  New suite with 12 component-focused thrash scenarios (MON, OSD, MGR,
  MDS, bluestore x light/moderate/aggressive intensity tiers).

Modified files:
- tests/rados/test_osd_thrashing.py: Refactored to use CephErrorInjector,
  added suite-driven error_injection config support, version-aware pool
  config path resolution, and independent scrub thrashing (thrash_scrubs)
  separated from PG count thrashing.
- suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml: Added
  enable_scrub_thrashing flag to all test entries.
- suites/squid/rados/tier-3_rados_osd_thrashing_tests.yaml: Added
  enable_scrub_thrashing flag to all test entries.