### PR TITLE
Update known issue and comment out known failures till 10.0

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_cloud_transition.yaml
+++ b/suites/squid/rgw/tier-2_rgw_cloud_transition.yaml
@@ -237,17 +237,17 @@ tests:
       module: exec.py
       name: set sse-s3 vault configs on Local cluster
 
-  - test:
-      clusters:
-        local:
-          config:
-            script-name: test_cloud_transition.py
-            config-file-name: test_cloud_transition_encrypted.yaml
-      desc: test cloud transition of ecnrypted objects
-      module: sanity_rgw.py
-      name: Test cloud transition of SSE-S3 encrypted objects
-      polarion-id: CEPH-83575497
-      comments: known issue Bug 2294512 targetted to 9.0
+  # - test:
+  #     clusters:
+  #       local:
+  #         config:
+  #           script-name: test_cloud_transition.py
+  #           config-file-name: test_cloud_transition_encrypted.yaml
+  #     desc: test cloud transition of ecnrypted objects
+  #     module: sanity_rgw.py
+  #     name: Test cloud transition of SSE-S3 encrypted objects
+  #     polarion-id: CEPH-83575497
+  #     comments: known issue JIRA https://ibm-ceph.atlassian.net/browse/IBMCEPH-9241  targeted to 10.0
 
   - test:
       abort-on-fail: true
@@ -263,17 +263,17 @@ tests:
       name: Enable compression on zone
       polarion-id: CEPH-83575497
 
-  - test:
-      clusters:
-        local:
-          config:
-            script-name: test_cloud_transition.py
-            config-file-name: test_cloud_transition_headobject_false.yaml
-      desc: test clould transition of compressed objects
-      module: sanity_rgw.py
-      name: Test cloud transition with compression enabled
-      polarion-id: CEPH-83575278
-      comments: known issue Bug 2294706 targetted to 9.0
+  # - test:
+  #     clusters:
+  #       local:
+  #         config:
+  #           script-name: test_cloud_transition.py
+  #           config-file-name: test_cloud_transition_headobject_false.yaml
+  #     desc: test clould transition of compressed objects
+  #     module: sanity_rgw.py
+  #     name: Test cloud transition with compression enabled
+  #     polarion-id: CEPH-83575278
+  #     comments: known issue JIRA  https://ibm-ceph.atlassian.net/browse/IBMCEPH-9256 targeted to 10.0
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/rgw/tier-2_rgw_cloud_transition.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_cloud_transition.yaml
@@ -237,17 +237,17 @@ tests:
       module: exec.py
       name: set sse-s3 vault configs on Local cluster
 
-  - test:
-      clusters:
-        local:
-          config:
-            script-name: test_cloud_transition.py
-            config-file-name: test_cloud_transition_encrypted.yaml
-      desc: test cloud transition of ecnrypted objects
-      module: sanity_rgw.py
-      name: Test cloud transition of SSE-S3 encrypted objects
-      polarion-id: CEPH-83575497
-      comments: known issue Bug 2294512 targetted to 9.0
+  # - test:
+  #     clusters:
+  #       local:
+  #         config:
+  #           script-name: test_cloud_transition.py
+  #           config-file-name: test_cloud_transition_encrypted.yaml
+  #     desc: test cloud transition of ecnrypted objects
+  #     module: sanity_rgw.py
+  #     name: Test cloud transition of SSE-S3 encrypted objects
+  #     polarion-id: CEPH-83575497
+  #     comments: known issue JIRA https://ibm-ceph.atlassian.net/browse/IBMCEPH-9241  targeted to 10.0
 
   - test:
       abort-on-fail: true
@@ -263,17 +263,17 @@ tests:
       name: Enable compression on zone
       polarion-id: CEPH-83575497
 
-  - test:
-      clusters:
-        local:
-          config:
-            script-name: test_cloud_transition.py
-            config-file-name: test_cloud_transition_headobject_false.yaml
-      desc: test clould transition of compressed objects
-      module: sanity_rgw.py
-      name: Test cloud transition with compression enabled
-      polarion-id: CEPH-83575278
-      comments: known issue Bug 2294706 targetted to 9.0
+  # - test:
+  #     clusters:
+  #       local:
+  #         config:
+  #           script-name: test_cloud_transition.py
+  #           config-file-name: test_cloud_transition_headobject_false.yaml
+  #     desc: test clould transition of compressed objects
+  #     module: sanity_rgw.py
+  #     name: Test cloud transition with compression enabled
+  #     polarion-id: CEPH-83575278
+  #     comments: known issue JIRA  https://ibm-ceph.atlassian.net/browse/IBMCEPH-9256 targeted to 10.0
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
We have cloud transition of encrypted and compressed objects tests which have JIRAs not to be fixed until 10.0, so updated the known issue and commented out the tests in the respective YAMLs
 https://ibm-ceph.atlassian.net/browse/IBMCEPH-9241 

 https://ibm-ceph.atlassian.net/browse/IBMCEPH-9256 