### PR TITLE
Enable IBM image license acceptance post upgrade

### DIFF
--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -89,7 +89,7 @@ class UpgradeMixin:
             LOG.debug("Ceph product: %s", config.get("product"))
             LOG.debug("Target version: %s", config.get("release"))
             mgr_version_common, mgr_version_downstream = get_daemon_versions(
-                node=self.installer, daemon_type="mgr"
+                node=self, daemon_type="mgr"
             )
             LOG.debug("MGR common version: %s", mgr_version_common)
             LOG.debug("MGR downstream version: %s", mgr_version_downstream)
@@ -123,7 +123,7 @@ class UpgradeMixin:
         active_mgr = loads(out)["active_name"]
         LOG.debug("Active Mgr for the cluster: %s", active_mgr)
         mgr_version_common, mgr_version_downstream = get_daemon_versions(
-            node=self.installer, daemon_type="mgr", daemon_id=active_mgr
+            node=self, daemon_type="mgr", daemon_id=active_mgr
         )
         LOG.debug("MGR common version: %s", mgr_version_common)
         LOG.debug("MGR downstream version: %s", mgr_version_downstream)

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -8,6 +8,7 @@ import traceback
 from json import loads
 from pathlib import Path
 from time import mktime, sleep
+from typing import Tuple
 
 import requests
 import yaml
@@ -15,6 +16,7 @@ from htmllistparse import fetch_listing
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
+from packaging.version import Version
 
 from cli.utilities.configure import add_centos_epel_repo
 from compute.baremetal import CephBaremetalNode
@@ -2027,13 +2029,18 @@ def enable_coredump(node):
         log.info("Out: %s \n Err: %s" % (out, err))
 
 
-def get_daemon_versions(node, daemon_type: str, daemon_id: str = None):
+def get_daemon_versions(
+    node, daemon_type: str, daemon_id: str = None
+) -> Tuple[str, str]:
     """
     Method to get a ceph daemon's versions.
+    This function requires a CephAdmin node object
+    instead of a generic ceph node object.
+    Use node.shell() method instead of exec_command().
     Note that in case multiple versions of input daemon type exist, \
     this method returns version of the first entry.
     Args:
-        node: ceph node object having cephadm package
+        node: cephAdmin node object having cephadm package
         daemon_type: The type of ceph daemon e.g. mgr, mon, osd, etc
         daemon_id: name or id of ceph daemon e.g. 0, ceph-name-dc0dxh-node2
     Returns:
@@ -2043,13 +2050,16 @@ def get_daemon_versions(node, daemon_type: str, daemon_id: str = None):
     if daemon_id:
         out = get_daemon_metadata(node, daemon_type, daemon_id)
     else:
-        out, _ = node.exec_command(sudo=True, cmd="cephadm shell ceph versions -f json")
+        out, _ = node.shell(args=["ceph versions -f json"])
     try:
         ceph_versions = json.loads(out)
     except json.JSONDecodeError as e:
         log.exception(e)
         raise
 
+    if daemon_id and ceph_versions.get("ceph_version"):
+        daemon_ver_text = ceph_versions["ceph_version"]
+        return extract_ceph_version(daemon_ver_text), extract_version(daemon_ver_text)
     if ceph_versions.get(daemon_type):
         daemon_ver_text = next(iter(ceph_versions[daemon_type]))
         return extract_ceph_version(daemon_ver_text), extract_version(daemon_ver_text)
@@ -2073,13 +2083,13 @@ def get_daemon_metadata(node, daemon_type: str, daemon_id: str = None):
         None if metadata is not found
     """
     log.debug("Passed daemon type : %s, Daemon ID : %s", daemon_type, daemon_id)
-    base_cmd = f"cephadm shell ceph {daemon_type} metadata "
+    base_cmd = f"ceph {daemon_type} metadata "
     if daemon_id is not None:
         base_cmd += daemon_id
 
     for _ in range(3):
         try:
-            out, _ = node.exec_command(cmd=base_cmd, sudo=True)
+            out, _ = node.shell(args=[base_cmd])
             break
         except Exception as e:
             debug_msg = f"Passed daemon type : {daemon_type}, Daemon ID : {daemon_id}, Error : {e}"
@@ -2097,3 +2107,33 @@ def get_daemon_metadata(node, daemon_type: str, daemon_id: str = None):
             daemon_id,
         )
     return out
+
+
+def mgr_accept_license(node, img):
+    """
+    Method to accept IBM ceph license
+    Args:
+        node: cephadm(CephAdmin) node object
+        img: ibm ceph image for which license is to be accepted
+    Returns: None
+    """
+    mgr_version_common, mgr_version_downstream = get_daemon_versions(
+        node=node, daemon_type="mgr"
+    )
+    log.debug("MGR common version: %s", mgr_version_common)
+    log.debug("MGR downstream version: %s", mgr_version_downstream)
+    common_ver_check = mgr_version_common and Version(mgr_version_common) >= Version(
+        "20.2.1"
+    )
+    downstream_ver_check = mgr_version_downstream and Version(
+        mgr_version_downstream
+    ) >= Version("9.9.1.0")
+    if common_ver_check or downstream_ver_check:
+        license_cmd = f"ceph orch accept-license --image {img}"
+        try:
+            out, _ = node.shell(args=[license_cmd])
+            log.debug(out)
+            log.info("Successfully accepted license for image: %s", img)
+        except Exception as e:
+            log.error("Failed to accept license for image %s: %s", img, e)
+            raise

--- a/tests/cephadm/test_cephadm_upgrade.py
+++ b/tests/cephadm/test_cephadm_upgrade.py
@@ -3,9 +3,12 @@ Test module that verifies the Upgrade of Ceph Storage via the cephadm CLI.
 
 """
 
+from looseversion import LooseVersion
+
+from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.orch import Orch
 from ceph.rados.rados_bench import RadosBench
-from ceph.utils import is_legacy_container_present, remove_repos
+from ceph.utils import is_legacy_container_present, mgr_accept_license, remove_repos
 from cephci.utils.build_info import CephTestManifest
 from utility.log import Log
 
@@ -42,7 +45,9 @@ def run(ceph_cluster, **kwargs) -> int:
     log.info("Upgrade Ceph cluster...")
 
     config = kwargs["config"]
+    cephadm_obj = CephAdmin(cluster=ceph_cluster, **config)
     config["overrides"] = kwargs.get("test_data", {}).get("custom_config_dict")
+    product: str = config.get("args", {}).get("--product", config["product"])
     verify_image = bool(config.get("verify_cluster_health", False))
 
     ctm: CephTestManifest = config["manifest"]
@@ -130,6 +135,13 @@ def run(ceph_cluster, **kwargs) -> int:
 
         # Monitor upgrade status, till completion
         orch.monitor_upgrade_status()
+
+        # IBM Storage Ceph 9.1 and greater would require license acceptance
+        if product == "ibm" and LooseVersion(
+            str(config.get("release"))
+        ) >= LooseVersion("9.1"):
+            log.info("Accept license for image: %s", config["container_image"])
+            mgr_accept_license(node=cephadm_obj, img=config["container_image"])
 
         if verify_image:
             # BZ: 2077843

--- a/tests/rados/test_fast_ec_config_params.py
+++ b/tests/rados/test_fast_ec_config_params.py
@@ -594,7 +594,7 @@ def run(ceph_cluster, **kw):
         start_time = get_cluster_timestamp(rados_obj.node)
         log.debug(f"Test workflow started. Start time: {start_time}")
         try:
-            version_info = get_daemon_versions(rados_obj)
+            version_info = _get_daemon_versions(rados_obj)
             log.info("Daemon version distribution:")
             for daemon_type, versions in version_info.items():
                 log.info("  %s: %s", daemon_type, versions)
@@ -3115,7 +3115,7 @@ def write_and_verify_objects(
         raise
 
 
-def get_daemon_versions(rados_obj):
+def _get_daemon_versions(rados_obj):
     """
     Fetch and parse daemon versions from the cluster using 'ceph versions'
 
@@ -3207,7 +3207,7 @@ def get_expected_osd_release(version_info):
     - 9.x (20.x) -> tentacle
 
     Args:
-        version_info: Dictionary from get_daemon_versions()
+        version_info: Dictionary from _get_daemon_versions()
 
     Returns:
         String with expected release name (e.g., 'reef', 'squid', 'tentacle')
@@ -3253,7 +3253,7 @@ def identify_upgrade_case(version_info):
     2. Case 5 only runs if NO MDS are upgraded (tests backward compatibility with older MDS)
 
     Args:
-        version_info: Dictionary from get_daemon_versions()
+        version_info: Dictionary from _get_daemon_versions()
 
     Returns:
         String indicating the upgrade case, or None if not in a recognized state

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -14,14 +14,13 @@ import json
 import time
 
 from looseversion import LooseVersion
-from packaging.version import Version
 
 from ceph.ceph import CommandFailed
 from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.orch import Orch
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.utils import get_cluster_timestamp
-from ceph.utils import get_daemon_versions, get_node_by_id, remove_repos
+from ceph.utils import get_node_by_id, mgr_accept_license, remove_repos
 from cephci.utils.build_info import CephTestManifest
 from tests.rados.monitor_configurations import MonConfigMethods
 from utility.log import Log
@@ -83,26 +82,6 @@ def run(ceph_cluster, **kw):
     verify_cluster_health = config.get("verify_cluster_health", False)
     enable_debug_level = config.get("enable_debug_level", False)
     installer = ceph_cluster.get_nodes(role="installer")[0]
-
-    def mgr_accept_license():
-        log.debug("Ceph product: %s", product)
-        mgr_version_common, mgr_version_downstream = get_daemon_versions(
-            node=installer, daemon_type="mgr"
-        )
-        log.debug("MGR common version: %s", mgr_version_common)
-        log.debug("MGR downstream version: %s", mgr_version_downstream)
-        common_ver_check = mgr_version_common and Version(
-            mgr_version_common
-        ) >= Version("20.2.1")
-        downstream_ver_check = mgr_version_downstream and Version(
-            mgr_version_downstream
-        ) >= Version("9.9.1.0")
-        if common_ver_check or downstream_ver_check:
-            license_cmd = (
-                f"ceph orch accept-license --image {config['container_image']}"
-            )
-            out, _ = cephadm_obj.shell(args=[license_cmd], check_status=False)
-            log.debug(out)
 
     init_time, _ = installer.exec_command(cmd="sudo date '+%Y-%m-%d %H:%M:%S'")
     msg = f"time when upgrade test was started : {init_time}"
@@ -244,13 +223,6 @@ def run(ceph_cluster, **kw):
                 config["args"]["hosts"] = ",".join(hostnames)
                 log.info(f"Converted node IDs to hostnames: {hostnames}")
 
-        # IBM Storage Ceph 9.1 and greater would require license acceptance
-        # There is '--automatically-accept-license' option
-        if product == "ibm" and LooseVersion(
-            str(config.get("release"))
-        ) >= LooseVersion("9.1"):
-            mgr_accept_license()
-
         # Start Upgrade
         cluster_obj.start_upgrade(config)
         time.sleep(5)
@@ -379,6 +351,13 @@ def run(ceph_cluster, **kw):
             "Completed upgrade on the cluster successfully."
             "Proceeding to do further checks on the cluster post upgrade"
         )
+
+        # IBM Storage Ceph 9.1 and greater would require license acceptance
+        if product == "ibm" and LooseVersion(
+            str(config.get("release"))
+        ) >= LooseVersion("9.1"):
+            log.info("Accept license for image: %s", config["container_image"])
+            mgr_accept_license(node=cephadm_obj, img=config["container_image"])
 
         log.info("\n\nCluster status post upgrade: \n")
         log_dump = (

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2976,7 +2976,8 @@ def extract_version(text: str) -> str:
     for token in text.split():
         try:
             Version(token)
-            log.debug("Extracted version token: %s", token)
+            _msg = f"Extracted version token: {token}"
+            log.debug(_msg)
             return token
         except InvalidVersion:
             continue


### PR DESCRIPTION
Adds support to accept IBM ceph image license post upgrade.

Fixes potential issues in logging in `def extract_version`

Logs:
RADOS - https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/executor/20.2.1-294/rados/2017/logs/

CEPHFS - https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/upgrade/20.2.1-294/cephfs/82/logs/

NFS - https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/upgrade/20.2.1-294/nfs-ganesha/65/logs/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>