### PR TITLE
[TFA] removing checksum awscli tests from reef suite as the feature support is not there

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -405,33 +405,6 @@ tests:
   #       config-file-name: test_public_access_block_restricted_public_buckets.yaml
   #     comments: known issue - Bug 2344730 atrgetted to 9.0
 
-  # test checksum with awscli v1 and v2
-
-  - test:
-      name: test checksum with awscli_v1_v2 small objects
-      desc: test checksum with awscli_v1_v2 small objects
-      polarion-id: CEPH-83591699
-      module: sanity_rgw.py
-      config:
-        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
-        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
-  - test:
-      name: test checksum with awscli_v1_v2 non-multipart objects
-      desc: test checksum with awscli_v1_v2 non-multipart objects
-      polarion-id: CEPH-83591699
-      module: sanity_rgw.py
-      config:
-        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
-        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
-  - test:
-      name: test checksum with awscli_v1_v2 multipart objects
-      desc: test checksum with awscli_v1_v2 multipart objects
-      polarion-id: CEPH-83591699
-      module: sanity_rgw.py
-      config:
-        script-name: ../aws/test_checksum_with_awscli_v1_and_v2.py
-        config-file-name: ../../aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
-
   - test:
       name: Test scenario of object deletion with version id
       desc: Test scenario of object deletion with version id


### PR DESCRIPTION
this PR is to remove checksum testcases from reef pipeline as the feature support is not there. this was added by mistake in reef pipeline
feature support added from 8.0: https://jsw.ibm.com/browse/ISCE-603

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
