### PR TITLE
Updating tentacle upgrade suites to use released builds instead of rc

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-9x_upgrade.yaml
@@ -35,7 +35,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: "7.1"
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_8x-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_8x-to-9x_upgrade.yaml
@@ -36,7 +36,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: "8.1"
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -28,7 +28,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 platform: rhel-9
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
@@ -102,7 +102,7 @@ tests:
         nodes:                            # client node
           - node7:
               release: 7.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -24,7 +24,7 @@ tests:
           verbose: true
         args:
           rhcs-version: 7.1
-          release: rc
+          release: released
           platform: rhel-9
           mon-ip: node1
           orphan-initial-daemons: true
@@ -156,7 +156,7 @@ tests:
         nodes:                            # client node
           - node8:
               release: 7.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base
@@ -223,7 +223,7 @@ tests:
           verbose: true
         args:
           rhcs-version: 8.1
-          release: rc
+          release: released
           platform: rhel-9
       abort-on-fail: false
 

--- a/suites/tentacle/rados/tier-2_rados_test_ok_to_upgrade_holistic.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_ok_to_upgrade_holistic.yaml
@@ -20,7 +20,7 @@ tests:
         args:
           rhcs-version: 8.1
           platform: rhel-9
-          release: rc
+          release: released
           mon-ip: node1
           orphan-initial-daemons: true
           skip-dashboard: true
@@ -229,7 +229,7 @@ tests:
         nodes:                            # client node
           - node17:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -20,7 +20,7 @@ tests:
         args:
           mon-ip: node1
           rhcs-version: 8.1
-          release: rc
+          release: released
           platform: rhel-9
           ssh-user: cephuser
           skip-monitoring-stack: true
@@ -160,7 +160,7 @@ tests:
         nodes:                                  # client node
           - node10:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -23,7 +23,7 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 platform: rhel-9
                 skip-monitoring-stack: true
 
@@ -145,7 +145,7 @@ tests:
         nodes:                            # client node
           - node6:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
@@ -32,7 +32,7 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 platform: rhel-9
                 skip-monitoring-stack: true
 
@@ -155,7 +155,7 @@ tests:
         nodes:                            # client node
           - node6:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
@@ -23,7 +23,7 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 platform: rhel-9
                 skip-monitoring-stack: true
 
@@ -149,7 +149,7 @@ tests:
         nodes:                            # client node
           - node7:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/tentacle/rbd/tier-3_rbd_mirror_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/rbd/tier-3_rbd_mirror_upgrade_7x_to_9x.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -63,7 +63,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 7.1
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/rbd/tier-3_rbd_mirror_upgrade_8x_to_9x.yaml
+++ b/suites/tentacle/rbd/tier-3_rbd_mirror_upgrade_8x_to_9x.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -63,7 +63,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 8.1
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/tentacle/smb/tier-0-smb-upgrade-ibm-8x-to-9x-latest.yaml
+++ b/suites/tentacle/smb/tier-0-smb-upgrade-ibm-8x-to-9x-latest.yaml
@@ -17,7 +17,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: "8.1"
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
@@ -84,7 +84,7 @@ tests:
       polarion-id: CEPH-83622441
       config:
         deployment_version: 8.1
-        deployment_release: rc
+        deployment_release: released
         operations:
           - deploy_smb
           - upgrade

--- a/suites/tentacle/smb/tier-0-smb-upgrade-ibm-9x-to-9x-latest.yaml
+++ b/suites/tentacle/smb/tier-0-smb-upgrade-ibm-9x-to-9x-latest.yaml
@@ -17,7 +17,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: "9.0"
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
@@ -83,7 +83,7 @@ tests:
       polarion-id: CEPH-83622441
       config:
         deployment_version: 9.0
-        deployment_release: rc
+        deployment_release: released
         operations:
           - deploy_smb
           - upgrade

--- a/suites/tentacle/smb/tier-1-smb-disable-casesensitivity-upgrade-ibm-8x-to-9x-latest.yaml
+++ b/suites/tentacle/smb/tier-1-smb-disable-casesensitivity-upgrade-ibm-8x-to-9x-latest.yaml
@@ -17,7 +17,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: "9.0"
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
@@ -119,7 +119,7 @@ tests:
       polarion-id: CEPH-83622441
       config:
         deployment_version: 9.0
-        deployment_release: rc
+        deployment_release: released
         operations:
           - upgrade
           - cleanup


### PR DESCRIPTION
Summary
Updates tentacle upgrade test suites to bootstrap clusters from released GA builds instead of rc (and stable where applicable) to meet the requirement that upgrade validation should always be performed from a released version and not from other build types such as RC or stable candidate builds.

Changes
Replace release: rc with release: released in cluster bootstrap and upgrade steps
Replace tag: rc with tag: released in client package install configs
Replace deployment_release: rc with deployment_release: released where applicable
Replace release: stable with release: released for consistency

Affected suites (14 files)

NVMe-oF
tier-2_nvmeof_7x-to-9x_upgrade
tier-2_nvmeof_8x-to-9x_upgrade

RADOS
tier-2_rados_ec-pool_recovery
tier-2_rados_test-stretch-mode-upgrade
tier-2_rados_test_ok_to_upgrade_holistic
tier-3_rados_test-3-AZ-Cluster
tier-3_rados_test-4-node-8+6-msr-ecpools
tier-3_rados_test-4-node-fast-ecpools
tier-3_rados_test_6+2_ecpools

RBD
tier-3_rbd_mirror_upgrade_7x_to_9x
tier-3_rbd_mirror_upgrade_8x_to_9x

SMB
tier-0-smb-upgrade-ibm-8x-to-9x-latest
tier-0-smb-upgrade-ibm-9x-to-9x-latest
tier-1-smb-disable-casesensitivity-upgrade-ibm-8x-to-9x-latest