### PR TITLE
Updating reef upgrade suites to use released builds instead of rc

### DIFF
--- a/suites/reef/cephfs/tier-0_cephfs_mirrror_upgrade_5x_to_6x_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_mirrror_upgrade_5x_to_6x_to_7x.yaml
@@ -19,7 +19,7 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     rhcs-version: 5.3
-                    release: rc
+                    release: released
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
               - config:
@@ -79,7 +79,7 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     rhcs-version: 5.3
-                    release: rc
+                    release: released
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
               - config:
@@ -191,7 +191,7 @@ tests:
                     verbose: true
                   args:
                     rhcs-version: 6.1  #Need change in version when there is minor version change
-                    release: rc
+                    release: released
                   benchmark:
                     type: rados
                     pool_per_client: true

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_5x_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_5x_to_7x.yaml
@@ -25,7 +25,7 @@ tests:
           - config:
               args:
                 rhcs-version: 5.3
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_61_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_61_to_7x.yaml
@@ -25,7 +25,7 @@ tests:
           - config:
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io

--- a/suites/reef/nfs/tier1-nfs-ganesha-upgrade-7x-to-7x-latest.yaml
+++ b/suites/reef/nfs/tier1-nfs-ganesha-upgrade-7x-to-7x-latest.yaml
@@ -27,7 +27,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.0
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/rbd/tier-3_rbd_mirror_upgrade_5xto7x_scale.yaml
+++ b/suites/reef/rbd/tier-3_rbd_mirror_upgrade_5xto7x_scale.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 5.3
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -63,7 +63,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 5.3
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/rbd/tier-3_rbd_mirror_upgrade_6xto7x_scale.yaml
+++ b/suites/reef/rbd/tier-3_rbd_mirror_upgrade_6xto7x_scale.yaml
@@ -26,7 +26,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
@@ -63,7 +63,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 6.1
-                    release: "rc"
+                    release: "released"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true

--- a/suites/reef/upgrades/tier-2-upgrade-rhcs-5x-to-7x-standby-mgr.yaml
+++ b/suites/reef/upgrades/tier-2-upgrade-rhcs-5x-to-7x-standby-mgr.yaml
@@ -25,7 +25,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 5.3
-                release: "rc"
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier1-upgrade-rhcs-5x-to-7x-mix-os.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-rhcs-5x-to-7x-mix-os.yaml
@@ -27,7 +27,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 5.3
-                release: "rc"
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier1-upgrade-rhcs-5x-to-7x.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-rhcs-5x-to-7x.yaml
@@ -29,7 +29,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 5.3
-                release: "rc"
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier1-upgrade-rhcs-6x-to-7x.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-rhcs-6x-to-7x.yaml
@@ -29,7 +29,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 6.1
-                release: "rc"
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier1-upgrade-rhcs-7x-to-7x-latest.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-rhcs-7x-to-7x-latest.yaml
@@ -31,7 +31,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.0
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier2-upgrade-rhcs-staggered-5x-to-7x.yaml
+++ b/suites/reef/upgrades/tier2-upgrade-rhcs-staggered-5x-to-7x.yaml
@@ -37,7 +37,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 5.3
-                release: "rc"
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/reef/upgrades/tier2-upgrade-rhcs-staggered-6x-to-7x.yaml
+++ b/suites/reef/upgrades/tier2-upgrade-rhcs-staggered-6x-to-7x.yaml
@@ -37,7 +37,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 6.1
-                release: "rc"
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true


### PR DESCRIPTION
Updating reef upgrade suite bootstrap configs from `release: rc` to `release: released` across CephFS, NFS, RBD, and DMFG upgrade suites.

Affected suites
- CephFS: tier-0 mirror and upgrade suites (5x→6x→7x, 5x→7x, 6.1→7x)
- NFS: tier1-nfs-ganesha-upgrade-7x-to-7x-latest
- RBD: tier-3 mirror upgrade scale suites (5x→7x, 6x→7x)
- DMFG: tier1/tier2 RHCS upgrade suites (5x→7x, 6x→7x, 7x→7x-latest, staggered, standby-mgr, mix-os)