### PR TITLE
Upgrade rc to released

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_71x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -76,7 +76,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/test_ss_upgrade_7_1_GA_to_9.x_latest.yaml
+++ b/suites/tentacle/rgw/test_ss_upgrade_7_1_GA_to_9.x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/rgw/tier-1_rgw_archive_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_archive_ms_upgrade_81GA_to_9x_latest.yaml
@@ -21,7 +21,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -70,7 +70,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -119,7 +119,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -74,7 +74,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_71GA_to_9x_latest.yaml
@@ -27,7 +27,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -76,7 +76,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_upgrade_multirealm_81GA_to_9x_latest.yaml
@@ -23,7 +23,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -82,7 +82,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -79,7 +79,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -87,7 +87,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -155,7 +155,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -94,7 +94,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: rc
+                    release: released
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true


### PR DESCRIPTION
# Description



- Modified initial deployment from `release: rc` to `release: released` in reef and tentacle RGW upgrade suites
- Upgrade tests should follow the path from a **released GA build (n-1)/(n-2)** to the **latest build (n)**
- Using `rc` for the initial deployment does not match the intended upgrade path; the base cluster should be deployed from a released build before upgrading to latest