### PR TITLE
NFS: TLS negative invalid certificate scenarios

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
@@ -517,6 +517,23 @@ tests:
         redeploy_cluster_min_tls12: false
 
   - test:
+      name: TLS negative invalid certificate scenarios
+      module: security.test_tls_feature.py
+      desc: >
+        Valid TLS mount and IO, then negative tests: corrupted Ganesha server certs
+        (mount must fail; capture mount error and systemctl status tlshd) and
+        corrupted client trust anchor (mount must fail; capture tlshd status).
+      abort-on-fail: false
+      polarion-id: CEPH-83629233
+      config:
+        nfs_version: 4.2
+        clients: 1
+        nfs_cluster_name: cephfs-nfs-tls
+        operation: tls_negative_invalid_certs
+        negative_cert_scenario: both
+        timeout: 1800
+
+  - test:
       name: TLS mount fio IO with tcpdump encryption verification
       module: security.test_tls_feature.py
       desc: >

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -480,12 +480,6 @@ def write_client_tls_ca_cert(client_node, ca_cert):
     client_node.exec_command(sudo=True, cmd="systemctl restart tlshd")
 
 
-def mount_path_is_active(client_node, mount_path):
-    """Return True if ``mount_path`` appears in the remote ``mount`` output."""
-    out, _ = client_node.exec_command(sudo=True, cmd="mount", check_ec=False)
-    return mount_path.rstrip("/") in str(out or "")
-
-
 def _write_remote_pem(client_node, file_path, pem_text):
     """Write PEM material to ``file_path`` on the remote client."""
     try:

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -1,8 +1,10 @@
 import json
+import os
+import re
 import shlex
 import time
+from pathlib import Path
 
-from ceph.ceph import CommandFailed
 from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
 from cli.exceptions import OperationFailedError
@@ -21,6 +23,7 @@ TLS_TEST_MOUNT_CANDIDATES = [
     "/mnt/plain_tc4_0",
     "/mnt/tls_tc4_0",
     "/mnt/tls_stunnel_tc",
+    "/mnt/tls_neg_tc",
 ]
 STUNNEL_DIR = "/etc/stunnel"
 STUNNEL_CA_PATH = f"{STUNNEL_DIR}/tls_ca_cert.pem"
@@ -28,6 +31,7 @@ STUNNEL_CONF_PATH = f"{STUNNEL_DIR}/stunnel.conf"
 STUNNEL_RUN_DIR = "/run/stunnel"
 STUNNEL_PID_PATH = "/var/run/stunnel/stunnel.pid"
 DEFAULT_STUNNEL_ACCEPT_PORT = 49152
+TLS_CLIENT_CA_PATH = "/etc/pki/ca-trust/source/anchors/tls_ca_cert.pem"
 
 
 def _nfs_ls_to_cluster_names(clusters):
@@ -290,14 +294,190 @@ def check_mount_fails(client_node, mount_cmd):
 
     Returns True if the command failed as expected, False if it succeeded.
     """
-    log.info("Attempting intentionally failing mount: %s", mount_cmd)
-    try:
-        client_node.exec_command(sudo=True, cmd=mount_cmd)
+    result = attempt_nfs_mount_expect_failure(client_node, mount_cmd)
+    if result["exit_code"] == 0:
         log.error("Mount succeeded but was expected to fail!")
         return False
-    except CommandFailed:
-        log.info("Mount failed as expected.")
-        return True
+    log.info("Mount failed as expected (exit=%s).", result["exit_code"])
+    return True
+
+
+def build_tls_nfs_mount_cmd(server, export, mount, version, port):
+    """Return a shell mount command for NFSv4 with RPC-with-TLS (xprtsec=tls)."""
+    return (
+        f"mount -t nfs -o vers={version},port={port},xprtsec=tls "
+        f"{server}:{export} {mount}"
+    )
+
+
+def attempt_nfs_mount_expect_failure(client_node, mount_cmd, timeout=120):
+    """
+    Run a mount command without raising on non-zero exit.
+
+    Returns a dict with exit_code, stdout, stderr, and mount_cmd.
+    """
+    timeout = int(os.environ.get("NFS_MOUNT_TIMEOUT", timeout))
+    log.info(
+        "Attempting mount (failure expected, timeout=%ds): %s",
+        timeout,
+        mount_cmd,
+    )
+    start_time = time.time()
+    out, err, exit_code, _duration = client_node.exec_command(
+        sudo=True,
+        cmd=mount_cmd,
+        check_ec=False,
+        verbose=True,
+        timeout=timeout,
+    )
+    elapsed = time.time() - start_time
+    result = {
+        "exit_code": exit_code,
+        "stdout": (out or "").strip(),
+        "stderr": (err or "").strip(),
+        "mount_cmd": mount_cmd,
+    }
+    log.info(
+        "Mount attempt finished in %.2fs (timeout=%ds): exit=%s stderr=%r",
+        elapsed,
+        timeout,
+        exit_code,
+        result["stderr"][:500],
+    )
+    return result
+
+
+def capture_tlshd_status(client_node):
+    """Return full ``systemctl status tlshd`` output (stdout + stderr)."""
+    out, err = client_node.exec_command(
+        sudo=True,
+        cmd="systemctl status tlshd --no-pager -l",
+        check_ec=False,
+        timeout=60,
+    )
+    combined = "\n".join(part for part in (out, err) if part).strip()
+    log.info("tlshd status on %s:\n%s", client_node.hostname, combined)
+    return combined
+
+
+def mount_path_is_active(client_node, mount_path):
+    """Return True if ``mount_path`` appears in the remote ``mount`` output."""
+    out, _ = client_node.exec_command(sudo=True, cmd="mount", check_ec=False)
+    return mount_path.rstrip("/") in str(out or "")
+
+
+def assert_mount_failed(mount_result, context, client_node=None, mount_path=None):
+    """Raise if a mount attempt did not fail as expected."""
+    mount_active = False
+    if client_node is not None and mount_path is not None:
+        mount_active = mount_path_is_active(client_node, mount_path)
+    if mount_result.get("exit_code") == 0 and mount_active:
+        raise OperationFailedError(
+            f"{context}: mount succeeded but was expected to fail "
+            f"(cmd={mount_result.get('mount_cmd')!r})"
+        )
+    if mount_result.get("exit_code") == 0 and not mount_active:
+        log.info(
+            "%s: mount exit=0 but %s is not active; treating as expected failure",
+            context,
+            mount_path,
+        )
+
+
+def assert_tlshd_handshake_failure(tlshd_status, context):
+    """Raise if recent tlshd journal output does not show a TLS handshake failure."""
+    status = str(tlshd_status or "")
+    status_lower = status.lower()
+    if "handshake" in status_lower and "failed" in status_lower:
+        return
+    if "eacces" in status_lower:
+        return
+    if "certificate verify failed" in status_lower:
+        return
+    if "unable to get local issuer" in status_lower:
+        return
+    raise OperationFailedError(
+        f"{context}: tlshd status did not report a TLS handshake failure "
+        f"(expected 'Handshake ... failed' or EACCES in journal)"
+    )
+
+
+def generate_mismatched_tls_trust_cert(nfs_node):
+    """
+    Return a valid PEM for tlshd trust store that does not match the NFS server cert.
+
+    Subtle PEM corruption is not reliable here: when cephqe CA is unavailable the client
+    trust anchor is the server's self-signed cert and tlshd may still complete the
+    handshake. A wholly different valid certificate forces verification failure.
+    """
+    mismatched_subject = {
+        "common_name": f"invalid-trust.{nfs_node.hostname}",
+        "ip_address": "127.0.0.1",
+    }
+    _, cert, ca_cert = generate_self_signed_certificate(mismatched_subject)
+    return ca_cert or cert
+
+
+def generate_tls_cert_bundle(nfs_node):
+    """
+    Generate TLS key/cert/CA PEM strings for an NFS Ganesha node.
+
+    Returns (cert_key, cert, ca_cert) where ca_cert falls back to cert when cephqe CA
+    is unavailable.
+    """
+    log.info("Generating self-signed certificate for %s", nfs_node.hostname)
+    subject = {
+        "common_name": nfs_node.hostname,
+        "ip_address": nfs_node.ip_address,
+    }
+    cert_key, cert, ca_cert = generate_self_signed_certificate(subject)
+    if not ca_cert:
+        ca_cert = cert
+        log.warning(
+            "No cephqe CA available (offline DNS/network to root-ca-location); "
+            "using self-signed server cert PEM as ssl_ca_cert for NFS orch apply."
+        )
+    return cert_key, cert, ca_cert
+
+
+def corrupt_pem_material(pem_text):
+    """
+    Return a copy of ``pem_text`` with a few characters altered in the first base64 body
+    line so TLS certificate validation fails.
+    """
+    if not pem_text or "BEGIN" not in pem_text:
+        return pem_text
+    lines = pem_text.strip().splitlines()
+    for idx, line in enumerate(lines):
+        if line.startswith("-----") or not line.strip():
+            continue
+        if len(line) > 20:
+            mid = len(line) // 2
+            lines[idx] = line[:mid] + "XXX" + line[mid + 3 :]
+            break
+    return "\n".join(lines) + "\n"
+
+
+def write_client_tls_ca_cert(client_node, ca_cert):
+    """Overwrite the tlshd trust anchor PEM and restart tlshd."""
+    cert_dir = "/etc/pki/ca-trust/source/anchors"
+    client_node.exec_command(sudo=True, cmd=f"mkdir -p {cert_dir}")
+    try:
+        cert_file = client_node.remote_file(
+            sudo=True, file_name=TLS_CLIENT_CA_PATH, file_mode="w"
+        )
+        cert_file.write(ca_cert)
+        cert_file.flush()
+    except AttributeError:
+        cert_file = client_node.remote_file(
+            sudo=True, file_name=TLS_CLIENT_CA_PATH, file_mode="wb"
+        )
+        cert_file.write(ca_cert.encode("utf-8"))
+        cert_file.flush()
+    client_node.exec_command(
+        sudo=True, cmd=f"restorecon -Rv {cert_dir}", check_ec=False
+    )
+    client_node.exec_command(sudo=True, cmd="systemctl restart tlshd")
 
 
 def mount_path_is_active(client_node, mount_path):
@@ -644,7 +824,14 @@ def probe_tls_handshake_with_openssl(
 
 def _quote_shell_path(path):
     """Return ``path`` safely escaped for use in remote shell commands."""
-    return shlex.quote(str(path))
+    if not path or not isinstance(path, (str, Path)):
+        raise OperationFailedError(f"Invalid path type: {type(path)}")
+    path_str = str(path).strip()
+    if not path_str:
+        raise OperationFailedError("Empty path provided")
+    if "\x00" in path_str:
+        raise OperationFailedError("Path contains null bytes")
+    return shlex.quote(path_str)
 
 
 def _validate_max_packets(max_packets):
@@ -656,17 +843,33 @@ def _validate_max_packets(max_packets):
 
 def _wait_for_pcap_closed(client_node, pcap_path, max_wait=5):
     """Wait until no tcpdump process holds ``pcap_path`` open."""
-    quoted = _quote_shell_path(pcap_path)
-    for _ in range(max_wait):
+    quoted_pcap = _quote_shell_path(pcap_path)
+    for attempt in range(max_wait):
         out, _ = client_node.exec_command(
             sudo=True,
-            cmd=f"lsof {quoted} 2>/dev/null",
+            cmd=f"lsof {quoted_pcap} 2>/dev/null",
             check_ec=False,
         )
         if not out or "tcpdump" not in str(out):
+            log.info("pcap file %s closed after %d seconds", pcap_path, attempt)
             return
+        log.debug(
+            "Waiting for pcap file to close (attempt %d/%d): %s",
+            attempt + 1,
+            max_wait,
+            str(out)[:200],
+        )
         time.sleep(1)
-    log.warning("pcap file %s still open after %ss", pcap_path, max_wait)
+
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=f"lsof {quoted_pcap} 2>/dev/null",
+        check_ec=False,
+    )
+    raise OperationFailedError(
+        f"pcap file {pcap_path} still open after {max_wait}s. "
+        f"Holding processes: {str(out)[:500]}"
+    )
 
 
 def normalize_fio_buffer_pattern(pattern):
@@ -711,20 +914,31 @@ def fio_pattern_to_binary_grep_literal(pattern):
 def _pcap_count_tls_records(client_node, pcap_path, tls_regex, max_packets, timeout):
     """Count TLS record headers in the first ``max_packets`` of a pcap via on-node grep."""
     _validate_max_packets(max_packets)
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        raise OperationFailedError(f"timeout must be positive, got {timeout}")
+
     quoted_pcap = _quote_shell_path(pcap_path)
     cmd = (
-        f"timeout {timeout} tcpdump -r {quoted_pcap} -xx -n -c {max_packets} "
-        f"2>/dev/null | grep -cE '{tls_regex}' || true"
-    )
-    out, _ = client_node.exec_command(
-        sudo=True,
-        cmd=cmd,
-        check_ec=False,
-        timeout=timeout + 5,
+        f"timeout {int(timeout)} tcpdump -r {quoted_pcap} -xx -n "
+        f"-c {max_packets} 2>/dev/null"
     )
     try:
-        return int(str(out).strip() or "0")
-    except ValueError:
+        out, _ = client_node.exec_command(
+            sudo=True,
+            cmd=cmd,
+            check_ec=False,
+            timeout=min(int(timeout) + 10, 600),
+        )
+        if not out:
+            log.warning("tcpdump produced no output for %s", pcap_path)
+            return 0
+
+        pattern = re.compile(tls_regex)
+        count = sum(1 for line in str(out).splitlines() if pattern.search(line))
+        log.debug("Found %d TLS record matches in %s", count, pcap_path)
+        return count
+    except Exception as err:
+        log.error("Failed to count TLS records in %s: %s", pcap_path, err)
         return 0
 
 
@@ -778,6 +992,7 @@ def start_tcpdump_capture(client_node, server_host, port, pcap_path, snaplen=512
             cmd=f"pkill -f 'tcpdump.*{quoted_pcap}'",
             check_ec=False,
         )
+        time.sleep(1)
         bpf = f"host {server_host} and tcp port {port}"
         log_name = pcap_path.rsplit("/", 1)[-1]
         cmd = (
@@ -789,6 +1004,13 @@ def start_tcpdump_capture(client_node, server_host, port, pcap_path, snaplen=512
         if not pid or not pid.isdigit():
             raise OperationFailedError(f"Failed to start tcpdump: invalid pid {pid!r}")
         time.sleep(2)
+        out, _ = client_node.exec_command(
+            sudo=True,
+            cmd=f"ps -p {pid} -o comm=",
+            check_ec=False,
+        )
+        if not out or "tcpdump" not in str(out):
+            raise OperationFailedError(f"tcpdump process {pid} not running after start")
         log.info(
             "tcpdump capture started on %s (pid=%s, bpf=%r, pcap=%s, snaplen=%s)",
             client_node.hostname,
@@ -812,34 +1034,49 @@ def start_tcpdump_capture(client_node, server_host, port, pcap_path, snaplen=512
 
 def stop_tcpdump_capture(client_node, pcap_path, pid=None):
     """Stop a background ``tcpdump`` and wait briefly for the pcap to flush."""
-    quoted_pcap = _quote_shell_path(pcap_path)
-    if pid:
+    if not pid:
+        log.warning("No pid provided to stop_tcpdump_capture")
+        return
+
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=f"ps -p {pid} -o comm=",
+        check_ec=False,
+    )
+    if not out or "tcpdump" not in str(out):
+        log.info("tcpdump pid=%s already stopped", pid)
+        _wait_for_pcap_closed(client_node, pcap_path)
+        return
+
+    try:
         log.info("Stopping tcpdump pid=%s", pid)
         client_node.exec_command(
             sudo=True,
             cmd=f"kill -TERM {pid}",
             check_ec=False,
         )
-        time.sleep(1)
-        out, _ = client_node.exec_command(
-            sudo=True,
-            cmd=f"ps -p {pid} -o comm=",
-            check_ec=False,
-        )
-        if out and "tcpdump" in str(out):
+        for i in range(5):
+            time.sleep(1)
+            out, _ = client_node.exec_command(
+                sudo=True,
+                cmd=f"ps -p {pid} -o comm=",
+                check_ec=False,
+            )
+            if not out or "tcpdump" not in str(out):
+                log.info("tcpdump stopped gracefully after %ds", i + 1)
+                break
+        else:
             log.warning("tcpdump %s did not stop with TERM, using KILL", pid)
             client_node.exec_command(
                 sudo=True,
                 cmd=f"kill -KILL {pid}",
                 check_ec=False,
             )
-    client_node.exec_command(
-        sudo=True,
-        cmd=f"pkill -9 -f 'tcpdump.*{quoted_pcap}'",
-        check_ec=False,
-    )
-    _wait_for_pcap_closed(client_node, pcap_path)
-    time.sleep(1)
+            time.sleep(1)
+    finally:
+        _wait_for_pcap_closed(client_node, pcap_path)
+
+    quoted_pcap = _quote_shell_path(pcap_path)
     out, _ = client_node.exec_command(
         sudo=True,
         cmd=f"test -s {quoted_pcap} && echo exists || echo missing",
@@ -868,13 +1105,19 @@ def analyze_pcap_traffic(
     _wait_for_pcap_closed(client_node, pcap_path)
     size_out, _ = client_node.exec_command(
         sudo=True,
-        cmd=f"test -s {quoted_pcap} && wc -c < {quoted_pcap}",
+        cmd=f"test -s {quoted_pcap} && wc -c < {quoted_pcap} || echo missing",
         check_ec=False,
+        timeout=min(int(pcap_analyze_timeout) + 5, 600),
     )
-    if not size_out or not str(size_out).strip().isdigit():
+    size_str = str(size_out).strip()
+    if size_str == "missing" or not size_str:
         raise OperationFailedError(f"Capture file missing or empty: {pcap_path}")
-
-    pcap_bytes = int(str(size_out).strip())
+    try:
+        pcap_bytes = int(size_str)
+    except ValueError as err:
+        raise OperationFailedError(
+            f"Could not parse pcap size from: {size_str[:100]}"
+        ) from err
     log.info("pcap %s size=%s bytes", pcap_path, pcap_bytes)
 
     pkt_out, _ = client_node.exec_command(
@@ -884,7 +1127,7 @@ def analyze_pcap_traffic(
             f"2>/dev/null | wc -l"
         ),
         check_ec=False,
-        timeout=pcap_analyze_timeout + 5,
+        timeout=min(int(pcap_analyze_timeout) + 5, 600),
     )
     packet_count = int(str(pkt_out).strip().splitlines()[-1].strip() or "0")
     if packet_count < min_total_packets:
@@ -1102,6 +1345,45 @@ def setup_plain_nfs_cluster(installer_node, nfs_node, nfs_name):
     log.info("Successfully deployed plain NFS cluster %s", nfs_name)
 
 
+def deploy_tls_nfs_cluster_with_certs(
+    installer_node,
+    nfs_node,
+    nfs_name,
+    cert_key,
+    cert,
+    ca_cert,
+    tls_min_version="TLSv1.3",
+    tls_ciphers="ALL",
+    tls_ktls=True,
+    tls_debug=True,
+    orch_wait_timeout=300,
+):
+    """Apply or update an NFS-Ganesha cluster with inline TLS certificate material."""
+    nfs_spec = {
+        "service_type": "nfs",
+        "service_id": nfs_name,
+        "placement": {"hosts": [nfs_node.hostname]},
+        "spec": {
+            "certificate_source": "inline",
+            "ssl": True,
+            "ssl_cert": cert.rstrip("\n"),
+            "ssl_key": cert_key.rstrip("\n"),
+            "ssl_ca_cert": ca_cert.rstrip("\n"),
+            "tls_ktls": tls_ktls,
+            "tls_debug": tls_debug,
+            "tls_min_version": tls_min_version,
+            "tls_ciphers": tls_ciphers,
+        },
+    }
+    log.info("Deploying TLS-enabled NFS cluster %s via spec file", nfs_name)
+    if not create_nfs_via_file_and_verify(
+        installer_node, [nfs_spec], timeout=orch_wait_timeout
+    ):
+        raise OperationFailedError(f"Failed to create TLS NFS cluster {nfs_name}")
+    log.info("Successfully deployed TLS NFS cluster %s", nfs_name)
+    return ca_cert
+
+
 def setup_tls_nfs_cluster(
     installer_node,
     nfs_node,
@@ -1124,44 +1406,16 @@ def setup_tls_nfs_cluster(
         tls_ktls: Boolean flag for ktls.
         tls_debug: Boolean flag for tls debug.
     """
-    log.info(f"Generating self-signed certificate for {nfs_node.hostname}")
-    subject = {
-        "common_name": nfs_node.hostname,
-        "ip_address": nfs_node.ip_address,
-    }
-    cert_key, cert, ca_cert = generate_self_signed_certificate(subject)
-
-    # Note: `generate_self_signed_certificate` returns cephqe-signed cert + CA PEM when
-    # `get_cephqe_ca()` can download from root-ca-location; otherwise ca_cert is None.
-    # Orchestrator rejects nfs specs with ssl:true but no ssl_ca_cert (EINVAL: CA required).
-    if not ca_cert:
-        ca_cert = cert
-        log.warning(
-            "No cephqe CA available (offline DNS/network to root-ca-location); "
-            "using self-signed server cert PEM as ssl_ca_cert for NFS orch apply."
-        )
-
-    # Construct the TLS cluster spec
-    nfs_spec = {
-        "service_type": "nfs",
-        "service_id": nfs_name,
-        "placement": {"hosts": [nfs_node.hostname]},
-        "spec": {
-            "certificate_source": "inline",
-            "ssl": True,
-            "ssl_cert": cert.rstrip("\n"),
-            "ssl_key": cert_key.rstrip("\n"),
-            "ssl_ca_cert": ca_cert.rstrip("\n"),
-            "tls_ktls": tls_ktls,
-            "tls_debug": tls_debug,
-            "tls_min_version": tls_min_version,
-            "tls_ciphers": tls_ciphers,
-        },
-    }
-
-    log.info(f"Deploying TLS-enabled NFS cluster {nfs_name} via spec file")
-    if not create_nfs_via_file_and_verify(installer_node, [nfs_spec], timeout=300):
-        raise OperationFailedError(f"Failed to create TLS NFS cluster {nfs_name}")
-
-    log.info(f"Successfully deployed TLS NFS cluster {nfs_name}")
-    return ca_cert or cert
+    cert_key, cert, ca_cert = generate_tls_cert_bundle(nfs_node)
+    return deploy_tls_nfs_cluster_with_certs(
+        installer_node=installer_node,
+        nfs_node=nfs_node,
+        nfs_name=nfs_name,
+        cert_key=cert_key,
+        cert=cert,
+        ca_cert=ca_cert,
+        tls_min_version=tls_min_version,
+        tls_ciphers=tls_ciphers,
+        tls_ktls=tls_ktls,
+        tls_debug=tls_debug,
+    )

--- a/tests/nfs/security/test_tls_feature.py
+++ b/tests/nfs/security/test_tls_feature.py
@@ -12,9 +12,18 @@ from tests.nfs.nfs_operations import (
     mount_retry,
 )
 from tests.nfs.security.security_utils import (
+    assert_mount_failed,
+    assert_tlshd_handshake_failure,
+    attempt_nfs_mount_expect_failure,
+    build_tls_nfs_mount_cmd,
+    capture_tlshd_status,
     check_mount_fails,
+    corrupt_pem_material,
+    deploy_tls_nfs_cluster_with_certs,
     ensure_package_installed,
     full_tls_stack_cleanup,
+    generate_mismatched_tls_trust_cert,
+    generate_tls_cert_bundle,
     mount_export_via_stunnel,
     normalize_fio_buffer_pattern,
     probe_tls_handshake_with_openssl,
@@ -33,6 +42,7 @@ from tests.nfs.security.security_utils import (
     wait_for_tls_strings_in_nfs_logs,
     wait_until_ceph_orch_nfs_ps_ready,
     wait_until_nfs_export_visible,
+    write_client_tls_ca_cert,
 )
 from tests.nfs.test_nfs_io_operations_during_upgrade import (
     create_export_and_mount_for_existing_nfs_cluster,
@@ -58,6 +68,7 @@ OP_TLS_EXPORT_ENFORCEMENT = "tls_export_enforcement"
 OP_TLS_LOGS_OPENSSL_PROBE = "tls_logs_openssl_probe"
 OP_TLS_IO_TCPDUMP_ENCRYPTION = "tls_io_tcpdump_encryption"
 OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION = "tls_stunnel_io_tcpdump_encryption"
+OP_TLS_NEGATIVE_INVALID_CERTS = "tls_negative_invalid_certs"
 OP_TLS_FULL_WORKFLOW = "tls_full_workflow"
 _TLS_FULL_SEQUENCE = [
     OP_TLS_DEPLOY_MOUNT_VERIFY,
@@ -67,6 +78,7 @@ _TLS_FULL_SEQUENCE = [
 _TLS_STANDALONE_OPERATIONS = _TLS_FULL_SEQUENCE + [
     OP_TLS_IO_TCPDUMP_ENCRYPTION,
     OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION,
+    OP_TLS_NEGATIVE_INVALID_CERTS,
 ]
 # fio --buffer_pattern requires hex (e.g. 0xCEFACEFE), not ASCII strings.
 DEFAULT_TLS_IO_MARKER = "0xCEFACEFE"
@@ -125,6 +137,7 @@ def _operations_to_run(config):
             f"{OP_TLS_DEPLOY_MOUNT_VERIFY}, {OP_TLS_EXPORT_ENFORCEMENT}, "
             f"{OP_TLS_LOGS_OPENSSL_PROBE}, {OP_TLS_IO_TCPDUMP_ENCRYPTION}, "
             f"{OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION}, "
+            f"{OP_TLS_NEGATIVE_INVALID_CERTS}, "
             f"{OP_TLS_FULL_WORKFLOW} (or tls_all_in_one)."
         )
     op = _normalize_operation(raw)
@@ -143,13 +156,23 @@ def _parse_fio_json(fio_stdout, rw_type):
     raw = str(fio_stdout).strip()
     try:
         data = json.loads(raw)
-        rw_stats = data["jobs"][0][rw_type]
-    except (json.JSONDecodeError, KeyError, IndexError) as err:
+        if not isinstance(data, dict) or "jobs" not in data:
+            raise ValueError("Missing 'jobs' key in fio output")
+        if not isinstance(data["jobs"], list) or not data["jobs"]:
+            raise ValueError("'jobs' is not a non-empty list")
+        rw_stats = data["jobs"][0].get(rw_type)
+        if not rw_stats:
+            raise ValueError(f"Missing '{rw_type}' in job stats")
+        bw = rw_stats.get("bw")
+        iops = rw_stats.get("iops")
+        if bw is None or iops is None:
+            raise ValueError(f"Missing 'bw' or 'iops' in {rw_type} stats")
+        return float(bw) / 1024.0, float(iops)
+    except (json.JSONDecodeError, KeyError, IndexError, ValueError, TypeError) as err:
         raise OperationFailedError(
             f"Could not parse fio {rw_type} JSON output: {err}\n"
             f"Raw (first 500 chars): {raw[:500]}"
         ) from err
-    return rw_stats["bw"] / 1024.0, rw_stats["iops"]
 
 
 def _run_fio_write_read_on_mount(client_node, mount_path, config):
@@ -504,6 +527,494 @@ def op_tls_logs_openssl_probe(installer_node, client_node, nfs_node, config, nfs
             )
 
     log.info("tls_logs_openssl_probe completed.")
+
+
+_NEG_SCENARIO_SERVER = "Scenario-1 invalid-server-certs"
+_NEG_SCENARIO_CLIENT = "Scenario-2 invalid-client-certs"
+
+
+def _log_neg_step(scenario, step, total, message):
+    """Emit a numbered step line for negative TLS scenario execution."""
+    log.info("[%s] Step %s/%s: %s", scenario, step, total, message)
+
+
+def _log_neg_step_done(scenario, step, total, message):
+    """Emit completion of a numbered negative TLS scenario step."""
+    log.info("[%s] Step %s/%s complete: %s", scenario, step, total, message)
+
+
+def _negative_cert_scenarios_to_run(config):
+    """Resolve which negative TLS cert scenarios to run (server, client, or both)."""
+    raw = tls_config_get(
+        config, "negative_cert_scenario", "tc_neg_scenario", default="both"
+    )
+    op = _normalize_operation(raw)
+    if op in ("both", "all"):
+        return ["server", "client"]
+    if op in ("server", "invalid_server", "server_certs"):
+        return ["server"]
+    if op in ("client", "invalid_client", "client_certs"):
+        return ["client"]
+    raise OperationFailedError(
+        f"Unknown negative_cert_scenario {raw!r}; expected server, client, or both"
+    )
+
+
+def _tls_cluster_tls_options(config):
+    return {
+        "tls_min_version": config.get("tls_min_version", "TLSv1.3"),
+        "tls_ciphers": config.get("tls_ciphers", "ALL"),
+        "tls_ktls": config.get("tls_ktls", True),
+        "tls_debug": config.get("tls_debug", True),
+        "orch_wait_timeout": int(
+            tls_config_get(
+                config,
+                "negative_redeploy_orch_wait_timeout_sec",
+                "tc_neg_redeploy_orch_wait_timeout_sec",
+                default=300,
+            )
+        ),
+    }
+
+
+def _restore_valid_tls_stack(
+    installer, client_node, nfs_node, nfs_name, config, scenario_label="inter-scenario"
+):
+    """Redeploy valid server certs and restore the client tlshd trust anchor."""
+    log.info(
+        "[%s] Restoring valid TLS server certs and client trust before next scenario",
+        scenario_label,
+    )
+    _log_neg_step(scenario_label, 1, 3, "Generate fresh valid TLS certificate bundle")
+    cert_key, cert, ca_cert = generate_tls_cert_bundle(nfs_node)
+    _log_neg_step_done(scenario_label, 1, 3, "Valid cert bundle generated")
+
+    _log_neg_step(
+        scenario_label,
+        2,
+        3,
+        f"Redeploy NFS cluster {nfs_name!r} with valid server certificates",
+    )
+    deploy_tls_nfs_cluster_with_certs(
+        installer_node=installer,
+        nfs_node=nfs_node,
+        nfs_name=nfs_name,
+        cert_key=cert_key,
+        cert=cert,
+        ca_cert=ca_cert,
+        **_tls_cluster_tls_options(config),
+    )
+    _log_neg_step_done(scenario_label, 2, 3, "Valid server TLS redeploy applied")
+
+    _log_neg_step(
+        scenario_label,
+        3,
+        3,
+        f"Restore client tlshd trust anchor on {client_node.hostname}",
+    )
+    setup_tls_client(client_node, ca_cert)
+    redeploy_wait = int(
+        tls_config_get(
+            config,
+            "negative_redeploy_orch_wait_timeout_sec",
+            "tc_neg_redeploy_orch_wait_timeout_sec",
+            default=300,
+        )
+    )
+    if not wait_until_ceph_orch_nfs_ps_ready(
+        client_node, nfs_name, timeout=redeploy_wait, interval=5
+    ):
+        raise OperationFailedError(
+            f"NFS service {nfs_name} not ready after valid TLS redeploy"
+        )
+    _log_neg_step_done(
+        scenario_label,
+        3,
+        3,
+        f"Client trust restored; nfs.{nfs_name} ready in ceph orch ps",
+    )
+
+
+def _run_small_io_on_tls_mount(client_node, mount_path, label="neg_tls", scenario=None):
+    """Quick IO sanity check on a TLS mount (lookup, dd write/read, delete)."""
+    if scenario:
+        log.info("[%s] Running small IO (lookup, 1MiB dd write/read, delete)", scenario)
+    lookup_in_directory(client_node, mount_path)
+    io_file = f"{label}_io"
+    create_file(client_node, mount_path, io_file)
+    write_to_file_using_dd_command(client_node, mount_path, io_file, 1)
+    read_from_file_using_dd_command(client_node, mount_path, io_file, 1)
+    delete_file(client_node, mount_path, io_file)
+    log.info(
+        "Small IO on %s completed successfully%s",
+        mount_path,
+        f" [{scenario}]" if scenario else "",
+    )
+
+
+def _mount_tls_export_expect_success(
+    client_node,
+    nfs_node,
+    export_path,
+    mount_path,
+    version,
+    port,
+    scenario=None,
+):
+    """Mount a TLS export and verify it appears in the mount table."""
+    client_node.create_dirs(dir_path=mount_path, sudo=True)
+    mount_cmd = build_tls_nfs_mount_cmd(
+        nfs_node.hostname, export_path, mount_path, version, port
+    )
+    if scenario:
+        log.info("[%s] Mount command: %s", scenario, mount_cmd)
+    result = attempt_nfs_mount_expect_failure(client_node, mount_cmd)
+    if result["exit_code"] != 0:
+        raise OperationFailedError(
+            f"TLS mount failed unexpectedly: {result['stderr'] or result['stdout']}"
+        )
+    out, _ = client_node.exec_command(sudo=True, cmd="mount", check_ec=False)
+    if mount_path.rstrip("/") not in str(out or ""):
+        raise OperationFailedError(f"TLS mount missing from mount table: {mount_path}")
+    log.info(
+        "TLS mount succeeded on %s at %s%s",
+        client_node.hostname,
+        mount_path,
+        f" [{scenario}]" if scenario else "",
+    )
+
+
+def _log_negative_mount_failure(context, mount_result, tlshd_status):
+    """Log mount failure details and full tlshd status for negative TLS scenarios."""
+    log.info(
+        "%s: mount failed as expected (exit=%s, cmd=%r)",
+        context,
+        mount_result.get("exit_code"),
+        mount_result.get("mount_cmd"),
+    )
+    if mount_result.get("stderr"):
+        log.info("%s mount stderr:\n%s", context, mount_result["stderr"])
+    if mount_result.get("stdout"):
+        log.info("%s mount stdout:\n%s", context, mount_result["stdout"])
+    log.info("%s tlshd status:\n%s", context, tlshd_status)
+
+
+def _attempt_tls_mount_and_capture_tlshd(
+    client_node,
+    nfs_node,
+    export_path,
+    mount_path,
+    version,
+    port,
+    context,
+    scenario=None,
+    mount_step=None,
+    tlshd_step=None,
+    total_steps=None,
+):
+    """Attempt a TLS mount expecting failure; return mount result and tlshd status."""
+    if scenario and mount_step and total_steps:
+        _log_neg_step(
+            scenario,
+            mount_step,
+            total_steps,
+            "Attempt TLS mount (expect failure); capture mount error output",
+        )
+    client_node.create_dirs(dir_path=mount_path, sudo=True)
+    mount_cmd = build_tls_nfs_mount_cmd(
+        nfs_node.hostname, export_path, mount_path, version, port
+    )
+    log.info("[%s] Mount command: %s", context, mount_cmd)
+    mount_result = attempt_nfs_mount_expect_failure(client_node, mount_cmd)
+    if scenario and mount_step and total_steps:
+        _log_neg_step_done(
+            scenario,
+            mount_step,
+            total_steps,
+            f"Mount attempt finished (exit={mount_result.get('exit_code')})",
+        )
+
+    if scenario and tlshd_step and total_steps:
+        _log_neg_step(
+            scenario,
+            tlshd_step,
+            total_steps,
+            "Capture full systemctl status tlshd output",
+        )
+    tlshd_status = capture_tlshd_status(client_node)
+    if scenario and tlshd_step and total_steps:
+        _log_neg_step_done(
+            scenario,
+            tlshd_step,
+            total_steps,
+            "tlshd status captured; verifying handshake failure in journal",
+        )
+
+    _log_negative_mount_failure(context, mount_result, tlshd_status)
+    assert_mount_failed(
+        mount_result, context, client_node=client_node, mount_path=mount_path
+    )
+    assert_tlshd_handshake_failure(tlshd_status, context)
+    return mount_result, tlshd_status
+
+
+def _scenario_invalid_server_certs(
+    installer, client_node, nfs_node, config, nfs_name, export_path, mount_path
+):
+    """Valid TLS IO, redeploy Ganesha with corrupted certs, mount must fail."""
+    scenario = _NEG_SCENARIO_SERVER
+    version = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+    total = 7
+    log.info("=== %s: invalid server certificates on Ganesha ===", scenario)
+    log.info(
+        "[%s] Plan: valid mount+IO baseline → corrupt Ganesha certs → "
+        "expect mount failure + tlshd handshake error",
+        scenario,
+    )
+
+    _log_neg_step(
+        scenario,
+        1,
+        total,
+        f"Mount TLS export {export_path!r} at {mount_path!r} "
+        f"(valid Ganesha certs, xprtsec=tls)",
+    )
+    _mount_tls_export_expect_success(
+        client_node,
+        nfs_node,
+        export_path,
+        mount_path,
+        version,
+        port,
+        scenario=scenario,
+    )
+    _log_neg_step_done(scenario, 1, total, "Baseline TLS mount succeeded")
+
+    _log_neg_step(scenario, 2, total, "Run small IO on mount to verify TLS path works")
+    _run_small_io_on_tls_mount(
+        client_node, mount_path, label="valid_server", scenario=scenario
+    )
+    _log_neg_step_done(scenario, 2, total, "Baseline IO succeeded")
+
+    _log_neg_step(scenario, 3, total, f"Umount {mount_path!r} before cert redeploy")
+    Unmount(client_node).unmount(mount_path)
+    _log_neg_step_done(scenario, 3, total, "Mount point released")
+
+    _log_neg_step(
+        scenario,
+        4,
+        total,
+        "Generate corrupted server ssl_key/ssl_cert/ssl_ca_cert and redeploy Ganesha",
+    )
+    cert_key, cert, ca_cert = generate_tls_cert_bundle(nfs_node)
+    bad_key = corrupt_pem_material(cert_key)
+    bad_cert = corrupt_pem_material(cert)
+    bad_ca = corrupt_pem_material(ca_cert)
+    deploy_tls_nfs_cluster_with_certs(
+        installer_node=installer,
+        nfs_node=nfs_node,
+        nfs_name=nfs_name,
+        cert_key=bad_key,
+        cert=bad_cert,
+        ca_cert=bad_ca,
+        **_tls_cluster_tls_options(config),
+    )
+    _log_neg_step_done(
+        scenario, 4, total, f"NFS cluster {nfs_name!r} redeployed with invalid PEMs"
+    )
+
+    _log_neg_step(
+        scenario,
+        5,
+        total,
+        f"Wait for nfs.{nfs_name} daemon ready in ceph orch ps after redeploy",
+    )
+    redeploy_wait = int(
+        tls_config_get(
+            config,
+            "negative_redeploy_orch_wait_timeout_sec",
+            "tc_neg_redeploy_orch_wait_timeout_sec",
+            default=300,
+        )
+    )
+    if not wait_until_ceph_orch_nfs_ps_ready(
+        client_node, nfs_name, timeout=redeploy_wait, interval=5
+    ):
+        raise OperationFailedError(
+            f"NFS service {nfs_name} not ready after invalid-cert redeploy"
+        )
+    _log_neg_step_done(scenario, 5, total, "Ganesha daemon running with invalid certs")
+
+    _attempt_tls_mount_and_capture_tlshd(
+        client_node,
+        nfs_node,
+        export_path,
+        mount_path,
+        version,
+        port,
+        "invalid_server_certs",
+        scenario=scenario,
+        mount_step=6,
+        tlshd_step=7,
+        total_steps=total,
+    )
+    log.info(
+        "[%s] PASSED — mount and tlshd correctly rejected invalid server certs",
+        scenario,
+    )
+
+
+def _scenario_invalid_client_certs(
+    client_node, nfs_node, config, export_path, mount_path
+):
+    """Valid TLS IO, install mismatched client trust anchor, mount must fail."""
+    scenario = _NEG_SCENARIO_CLIENT
+    version = config.get("nfs_version", "4.2")
+    port = str(config.get("port", "2049"))
+    total = 7
+    log.info("=== %s: invalid client trust anchor (tlshd) ===", scenario)
+    log.info(
+        "[%s] Plan: valid mount+IO baseline → install mismatched client CA → "
+        "expect mount failure + tlshd handshake error",
+        scenario,
+    )
+
+    _log_neg_step(
+        scenario,
+        1,
+        total,
+        f"Mount TLS export {export_path!r} at {mount_path!r} "
+        f"(valid client trust anchor, xprtsec=tls)",
+    )
+    _mount_tls_export_expect_success(
+        client_node,
+        nfs_node,
+        export_path,
+        mount_path,
+        version,
+        port,
+        scenario=scenario,
+    )
+    _log_neg_step_done(scenario, 1, total, "Baseline TLS mount succeeded")
+
+    _log_neg_step(scenario, 2, total, "Run small IO on mount to verify TLS path works")
+    _run_small_io_on_tls_mount(
+        client_node, mount_path, label="valid_client", scenario=scenario
+    )
+    _log_neg_step_done(scenario, 2, total, "Baseline IO succeeded")
+
+    _log_neg_step(
+        scenario, 3, total, f"Umount {mount_path!r} before client cert change"
+    )
+    Unmount(client_node).unmount(mount_path)
+    _log_neg_step_done(scenario, 3, total, "Mount point released")
+
+    _log_neg_step(
+        scenario,
+        4,
+        total,
+        f"Install mismatched trust anchor on {client_node.hostname} "
+        f"(valid PEM, wrong CN/IP — does not match Ganesha server cert)",
+    )
+    invalid_ca = generate_mismatched_tls_trust_cert(nfs_node)
+    write_client_tls_ca_cert(client_node, invalid_ca)
+    _log_neg_step_done(
+        scenario,
+        4,
+        total,
+        "Client trust anchor replaced; tlshd restarted",
+    )
+
+    _log_neg_step(scenario, 5, total, "Wait for tlshd to settle after trust change")
+    sleep(2)
+    _log_neg_step_done(scenario, 5, total, "Settle wait complete")
+
+    _attempt_tls_mount_and_capture_tlshd(
+        client_node,
+        nfs_node,
+        export_path,
+        mount_path,
+        version,
+        port,
+        "invalid_client_certs",
+        scenario=scenario,
+        mount_step=6,
+        tlshd_step=7,
+        total_steps=total,
+    )
+    log.info(
+        "[%s] PASSED — mount and tlshd correctly rejected invalid client trust",
+        scenario,
+    )
+
+
+def op_tls_negative_invalid_certs(installer, client_node, nfs_node, config, nfs_name):
+    log.info("=== Operation: tls_negative_invalid_certs ===")
+    fs_name = config.get("fs_name", "cephfs")
+    export_name = tls_config_get(
+        config, "tls_negative_export", "tc_neg_export", default="/tls_export_neg"
+    )
+    mount_path = tls_config_get(
+        config, "tls_negative_mount", "tc_neg_mount", default="/mnt/tls_neg_tc"
+    )
+    scenarios = _negative_cert_scenarios_to_run(config)
+    log.info(
+        "Negative TLS cert test layout: export=%r mount=%r scenarios=%s",
+        export_name,
+        mount_path,
+        scenarios,
+    )
+    log.info(
+        "Pre-run: TLS cluster %r and client tlshd were configured by run() before "
+        "this operation",
+        nfs_name,
+    )
+
+    log.info(
+        "[Setup] Step 1/2: Create TLS export %r on cluster %r (--xprtsec tls)",
+        export_name,
+        nfs_name,
+    )
+    Ceph(client_node).nfs.export.create(
+        fs_name=fs_name,
+        nfs_name=nfs_name,
+        nfs_export=export_name,
+        fs=fs_name,
+        xprtsec="tls",
+    )
+    log.info("[Setup] Step 2/2: Wait until export is visible in ceph nfs export ls")
+    wait_until_nfs_export_visible(client_node, nfs_name, export_name)
+    log.info("[Setup] Export %r ready for negative TLS scenarios", export_name)
+
+    if "server" in scenarios:
+        _scenario_invalid_server_certs(
+            installer,
+            client_node,
+            nfs_node,
+            config,
+            nfs_name,
+            export_name,
+            mount_path,
+        )
+
+    if "client" in scenarios:
+        if "server" in scenarios:
+            _restore_valid_tls_stack(
+                installer,
+                client_node,
+                nfs_node,
+                nfs_name,
+                config,
+                scenario_label="inter-scenario-restore",
+            )
+        _scenario_invalid_client_certs(
+            client_node, nfs_node, config, export_name, mount_path
+        )
+
+    log.info("[Cleanup] Lazy-umount %r if still mounted", mount_path)
+    client_node.exec_command(sudo=True, cmd=f"umount -l {mount_path}", check_ec=False)
+    log.info("tls_negative_invalid_certs completed successfully.")
 
 
 def _setup_tls_io_capture_prerequisites(client_node):
@@ -1053,6 +1564,9 @@ _OP_DISPATCH = {
     OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION: lambda inst, c, n, cfg, name: op_tls_stunnel_io_tcpdump_encryption(
         inst, c, n, cfg, name
     ),
+    OP_TLS_NEGATIVE_INVALID_CERTS: lambda inst, c, n, cfg, name: op_tls_negative_invalid_certs(
+        inst, c, n, cfg, name
+    ),
 }
 
 
@@ -1062,7 +1576,7 @@ def run(ceph_cluster, **kw):
 
     config.operation: tls_deploy_mount_verify | tls_export_enforcement |
         tls_logs_openssl_probe | tls_io_tcpdump_encryption |
-        tls_stunnel_io_tcpdump_encryption |
+        tls_stunnel_io_tcpdump_encryption | tls_negative_invalid_certs |
         tls_full_workflow (or tls_all_in_one)
     """
     log.info("Starting NFS TLS feature tests (independent mode)")


### PR DESCRIPTION
**Summary**
- Add `tls_negative_invalid_certs` operation to `test_tls_feature.py` for corrupted Ganesha server certs and invalid client trust anchor.
- Extend `security_utils.py` with cert corruption, mount-failure capture, and tlshd handshake failure checks.
- Wire the test into `suites/tentacle/nfs/tier1-nfs-ganesha.yaml`.

**What the test does**
1. Creates a TLS export on the existing TLS NFS cluster.
2. Confirms a valid TLS mount and small IO succeed as baseline.
3. **Server negative:** corrupts Ganesha key/cert/CA, redeploys NFS, and verifies TLS mount fails with tlshd handshake failure logged.
4. **Client negative:** installs a mismatched client trust anchor and verifies TLS mount fails with tlshd status captured.
5. Cleans up the mount point.
