### PR TITLE
Additional delegation tests + Version check for delegation tests

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml
@@ -632,6 +632,50 @@ tests:
         lock_wait_seconds: 15
 
   - test:
+      name: NFSv4 delegation WRITE grant new vs existing file
+      module: nfs_verify_delegation_write_grant_scenarios.py
+      desc: >-
+        Capture WRITE delegation on new-file create (logged) and require WRITE
+        delegation when reopening the same file for write.
+      polarion-id: CEPH-83632380
+      abort-on-fail: false
+      config:
+        nfs_name: cephfs-nfs
+        auto_create_nfs_cluster: true
+        delegation_exit_wait_seconds: 120
+        delegation_hold_ready_seconds: 8
+        delegation_log_settle_seconds: 90
+
+  - test:
+      name: NFSv4 delegation WRITE peer access recall and grant
+      module: nfs_verify_delegation_write_peer_access.py
+      desc: >-
+        Peer write recalls holder WRITE delegation; after holder returns
+        delegation, peer can obtain WRITE delegation on the same file.
+      polarion-id: CEPH-83632380
+      abort-on-fail: false
+      config:
+        nfs_name: cephfs-nfs
+        auto_create_nfs_cluster: true
+        clients: 2
+        delegation_exit_wait_seconds: 120
+        delegation_hold_ready_seconds: 8
+        delegation_log_settle_seconds: 90
+        delegation_return_wait_seconds: 15
+
+  - test:
+      name: NFSv4 delegation client unmount scenario
+      module: nfs_verify_delegation_client_lifecycle_scenarios.py
+      desc: Delegation is returned (DELEGRETURN) when client unmounts with active delegation.
+      polarion-id: CCEPH-83632378
+      abort-on-fail: false
+      config:
+        nfs_name: cephfs-nfs
+        auto_create_nfs_cluster: true
+        delegation_hold_ready_seconds: 8
+        delegation_log_settle_seconds: 90
+
+  - test:
       name: NFSv4 delegation stress and scale scenarios
       module: nfs_verify_delegation_stress_scenarios.py
       desc: >-
@@ -649,3 +693,4 @@ tests:
         strict_log_validation: false
         delegation_exit_wait_seconds: 120
         delegation_log_settle_seconds: 90
+

--- a/tests/nfs/nfs_delegation_operations.py
+++ b/tests/nfs/nfs_delegation_operations.py
@@ -4,11 +4,6 @@ Shared NFSv4 delegation test infrastructure.
 Cluster/export template (config-key), cephadm shell helpers, Ganesha container log I/O.
 Scenario-specific validation and multi-client recall logic live in the test modules.
 
-Recommended suite order (tier1-nfs-ganesha-v4-2.yaml):
-  1. nfs_verify_cluster_level_delegations (optional cluster/export toggles)
-  2. nfs_verify_delegation_rw_none_scenarios (may auto-create NFS cluster)
-  3. nfs_verify_delegation_revoke_recall / nfs_verify_delegation_conflict_scenarios
-     (require ``nfs_name`` cluster unless ``auto_create_nfs_cluster: true``)
 """
 
 from __future__ import annotations
@@ -19,6 +14,7 @@ import re
 import time
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -29,6 +25,7 @@ from typing import (
     Tuple,
 )
 
+from looseversion import LooseVersion
 from nfs_operations import setup_nfs_cluster, verify_nfs_ganesha_service
 
 from cli.exceptions import ConfigError, OperationFailedError
@@ -82,6 +79,7 @@ RE_DELEGATION_RECALLING = re.compile(r"Recalling", re.I)
 RE_DELEGATION_RECALLED = re.compile(r"successfully recalled", re.I)
 RE_DELEGATION_REVOKING = re.compile(r"Revoking", re.I)
 RE_DELEGATION_DELEGRETURN = re.compile(r"DELEGRETURN|OP_DELEGRETURN", re.I)
+RE_NFS4_CLOSE_HANDLER = re.compile(r"CLOSE handler", re.I)
 RE_DELEGATION_ATTEMPT_GRANT = re.compile(r"Attempting to grant delegation", re.I)
 RE_DELEGATION_TYPE_NOT_SUPPORTED = re.compile(r"Delegation type not supported", re.I)
 RE_DELEGATION_TYPE_VALUE = re.compile(r"delegation_type\s+(\d+)", re.I)
@@ -98,6 +96,52 @@ GANESHA_DELEGATION_TAILF_GREP_E = (
 GANESHA_DELEGATION_TAILF_CAPTURE = _delegation_tmp_path("tailf.log")
 GANESHA_DELEGATION_TAILF_PID = _delegation_tmp_path("tailf.pid")
 
+DELEGATION_MIN_UPSTREAM_BUILD = "20.2.1"
+DELEGATION_MIN_RHCS_BUILD = "9.1"
+
+
+def delegation_supported_for_rhbuild(rhbuild: Optional[str]) -> bool:
+    """
+    Return True when *rhbuild* (--rhbuild / config rhbuild) is RHCS 9.1+.
+
+    ``run.py`` sets ``config['rhbuild']`` to ``{rhbuild}-{platform}`` (e.g.
+    ``9.1-rhel-9``). Values with major version >= 10 are treated as upstream Ceph
+    and compared against ``DELEGATION_MIN_UPSTREAM_BUILD``.
+    """
+    if not rhbuild:
+        return False
+    token = str(rhbuild).split("-")[0]
+    if not token:
+        return False
+    major_str = token.split(".")[0]
+    if not major_str.isdigit():
+        return False
+    major = int(major_str)
+    lv = LooseVersion(token)
+    if major < 10:
+        return lv >= LooseVersion(DELEGATION_MIN_RHCS_BUILD)
+    return lv >= LooseVersion(DELEGATION_MIN_UPSTREAM_BUILD)
+
+
+def skip_delegation_tests_unless_supported(config: Optional[ConfigDict] = None) -> bool:
+    """
+    Return True when NFSv4 delegation tests should be skipped.
+
+    Uses only ``config['rhbuild']`` (from cephci ``--rhbuild``). Callers should
+    ``return 0`` immediately when this is True.
+    """
+    config = config or {}
+    rhbuild = config.get("rhbuild")
+    if delegation_supported_for_rhbuild(rhbuild):
+        return False
+    log.info(
+        "Skipping NFSv4 delegation test: requires --rhbuild >= %s (rhbuild=%s)",
+        DELEGATION_MIN_RHCS_BUILD,
+        rhbuild,
+    )
+    return True
+
+
 # Delegation test timing (seconds). Ganesha NFSv4 delegations are lease-driven; many
 # clusters use a ~90s lease. These values add margin for async grant/recall and for
 # FULL_DEBUG lines to reach the in-container tail -f | grep capture.
@@ -112,10 +156,6 @@ DELEGATION_HOLD_READY_SECONDS_DEFAULT = 8
 DELEGATION_RETURN_WAIT_SECONDS_DEFAULT = 15
 # After scenario IO: wait for recall/grant lines in the filtered ganesha.log capture.
 DELEGATION_LOG_SETTLE_SECONDS_DEFAULT = 90
-# clamp_delegation_log_settle_seconds() bounds when callers use that helper.
-DELEGATION_LOG_SETTLE_SECONDS_CLAMP_LO = 75
-DELEGATION_LOG_SETTLE_SECONDS_CLAMP_HI = 90
-DELEGATION_LOG_SETTLE_FALLBACK_DEFAULT = 82
 # Poll attempts when waiting for a seeded file to appear on an NFS mount.
 DELEGATION_PATH_WAIT_RETRIES_DEFAULT = 40
 
@@ -357,6 +397,53 @@ def validate_delegation_grant_capture(scenario_name, hits, hold_mode="write"):
         )
 
 
+def log_delegation_open_types(scenario_name, hits) -> List[int]:
+    """Log delegation_type values from nfs4_op_open END lines; return parsed types."""
+    types = parse_nfs4_open_delegation_types("\n".join(hits or []))
+    log.info(
+        "Scenario %s: nfs4_op_open delegation_type values %r",
+        scenario_name,
+        types,
+    )
+    return types
+
+
+def capture_delegation_ganesha_log_phase(
+    nfs_node: CephNode,
+    container_id: str,
+    settle_seconds: int,
+    phase_action: Callable[[], None],
+) -> List[str]:
+    """Truncate ganesha.log, run *phase_action*, capture delegation lines for one phase."""
+    truncate_ganesha_container_log(nfs_node, container_id)
+    start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+    phase_action()
+    time.sleep(int(settle_seconds))
+    stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+    return read_ganesha_delegation_tailf_capture(nfs_node, container_id)
+
+
+def hold_new_file_write_open(client: CephNode, path: str, seconds: int) -> None:
+    """Create *path* with mode ``w`` and keep it OPEN in the background."""
+    safe = q_delegation_shell(path)
+    pidfile = _delegation_hold_pidfile(client)
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "nohup python3 -c "
+            "\"f=open('%s','w'); f.write('new-file\\\\n'); import time; time.sleep(%s)\" "
+            ">/dev/null 2>&1 & echo $! >> %s" % (safe, int(seconds), pidfile)
+        ),
+        check_ec=False,
+    )
+    log.info(
+        "Holding new-file write OPEN on %s for %ss from %s",
+        path,
+        int(seconds),
+        getattr(client, "hostname", client),
+    )
+
+
 def validate_delegation_open_close_cycles_capture(
     scenario_name, hits, open_close_cycles, hold_mode="write"
 ):
@@ -388,6 +475,29 @@ def validate_delegation_lock_capture(scenario_name, hits, hold_mode="write"):
 def validate_delegation_setattr_capture(scenario_name, hits, hold_mode="write"):
     """Delegation grant during setattr/truncate metadata operations."""
     validate_delegation_grant_capture(scenario_name, hits, hold_mode)
+
+
+def validate_delegation_close_and_return_capture(
+    scenario_name: str, hits: Iterable[str], *, require_close: bool = False
+) -> None:
+    """Assert *hits* contain DELEGRETURN after client close/unmount/shutdown."""
+    hit_list = list(hits or [])
+    if not hit_list:
+        raise OperationFailedError("Scenario %s: empty tail -f capture" % scenario_name)
+    text = "\n".join(hit_list)
+    if not RE_DELEGATION_DELEGRETURN.search(text):
+        raise OperationFailedError(
+            "Scenario %s: missing DELEGRETURN/OP_DELEGRETURN in capture" % scenario_name
+        )
+    if require_close and not RE_NFS4_CLOSE_HANDLER.search(text):
+        raise OperationFailedError(
+            "Scenario %s: missing CLOSE handler before DELEGRETURN" % scenario_name
+        )
+    log.info(
+        "Scenario %s: delegation return observed (DELEGRETURN%s)",
+        scenario_name,
+        ", CLOSE handler" if RE_NFS4_CLOSE_HANDLER.search(text) else "",
+    )
 
 
 def validate_delegation_revoke_ganesha_capture(
@@ -668,18 +778,24 @@ def unmount_delegation_export(
         client.exec_command(sudo=True, cmd="rm -rf %s" % mount_point, check_ec=False)
 
 
+def lazy_unmount_delegation_export(client: CephNode, mount_point: str) -> None:
+    """Lazy-unmount an NFS export while local opens may still be active."""
+    client.exec_command(sudo=True, cmd="umount -l %s" % mount_point, check_ec=False)
+    log.info(
+        "Lazy-unmounted %s on %s",
+        mount_point,
+        getattr(client, "hostname", client),
+    )
+
+
 def _delegation_hold_pidfile(client: CephNode) -> str:
     host = str(getattr(client, "hostname", "client")).replace("/", "_")
     return _delegation_tmp_path("hold_%s.pids" % host)
 
 
-def _q_delegation_hold_path(path: str) -> str:
-    return q_delegation_shell(path)
-
-
 def hold_delegation_open(client: CephNode, path: str, mode: str, seconds: int) -> None:
     """Keep a file OPEN in the background; record its PID for kill_delegation_holds()."""
-    safe = _q_delegation_hold_path(path)
+    safe = q_delegation_shell(path)
     pidfile = _delegation_hold_pidfile(client)
     client.exec_command(
         sudo=True,
@@ -993,11 +1109,54 @@ def _expect_delegation(conf, label, expected):
         )
 
 
-def verify_container_delegation(nfs_nodes, daemons, nfs_name, delegation):
-    by_short = {(d.get("hostname") or "").split(".")[0]: d for d in daemons}
-    for node in nfs_nodes:
+def _nfs_node_for_daemon(
+    nfs_nodes: Sequence[CephNode], daemon: Mapping[str, Any]
+) -> Optional[CephNode]:
+    """Return the CephNode matching an orch ps NFS daemon entry."""
+    daemon_short = (daemon.get("hostname") or "").split(".")[0]
+    if not daemon_short:
+        return None
+    by_short = {node.hostname.split(".")[0]: node for node in nfs_nodes}
+    node = by_short.get(daemon_short)
+    if node:
+        return node
+    for short, candidate in by_short.items():
+        if short == daemon_short or short in daemon_short or daemon_short in short:
+            return candidate
+    return None
+
+
+def _nfs_nodes_with_daemons(
+    nfs_nodes: Sequence[CephNode], daemons: Sequence[Mapping[str, Any]]
+) -> List[CephNode]:
+    """Return nfs nodes that host at least one orch ps daemon (deduplicated)."""
+    matched: List[CephNode] = []
+    seen = set()
+    for daemon in daemons:
+        node = _nfs_node_for_daemon(nfs_nodes, daemon)
+        if not node:
+            continue
         short = node.hostname.split(".")[0]
-        daemon = by_short.get(short, {})
+        if short in seen:
+            continue
+        seen.add(short)
+        matched.append(node)
+    return matched
+
+
+def verify_container_delegation(nfs_nodes, daemons, nfs_name, delegation):
+    if not daemons:
+        raise OperationFailedError(
+            "No nfs daemons in orch ps for nfs.%s container verify" % nfs_name
+        )
+    active_nodes = _nfs_nodes_with_daemons(nfs_nodes, daemons)
+    for daemon in daemons:
+        node = _nfs_node_for_daemon(nfs_nodes, daemon)
+        if not node:
+            raise OperationFailedError(
+                "No nfs node in test inventory for orch daemon %s (nfs.%s)"
+                % (daemon.get("hostname"), nfs_name)
+            )
         cid = daemon.get("container_id")
         if not cid:
             status = daemon.get("status_desc", "missing")
@@ -1016,10 +1175,27 @@ def verify_container_delegation(nfs_nodes, daemons, nfs_name, delegation):
             node.hostname,
             cid,
         )
+    inventory_only = [
+        node.hostname
+        for node in nfs_nodes
+        if node.hostname.split(".")[0]
+        not in {n.hostname.split(".")[0] for n in active_nodes}
+    ]
+    if inventory_only:
+        log.info(
+            "Skipping container delegation verify on nfs nodes without orch daemons: %s",
+            ", ".join(inventory_only),
+        )
 
 
-def verify_host_conf_delegation(nfs_nodes, nfs_name, delegation):
-    for node in nfs_nodes:
+def verify_host_conf_delegation(nfs_nodes, daemons, nfs_name, delegation):
+    nodes = _nfs_nodes_with_daemons(nfs_nodes, daemons)
+    if not nodes:
+        raise OperationFailedError(
+            "No nfs nodes matched orch ps daemons for nfs.%s host conf verify"
+            % nfs_name
+        )
+    for node in nodes:
         fsids = node.get_dir_list("/var/lib/ceph", sudo=True)
         if not fsids:
             raise OperationFailedError(
@@ -1044,6 +1220,54 @@ def verify_host_conf_delegation(nfs_nodes, nfs_name, delegation):
                 "Unable to read ganesha.conf for %s on %s" % (nfs_name, node.hostname)
             )
         _expect_delegation(conf, "host ganesha.conf on %s" % node.hostname, delegation)
+
+
+def verify_cluster_delegation_on_nfs_nodes(
+    cephadm,
+    nfs_nodes,
+    nfs_clusters,
+    delegation: str,
+    timeout_seconds: int = 120,
+    poll_interval: int = 5,
+) -> None:
+    """
+    Poll ``ceph orch ps`` and verify Delegations in container and host ganesha.conf.
+
+    After redeploy, per-daemon container ids can lag behind aggregate service-ready
+    checks; retry until every NFS node is inspectable or *timeout_seconds* elapses.
+    """
+    deadline = time.time() + int(timeout_seconds)
+    last_error = None
+    while time.time() < deadline:
+        try:
+            for cluster_name in nfs_clusters:
+                raw = cephadm.orch.ps(
+                    service_name="nfs.%s" % cluster_name, format="json"
+                )
+                daemons = json.loads(raw) if raw else []
+                if not daemons:
+                    raise OperationFailedError(
+                        "No nfs daemons found in orch ps for nfs.%s" % cluster_name
+                    )
+                verify_container_delegation(
+                    nfs_nodes, daemons, cluster_name, delegation
+                )
+                verify_host_conf_delegation(
+                    nfs_nodes, daemons, cluster_name, delegation
+                )
+            return
+        except OperationFailedError as err:
+            last_error = err
+            log.info(
+                "Cluster delegation verify not ready, retrying in %ss: %s",
+                poll_interval,
+                err,
+            )
+            time.sleep(int(poll_interval))
+    raise last_error or OperationFailedError(
+        "Timed out after %ss verifying cluster delegation on nfs nodes"
+        % timeout_seconds
+    )
 
 
 def _expect_export_delegation(cmd_host, nfs_name, export_name, expected):
@@ -1334,22 +1558,6 @@ def read_ganesha_delegation_tailf_capture(
     if not raw:
         return []
     return [ln for ln in raw.splitlines() if ln.strip()]
-
-
-def clamp_delegation_log_settle_seconds(
-    config: Mapping[str, Any],
-    default=DELEGATION_LOG_SETTLE_FALLBACK_DEFAULT,
-    lo=DELEGATION_LOG_SETTLE_SECONDS_CLAMP_LO,
-    hi=DELEGATION_LOG_SETTLE_SECONDS_CLAMP_HI,
-):
-    """
-    Return delegation_log_settle_seconds from *config*, clamped to [lo, hi].
-
-    Fallback default (82) is the midpoint of the clamp range when the suite omits
-    an explicit value; tier1 YAML usually sets 90 (~one NFSv4 lease) for capture.
-    """
-    settle = int(config.get("delegation_log_settle_seconds", default))
-    return max(lo, min(hi, settle))
 
 
 def create_delegation_exports(

--- a/tests/nfs/nfs_verify_cluster_level_delegations.py
+++ b/tests/nfs/nfs_verify_cluster_level_delegations.py
@@ -1,5 +1,3 @@
-import json
-
 from nfs_delegation_operations import (
     CONF_KEY,
     LOG_TEMPLATE_BACKUP_PATH,
@@ -11,8 +9,8 @@ from nfs_delegation_operations import (
     run_cephadm_shell,
     run_export_level_delegation_checks,
     set_cluster_delegation,
-    verify_container_delegation,
-    verify_host_conf_delegation,
+    skip_delegation_tests_unless_supported,
+    verify_cluster_delegation_on_nfs_nodes,
 )
 from nfs_operations import (
     cleanup_cluster,
@@ -35,6 +33,8 @@ def run(ceph_cluster, **kw):
     and host conf, optionally runs export create/update/negative checks when Delegations=true.
     """
     config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
     clients = ceph_cluster.get_nodes("client")
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     installers = ceph_cluster.get_nodes("installer")
@@ -55,6 +55,10 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdm(installer).ceph
     redeploy_wait = int(config.get("redeploy_wait", 10))
     service_wait_timeout = int(config.get("service_wait_timeout", 300))
+    delegation_verify_timeout = int(
+        config.get("delegation_verify_timeout", service_wait_timeout)
+    )
+    delegation_verify_poll = int(config.get("delegation_verify_poll_seconds", 5))
     delegation_sequence = [
         str(item).strip().lower()
         for item in config.get("delegation_sequence", ["true", "false"])
@@ -131,17 +135,14 @@ def run(ceph_cluster, **kw):
                 cephadm, nfs_clusters, installer, redeploy_wait, service_wait_timeout
             )
 
-            for cluster_name in nfs_clusters:
-                raw = cephadm.orch.ps(service_name=f"nfs.{cluster_name}", format="json")
-                daemons = json.loads(raw) if raw else []
-                if not daemons:
-                    raise OperationFailedError(
-                        f"No nfs daemons found in orch ps for nfs.{cluster_name}"
-                    )
-                verify_container_delegation(
-                    nfs_nodes, daemons, cluster_name, delegation
-                )
-                verify_host_conf_delegation(nfs_nodes, cluster_name, delegation)
+            verify_cluster_delegation_on_nfs_nodes(
+                cephadm,
+                nfs_nodes,
+                nfs_clusters,
+                delegation,
+                timeout_seconds=delegation_verify_timeout,
+                poll_interval=delegation_verify_poll,
+            )
 
             if run_export_level and delegation == "true" and not export_checks_done:
                 log.info(

--- a/tests/nfs/nfs_verify_delegation_client_lifecycle_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_client_lifecycle_scenarios.py
@@ -1,0 +1,191 @@
+"""
+NFSv4 delegation client unmount scenario (single client, rw export).
+
+Validates DELEGRETURN when a client lazy-unmounts with an active WRITE delegation.
+"""
+
+import time
+
+from nfs_delegation_operations import (
+    create_delegation_exports,
+    delegation_timing_from_config,
+    enable_cluster_delegation_and_debug_logging,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    ensure_nfs_cluster_for_delegation_test,
+    hold_delegation_open,
+    kill_delegation_holds,
+    lazy_unmount_delegation_export,
+    mount_delegation_export,
+    read_ganesha_delegation_tailf_capture,
+    release_delegation_hold_gracefully,
+    restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
+    start_ganesha_delegation_tailf_follow,
+    stop_ganesha_delegation_tailf_follow,
+    teardown_delegation_exports,
+    truncate_ganesha_container_log,
+    unmount_delegation_export,
+    validate_delegation_close_and_return_capture,
+    wait_for_delegation_path,
+    write_delegation_file,
+)
+from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+TEST_FILE = "deleg_lifecycle_unmount.txt"
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    installers = ceph_cluster.get_nodes("installer")
+    if not clients:
+        raise ConfigError("This test requires at least one client node")
+    if not nfs_nodes or not installers:
+        raise ConfigError("This test requires nfs and installer nodes")
+
+    client = clients[0]
+    installer, nfs_node = installers[0], nfs_nodes[0]
+    cephadm = CephAdm(installer).ceph
+    nfs_cmd_host = nfs_node
+
+    fs_name = config.get("fs_name", "cephfs")
+    nfs_name = config.get("nfs_name", "cephfs-nfs")
+    export_rw = config.get("lifecycle_export", "/deleg_lifecycle_rw")
+    mount_point = config.get("client_mount", "/mnt/deleg_lifecycle_c0")
+
+    timing = delegation_timing_from_config(config)
+    hold_s = timing.hold_seconds
+    ready_s = timing.hold_ready_seconds
+    settle_s = timing.log_settle_seconds
+    path_wait_retries = timing.path_wait_retries
+    redeploy_wait = int(config.get("redeploy_wait", 30))
+    service_wait = int(config.get("service_wait_timeout", 300))
+    subvol_group = config.get("subvolume_group", "deleglifecyclegrp")
+    nfs_mount = config.get("nfs_mount", "/mnt/delegation_bootstrap")
+    bootstrap_export = config.get("bootstrap_export", "/export_delegation_boot")
+
+    nfs_ver = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+    server = nfs_node.hostname
+    path = "%s/%s" % (mount_point, TEST_FILE)
+
+    delegation_template_backup = logging_template_backup = False
+    created_cluster = False
+    subvol_names = []
+    container_id = None
+
+    cephfs_utils = CephFSCommonUtils(ceph_cluster)
+    if not cephfs_utils.get_fs_info(client, fs_name):
+        cephfs_utils.create_fs(client, fs_name)
+    ensure_ceph_conf_and_admin_keyring_on_hosts(installer, nfs_nodes)
+
+    try:
+        nfs_clusters, created_cluster = ensure_nfs_cluster_for_delegation_test(
+            cephadm,
+            nfs_name,
+            config,
+            client=client,
+            nfs_nodes=nfs_nodes,
+            installer=installer,
+            ceph_cluster=ceph_cluster,
+        )
+
+        delegation_template_backup, logging_template_backup = (
+            enable_cluster_delegation_and_debug_logging(
+                nfs_cmd_host,
+                cephadm,
+                nfs_clusters,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        )
+        subvol_names = create_delegation_exports(
+            nfs_cmd_host, fs_name, nfs_name, subvol_group, [(export_rw, "rw")]
+        )
+        _, info = get_ganesha_info_from_container(installer, nfs_name, nfs_node)
+        container_id = (info or {}).get("container_id")
+        if not container_id:
+            raise OperationFailedError("No Ganesha container for nfs.%s" % nfs_name)
+
+        mount_delegation_export(client, mount_point, nfs_ver, port, server, export_rw)
+
+        write_delegation_file(client, path, "seed-client_unmount\n")
+        wait_for_delegation_path(
+            client, path, "seed client_unmount", retries=path_wait_retries
+        )
+
+        truncate_ganesha_container_log(nfs_node, container_id)
+        start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+
+        write_delegation_file(client, path, "hold-write\n")
+        wait_for_delegation_path(client, path, "pre write-hold")
+        hold_delegation_open(client, path, "r+b", hold_s)
+        time.sleep(ready_s)
+        write_delegation_file(client, path, "lifecycle-io\n", append=True)
+
+        lazy_unmount_delegation_export(client, mount_point)
+        release_delegation_hold_gracefully(client, term_wait_seconds=5)
+        time.sleep(settle_s)
+
+        stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+        validate_delegation_close_and_return_capture(
+            "client_unmount",
+            read_ganesha_delegation_tailf_capture(nfs_node, container_id),
+        )
+
+        return 0
+
+    except Exception as err:
+        log.error("Delegation client unmount test failed: %s", err)
+        return 1
+
+    finally:
+        kill_delegation_holds(client)
+        unmount_delegation_export(
+            client,
+            mount_point,
+            remove_mount_dir=True,
+            test_files=[TEST_FILE],
+        )
+
+        if subvol_names:
+            teardown_delegation_exports(
+                nfs_cmd_host, fs_name, nfs_name, subvol_group, [export_rw], subvol_names
+            )
+        try:
+            if container_id:
+                stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                truncate_ganesha_container_log(nfs_node, container_id)
+        except Exception as err:
+            log.warning("Ganesha log cleanup failed: %s", err)
+        try:
+            restore_delegation_ganesha_templates(
+                nfs_cmd_host,
+                delegation_template_backup,
+                logging_template_backup,
+                cephadm,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        except Exception as err:
+            log.warning("Template restore failed: %s", err)
+        if created_cluster:
+            cleanup_cluster(
+                clients=[client],
+                nfs_mount=nfs_mount,
+                nfs_name=nfs_name,
+                nfs_export=bootstrap_export,
+                nfs_nodes=nfs_nodes,
+            )

--- a/tests/nfs/nfs_verify_delegation_conflict_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_conflict_scenarios.py
@@ -18,6 +18,7 @@ from nfs_delegation_operations import (
     mount_delegation_export,
     read_ganesha_delegation_tailf_capture,
     restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
     start_ganesha_delegation_tailf_follow,
     stop_ganesha_delegation_tailf_follow,
     teardown_delegation_exports,
@@ -108,6 +109,8 @@ def _run_conflict_io(name, client_b, path_b):
 
 def run(ceph_cluster, **kw):
     config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
     clients = ceph_cluster.get_nodes("client")
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     installers = ceph_cluster.get_nodes("installer")

--- a/tests/nfs/nfs_verify_delegation_file_operations.py
+++ b/tests/nfs/nfs_verify_delegation_file_operations.py
@@ -17,6 +17,7 @@ from nfs_delegation_operations import (
     mount_delegation_export,
     read_ganesha_delegation_tailf_capture,
     restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
     start_ganesha_delegation_tailf_follow,
     stop_ganesha_delegation_tailf_follow,
     teardown_delegation_exports,
@@ -244,6 +245,8 @@ def _run_scenario_io(
 
 def run(ceph_cluster, **kw):
     config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
     clients = ceph_cluster.get_nodes("client")
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     installers = ceph_cluster.get_nodes("installer")

--- a/tests/nfs/nfs_verify_delegation_revoke_recall.py
+++ b/tests/nfs/nfs_verify_delegation_revoke_recall.py
@@ -23,6 +23,7 @@ from nfs_delegation_operations import (
     read_ganesha_delegation_tailf_capture,
     release_delegation_hold_gracefully,
     restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
     start_ganesha_delegation_tailf_follow,
     stop_ganesha_delegation_tailf_follow,
     teardown_delegation_exports,
@@ -197,6 +198,8 @@ def _validate_scenario_capture(scenario, kind, expect_positive, hits):
 
 def run(ceph_cluster, **kw):
     config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
     clients = ceph_cluster.get_nodes("client")
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     installers = ceph_cluster.get_nodes("installer")

--- a/tests/nfs/nfs_verify_delegation_rw_none_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_rw_none_scenarios.py
@@ -10,6 +10,7 @@ from nfs_delegation_operations import (
     parse_nfs4_open_delegation_types,
     read_ganesha_delegation_tailf_capture,
     restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
     start_ganesha_delegation_tailf_follow,
     stop_ganesha_delegation_tailf_follow,
     teardown_delegation_exports,
@@ -66,6 +67,8 @@ def _run_delegation_export_client_io(client, testfile, delegation_mode):
 def run(ceph_cluster, **kw):
     """Three exports (ro/rw/none) with cluster Delegations=true; validate Ganesha delegation logs."""
     config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
     clients = ceph_cluster.get_nodes("client")
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     installers = ceph_cluster.get_nodes("installer")

--- a/tests/nfs/nfs_verify_delegation_stress_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_stress_scenarios.py
@@ -21,6 +21,7 @@ from nfs_delegation_operations import (
     q_delegation_shell,
     read_ganesha_delegation_tailf_capture,
     restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
     start_ganesha_delegation_tailf_follow,
     stop_ganesha_delegation_tailf_follow,
     teardown_delegation_exports,
@@ -178,6 +179,8 @@ def _validate_stress_capture(hits, strict_validation, hold_mode):
 
 def run(ceph_cluster, **kw):
     config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
     clients = ceph_cluster.get_nodes("client")
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     installers = ceph_cluster.get_nodes("installer")

--- a/tests/nfs/nfs_verify_delegation_write_grant_scenarios.py
+++ b/tests/nfs/nfs_verify_delegation_write_grant_scenarios.py
@@ -1,0 +1,214 @@
+"""
+NFSv4 WRITE delegation grant: new file creation vs existing file reopen.
+
+Each OPEN is validated in an isolated ganesha.log capture window. On RHCS 9.1 /
+Ceph 20.2.1, new-file create may grant WRITE delegation; phase 1 records observed
+types and phase 2 requires WRITE delegation on reopen of the same file.
+"""
+
+import time
+
+from nfs_delegation_operations import (
+    capture_delegation_ganesha_log_phase,
+    create_delegation_exports,
+    delegation_timing_from_config,
+    enable_cluster_delegation_and_debug_logging,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    ensure_nfs_cluster_for_delegation_test,
+    hold_delegation_open,
+    hold_new_file_write_open,
+    kill_delegation_holds,
+    log_delegation_open_types,
+    mount_delegation_export,
+    release_delegation_hold_gracefully,
+    restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
+    stop_ganesha_delegation_tailf_follow,
+    teardown_delegation_exports,
+    truncate_ganesha_container_log,
+    unmount_delegation_export,
+    validate_delegation_grant_capture,
+    wait_for_delegation_path,
+)
+from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+NEW_FILE = "deleg_write_grant_new.txt"
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    installers = ceph_cluster.get_nodes("installer")
+    if not clients:
+        raise ConfigError("This test requires at least one client node")
+    if not nfs_nodes or not installers:
+        raise ConfigError("This test requires nfs and installer nodes")
+
+    client = clients[0]
+    installer, nfs_node = installers[0], nfs_nodes[0]
+    cephadm = CephAdm(installer).ceph
+    nfs_cmd_host = nfs_node
+
+    fs_name = config.get("fs_name", "cephfs")
+    nfs_name = config.get("nfs_name", "cephfs-nfs")
+    export_rw = config.get("write_grant_export", "/deleg_write_grant_rw")
+    mount_point = config.get("client_mount", "/mnt/deleg_write_grant_c0")
+    redeploy_wait = int(config.get("redeploy_wait", 30))
+    service_wait = int(config.get("service_wait_timeout", 300))
+    subvol_group = config.get("subvolume_group", "delegwritegrantgrp")
+    nfs_mount = config.get("nfs_mount", "/mnt/delegation_bootstrap")
+    bootstrap_export = config.get("bootstrap_export", "/export_delegation_boot")
+
+    timing = delegation_timing_from_config(config)
+    hold_s = timing.hold_seconds
+    ready_s = timing.hold_ready_seconds
+    settle_s = timing.log_settle_seconds
+    exit_wait = timing.exit_wait_seconds
+    path_wait_retries = timing.path_wait_retries
+
+    nfs_ver = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+    server = nfs_node.hostname
+    new_path = "%s/%s" % (mount_point, NEW_FILE)
+
+    delegation_template_backup = logging_template_backup = False
+    created_cluster = False
+    subvol_names = []
+    container_id = None
+
+    cephfs_utils = CephFSCommonUtils(ceph_cluster)
+    if not cephfs_utils.get_fs_info(client, fs_name):
+        cephfs_utils.create_fs(client, fs_name)
+    ensure_ceph_conf_and_admin_keyring_on_hosts(installer, nfs_nodes)
+
+    try:
+        nfs_clusters, created_cluster = ensure_nfs_cluster_for_delegation_test(
+            cephadm,
+            nfs_name,
+            config,
+            client=client,
+            nfs_nodes=nfs_nodes,
+            installer=installer,
+            ceph_cluster=ceph_cluster,
+        )
+
+        delegation_template_backup, logging_template_backup = (
+            enable_cluster_delegation_and_debug_logging(
+                nfs_cmd_host,
+                cephadm,
+                nfs_clusters,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        )
+        subvol_names = create_delegation_exports(
+            nfs_cmd_host, fs_name, nfs_name, subvol_group, [(export_rw, "rw")]
+        )
+        _, info = get_ganesha_info_from_container(installer, nfs_name, nfs_node)
+        container_id = (info or {}).get("container_id")
+        if not container_id:
+            raise OperationFailedError("No Ganesha container for nfs.%s" % nfs_name)
+
+        mount_delegation_export(client, mount_point, nfs_ver, port, server, export_rw)
+        client.exec_command(sudo=True, cmd="rm -f %s" % new_path, check_ec=False)
+
+        hold_duration = max(int(hold_s), int(ready_s) + int(settle_s) + 30)
+
+        log.info("Phase 1: new file create OPEN (observe delegation_type in log)")
+        new_file_hits = capture_delegation_ganesha_log_phase(
+            nfs_node,
+            container_id,
+            settle_s,
+            lambda: hold_new_file_write_open(client, new_path, hold_duration),
+        )
+        create_types = log_delegation_open_types(
+            "write_grant_new_file_create", new_file_hits
+        )
+        if not create_types:
+            raise OperationFailedError(
+                "write_grant_new_file_create: no nfs4_op_open END lines in capture"
+            )
+
+        release_delegation_hold_gracefully(client, term_wait_seconds=5)
+        wait_for_delegation_path(
+            client, new_path, "new file after create", retries=path_wait_retries
+        )
+        log.info("Waiting %ss between phases for prior delegation to exit", exit_wait)
+        time.sleep(exit_wait)
+
+        log.info("Phase 2: reopen existing file for WRITE (expect WRITE delegation)")
+        existing_hits = capture_delegation_ganesha_log_phase(
+            nfs_node,
+            container_id,
+            settle_s,
+            lambda: (
+                wait_for_delegation_path(
+                    client,
+                    new_path,
+                    "pre existing write-hold",
+                    retries=path_wait_retries,
+                ),
+                hold_delegation_open(client, new_path, "r+b", hold_duration),
+                time.sleep(ready_s),
+            ),
+        )
+        validate_delegation_grant_capture(
+            "write_grant_existing_reopen", existing_hits, "write"
+        )
+
+        release_delegation_hold_gracefully(client, term_wait_seconds=3)
+        return 0
+
+    except Exception as err:
+        log.error("WRITE delegation grant scenario test failed: %s", err)
+        return 1
+
+    finally:
+        kill_delegation_holds(client)
+        unmount_delegation_export(
+            client,
+            mount_point,
+            remove_mount_dir=True,
+            test_files=[NEW_FILE],
+        )
+        if subvol_names:
+            teardown_delegation_exports(
+                nfs_cmd_host, fs_name, nfs_name, subvol_group, [export_rw], subvol_names
+            )
+        try:
+            if container_id:
+                stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                truncate_ganesha_container_log(nfs_node, container_id)
+        except Exception as err:
+            log.warning("Ganesha log cleanup failed: %s", err)
+        try:
+            restore_delegation_ganesha_templates(
+                nfs_cmd_host,
+                delegation_template_backup,
+                logging_template_backup,
+                cephadm,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        except Exception as err:
+            log.warning("Template restore failed: %s", err)
+        if created_cluster:
+            cleanup_cluster(
+                clients=[client],
+                nfs_mount=nfs_mount,
+                nfs_name=nfs_name,
+                nfs_export=bootstrap_export,
+                nfs_nodes=nfs_nodes,
+            )

--- a/tests/nfs/nfs_verify_delegation_write_peer_access.py
+++ b/tests/nfs/nfs_verify_delegation_write_peer_access.py
@@ -1,0 +1,248 @@
+"""
+NFSv4 WRITE delegation peer access: recall while holder keeps FD open, grant after return.
+
+Phase A: Client A holds WRITE delegation; Client B write triggers recall.
+Phase B: Client A returns delegation; Client B obtains WRITE delegation.
+"""
+
+import time
+
+from nfs_delegation_operations import (
+    capture_delegation_ganesha_log_phase,
+    create_delegation_exports,
+    delegation_timing_from_config,
+    enable_cluster_delegation_and_debug_logging,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    ensure_nfs_cluster_for_delegation_test,
+    hold_delegation_open,
+    kill_delegation_holds,
+    mount_delegation_export,
+    release_delegation_hold_gracefully,
+    restore_delegation_ganesha_templates,
+    skip_delegation_tests_unless_supported,
+    stop_ganesha_delegation_tailf_follow,
+    teardown_delegation_exports,
+    truncate_ganesha_container_log,
+    unmount_delegation_export,
+    validate_delegation_grant_capture,
+    validate_delegation_recall_ganesha_capture,
+    wait_for_delegation_path,
+    wait_for_delegreturn_in_ganesha_capture,
+    write_delegation_file,
+)
+from nfs_operations import cleanup_cluster, get_ganesha_info_from_container
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+TEST_FILE = "deleg_write_peer_access.txt"
+
+
+def _seed_file(client, path, path_wait_retries):
+    write_delegation_file(client, path, "seed-peer-access\n")
+    wait_for_delegation_path(client, path, "seed", retries=path_wait_retries)
+
+
+def _hold_write_on_a(client_a, path_a, hold_s, ready_s):
+    write_delegation_file(client_a, path_a, "hold-write\n")
+    wait_for_delegation_path(client_a, path_a, "client A pre write-hold")
+    hold_delegation_open(client_a, path_a, "r+b", hold_s)
+    time.sleep(ready_s)
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    if skip_delegation_tests_unless_supported(config):
+        return 0
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    installers = ceph_cluster.get_nodes("installer")
+    if len(clients) < int(config.get("clients", 2)):
+        raise ConfigError("This test requires at least 2 client nodes")
+    if not nfs_nodes or not installers:
+        raise ConfigError("This test requires nfs and installer nodes")
+
+    client_a, client_b = clients[0], clients[1]
+    installer, nfs_node = installers[0], nfs_nodes[0]
+    cephadm = CephAdm(installer).ceph
+    nfs_cmd_host = nfs_node
+
+    fs_name = config.get("fs_name", "cephfs")
+    nfs_name = config.get("nfs_name", "cephfs-nfs")
+    export_rw = config.get("write_peer_export", "/deleg_write_peer_rw")
+    mount_a = config.get("client_a_mount", "/mnt/deleg_write_peer_c0")
+    mount_b = config.get("client_b_mount", "/mnt/deleg_write_peer_c1")
+    redeploy_wait = int(config.get("redeploy_wait", 30))
+    service_wait = int(config.get("service_wait_timeout", 300))
+    subvol_group = config.get("subvolume_group", "delegwritepeergrp")
+    nfs_mount = config.get("nfs_mount", "/mnt/delegation_bootstrap")
+    bootstrap_export = config.get("bootstrap_export", "/export_delegation_boot")
+
+    timing = delegation_timing_from_config(config)
+    hold_s = timing.hold_seconds
+    ready_s = timing.hold_ready_seconds
+    settle_s = timing.log_settle_seconds
+    exit_wait = timing.exit_wait_seconds
+    return_wait = timing.return_wait_seconds
+    path_wait_retries = timing.path_wait_retries
+
+    nfs_ver = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+    server = nfs_node.hostname
+    path_a = "%s/%s" % (mount_a, TEST_FILE)
+    path_b = "%s/%s" % (mount_b, TEST_FILE)
+
+    delegation_template_backup = logging_template_backup = False
+    created_cluster = False
+    subvol_names = []
+    container_id = None
+
+    cephfs_utils = CephFSCommonUtils(ceph_cluster)
+    if not cephfs_utils.get_fs_info(client_a, fs_name):
+        cephfs_utils.create_fs(client_a, fs_name)
+    ensure_ceph_conf_and_admin_keyring_on_hosts(installer, nfs_nodes)
+
+    try:
+        nfs_clusters, created_cluster = ensure_nfs_cluster_for_delegation_test(
+            cephadm,
+            nfs_name,
+            config,
+            client=client_a,
+            nfs_nodes=nfs_nodes,
+            installer=installer,
+            ceph_cluster=ceph_cluster,
+        )
+
+        delegation_template_backup, logging_template_backup = (
+            enable_cluster_delegation_and_debug_logging(
+                nfs_cmd_host,
+                cephadm,
+                nfs_clusters,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        )
+        subvol_names = create_delegation_exports(
+            nfs_cmd_host, fs_name, nfs_name, subvol_group, [(export_rw, "rw")]
+        )
+        _, info = get_ganesha_info_from_container(installer, nfs_name, nfs_node)
+        container_id = (info or {}).get("container_id")
+        if not container_id:
+            raise OperationFailedError("No Ganesha container for nfs.%s" % nfs_name)
+
+        for client, mp in ((client_a, mount_a), (client_b, mount_b)):
+            mount_delegation_export(client, mp, nfs_ver, port, server, export_rw)
+
+        _seed_file(client_a, path_a, path_wait_retries)
+        wait_for_delegation_path(
+            client_b,
+            path_b,
+            "client B sees shared file",
+            retries=path_wait_retries,
+        )
+        log.info("Waiting %ss after seed for delegations to exit", exit_wait)
+        time.sleep(exit_wait)
+
+        log.info("Phase A: Client B write while Client A holds WRITE delegation")
+        conflict_hits = capture_delegation_ganesha_log_phase(
+            nfs_node,
+            container_id,
+            settle_s,
+            lambda: (
+                _hold_write_on_a(client_a, path_a, hold_s, ready_s),
+                wait_for_delegation_path(
+                    client_b,
+                    path_b,
+                    "client B pre-conflict write",
+                    retries=path_wait_retries,
+                ),
+                write_delegation_file(
+                    client_b, path_b, "client-b-conflict\n", append=True
+                ),
+            ),
+        )
+        validate_delegation_recall_ganesha_capture(
+            "write_peer_conflict_while_a_holds", conflict_hits, True
+        )
+
+        log.info(
+            "Phase B: Client A returns delegation; Client B obtains WRITE delegation"
+        )
+        release_delegation_hold_gracefully(client_a, term_wait_seconds=5)
+        if not wait_for_delegreturn_in_ganesha_capture(
+            nfs_node, container_id, timeout_seconds=return_wait + 30
+        ):
+            raise OperationFailedError(
+                "write_peer_after_return: DELEGRETURN not seen after client A close"
+            )
+        time.sleep(2)
+
+        hold_duration = max(int(hold_s), int(ready_s) + int(settle_s) + 30)
+        grant_hits = capture_delegation_ganesha_log_phase(
+            nfs_node,
+            container_id,
+            settle_s,
+            lambda: (
+                wait_for_delegation_path(
+                    client_b,
+                    path_b,
+                    "client B pre write-hold",
+                    retries=path_wait_retries,
+                ),
+                hold_delegation_open(client_b, path_b, "r+b", hold_duration),
+                time.sleep(ready_s),
+            ),
+        )
+        validate_delegation_grant_capture(
+            "write_peer_grant_after_a_returns", grant_hits, "write"
+        )
+
+        release_delegation_hold_gracefully(client_b, term_wait_seconds=3)
+        return 0
+
+    except Exception as err:
+        log.error("WRITE delegation peer access test failed: %s", err)
+        return 1
+
+    finally:
+        for client in (client_a, client_b):
+            kill_delegation_holds(client)
+        for client, mp in ((client_a, mount_a), (client_b, mount_b)):
+            unmount_delegation_export(
+                client, mp, remove_mount_dir=True, test_files=[TEST_FILE]
+            )
+        if subvol_names:
+            teardown_delegation_exports(
+                nfs_cmd_host, fs_name, nfs_name, subvol_group, [export_rw], subvol_names
+            )
+        try:
+            if container_id:
+                stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+                truncate_ganesha_container_log(nfs_node, container_id)
+        except Exception as err:
+            log.warning("Ganesha log cleanup failed: %s", err)
+        try:
+            restore_delegation_ganesha_templates(
+                nfs_cmd_host,
+                delegation_template_backup,
+                logging_template_backup,
+                cephadm,
+                installer,
+                redeploy_wait,
+                service_wait,
+            )
+        except Exception as err:
+            log.warning("Template restore failed: %s", err)
+        if created_cluster:
+            cleanup_cluster(
+                clients=[client_a],
+                nfs_mount=nfs_mount,
+                nfs_name=nfs_name,
+                nfs_export=bootstrap_export,
+                nfs_nodes=nfs_nodes,
+            )


### PR DESCRIPTION
# Description

Adds NFSv4 delegation automation for version check "--rhbuild >= 9.1" , with shared helpers, 
Also added 3 new WRITE/lifecycle scenarios, and fixes for cluster-level validation on single-daemon NFS clusters.

- nfs_verify_delegation_write_grant_scenarios.py  - Logs delegation_type on new-file create; requires WRITE delegation (type 5) on reopen
- nfs_verify_delegation_write_peer_access.py  - Peer write recalls holder’s WRITE delegation; peer gets WRITE delegation after holder returns
- nfs_verify_delegation_client_lifecycle_scenarios.py -  DELEGRETURN when client disconnects with an active WRITE delegation

9.0z3 Test Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PR1B4K/ 
9.1 Test Log:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0WTOF9/ 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UG6X8O/ 


===============

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
