### PR TITLE
[rgw-tfa]Fix root SSH access on IBM Cloud VMs

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -133,6 +133,26 @@ def run(**kw):
     return 0
 
 
+def setup_ibmc_root_ssh_access(ceph):
+    """Enable root password SSH login after yum upgrade/reboot on IBM Cloud VMs."""
+    sshd_config_file = "/etc/ssh/sshd_config.d/50-ceph-qe.conf"
+    root_password = ceph.root_passwd or "passwd"
+    log.info("Enabling root password authentication on %s", ceph.hostname)
+
+    ceph.exec_command(cmd=f"echo 'root:{root_password}' | chpasswd", sudo=True)
+    ceph.exec_command(
+        cmd=(
+            f"tee {sshd_config_file} <<'EOF'\n"
+            "PermitRootLogin yes\n"
+            "PasswordAuthentication yes\n"
+            "EOF"
+        ),
+        sudo=True,
+    )
+    ceph.exec_command(cmd="systemctl restart sshd", sudo=True)
+    log.info("Root password authentication enabled on %s", ceph.hostname)
+
+
 def install_prereq(
     ceph,
     test_data=None,  # Default value for test_data
@@ -243,6 +263,9 @@ def install_prereq(
             time.sleep(60)
             ceph.reconnect()
             time.sleep(10)
+
+            if cloud_type.lower() == "ibmc":
+                setup_ibmc_root_ssh_access(ceph)
 
         if skip_enabling_rhel_rpms and skip_subscription:
             # Ansible is required for RHCS 4.x


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>


sshpass was failing when copying certs between nodes on IBM Cloud during SSL RGW suites.

This adds setup_ibmc_root_ssh_access() in install_prereq.py for ibmc nodes. It sets the root password and enables PermitRootLogin and PasswordAuthentication in sshd so sshpass scp works for cert distribution across nodes.

pass log:
https://10.8.128.2/cephci-jenkins/ibm-cos//RH/9.1/rhel-9/executor/20.2.1-292/rgw/1965/logs/tier_1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest/

fail logs:
https://10.8.128.2/cephci-jenkins/ibm-cos//RH/9.1/rhel-9/upgrade/20.2.1-292/rgw/40/logs/Tier_1_rgw_ms_upgrade_ssl_81GA_to_9x_latest/
