### PR TITLE
[RADOS] Enable monitoring stack and replace rc tag with GA

### DIFF
--- a/suites/reef/rados/test_rados_all_generic_features.yaml
+++ b/suites/reef/rados/test_rados_all_generic_features.yaml
@@ -23,7 +23,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: released
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
@@ -94,7 +94,7 @@ tests:
         nodes:                            # client node
           - node7:
               release: 6.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -30,7 +30,6 @@ tests:
                 mon-ip: node1
                 allow-fqdn-hostname: true
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/reef/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -30,7 +30,6 @@ tests:
                 release: z0
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -23,13 +23,10 @@ tests:
           verbose: true
         args:
           rhcs-version: 6.1
-          release: rc
+          release: released
           mon-ip: node1
           orphan-initial-daemons: true
           registry-url: registry.redhat.io
-          skip-monitoring-stack: true
-          registry-json: registry.redhat.io
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host
@@ -154,7 +151,7 @@ tests:
         nodes:                            # client node
           - node8:
               release: 6.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -24,7 +24,6 @@ tests:
           registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -27,9 +27,8 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: released
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 allow-fqdn-hostname: true
@@ -100,7 +99,7 @@ tests:
         nodes:                            # client node
           - node7:
               release: 6.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/squid/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/squid/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -31,7 +31,6 @@ tests:
                 release: z0
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
           - config:
               command: add_hosts
               service: host

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -24,13 +24,10 @@ tests:
           verbose: true
         args:
           rhcs-version: 8.0
-          release: rc
+          release: released
           mon-ip: node1
           orphan-initial-daemons: true
           registry-url: registry.redhat.io
-          skip-monitoring-stack: true
-          registry-json: registry.redhat.io
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host
@@ -155,7 +152,7 @@ tests:
         nodes:                            # client node
           - node8:
               release: 8.0
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/squid/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/squid/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -20,9 +20,8 @@ tests:
         args:
           mon-ip: node1
           rhcs-version: 8.0
-          release: rc
+          release: released
           ssh-user: cephuser
-          skip-monitoring-stack: true
           apply-spec:
             - service_type: host
               address: true
@@ -159,7 +158,7 @@ tests:
         nodes:                                  # client node
           - node10:
               release: 8.0
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -23,8 +23,7 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.0
-                release: rc
-                skip-monitoring-stack: true
+                release: released
 
   - test:
       name: Add host
@@ -144,7 +143,7 @@ tests:
         nodes:                            # client node
           - node6:
               release: 8.0
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -23,7 +23,6 @@ tests:
           registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -21,7 +21,6 @@ tests:
           registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/tentacle/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -28,10 +28,9 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 platform: rhel-9
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 allow-fqdn-hostname: true
@@ -102,7 +101,7 @@ tests:
         nodes:                            # client node
           - node7:
               release: 7.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -32,7 +32,6 @@ tests:
                 platform: rhel-9
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-monitoring-stack: true
           - config:
               command: add_hosts
               service: host

--- a/suites/tentacle/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -23,7 +23,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 8.0
-                release: rc
+                release: released
                 platform: rhel-9
                 mon-ip: mero001
                 allow-fqdn-hostname: true

--- a/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -24,14 +24,11 @@ tests:
           verbose: true
         args:
           rhcs-version: 7.1
-          release: rc
+          release: released
           platform: rhel-9
           mon-ip: node1
           orphan-initial-daemons: true
           registry-url: registry.redhat.io
-          skip-monitoring-stack: true
-          registry-json: registry.redhat.io
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host
@@ -156,7 +153,7 @@ tests:
         nodes:                            # client node
           - node8:
               release: 7.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base
@@ -223,7 +220,7 @@ tests:
           verbose: true
         args:
           rhcs-version: 8.1
-          release: rc
+          release: released
           platform: rhel-9
       abort-on-fail: false
 

--- a/suites/tentacle/rados/tier-2_rados_test_ok_to_upgrade_holistic.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_ok_to_upgrade_holistic.yaml
@@ -20,10 +20,9 @@ tests:
         args:
           rhcs-version: 8.1
           platform: rhel-9
-          release: rc
+          release: released
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           # 6 racks × 2 chassis; each chassis has exactly one host (node1–node12)
           # NOTE: node13,14,15 and 16 are not used in test modules.
@@ -229,7 +228,7 @@ tests:
         nodes:                            # client node
           - node17:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-2_rados_test_osd_ok_to_upgrade.yaml
+++ b/suites/tentacle/rados/tier-2_rados_test_osd_ok_to_upgrade.yaml
@@ -20,7 +20,6 @@ tests:
         args:
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           # 6 racks × 2 chassis; each chassis has exactly one host (node1–node12)
           # NOTE: node13,14,15 and 16 are not used in test modules.

--- a/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -20,10 +20,9 @@ tests:
         args:
           mon-ip: node1
           rhcs-version: 8.1
-          release: rc
+          release: released
           platform: rhel-9
           ssh-user: cephuser
-          skip-monitoring-stack: true
           apply-spec:
             - service_type: host
               address: true
@@ -160,7 +159,7 @@ tests:
         nodes:                                  # client node
           - node10:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -23,9 +23,8 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 platform: rhel-9
-                skip-monitoring-stack: true
 
   - test:
       name: Add host
@@ -145,7 +144,7 @@ tests:
         nodes:                            # client node
           - node6:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -143,7 +143,7 @@ tests:
         nodes:                            # client node
           - node6:
               release: 7.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-4-node-fast-ecpools.yaml
@@ -32,9 +32,8 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 platform: rhel-9
-                skip-monitoring-stack: true
 
   - test:
       name: Add host
@@ -155,7 +154,7 @@ tests:
         nodes:                            # client node
           - node6:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/tentacle/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -23,7 +23,6 @@ tests:
           registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -21,7 +21,6 @@ tests:
           registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test-stretch-mode-new-features.yaml
@@ -23,7 +23,6 @@ tests:
           registry-json: registry.redhat.io
           mon-ip: node1
           orphan-initial-daemons: true
-          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host

--- a/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
+++ b/suites/tentacle/rados/tier-3_rados_test_6+2_ecpools.yaml
@@ -23,9 +23,8 @@ tests:
               args:
                 mon-ip: node1
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 platform: rhel-9
-                skip-monitoring-stack: true
 
   - test:
       name: Add host
@@ -149,7 +148,7 @@ tests:
         nodes:                            # client node
           - node7:
               release: 8.1
-              tag: rc
+              tag: released
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node


### PR DESCRIPTION
Replaces RC tag with released/GA in RADOS test suites

Enables monitoring stack across the board

Signed-off-by: Harsh Kumar <hakumar@redhat.com>