### PR TITLE
TFA fix for cloud trans/rest tests in cephci. 

### DIFF
--- a/suites/squid/common/regression/3way_rgw_ms_ecpool.yaml
+++ b/suites/squid/common/regression/3way_rgw_ms_ecpool.yaml
@@ -283,19 +283,6 @@ tests:
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            git_clone_configs_repo: true
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-      desc: test LC cloud transition to IBM cos with retain false
-      polarion-id: CEPH-83581973 #CEPH-83581975
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain false
-
   - test:
       clusters:
         ceph-pri:
@@ -306,18 +293,6 @@ tests:
       polarion-id: CEPH-83575592
       module: sanity_rgw_multisite.py
       name: test assume role at secondary, with s3 ops
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-      desc: test LC cloud transition to IBM cos with retain true
-      polarion-id: CEPH-83581972 #CEPH-83575498
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain true
-
   - test:
       clusters:
         ceph-sec:

--- a/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -650,18 +650,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            git_clone_configs_repo: true
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-      desc: test LC cloud transition to IBM cos with retain false
-      polarion-id: CEPH-83581973 #CEPH-83581975
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain false
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             script-name: test_sts_using_boto.py
             config-file-name: test_sts_multisite.yaml
       desc: test assume role at secondary, with s3 ops
@@ -669,13 +657,3 @@ tests:
       module: sanity_rgw_multisite.py
       name: test assume role at secondary, with s3 ops
 
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-      desc: test LC cloud transition to IBM cos with retain true
-      polarion-id: CEPH-83581972 #CEPH-83575498
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain true

--- a/suites/tentacle/common/regression/3way_rgw_ms_ecpool.yaml
+++ b/suites/tentacle/common/regression/3way_rgw_ms_ecpool.yaml
@@ -283,19 +283,6 @@ tests:
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            git_clone_configs_repo: true
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-      desc: test LC cloud transition to IBM cos with retain false
-      polarion-id: CEPH-83581973 #CEPH-83581975
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain false
-
   - test:
       clusters:
         ceph-pri:
@@ -306,18 +293,6 @@ tests:
       polarion-id: CEPH-83575592
       module: sanity_rgw_multisite.py
       name: test assume role at secondary, with s3 ops
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-      desc: test LC cloud transition to IBM cos with retain true
-      polarion-id: CEPH-83581972 #CEPH-83575498
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain true
-
   - test:
       clusters:
         ceph-sec:

--- a/suites/tentacle/rgw/rgw_ms_s3_restore.yaml
+++ b/suites/tentacle/rgw/rgw_ms_s3_restore.yaml
@@ -250,7 +250,7 @@ tests:
       desc: IBM cloud transition and permanent restore with retain_head=true, verify at remote site
       module: sanity_rgw_multisite.py
       name: IBM cloud transition restore retain_head true
-      polarion-id: CEPH-83581972 # CEPH-83575498 CEPH-83591622 CEPH-83591621
+      polarion-id: CEPH-83581972 # CEPH-83575498
 
   # Test 3: AWS cloud transition + permanent restore, versioned objects eu-north-1
   - test:
@@ -263,6 +263,33 @@ tests:
       desc: AWS cloud transition and permanent restore for versioned objects in eu-north-1
       module: sanity_rgw_multisite.py
       name: AWS cloud transition restore versioned objects
+
+  # Test 4: IBM cloud transition + restore with bug verification
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_cloud_transition_restore_object.yaml
+
+      desc: IBM cloud transition and restore with bug verification for multipart and ETag issues
+      module: sanity_rgw_multisite.py
+      name: IBM cloud transition restore with bug verification
+      polarion-id: CEPH-83591622 # CEPH-83591672 CEPH-83591621
+
+  # Test 5: AWS cloud transition + restore for multipart >50MB with bug verification
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_aws_cloud_transition_restore_multipart.yaml
+
+      desc: AWS cloud transition and restore for multipart objects >50MB with bug verification
+      module: sanity_rgw_multisite.py
+      name: AWS cloud transition restore multipart with bug verification
+
+  # Test 6: IBM cloud transition + restore with retain_head=false primary-only
   - test:
       clusters:
         ceph-pri:
@@ -274,3 +301,4 @@ tests:
       module: sanity_rgw_multisite.py
       name: IBM cloud transition restore retain_head false
       polarion-id: CEPH-83581973 # CEPH-83581975 CEPH-83581977
+

--- a/suites/tentacle/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -537,18 +537,6 @@ tests:
 
   # Test work flow
 
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            git_clone_configs_repo: true
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_restore_object.yaml
-      desc: test s3 object restore and download, and restore attrs
-      module: sanity_rgw_multisite.py
-      name: test s3 object restore and download, and restore attrs
-      polarion-id: CEPH-83591622 #CEPH-83591672 #CEPH-83591621
-
 # configuring vault agent on all the sites
 
   - test:
@@ -642,18 +630,6 @@ tests:
             config-file-name: ../../s3cmd/configs/test_get_s3cmd_tertiary.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-      desc: test LC cloud transition to IBM cos with retain false
-      polarion-id: CEPH-83581973 #CEPH-83581975
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain false
-
   - test:
       clusters:
         ceph-pri:
@@ -665,13 +641,3 @@ tests:
       module: sanity_rgw_multisite.py
       name: test assume role at secondary, with s3 ops
 
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-      desc: test LC cloud transition to IBM cos with retain true
-      polarion-id: CEPH-83581972 #CEPH-83575498
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain true


### PR DESCRIPTION


# Description
TFA fix for cloud trans/rest tests in cephci. Having just one suite file for all of the cloud transition and restore tests in squid and tentacle

Complete suite passed logs

1. Squid - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8AOYYC
2. Tentacle -  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3KNSJK

Please note that the failed test is not included in the suites (just a regression test that failed due to an incorrect config provided). 
It has however, passed when changing the config path to multisite [http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-47ISWD]