### PR TITLE
Rgw cephadm ca cert copy

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_and_lc.yaml
+++ b/suites/squid/rgw/tier-1_rgw_and_lc.yaml
@@ -65,6 +65,17 @@ tests:
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       name: Deploy RHCS cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       name: enable bucket versioning
       desc: Basic versioning test, also called as test to enable bucket versioning

--- a/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -337,6 +337,30 @@ tests:
       module: test_client.py
       name: configure client
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-arc:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -356,17 +380,10 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node4}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-arc#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-arc#node4}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.shared.sec rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -377,15 +394,10 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node4}:/etc/pki/ca-trust/source/anchors/"
         ceph-arc:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.shared.arc rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -397,68 +409,11 @@ tests:
               - "ceph config set client.rgw.shared.arc rgw_zone archive"
               - "ceph orch restart {service_name:shared.arc}"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node4}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment with archive zone
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10704
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-arc:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-arc:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
-
-#verify ceph cluster s3_details
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -241,6 +241,25 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -260,15 +279,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node8}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -280,55 +294,11 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node8}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest.yaml
@@ -104,44 +104,17 @@ tests:
       name: Configure client
       polarion-id: CEPH-83573758
 
-  - test:
-      abort-on-fail: true
-      config:
-        commands:
-          - "ceph config set client.rgw.rgw.ssl rgw_verify_ssl False"
-          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-          - "sudo yum install -y sshpass"
-          - "sleep 20"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node7}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node8}:/etc/pki/ca-trust/source/anchors/"
-      name: copy-crt to rgw and client node
-      desc: Copying crt to rgw and client node
-      polarion-id: CEPH-83575227
-      module: exec.py
 
   - test:
       abort-on-fail: true
       config:
-        role: rgw
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on rgw node
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw node
-  - test:
-      abort-on-fail: true
-      config:
-        role: client
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on client node
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client node
-
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       name: Manual Resharding tests pre upgrade
       desc: Resharding test - manual

--- a/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -148,6 +148,25 @@ tests:
       module: test_client.py
       name: configure client
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -167,15 +186,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node6}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -187,55 +201,11 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node6}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rgw/tier-2_ssl_rgw_ecpool_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ecpool_test.yaml
@@ -145,6 +145,17 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       abort-on-fail: true
       config:

--- a/suites/squid/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -235,6 +235,25 @@ tests:
       module: test_client.py
       name: configure client
       polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -254,15 +273,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node8}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -274,74 +288,12 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node8}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
 
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/squid/rgw/tier-2_ssl_rgw_ms_msr_8+6.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ms_msr_8+6.yaml
@@ -244,6 +244,25 @@ tests:
       module: test_client.py
       name: configure client
       polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -263,15 +282,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node4}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -282,55 +296,12 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node4}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
 
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -116,47 +116,17 @@ tests:
       module: test_client.py
       name: configure client
 
+
   - test:
       abort-on-fail: true
       config:
-        commands:
-          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-          - "sudo yum install -y sshpass"
-          - "sleep 20"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node3}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node4}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node5}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node6}:/etc/pki/ca-trust/source/anchors/"
-      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
-      module: exec.py
-      name: copying cephadm_root_ca_cert
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      config:
-        role: rgw
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      config:
-        role: client
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
-
-
   - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -118,6 +118,17 @@ tests:
 
   # STS tests
 
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       name: STS Tests to perform assume role on principle user and perform IOs
       desc: Perform assume role on principle user and perform IOs

--- a/suites/tentacle/rgw/tier-1_rgw_and_lc.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_and_lc.yaml
@@ -65,6 +65,17 @@ tests:
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       name: Deploy RHCS cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       name: overwrite objects after suspending versioning
       desc: test to overwrite objects after suspending versioning

--- a/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ssl_multisite_test_upgrade_81GA_to_9x_latest.yaml
@@ -215,6 +215,25 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -234,15 +253,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node6}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -254,35 +268,11 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node6}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
 
   - test:
       abort-on-fail: true
@@ -366,6 +356,24 @@ tests:
             command: start
             service: upgrade
             verify_cluster_health: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes post upgrade
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert post upgrade
+      polarion-id: CEPH-10362
 
   - test:
       clusters:

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -341,6 +341,30 @@ tests:
       module: test_client.py
       name: configure client
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-arc:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -360,17 +384,9 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
-              - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node4}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-arc#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-arc#node4}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.shared.sec rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -381,15 +397,9 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
-              - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node4}:/etc/pki/ca-trust/source/anchors/"
         ceph-arc:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.shared.arc rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node3} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -401,68 +411,10 @@ tests:
               - "ceph config set client.rgw.shared.arc rgw_zone archive"
               - "ceph orch restart {service_name:shared.arc}"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
-              - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node3}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node4}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment with archive zone
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10704
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-arc:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-arc:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
-
-#verify ceph cluster s3_details
   - test:
       abort-on-fail: true
       clusters:
@@ -577,6 +529,29 @@ tests:
             command: start
             service: upgrade
             verify_cluster_health: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-arc:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes post upgrade
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert post upgrade
+      polarion-id: CEPH-10362
 
   - test:
       name: Verify DBR feature enabled on upgraded cluster

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -245,6 +245,25 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -264,15 +283,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node8}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -284,55 +298,11 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node8}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
 
   - test:
       abort-on-fail: true
@@ -463,6 +433,24 @@ tests:
             command: start
             service: upgrade
             verify_cluster_health: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes post upgrade
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert post upgrade
+      polarion-id: CEPH-10362
 
   - test:
       name: Test NFS cluster and export create

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_81GA_to_9x_latest.yaml
@@ -85,6 +85,17 @@ tests:
       name: Configure client
       polarion-id: CEPH-83573758
 
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
       desc: test etag verification
@@ -129,6 +140,17 @@ tests:
               service: upgrade
               base_cmd_args:
                 verbose: true
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes post upgrade
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert post upgrade
+      polarion-id: CEPH-10362
 
 # Post Upgrade tests
 

--- a/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_9x_latest.yaml
@@ -106,43 +106,17 @@ tests:
       name: Configure client
       polarion-id: CEPH-83573758
 
+
   - test:
       abort-on-fail: true
       config:
-        commands:
-          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-          - "sudo yum install -y sshpass"
-          - "sleep 20"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node7}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node8}:/etc/pki/ca-trust/source/anchors/"
-      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
-      module: exec.py
-      name: copying cephadm_root_ca_cert
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      config:
-        role: rgw
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      config:
-        role: client
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -202,6 +176,17 @@ tests:
         service: upgrade
         base_cmd_args:
           verbose: true
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes post upgrade
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert post upgrade
+      polarion-id: CEPH-10362
 
 # Post Upgrade tests
   - test:

--- a/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
@@ -123,66 +123,66 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
 
-  # - test:
-  #     clusters:
-  #       ceph-pri:
-  #         config:
-  #           verify_cluster_health: true
-  #           steps:
-  #             - config:
-  #                 command: apply_spec
-  #                 service: orch
-  #                 validate-spec-services: true
-  #                 specs:
-  #                   - service_type: prometheus
-  #                     placement:
-  #                       count: 1
-  #                       nodes:
-  #                         - node1
-  #                   - service_type: grafana
-  #                     placement:
-  #                       nodes:
-  #                         - node1
-  #                   - service_type: alertmanager
-  #                     placement:
-  #                       count: 1
-  #                   - service_type: node-exporter
-  #                     placement:
-  #                       host_pattern: "*"
-  #                   - service_type: crash
-  #                     placement:
-  #                       host_pattern: "*"
-  #       ceph-sec:
-  #         config:
-  #           verify_cluster_health: true
-  #           steps:
-  #             - config:
-  #                 command: apply_spec
-  #                 service: orch
-  #                 validate-spec-services: true
-  #                 specs:
-  #                   - service_type: prometheus
-  #                     placement:
-  #                       count: 1
-  #                       nodes:
-  #                         - node1
-  #                   - service_type: grafana
-  #                     placement:
-  #                       nodes:
-  #                         - node1
-  #                   - service_type: alertmanager
-  #                     placement:
-  #                       count: 1
-  #                   - service_type: node-exporter
-  #                     placement:
-  #                       host_pattern: "*"
-  #                   - service_type: crash
-  #                     placement:
-  #                       host_pattern: "*"
-  #     name: Monitoring Services deployment
-  #     desc: Add monitoring services using spec file.
-  #     module: test_cephadm.py
-  #     polarion-id: CEPH-83574727
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -148,6 +148,25 @@ tests:
       module: test_client.py
       name: configure client
 
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -167,15 +186,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node6}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -187,55 +201,11 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node6}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_ecpool_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_ecpool_test.yaml
@@ -145,6 +145,17 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       abort-on-fail: true
       config:

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -235,6 +235,25 @@ tests:
       module: test_client.py
       name: configure client
       polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -254,15 +273,10 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
               - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node8}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node7} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -274,74 +288,12 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node7}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node8}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
 
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_ms_msr_8+6.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_ms_msr_8+6.yaml
@@ -249,6 +249,23 @@ tests:
       clusters:
         ceph-pri:
           config:
+            roles:
+              - rgw
+              - client
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+              - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
             commands:
               - "radosgw-admin realm create --rgw-realm india --default"
               - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints https://{node_ip:node4} --master --default"
@@ -263,15 +280,9 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sudo yum install -y sshpass"
-              - "sleep 20"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node4}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
         ceph-sec:
           config:
             commands:
-              - "sudo update-ca-trust"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -282,55 +293,11 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
               - "ceph orch restart {service_name:shared.sec}"
-              - "sudo yum install -y sshpass"
-              - "sleep 120"
-              - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node4}:/etc/pki/ca-trust/source/anchors/"
-              - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
 
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: rgw
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-        ceph-sec:
-          config:
-            role: client
-            sudo: True
-            commands:
-              - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -119,42 +119,13 @@ tests:
   - test:
       abort-on-fail: true
       config:
-        commands:
-          - "ceph_version=$(ceph version | cut -d ' ' -f 3 | cut -d '-' -f 1); if [ \"$ceph_version\" = \"19.2.0\" ]; then ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; else ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt; fi"
-          - "sudo yum install -y sshpass"
-          - "sleep 20"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node3}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node4}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node5}:/etc/pki/ca-trust/source/anchors/"
-          - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:node6}:/etc/pki/ca-trust/source/anchors/"
-      desc: copying cephadm_root_ca_cert to rgw and client nodes ca_trust_path
-      module: exec.py
-      name: copying cephadm_root_ca_cert
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
       polarion-id: CEPH-10362
-
-  - test:
-      abort-on-fail: true
-      config:
-        role: rgw
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on rgw nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on rgw nodes
-
-  - test:
-      abort-on-fail: true
-      config:
-        role: client
-        sudo: True
-        commands:
-          - "update-ca-trust"
-      desc: update-ca-trust on client nodes
-      polarion-id: CEPH-83575227
-      module: exec.py
-      name: update-ca-trust on client nodes
 
   - test:
       name: Test NFS cluster and export create

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -118,6 +118,17 @@ tests:
 
   # STS tests
 
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+          - client
+      desc: Copy cephadm root CA cert to rgw and client nodes
+      module: copy_cephadm_root_ca_cert.py
+      name: copy cephadm root ca cert
+      polarion-id: CEPH-10362
   - test:
       name: STS Tests to perform assume role on principle user and perform IOs
       desc: Perform assume role on principle user and perform IOs

--- a/tests/rgw/copy_cephadm_root_ca_cert.py
+++ b/tests/rgw/copy_cephadm_root_ca_cert.py
@@ -1,0 +1,107 @@
+"""Copy cephadm root CA cert to RGW and client nodes without sshpass."""
+
+import os
+import re
+
+from utility.log import Log
+
+LOG = Log(__name__)
+
+CEPHADM_ROOT_CA_FILE = "cephadm-root-ca.crt"
+CA_TRUST_ANCHORS = "/etc/pki/ca-trust/source/anchors"
+
+
+def get_cephadm_root_ca_cert(installer):
+    """Fetch the cephadm root CA certificate from the cluster."""
+    version_out, _ = installer.exec_command(
+        cmd="cephadm shell -- ceph version", sudo=True
+    )
+    ceph_version = ""
+    match = re.search(r"ceph version (\S+)", version_out)
+    if match:
+        ceph_version = match.group(1).split("-")[0]
+
+    if ceph_version == "19.2.0":
+        cmd = "cephadm shell -- ceph orch cert-store get cert cephadm_root_ca_cert"
+    else:
+        cmd = "cephadm shell -- ceph orch certmgr cert get cephadm_root_ca_cert"
+
+    cert, _ = installer.exec_command(cmd=cmd, sudo=True)
+    return cert
+
+
+def install_cephadm_root_ca_cert(node, cert_content, cert_name=CEPHADM_ROOT_CA_FILE):
+    """Install cephadm root CA cert on a node using remote_file."""
+    if node.pkg_type == "deb":
+        cert_path = f"/usr/local/share/ca-certificates/{cert_name}"
+        update_cmd = "update-ca-certificates"
+    else:
+        cert_path = f"{CA_TRUST_ANCHORS}/{cert_name}"
+        update_cmd = "update-ca-trust extract"
+
+    node.exec_command(sudo=True, cmd=f"mkdir -p {os.path.dirname(cert_path)}")
+    cert_file = node.remote_file(sudo=True, file_name=cert_path, file_mode="w")
+    cert_file.write(cert_content)
+    cert_file.flush()
+    cert_file.close()
+    node.exec_command(sudo=True, cmd=update_cmd)
+
+
+def copy_cephadm_root_ca_cert_to_roles(cluster, roles=("rgw", "client")):
+    """Copy cephadm root CA cert to nodes matching the given roles."""
+    installer = cluster.get_nodes(role="installer")[0]
+    cert = get_cephadm_root_ca_cert(installer)
+    seen = set()
+    for role in roles:
+        for node in cluster.get_nodes(role=role):
+            if node.hostname in seen:
+                continue
+            seen.add(node.hostname)
+            LOG.info("Copying cephadm root CA cert to %s", node.hostname)
+            install_cephadm_root_ca_cert(node, cert)
+
+
+def copy_peer_cas_to_roles(cluster, ceph_cluster_dict, roles=("rgw", "client")):
+    """Install peer cluster cephadm root CAs for multisite SSL trust."""
+    if len(ceph_cluster_dict) <= 1:
+        return
+
+    for peer_name, peer_cluster in ceph_cluster_dict.items():
+        if peer_cluster.name == cluster.name:
+            continue
+        peer_installer = peer_cluster.get_nodes(role="installer")[0]
+        cert = get_cephadm_root_ca_cert(peer_installer)
+        cert_name = f"cephadm-root-ca-{peer_name}.crt"
+        seen = set()
+        for role in roles:
+            for node in cluster.get_nodes(role=role):
+                if node.hostname in seen:
+                    continue
+                seen.add(node.hostname)
+                LOG.info(
+                    "Copying peer %s cephadm root CA cert to %s",
+                    peer_name,
+                    node.hostname,
+                )
+                install_cephadm_root_ca_cert(node, cert, cert_name=cert_name)
+
+
+def run(ceph_cluster, **kwargs):
+    """
+    Copy cephadm root CA cert to nodes by role.
+
+    Run after client setup in SSL RGW suites.
+
+    Config keys:
+        roles: list of node roles (default: rgw, client)
+    """
+    config = kwargs.get("config", {})
+    roles = config.get("roles", ["rgw", "client"])
+    ceph_cluster_dict = kwargs.get("ceph_cluster_dict", {})
+    try:
+        copy_cephadm_root_ca_cert_to_roles(ceph_cluster, roles=roles)
+        copy_peer_cas_to_roles(ceph_cluster, ceph_cluster_dict, roles=roles)
+    except Exception as exc:
+        LOG.error("Failed to copy cephadm root CA cert: %s", exc)
+        return 1
+    return 0


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>



SSL RGW suites with generate_cert: true previously copied the cephadm root CA to rgw/client nodes using sshpass + scp, followed by manual update-ca-trust exec steps. For multisite, pri’s CA had to be copied to sec nodes before realm pull over HTTPS could succeed.

This PR replaces that with a dedicated test module, tests/rgw/copy_cephadm_root_ca_cert.py, which uses CephCI’s remote_file (SFTP) to install certs and refresh the system trust store.

**copy_cephadm_root_ca_cert.py**
Fetches the cephadm root CA via cephadm shell (cert-store on 19.2.0, certmgr otherwise)
Installs the cert on rgw/client nodes and runs update-ca-trust extract (or update-ca-certificates on deb)
Multisite: when a suite uses a clusters: block, peer cluster CAs are installed automatically via ceph_cluster_dict:
Local CA → cephadm-root-ca.crt
Peer CAs → cephadm-root-ca-ceph-pri.crt, cephadm-root-ca-ceph-sec.crt, etc.
Suite changes (suites/*/rgw/ — 23 YAML files)

Add copy_cephadm_root_ca_cert.py after client setup in all generate_cert: true SSL RGW suites

Remove legacy sshpass cert-copy exec tests and redundant update-ca-trust steps

**Typical usage**
**_Single-site:_**

```
- test:
    config:
      roles: [rgw, client]
    module: copy_cephadm_root_ca_cert.py
    name: copy cephadm root ca cert
```
**_Multisite (peer CA exchange is automatic):_**
```

- test:
    clusters:
      ceph-pri:
        config:
          roles: [rgw, client]
      ceph-sec:
        config:
          roles: [rgw, client]
    module: copy_cephadm_root_ca_cert.py
    name: copy cephadm root ca cert
```
fail logs:
http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.1/rhel-9/upgrade/20.2.1-294/rgw/43/logs/
pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.1/rhel-9/upgrade/20.2.1-294/rgw/45/logs/ 