### PR TITLE
Fix cert issue in ssl upgrade suite s3cmd testcase

### DIFF
--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -19,7 +19,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
@@ -105,6 +105,44 @@ tests:
       module: test_client.py
       name: Configure client
       polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        commands:
+          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
+          - "sudo yum install -y sshpass"
+          - "sleep 20"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node7}:/etc/pki/ca-trust/source/anchors/"
+          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node8}:/etc/pki/ca-trust/source/anchors/"
+      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
+      module: exec.py
+      name: copying cephadm_root_ca_cert
+      polarion-id: CEPH-10362
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: rgw
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on rgw nodes
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on rgw nodes
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: client
+        sudo: True
+        commands:
+          - "update-ca-trust"
+      desc: update-ca-trust on client nodes
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: update-ca-trust on client nodes
 
   - test:
       name: Manual Resharding tests pre upgrade


### PR DESCRIPTION
# Description

Failure seen due to missing testcases of cert copy to rGW/Client node and cert update.
which is added in this PR.

Failure seen in log: http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.1/rhel-9/executor/20.2.1-292/rgw/1991/logs/tier_1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest/
is addressed in PR: https://github.com/red-hat-storage/cephci/pull/5938

Below changes add added:
1. Included TC: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
2. Included TC: update-ca-trust on rgw nodes
3. Included TC: update-ca-trust on client nodes
4. Change base version tag to : released 

Pass log:(with changes from current PR and  https://github.com/red-hat-storage/cephci/pull/5938)

http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.1/rhel-9/executor/20.2.1-292/rgw/2002/logs/tier_1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest/





Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
