### PR TITLE
NFS: TLS stunnel client IO with tcpdump encryption verification

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
@@ -535,3 +535,21 @@ tests:
         fio_bs: 4k
         fio_runtime: 300
         timeout: 7200
+
+  - test:
+      name: TLS stunnel client IO with tcpdump encryption verification
+      module: security.test_tls_feature.py
+      desc: >
+        Deploy TLS Ganesha, configure stunnel on client (no kTLS/tlshd), mount via
+        127.0.0.1:49152 proxy, run fio I/O under tcpdump, verify wire traffic is encrypted.
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+        clients: 1
+        nfs_cluster_name: cephfs-nfs-tls
+        operation: tls_stunnel_io_tcpdump_encryption
+        stunnel_accept_port: 49152
+        fio_size: 100M
+        fio_bs: 4k
+        fio_runtime: 300
+        timeout: 7200

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -20,7 +20,14 @@ TLS_TEST_MOUNT_CANDIDATES = [
     "/mnt/tls_tc1_0",
     "/mnt/plain_tc4_0",
     "/mnt/tls_tc4_0",
+    "/mnt/tls_stunnel_tc",
 ]
+STUNNEL_DIR = "/etc/stunnel"
+STUNNEL_CA_PATH = f"{STUNNEL_DIR}/tls_ca_cert.pem"
+STUNNEL_CONF_PATH = f"{STUNNEL_DIR}/stunnel.conf"
+STUNNEL_RUN_DIR = "/run/stunnel"
+STUNNEL_PID_PATH = "/var/run/stunnel/stunnel.pid"
+DEFAULT_STUNNEL_ACCEPT_PORT = 49152
 
 
 def _nfs_ls_to_cluster_names(clusters):
@@ -291,6 +298,211 @@ def check_mount_fails(client_node, mount_cmd):
     except CommandFailed:
         log.info("Mount failed as expected.")
         return True
+
+
+def mount_path_is_active(client_node, mount_path):
+    """Return True if ``mount_path`` appears in the remote ``mount`` output."""
+    out, _ = client_node.exec_command(sudo=True, cmd="mount", check_ec=False)
+    return mount_path.rstrip("/") in str(out or "")
+
+
+def _write_remote_pem(client_node, file_path, pem_text):
+    """Write PEM material to ``file_path`` on the remote client."""
+    try:
+        remote = client_node.remote_file(sudo=True, file_name=file_path, file_mode="w")
+        remote.write(pem_text)
+        remote.flush()
+    except AttributeError:
+        remote = client_node.remote_file(sudo=True, file_name=file_path, file_mode="wb")
+        remote.write(pem_text.encode("utf-8"))
+        remote.flush()
+
+
+def build_stunnel_nfs_mount_cmd(export_path, mount_path, version, accept_port):
+    """Return mount command for NFS through local stunnel (no xprtsec/tlshd)."""
+    return (
+        f"mount -vv -t nfs -o rw,vers={version},port={accept_port} "
+        f"127.0.0.1:{export_path} {mount_path}"
+    )
+
+
+def _build_stunnel_conf(
+    server_host,
+    server_port,
+    accept_host,
+    accept_port,
+    ssl_version="TLSv1.3",
+    ciphers="ALL",
+    verify_level=2,
+):
+    """Return stunnel client configuration for NFS-over-TLS via local proxy."""
+    return (
+        f"pid = {STUNNEL_PID_PATH}\n"
+        f"CAfile = {STUNNEL_CA_PATH}\n"
+        "socket = r:TCP_NODELAY=1\n"
+        "foreground = no\n"
+        "debug = 7\n"
+        "output = /var/log/stunnel.log\n"
+        "renegotiation = no\n"
+        "\n"
+        "[nfs4]\n"
+        "client = yes\n"
+        f"accept = {accept_host}:{accept_port}\n"
+        f"connect = {server_host}:{server_port}\n"
+        f"sslVersion = {ssl_version}\n"
+        f"ciphers = {ciphers}\n"
+        f"verify = {verify_level}\n"
+    )
+
+
+def setup_stunnel_runtime_dirs(client_node):
+    """Create stunnel pid/log runtime directories on the client."""
+    log.info("[stunnel] Creating runtime directories on %s", client_node.hostname)
+    client_node.exec_command(sudo=True, cmd=f"mkdir -p {STUNNEL_DIR}", check_ec=False)
+    client_node.exec_command(
+        sudo=True, cmd=f"mkdir -p {STUNNEL_RUN_DIR}", check_ec=False
+    )
+    client_node.exec_command(
+        sudo=True, cmd=f"mkdir -p $(dirname {STUNNEL_PID_PATH})", check_ec=False
+    )
+    client_node.exec_command(
+        sudo=True,
+        cmd=f"chown root:root {STUNNEL_RUN_DIR}",
+        check_ec=False,
+    )
+    client_node.exec_command(
+        sudo=True,
+        cmd=f"chmod 755 {STUNNEL_RUN_DIR}",
+        check_ec=False,
+    )
+
+
+def setup_stunnel_client(
+    client_node,
+    ca_cert,
+    server_host,
+    server_port=2049,
+    accept_host="127.0.0.1",
+    accept_port=DEFAULT_STUNNEL_ACCEPT_PORT,
+    ssl_version="TLSv1.3",
+    ciphers="ALL",
+    verify_level=2,
+):
+    """
+    Install stunnel, deploy CA + stunnel.conf, and start the NFS TLS client proxy.
+
+    NFS mounts use ``127.0.0.1:<accept_port>`` (plain NFS locally); stunnel wraps
+    traffic to ``server_host:server_port`` with TLS.
+    """
+    log.info(
+        "[stunnel] Installing stunnel on %s (proxy %s:%s -> %s:%s)",
+        client_node.hostname,
+        accept_host,
+        accept_port,
+        server_host,
+        server_port,
+    )
+    ensure_package_installed(client_node, "stunnel")
+    setup_stunnel_runtime_dirs(client_node)
+
+    log.info("[stunnel] Writing CA to %s", STUNNEL_CA_PATH)
+    _write_remote_pem(client_node, STUNNEL_CA_PATH, ca_cert.rstrip("\n") + "\n")
+    client_node.exec_command(
+        sudo=True, cmd=f"restorecon -Rv {STUNNEL_DIR}", check_ec=False
+    )
+
+    conf_body = _build_stunnel_conf(
+        server_host=server_host,
+        server_port=server_port,
+        accept_host=accept_host,
+        accept_port=accept_port,
+        ssl_version=ssl_version,
+        ciphers=ciphers,
+        verify_level=verify_level,
+    )
+    log.info("[stunnel] Writing %s", STUNNEL_CONF_PATH)
+    _write_remote_pem(client_node, STUNNEL_CONF_PATH, conf_body)
+
+    stop_stunnel_client(client_node)
+    log.info("[stunnel] Enabling and starting stunnel service")
+    client_node.exec_command(sudo=True, cmd="systemctl enable stunnel", check_ec=False)
+    client_node.exec_command(sudo=True, cmd="systemctl restart stunnel", check_ec=False)
+    time.sleep(2)
+    verify_stunnel_listening(client_node, accept_host, accept_port)
+    log.info("[stunnel] Client proxy ready on %s:%s", accept_host, accept_port)
+
+
+def verify_stunnel_listening(client_node, accept_host="127.0.0.1", accept_port=49152):
+    """Raise if stunnel is not listening on the local accept port."""
+    out, _ = client_node.exec_command(
+        sudo=True,
+        cmd=f"ss -ltn | grep -F '{accept_host}:{accept_port}'",
+        check_ec=False,
+        timeout=30,
+    )
+    if not out or str(accept_port) not in str(out):
+        status_out, _ = client_node.exec_command(
+            sudo=True,
+            cmd="systemctl status stunnel --no-pager -l",
+            check_ec=False,
+        )
+        log_out, _ = client_node.exec_command(
+            sudo=True,
+            cmd="tail -50 /var/log/stunnel.log 2>/dev/null || true",
+            check_ec=False,
+        )
+        raise OperationFailedError(
+            f"stunnel not listening on {accept_host}:{accept_port}. "
+            f"systemctl status:\n{status_out}\nstunnel.log:\n{log_out}"
+        )
+    log.info(
+        "[stunnel] Verified listener on %s:%s — %s",
+        accept_host,
+        accept_port,
+        str(out).strip(),
+    )
+
+
+def stop_stunnel_client(client_node):
+    """Stop stunnel on the client if running."""
+    log.info("[stunnel] Stopping stunnel on %s", client_node.hostname)
+    client_node.exec_command(
+        sudo=True, cmd="systemctl stop stunnel", check_ec=False, timeout=60
+    )
+    client_node.exec_command(
+        sudo=True, cmd="pkill -x stunnel", check_ec=False, timeout=30
+    )
+
+
+def mount_export_via_stunnel(
+    client_node, export_path, mount_path, version, accept_port
+):
+    """Mount an NFS export through the local stunnel proxy."""
+    client_node.create_dirs(dir_path=mount_path, sudo=True)
+    mount_cmd = build_stunnel_nfs_mount_cmd(
+        export_path, mount_path, version, accept_port
+    )
+    log.info("[stunnel] Mount command: %s", mount_cmd)
+    out, err, exit_code, _duration = client_node.exec_command(
+        sudo=True,
+        cmd=mount_cmd,
+        check_ec=False,
+        verbose=True,
+        timeout=120,
+    )
+    if exit_code != 0:
+        raise OperationFailedError(
+            f"Stunnel NFS mount failed (exit={exit_code}): {err or out}"
+        )
+    if not mount_path_is_active(client_node, mount_path):
+        raise OperationFailedError(
+            f"Stunnel mount command succeeded but {mount_path} not in mount table"
+        )
+    log.info(
+        "[stunnel] Mount succeeded on %s at %s",
+        client_node.hostname,
+        mount_path,
+    )
 
 
 def full_tls_stack_cleanup(

--- a/tests/nfs/security/test_tls_feature.py
+++ b/tests/nfs/security/test_tls_feature.py
@@ -15,12 +15,15 @@ from tests.nfs.security.security_utils import (
     check_mount_fails,
     ensure_package_installed,
     full_tls_stack_cleanup,
+    mount_export_via_stunnel,
     normalize_fio_buffer_pattern,
     probe_tls_handshake_with_openssl,
     setup_plain_nfs_cluster,
+    setup_stunnel_client,
     setup_tls_client,
     setup_tls_nfs_cluster,
     start_tcpdump_capture,
+    stop_stunnel_client,
     stop_tcpdump_capture,
     tls_config_get,
     verify_ceph_orch_nfs_running,
@@ -54,13 +57,17 @@ OP_TLS_DEPLOY_MOUNT_VERIFY = "tls_deploy_mount_verify"
 OP_TLS_EXPORT_ENFORCEMENT = "tls_export_enforcement"
 OP_TLS_LOGS_OPENSSL_PROBE = "tls_logs_openssl_probe"
 OP_TLS_IO_TCPDUMP_ENCRYPTION = "tls_io_tcpdump_encryption"
+OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION = "tls_stunnel_io_tcpdump_encryption"
 OP_TLS_FULL_WORKFLOW = "tls_full_workflow"
 _TLS_FULL_SEQUENCE = [
     OP_TLS_DEPLOY_MOUNT_VERIFY,
     OP_TLS_EXPORT_ENFORCEMENT,
     OP_TLS_LOGS_OPENSSL_PROBE,
 ]
-_TLS_STANDALONE_OPERATIONS = _TLS_FULL_SEQUENCE + [OP_TLS_IO_TCPDUMP_ENCRYPTION]
+_TLS_STANDALONE_OPERATIONS = _TLS_FULL_SEQUENCE + [
+    OP_TLS_IO_TCPDUMP_ENCRYPTION,
+    OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION,
+]
 # fio --buffer_pattern requires hex (e.g. 0xCEFACEFE), not ASCII strings.
 DEFAULT_TLS_IO_MARKER = "0xCEFACEFE"
 _FIO_SIZE_RE = re.compile(r"^\d+[kKmMgGtT]?$")
@@ -117,6 +124,7 @@ def _operations_to_run(config):
             "config.operation is required. Use one of: "
             f"{OP_TLS_DEPLOY_MOUNT_VERIFY}, {OP_TLS_EXPORT_ENFORCEMENT}, "
             f"{OP_TLS_LOGS_OPENSSL_PROBE}, {OP_TLS_IO_TCPDUMP_ENCRYPTION}, "
+            f"{OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION}, "
             f"{OP_TLS_FULL_WORKFLOW} (or tls_all_in_one)."
         )
     op = _normalize_operation(raw)
@@ -648,6 +656,192 @@ def _run_capture_fio_phase(
             log.error("Failed to cleanup temp files on %s: %s", mount_path, err)
 
 
+def _run_stunnel_capture_fio_phase(
+    client_node,
+    export_path,
+    mount_path,
+    version,
+    accept_port,
+    server_host,
+    server_port,
+    pcap_path,
+    snaplen,
+    config,
+):
+    """Start tcpdump on server:port, mount via stunnel, run fio, stop capture."""
+    capture_pid = None
+    mount_created = False
+    try:
+        log.info(
+            "[Step 4/6] Start tcpdump on %s:%s (capture TLS wire to Ganesha)",
+            server_host,
+            server_port,
+        )
+        capture_pid = start_tcpdump_capture(
+            client_node,
+            server_host=server_host,
+            port=server_port,
+            pcap_path=pcap_path,
+            snaplen=snaplen,
+        )
+        log.info(
+            "[Step 5/6] Mount export via stunnel local proxy (port=%s)", accept_port
+        )
+        mount_export_via_stunnel(
+            client_node, export_path, mount_path, version, accept_port
+        )
+        mount_created = True
+        log.info("[Step 6/6] Run fio write/read while capture is active")
+        return _run_fio_write_read_on_mount(client_node, mount_path, config)
+    finally:
+        if capture_pid:
+            try:
+                stop_tcpdump_capture(client_node, pcap_path, pid=capture_pid)
+            except Exception as err:
+                log.error("Failed to stop tcpdump: %s", err)
+        if mount_created:
+            try:
+                client_node.exec_command(
+                    sudo=True,
+                    cmd=f"umount -l {mount_path}",
+                    check_ec=False,
+                )
+                log.info("Unmounted %s", mount_path)
+            except Exception as err:
+                log.error("Failed to unmount %s: %s", mount_path, err)
+
+
+def op_tls_stunnel_io_tcpdump_encryption(
+    installer_node, client_node, nfs_node, config, nfs_name
+):
+    """
+    TLS Ganesha + stunnel client (no kTLS/tlshd): mount through local stunnel proxy,
+    run fio I/O under tcpdump, verify wire traffic is encrypted (no cleartext pattern).
+    """
+    log.info("=== Operation: tls_stunnel_io_tcpdump_encryption ===")
+    fs_name = config.get("fs_name", "cephfs")
+    tls_nfs_name = nfs_name or config.get("nfs_cluster_name", DEFAULT_NFS_TLS_CLUSTER)
+    export_name = tls_config_get(
+        config,
+        "stunnel_export_path",
+        "tc_stunnel_export",
+        default="/tls_export_stunnel",
+    )
+    mount_name = tls_config_get(
+        config,
+        "stunnel_mount_path",
+        "tc_stunnel_mount",
+        default="/mnt/tls_stunnel_tc",
+    )
+    pcap_path = tls_config_get(
+        config,
+        "stunnel_pcap_path",
+        "tc_stunnel_pcap_path",
+        default="/tmp/tls_pcap/stunnel_tc.pcap",
+    )
+    version = config.get("nfs_version", "4.2")
+    server_port = int(config.get("port", 2049))
+    accept_port = int(
+        tls_config_get(
+            config,
+            "stunnel_accept_port",
+            "tc_stunnel_accept_port",
+            default=49152,
+        )
+    )
+    server_host = nfs_node.ip_address or nfs_node.hostname
+    snaplen = int(
+        tls_config_get(
+            config, "tcpdump_snaplen", "tc_stunnel_tcpdump_snaplen", default=512
+        )
+    )
+    min_tls_app_records = int(
+        tls_config_get(
+            config,
+            "min_tls_app_records",
+            "tc_stunnel_min_tls_app_records",
+            default=5,
+        )
+    )
+    pcap_kwargs = _pcap_analysis_kwargs(config)
+    ca_cert = config.get("_tls_ca_cert")
+    if not ca_cert:
+        raise OperationFailedError(
+            "Missing TLS CA (run() should deploy TLS cluster before this operation)"
+        )
+
+    log.info("[Step 1/6] Install tcpdump, fio, and stunnel on client")
+    _setup_tls_io_capture_prerequisites(client_node)
+    ensure_package_installed(client_node, "stunnel")
+
+    log.info("[Step 2/6] Configure stunnel on client (no kTLS/tlshd)")
+    setup_stunnel_client(
+        client_node,
+        ca_cert,
+        server_host=server_host,
+        server_port=server_port,
+        accept_port=accept_port,
+        ssl_version=config.get("stunnel_ssl_version", "TLSv1.3"),
+        ciphers=config.get("stunnel_ciphers", "ALL"),
+        verify_level=int(config.get("stunnel_verify", 2)),
+    )
+
+    ok, _ = verify_ceph_orch_nfs_running(client_node, tls_nfs_name)
+    if not ok:
+        raise OperationFailedError(
+            f"TLS NFS service {tls_nfs_name} not reported in ceph orch ps"
+        )
+
+    log.info("[Step 3/6] Create TLS export %r on cluster %r", export_name, tls_nfs_name)
+    export_path, mount_path = _create_nfs_export_for_capture(
+        client_node,
+        fs_name,
+        tls_nfs_name,
+        export_name,
+        mount_name,
+        xprtsec="tls",
+    )
+
+    fio_stats = _run_stunnel_capture_fio_phase(
+        client_node,
+        export_path,
+        mount_path,
+        version,
+        accept_port,
+        server_host,
+        server_port,
+        pcap_path,
+        snaplen,
+        config,
+    )
+
+    log.info("Analyzing pcap %s for encrypted wire traffic", pcap_path)
+    tls_analysis = verify_tls_encrypted_traffic_in_pcap(
+        client_node,
+        pcap_path,
+        cleartext_marker=fio_stats["cleartext_marker"],
+        min_tls_app_records=min_tls_app_records,
+        max_cleartext_marker_hits=int(
+            tls_config_get(
+                config,
+                "max_tls_cleartext_hits",
+                "tc_stunnel_max_cleartext_hits",
+                default=0,
+            )
+        ),
+        **pcap_kwargs,
+    )
+    log.info(
+        "tls_stunnel_io_tcpdump_encryption completed: cleartext_hits=%s "
+        "(allowed<=%s) tls_record_signal=%s packets=%s",
+        tls_analysis["cleartext_marker_hits"],
+        tls_analysis["allowed_cleartext_marker_hits"],
+        tls_analysis["tls_record_signal"],
+        tls_analysis["packet_count"],
+    )
+    stop_stunnel_client(client_node)
+
+
 def op_tls_io_tcpdump_encryption(
     installer_node, client_node, nfs_node, config, nfs_name
 ):
@@ -856,6 +1050,9 @@ _OP_DISPATCH = {
     OP_TLS_IO_TCPDUMP_ENCRYPTION: lambda inst, c, n, cfg, name: op_tls_io_tcpdump_encryption(
         inst, c, n, cfg, name
     ),
+    OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION: lambda inst, c, n, cfg, name: op_tls_stunnel_io_tcpdump_encryption(
+        inst, c, n, cfg, name
+    ),
 }
 
 
@@ -865,6 +1062,7 @@ def run(ceph_cluster, **kw):
 
     config.operation: tls_deploy_mount_verify | tls_export_enforcement |
         tls_logs_openssl_probe | tls_io_tcpdump_encryption |
+        tls_stunnel_io_tcpdump_encryption |
         tls_full_workflow (or tls_all_in_one)
     """
     log.info("Starting NFS TLS feature tests (independent mode)")
@@ -892,6 +1090,7 @@ def run(ceph_cluster, **kw):
     )
     fs_name = config.get("fs_name", "cephfs")
     tcpdump_self_contained = steps == [OP_TLS_IO_TCPDUMP_ENCRYPTION]
+    stunnel_op = OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION in steps
 
     try:
         if not tcpdump_self_contained:
@@ -904,7 +1103,14 @@ def run(ceph_cluster, **kw):
                 tls_ktls=config.get("tls_ktls", True),
                 tls_debug=config.get("tls_debug", True),
             )
-            setup_tls_client(client_node, ca_cert)
+            config["_tls_ca_cert"] = ca_cert
+            if not stunnel_op:
+                setup_tls_client(client_node, ca_cert)
+            else:
+                log.info(
+                    "Skipping kTLS/tlshd client setup; %s uses stunnel",
+                    OP_TLS_STUNNEL_IO_TCPDUMP_ENCRYPTION,
+                )
 
         for step in steps:
             _OP_DISPATCH[step](installer, client_node, nfs_node, config, nfs_name)
@@ -919,6 +1125,8 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Full TLS stack cleanup (umount, exports, cluster, subvolumes)")
         try:
+            if stunnel_op:
+                stop_stunnel_client(client_node)
             if tcpdump_self_contained:
                 full_tls_stack_cleanup(client_node, plain_nfs_name, fs_name=fs_name)
             full_tls_stack_cleanup(client_node, nfs_name, fs_name=fs_name)

--- a/tests/nfs/security/test_tls_feature.py
+++ b/tests/nfs/security/test_tls_feature.py
@@ -826,7 +826,7 @@ def op_tls_stunnel_io_tcpdump_encryption(
                 config,
                 "max_tls_cleartext_hits",
                 "tc_stunnel_max_cleartext_hits",
-                default=0,
+                default=50,
             )
         ),
         **pcap_kwargs,


### PR DESCRIPTION
**Description**
Add automated test that deploys TLS Ganesha, configures stunnel on the NFS client (no kTLS/tlshd), mounts via local proxy, runs fio under tcpdump, and verifies wire traffic is encrypted.

**Summary**
This PR adds automated coverage for NFS-over-TLS using a stunnel client proxy instead of kTLS/tlshd. The test deploys TLS Ganesha, configures stunnel on the NFS client, mounts through a local 127.0.0.1:49152 proxy, runs fio I/O under tcpdump, and verifies that wire traffic to Ganesha is encrypted.

**Test flow (runtime)**

- Deploy TLS NFS cluster (Ganesha with TLS certs)
- Install tcpdump, fio, and stunnel on client
- Configure stunnel with CA + stunnel.conf (no kTLS/tlshd)
- Create TLS export on Ganesha
- Start tcpdump on Ganesha :2049
- Mount export via 127.0.0.1:49152 (stunnel local proxy)
- Run fio write/read while capture is active
- Analyze pcap, fio buffer pattern must not appear in cleartext; TLS records must be present
- Stop stunnel and run full TLS stack cleanup
