### PR TITLE
Add NFS and SMB enhanced thrashing workflows with pre/post-thrash verification

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -524,9 +524,12 @@ class RadosOrchestrator:
             log.debug("Retrying check after 15 seconds")
             time.sleep(5)
         else:
-            log_error_msg = f"Stats in the pool did not match the expected object count {exp_objs} \
-                within timeout {timeout}"
-            log.error(log_error_msg)
+            log.error(
+                "Stats in the pool did not match the expected object count %s "
+                "within timeout %s",
+                exp_objs,
+                timeout,
+            )
             return False
         return True
 
@@ -4345,6 +4348,146 @@ EOF"""
                 return True
         return True
 
+    def change_daemon_orch_state(
+        self, action: str, daemon_type: str, daemon_id: str, timeout: int = 120
+    ) -> bool:
+        """Start, stop, or restart a daemon via ``ceph orch daemon`` commands.
+
+        Executes ``ceph orch daemon {action} {daemon_type}.{daemon_id}``
+        and polls ``get_daemon_status`` every 10 seconds until the daemon
+        reaches the expected state or the timeout expires.
+
+        Behavior notes:
+
+        * If the daemon is already in the desired state (e.g. ``stop``
+          requested but daemon is already stopped), the method returns
+          ``True`` immediately without issuing the orch command.
+        * If the daemon is not found via ``get_daemon_status`` before
+          issuing the command, a warning is logged but the action is
+          still attempted.
+        * For ``restart``, the expected post-action state is
+          ``running`` (status 1).
+
+        Args:
+            action (str): One of ``"stop"``, ``"start"``, or
+                ``"restart"``.
+            daemon_type (str): Daemon type string (e.g. ``"nfs"``,
+                ``"smb"``, ``"mds"``, ``"mgr"``, ``"mon"``, ``"osd"``).
+            daemon_id (str): Daemon identifier as shown by
+                ``ceph orch ps`` (e.g. ``"nfs-cluster-1.node1.abcdef"``).
+            timeout (int): Maximum seconds to wait for the daemon to
+                reach the desired state (default 120).
+
+        Returns:
+            bool: ``True`` if the daemon reached the desired state within
+            *timeout*, ``False`` otherwise.
+
+        Examples:
+            Stop an NFS daemon and wait up to 2 minutes::
+
+                rados_obj.change_daemon_orch_state(
+                    action="stop",
+                    daemon_type="nfs",
+                    daemon_id="nfs-cluster-1.node1.abcdef",
+                )
+
+            Restart an MDS daemon with a longer timeout::
+
+                rados_obj.change_daemon_orch_state(
+                    action="restart",
+                    daemon_type="mds",
+                    daemon_id="cephfs.node2.ghijkl",
+                    timeout=300,
+                )
+        """
+        allowed_actions = ("stop", "start", "restart")
+        if action not in allowed_actions:
+            raise ValueError(
+                f"Invalid action '{action}'. Must be one of {allowed_actions}"
+            )
+
+        daemon_name = f"{daemon_type}.{daemon_id}"
+        log.info(
+            "[orch_state] Requesting '%s' on %s (timeout=%ss)",
+            action,
+            daemon_name,
+            timeout,
+        )
+
+        result = self.get_daemon_status(daemon_type=daemon_type, daemon_id=daemon_id)
+        if not result:
+            log.warning(
+                "[orch_state] %s not found in orch ps, proceeding with %s anyway",
+                daemon_name,
+                action,
+            )
+        else:
+            daemon_status, status_desc = result
+            if (
+                action == "stop" and (daemon_status == 0 or status_desc == "stopped")
+            ) or (
+                action == "start" and (daemon_status == 1 or status_desc == "running")
+            ):
+                log.info(
+                    "[orch_state] %s already in desired state (%s), skipping %s",
+                    daemon_name,
+                    status_desc,
+                    action,
+                )
+                return True
+
+        cmd = f"ceph orch daemon {action} {daemon_name}"
+        self.client.exec_command(sudo=True, cmd=cmd, timeout=30)
+        log.info("[orch_state] Executed: %s", cmd)
+        time.sleep(5)
+
+        if action in ("stop", "start"):
+            want_status = 0 if action == "stop" else 1
+            want_desc = "stopped" if action == "stop" else "running"
+        else:
+            want_status = 1
+            want_desc = "running"
+
+        start_time = datetime.datetime.now()
+        timeout_time = start_time + datetime.timedelta(seconds=timeout)
+        daemon_status = None
+        status_desc = "unknown"
+        while datetime.datetime.now() <= timeout_time:
+            result = self.get_daemon_status(
+                daemon_type=daemon_type, daemon_id=daemon_id
+            )
+            if not result:
+                log.debug("[orch_state] Poll %s: not found, retrying", daemon_name)
+                time.sleep(10)
+                continue
+            daemon_status, status_desc = result
+            log.debug(
+                "[orch_state] Poll %s: status=%s, desc=%s",
+                daemon_name,
+                daemon_status,
+                status_desc,
+            )
+            if daemon_status == want_status or status_desc == want_desc:
+                log.info(
+                    "[orch_state] %s reached '%s' after %s",
+                    daemon_name,
+                    want_desc,
+                    action,
+                )
+                return True
+            time.sleep(10)
+
+        log.error(
+            "[orch_state] Timeout waiting for %s to reach '%s' after %s "
+            "(last status=%s, desc=%s)",
+            daemon_name,
+            want_desc,
+            action,
+            daemon_status,
+            status_desc,
+        )
+        return False
+
     def get_osd_uuid(self, osd_id):
         """
         Method return ths osd fsid
@@ -5299,6 +5442,7 @@ EOF"""
         check_mds=False,
         check_nfs=False,
         check_rgw=False,
+        check_smb=False,
     ):
         """
         Module to check crashes on the cluster using multiple methods:
@@ -5316,6 +5460,8 @@ EOF"""
             check_nfs: If True, also scan NFS-Ganesha daemon logs for crash
                        patterns (via cephadm logs / journalctl)
             check_rgw: If True, also scan RGW daemon logs for crash patterns
+            check_smb: If True, also scan SMB/Samba daemon logs for crash
+                       patterns (via cephadm logs / journalctl)
 
         Returns:
             True -> crash detected (in either crash ls or log scan)
@@ -5353,6 +5499,8 @@ EOF"""
                     daemon_types.append("nfs")
                 if check_rgw:
                     daemon_types.append("rgw")
+                if check_smb:
+                    daemon_types.append("smb")
 
                 crash_report = self.scan_daemon_logs_for_crashes(
                     start_time=start_time,
@@ -7312,29 +7460,74 @@ EOF"""
         enable_nfsv3: bool = False,
         nfs_placement_label: Optional[str] = None,
     ) -> dict:
-        """
-        Create NFS clusters with a dedicated CephFS filesystem and exports.
+        """Create NFS clusters with a dedicated CephFS filesystem and exports.
+
+        Creates a CephFS filesystem, then provisions ``num_clusters`` NFS
+        clusters each with ``exports_per_cluster`` pseudo-path exports.
+        Hosts for each cluster are selected via round-robin from the
+        available host list so that consecutive clusters start on
+        different hosts (cluster *i* begins at ``available_hosts[i]``
+        and wraps around using modular arithmetic for ``placement``
+        hosts).
+
+        Placement is validated before any cluster is created:
+
+        * Must be a positive integer (``>= 1``).
+        * Must not exceed the number of available hosts; a ``ValueError``
+          is raised otherwise.
 
         Args:
-            client_node: Client node to execute commands
-            num_clusters: Number of NFS clusters to create (default: 3)
-            exports_per_cluster: Number of exports per cluster (default: 4)
-            placement: Placement count for NFS daemons (default: 1)
-            nfs_fs_name: CephFS filesystem name for NFS (default: "nfs-cephfs")
-            pool_type: Pool type for CephFS - "erasure" or "replicated"
-            enable_fast_ec_config_params: Whether to enable fast EC config params
-            enable_rdma: Pass --enable-rdma to ceph nfs cluster create
-            rdma_port: Optional base RDMA port; per-cluster port is
-                rdma_port + cluster_index (same pattern as NFS TCP 2049+i).
-                If omitted when enable_rdma is True, uses ``NFS_RDMA_DEFAULT_BASE_PORT``
-                (20049), i.e. 20049, 20050, … for multi-cluster.
-            enable_nfsv3: Pass --enable-nfsv3 to ceph nfs cluster create
-            nfs_placement_label: If set, prefer orch hosts whose ``labels`` include
-                this string. If no orch host has the label, fall back to all orch hosts.
-                If unset, use all orch hosts.
+            client_node: Client node to execute commands.
+            num_clusters (int): Number of NFS clusters to create (default: 3).
+            exports_per_cluster (int): Number of exports per cluster
+                (default: 4).
+            placement (int): Number of NFS daemon hosts per cluster
+                (default: 1). Validated to be a positive integer that does
+                not exceed the available host count.
+            nfs_fs_name (str): CephFS filesystem name for NFS
+                (default: ``"nfs-cephfs"``).
+            pool_type (str): Pool type for CephFS -- ``"erasure"`` or
+                ``"replicated"``.
+            enable_fast_ec_config_params (bool): Whether to enable fast EC
+                config params.
+            enable_rdma (bool): Pass ``--enable-rdma`` to
+                ``ceph nfs cluster create``.
+            rdma_port (int or None): Optional base RDMA port; per-cluster
+                port is ``rdma_port + cluster_index`` (same pattern as NFS
+                TCP 2049+i). If omitted when *enable_rdma* is True, uses
+                ``NFS_RDMA_DEFAULT_BASE_PORT`` (20049).
+            enable_nfsv3 (bool): Pass ``--enable-nfsv3`` to
+                ``ceph nfs cluster create``.
+            nfs_placement_label (str or None): If set, prefer orch hosts
+                whose ``labels`` include this string. If no orch host has
+                the label, fall back to all orch hosts. If unset, use all
+                orch hosts.
 
         Returns:
-            Dict with nfs_config containing clusters, exports, fs_name, and pool info
+            dict: NFS configuration with structure::
+
+                {
+                    "nfs_config": {
+                        "clusters": [
+                            {
+                                "cluster_id": str,
+                                "port": int,
+                                "host": str,       # first selected host
+                                "hosts": [str],    # all placement hosts
+                                "rdma_port": int or None,
+                            },
+                            ...
+                        ],
+                        "exports": [...],
+                        "fs_name": str,
+                        "pool_info": {...},
+                    }
+                }
+
+        Raises:
+            ValueError: If no hosts are available for NFS placement, or
+                if *placement* is not a positive integer, or if it exceeds
+                the available host count.
         """
         rdma_base = (
             (rdma_port if rdma_port is not None else NFS_RDMA_DEFAULT_BASE_PORT)
@@ -7400,6 +7593,22 @@ EOF"""
             raise ValueError(
                 "create_nfs_clusters_and_exports: no hosts available for NFS placement"
             )
+        try:
+            placement = int(placement)
+        except (TypeError, ValueError) as err:
+            raise ValueError(
+                f"create_nfs_clusters_and_exports: placement must be an integer, got {placement!r}"
+            ) from err
+        if placement < 1:
+            raise ValueError(
+                f"create_nfs_clusters_and_exports: placement must be >= 1, got {placement}"
+            )
+        if placement > len(available_hosts):
+            raise ValueError(
+                "create_nfs_clusters_and_exports: placement "
+                f"{placement} exceeds available host count {len(available_hosts)}. "
+                f"Available hosts: {available_hosts}"
+            )
         log.info("NFS cluster placement hosts: %s", available_hosts)
 
         # Step 2: Create NFS clusters with unique ports starting from 2049
@@ -7409,20 +7618,25 @@ EOF"""
             cluster_id = f"nfs-cluster-{i + 1}"
             port = base_port + i
 
-            # Distribute clusters across hosts (round-robin)
-            host_idx = i % len(available_hosts)
-            selected_host = available_hosts[host_idx]
-            placement_str = f'"{placement} {selected_host}"'
+            # Build placement hosts per cluster using round-robin selection.
+            selected_hosts = [
+                available_hosts[(i + offset) % len(available_hosts)]
+                for offset in range(placement)
+            ]
+            placement_hosts = " ".join(selected_hosts)
+            placement_str = f'"{placement} {placement_hosts}"'
+            selected_host = selected_hosts[0]
 
             cluster_rdma_port = (rdma_base + i) if enable_rdma else None
-            log.info(
-                f"Creating NFS cluster: {cluster_id} on port {port}, host {selected_host}"
-                + (
-                    f", rdma_port {cluster_rdma_port}"
-                    if cluster_rdma_port is not None
-                    else ""
-                )
+            _nfs_create_msg = (
+                "Creating NFS cluster: %s on port %s, placement %s, "
+                "selected_hosts %s"
             )
+            _nfs_create_args = [cluster_id, port, placement, selected_hosts]
+            if cluster_rdma_port is not None:
+                _nfs_create_msg += ", rdma_port %s"
+                _nfs_create_args.append(cluster_rdma_port)
+            log.info(_nfs_create_msg, *_nfs_create_args)
 
             cmd = f"ceph nfs cluster create {cluster_id} {placement_str} --port={port}"
             if enable_nfsv3:
@@ -7434,6 +7648,7 @@ EOF"""
                 "cluster_id": cluster_id,
                 "port": port,
                 "host": selected_host,
+                "hosts": selected_hosts,
                 "rdma_port": cluster_rdma_port,
             }
             clusters.append(cluster_entry)

--- a/conf/squid/rados/9-node-ec-cluster-1-client.yaml
+++ b/conf/squid/rados/9-node-ec-cluster-1-client.yaml
@@ -25,6 +25,7 @@ globals:
           - mgr
           - mds
           - rgw
+          - smb
         no-of-volumes: 3
         disk-size: 15
 
@@ -35,6 +36,7 @@ globals:
           - mgr
           - mds
           - rgw
+          - smb
         no-of-volumes: 3
         disk-size: 15
 
@@ -51,6 +53,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - nfs
         no-of-volumes: 3
         disk-size: 15
 
@@ -59,6 +62,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - nfs
         no-of-volumes: 3
         disk-size: 15
 
@@ -71,6 +75,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - nfs
         no-of-volumes: 3
         disk-size: 15
 
@@ -81,6 +86,7 @@ globals:
           - rgw
           - osd
           - crash
+          - smb
         no-of-volumes: 3
         disk-size: 15
 

--- a/conf/tentacle/rados/9-node-ec-cluster-1-client.yaml
+++ b/conf/tentacle/rados/9-node-ec-cluster-1-client.yaml
@@ -25,6 +25,7 @@ globals:
           - mgr
           - mds
           - rgw
+          - smb
         no-of-volumes: 3
         disk-size: 15
 
@@ -35,6 +36,7 @@ globals:
           - mgr
           - mds
           - rgw
+          - smb
         no-of-volumes: 3
         disk-size: 15
 
@@ -51,6 +53,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - nfs
         no-of-volumes: 3
         disk-size: 15
 
@@ -59,6 +62,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - nfs
         no-of-volumes: 3
         disk-size: 15
 
@@ -71,6 +75,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - nfs
         no-of-volumes: 3
         disk-size: 15
 
@@ -81,6 +86,7 @@ globals:
           - rgw
           - osd
           - crash
+          - smb
         no-of-volumes: 3
         disk-size: 15
 

--- a/suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml
+++ b/suites/tentacle/rados/tier-3_rados_osd_thrashing_tests.yaml
@@ -164,6 +164,8 @@ tests:
           - ceph-common
           - rbd-nbd
           - ceph-fuse
+          - nfs-utils
+          - samba-client
         copy_admin_keyring: true
         caps:
           mon: "allow *"
@@ -384,6 +386,103 @@ tests:
         enable_nfs_thrashing: false
         enable_cephfs_subvolume_thrashing: false
 
+  - test:
+      name: OSD thrashing with NFS enhanced workflows
+      desc: OSD thrashing with NFS daemon failover, integrity, and protocol-state churn
+      module: test_osd_thrashing.py
+      polarion-id: CEPH-83632230
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 40
+        duration: 1800
+        aggressive: true
+        enable_crush_thrashing: true
+        enable_pg_thrashing: true
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        compression: false
+        cleanup_pools: true
+        enable_debug_logs: false
+        inject_errors: false
+        inconsistent_object_fail: true
+        # Standard workloads
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: true
+        enable_cephfs_subvolume_thrashing: true
+        # NFS enhanced workflows
+        enable_nfs_thrashing: true
+        nfs_num_clusters: 1
+        nfs_exports_per_cluster: 2
+        nfs_placement: 2
+        enable_nfs_daemon_thrashing: true
+        nfs_daemon_kill_method: pkill
+        nfs_daemon_thrash_interval: 60
+        nfs_daemon_recovery_timeout: 180
+        enable_nfs_data_integrity: true
+        enable_nfs_protocol_state_thrash: true
+        nfs_client_churn_rate: 5
+        nfs_export_churn_enabled: true
+        nfs_admin_interleave_enabled: true
+        enable_smb_thrashing: false
+
+  - test:
+      name: OSD thrashing with SMB enhanced workflows
+      desc: OSD thrashing with SMB daemon chaos, client IO, and post-thrash validation
+      module: test_osd_thrashing.py
+      polarion-id: CEPH-83632230
+      config:
+        pool_configs:
+          - pool_type: erasure
+            sample_pool_id: sample-pool-7
+          - pool_type: replicated
+            sample_pool_id: sample-pool-2
+        iterations: 40
+        duration: 1800
+        aggressive: true
+        enable_crush_thrashing: true
+        enable_pg_thrashing: true
+        enable_scrub_thrashing: true
+        enable_rgw_thrashing: false
+        compression: false
+        cleanup_pools: true
+        enable_debug_logs: false
+        inject_errors: false
+        inconsistent_object_fail: true
+        # Standard workloads
+        enable_fio_cephfs: true
+        enable_fio_rbd: true
+        enable_cephfs_snapshots: true
+        enable_rbd_snapshots: true
+        enable_ec_snapshots: true
+        enable_osd_thrashing: true
+        enable_mon_thrashing: false
+        enable_election_strategy_thrash: false
+        enable_mgr_thrashing: false
+        enable_mds_thrashing: true
+        enable_cephfs_subvolume_thrashing: true
+        enable_nfs_thrashing: false
+        # SMB enhanced workflows
+        enable_smb_thrashing: true
+        smb_cluster_ids:
+          - smb1
+        smb_auth_mode: user
+        smb_num_shares: 4
+        smb_user_name: smbuser
+        smb_user_password: smbpassword
+        enable_smb_rados_config_check: true
+
   # ===========================================================================
   # Bug #70390 ESB Extent Map Resharding Verification
   # ===========================================================================
@@ -498,4 +597,128 @@ tests:
 #        # Prefer NFS daemon placement on orch hosts labeled nfs-rdma
 #        nfs_placement_label: nfs-rdma
 #        enable_cephfs_subvolume_thrashing: true
+
+# NFS HA with VIP thrash tests, to run on grim031-037 (VIP 10.64.66.99)
+# VIP is managed by keepalived + haproxy ingress; floats between placement hosts.
+
+# VIP without RDMA (TCP-only ingress)
+#  - test:
+#      name: OSD thrashing with NFS HA VIP (TCP)
+#      desc: >-
+#        OSD thrashing with NFS ingress VIP failover over TCP, daemon kills,
+#        integrity verification, and protocol-state churn
+#      module: test_osd_thrashing.py
+#      polarion-id: CEPH-83632230
+#      config:
+#        pool_configs:
+#          - pool_type: erasure
+#            sample_pool_id: sample-pool-7
+#          - pool_type: replicated
+#            sample_pool_id: sample-pool-2
+#        iterations: 40
+#        duration: 600
+#        aggressive: true
+#        enable_crush_thrashing: true
+#        enable_pg_thrashing: true
+#        enable_scrub_thrashing: true
+#        enable_rgw_thrashing: false
+#        compression: false
+#        cleanup_pools: true
+#        enable_debug_logs: false
+#        inject_errors: false
+#        inconsistent_object_fail: true
+#        enable_fio_cephfs: true
+#        enable_fio_rbd: false
+#        enable_cephfs_snapshots: true
+#        enable_rbd_snapshots: false
+#        enable_ec_snapshots: false
+#        enable_osd_thrashing: true
+#        enable_mon_thrashing: false
+#        enable_mgr_thrashing: false
+#        enable_mds_thrashing: true
+#        # NFS HA with VIP over TCP (ingress + keepalived, no RDMA)
+#        enable_nfs_thrashing: true
+#        nfs_num_clusters: 1
+#        nfs_exports_per_cluster: 2
+#        nfs_placement: 2
+#        enable_nfs_daemon_thrashing: true
+#        nfs_daemon_kill_method: pkill
+#        nfs_daemon_thrash_interval: 60
+#        nfs_daemon_recovery_timeout: 180
+#        enable_nfs_data_integrity: true
+#        enable_nfs_protocol_state_thrash: true
+#        nfs_client_churn_rate: 5
+#        nfs_export_churn_enabled: true
+#        nfs_admin_interleave_enabled: true
+#        enable_nfs_rdma: false
+#        enable_nfsv3: true
+#        # TODO: VIP support requires adding nfs_virtual_ip and
+#        # nfs_enable_ingress params to create_nfs_clusters_and_exports.
+#        # Target VIP: 10.64.66.99 -- client mounts via ingress TCP port.
+#        # nfs_enable_ingress: true
+#        # nfs_virtual_ip: 10.64.66.99
+#        enable_cephfs_subvolume_thrashing: false
+#        enable_smb_thrashing: false
+
+# VIP with RDMA (RDMA + TCP ingress)
+#  - test:
+#      name: OSD thrashing with NFS HA VIP (RDMA)
+#      desc: >-
+#        OSD thrashing with NFS ingress VIP failover over RDMA, daemon kills,
+#        integrity verification, and protocol-state churn
+#      module: test_osd_thrashing.py
+#      polarion-id: CEPH-83632230
+#      config:
+#        pool_configs:
+#          - pool_type: erasure
+#            sample_pool_id: sample-pool-7
+#          - pool_type: replicated
+#            sample_pool_id: sample-pool-2
+#        iterations: 40
+#        duration: 600
+#        aggressive: true
+#        enable_crush_thrashing: true
+#        enable_pg_thrashing: true
+#        enable_scrub_thrashing: true
+#        enable_rgw_thrashing: false
+#        compression: false
+#        cleanup_pools: true
+#        enable_debug_logs: false
+#        inject_errors: false
+#        inconsistent_object_fail: true
+#        enable_fio_cephfs: true
+#        enable_fio_rbd: false
+#        enable_cephfs_snapshots: true
+#        enable_rbd_snapshots: false
+#        enable_ec_snapshots: false
+#        enable_osd_thrashing: true
+#        enable_mon_thrashing: false
+#        enable_mgr_thrashing: false
+#        enable_mds_thrashing: true
+#        # NFS HA with VIP over RDMA (ingress + keepalived + RDMA)
+#        enable_nfs_thrashing: true
+#        nfs_num_clusters: 1
+#        nfs_exports_per_cluster: 2
+#        nfs_placement: 2
+#        enable_nfs_daemon_thrashing: true
+#        nfs_daemon_kill_method: pkill
+#        nfs_daemon_thrash_interval: 60
+#        nfs_daemon_recovery_timeout: 180
+#        enable_nfs_data_integrity: true
+#        enable_nfs_protocol_state_thrash: true
+#        nfs_client_churn_rate: 5
+#        nfs_export_churn_enabled: true
+#        nfs_admin_interleave_enabled: true
+#        # NFS-over-RDMA with VIP: requires RDMA-capable hardware (grim031-037)
+#        enable_nfs_rdma: true
+#        nfs_rdma_port: 20050
+#        enable_nfsv3: true
+#        nfs_placement_label: nfs-rdma
+#        # TODO: VIP support requires adding nfs_virtual_ip and
+#        # nfs_enable_ingress params to create_nfs_clusters_and_exports.
+#        # Target VIP: 10.64.66.99 -- RDMA direct to VIP, TCP via ingress.
+#        # nfs_enable_ingress: true
+#        # nfs_virtual_ip: 10.64.66.99
+#        enable_cephfs_subvolume_thrashing: false
+#        enable_smb_thrashing: false
 

--- a/tests/rados/test_osd_thrashing.py
+++ b/tests/rados/test_osd_thrashing.py
@@ -6,6 +6,93 @@ This module performs aggressive OSD thrashing with concurrent I/O workload to ve
 cluster stability under stress conditions. It tests both EC and replicated pools,
 and checks for any crashes or issues during OSD state transitions.
 
+The test is organized into five sequential phases:
+
+1. **Setup** -- Create pools (replicated, EC), mount CephFS/RBD, configure
+   RGW S3 clients, and optionally deploy NFS clusters/exports and SMB
+   clusters/shares.  Apply recovery tuning, compression, debug logging,
+   and error injection as configured.
+2. **Pre-thrash** -- On a healthy cluster, write integrity baselines for
+   NFS (fio --verify=crc32c) and SMB (smbclient put + md5).  Verification
+   failure here aborts the test (cluster broken before chaos begins).
+   Future: extend baselines to CephFS, RBD, and RGW clients.
+3. **Thrash** -- Launch parallel chaos threads: OSD stop/start, CRUSH weight
+   changes, PG count changes, scrub toggles, MON/MGR/MDS failovers,
+   NFS daemon kills, SMB daemon restarts, client churn, export churn,
+   and concurrent I/O on CephFS, RBD, RGW, NFS, and SMB.  Transient
+   errors during this phase are expected and logged as warnings.
+4. **Validation** -- After thrashing stops and PGs reach active+clean:
+   verify data integrity (NFS fio re-verify, SMB md5 re-verify), daemon
+   health (NFS/SMB daemons running), mount staleness, NFS export
+   accessibility, NFS/SMB RADOS config integrity, SMB endpoint
+   accessibility, and CTDB health.  Any failure sets ``test_failed``.
+5. **Cleanup** -- Unmount filesystems, delete pools/clusters/exports,
+   re-enable firewalls, remove temp files.
+
+Core Chaos Workflows:
+  - **OSD thrashing** (``enable_osd_thrashing``): Mark out -> daemon stop ->
+    wait -> mark in -> start.  Repeats for ``thrash_count`` iterations with
+    configurable delays and random OSD selection.
+  - **CRUSH weight thrashing** (``enable_crush_thrashing``): Reduce CRUSH
+    reweights on random OSDs -> wait for PG migration -> restore original
+    weights.  Stresses data redistribution under I/O.
+  - **PG count thrashing** (``enable_pg_thrashing``): Toggle bulk flag on
+    pools to trigger PG split/merge.  Validates PG autoscaler stability.
+  - **Scrub thrashing** (``enable_scrub_thrashing``): Periodic
+    ``ceph pg scrub`` / ``ceph pg deep-scrub`` on random PGs and pools.
+    Validates scrub does not stall under concurrent OSD restarts.
+
+Daemon Failover Workflows:
+  - **MON thrashing** (``enable_mon_thrashing``): Leader failover, rolling
+    restart, election strategy changes (classic/disallow/connectivity).
+    Verifies quorum stability and client reconnection.
+  - **MGR thrashing** (``enable_mgr_thrashing``): Failover active MGR,
+    rolling restart, random daemon fail.  Validates module continuity.
+  - **MDS thrashing** (``enable_mds_thrashing``): Active MDS failover,
+    rolling restart, random fail.  CephFS I/O must survive rank transitions.
+
+I/O Workloads:
+  - **CephFS FIO** (``enable_fio_cephfs``): FIO on kernel-mounted CephFS
+    with snapshot thrashing (periodic ``snap create`` / ``snap rm``).
+  - **RBD FIO** (``enable_fio_rbd``): FIO on mapped RBD image with
+    snapshot thrashing (``rbd snap create`` / ``rbd snap rm``).
+  - **EC pool snapshots** (``enable_ec_snapshots``): RADOS-level snapshots
+    + partial overwrites on EC pools to stress stripe recovery.
+  - **CephFS subvolume thrashing** (``enable_cephfs_subvolume_thrashing``):
+    Create/mount/ops/unmount/delete subvolumes in rapid cycles.
+  - **RGW S3 thrashing** (``enable_rgw_thrashing``): S3 PUT/GET/DELETE and
+    multipart upload with round-robin endpoint selection across gateways.
+
+NFS Workflows (all gated by individual config flags):
+  - **NFS FIO thrashing** (``enable_nfs_thrashing``): Mount -> FIO ->
+    FS ops -> unmount cycles on each NFS export with multi-host rotation
+    and version cycling (v4.0/v4.1/v4.2).
+  - **NFS daemon thrashing** (``enable_nfs_daemon_thrashing``):
+    Kill/restart NFS-Ganesha daemons via pkill, orch stop, or systemctl.
+    Delegates to RadosOrchestrator methods.  Recovery failures are
+    warn-only during thrash.
+  - **NFS data integrity** (``enable_nfs_data_integrity``):
+    Pre-thrash: write ``fio --verify=crc32c`` baseline files on each NFS
+    export.  Post-thrash: re-verify checksums.  A *mismatch* (corrupted
+    data) causes test failure; I/O errors alone are warn-only.
+  - **NFS protocol state thrash** (``enable_nfs_protocol_state_thrash``):
+    Parallel client-churn (mount/unmount/open/lock cycles), export-churn
+    (create/delete/modify), and admin-ops (orch restart, export reload)
+    threads that stress NFS state management.
+
+SMB Workflows (gated by ``enable_smb_thrashing``):
+  - **SMB daemon chaos** (``enable_smb_thrashing``): Kill/restart SMB
+    daemons, CTDB/smbd process kills, service restarts.  Delegates to
+    RadosOrchestrator.change_daemon_orch_state and
+    restart_daemon_services.
+  - **SMB client I/O** (``enable_smb_thrashing``): smbclient ls/put/get
+    operations under chaos.
+  - **SMB data integrity**: Pre-thrash ``smbclient put`` + md5 baseline,
+    post-thrash md5 re-verify.  Mismatch = test failure.
+  - **Post-thrash verification**: RADOS config integrity, endpoint
+    accessibility (``smbclient -L``), and CTDB node health.  Failures
+    cause test failure.
+
 TEST WORKFLOW:
 ==============
 
@@ -15,6 +102,7 @@ TEST WORKFLOW:
     │   ├── Create pools (RADOS EC/replicated, CephFS, RBD) in parallel
     │   ├── Setup RGW S3 client with buckets (if enabled)
     │   ├── Create NFS clusters and exports (if enabled)
+    │   ├── Create SMB clusters and shares (if enabled)
     │   ├── Enable EC optimizations for EC pools
     │   ├── Enable compression (if configured)
     │   ├── Configure aggressive recovery settings
@@ -26,6 +114,12 @@ TEST WORKFLOW:
     │       ├── Apply chaos profile (e.g., network_chaos, storage_corruption)
     │       ├── Apply individual config overrides
     │       └── Detect destructive MDS injection configs
+    │
+    ├── PRE-THRASH PHASE (if enable_nfs_data_integrity)
+    │   ├── Mount each NFS export to /mnt/nfs-integrity-pre-<N>
+    │   ├── Write 10 fio --verify=crc32c baseline files (4K-64M, varying block sizes)
+    │   ├── Run pre-thrash verify pass (abort on failure -- cluster already broken)
+    │   └── Check mount health (abort on stale mounts)
     │
     ├── THRASHING PHASE (dynamically configured parallel threads)
     │   ├── io_workload_burst: rados bench 30s write bursts (64K blocks) [always]
@@ -45,16 +139,31 @@ TEST WORKFLOW:
     │   ├── thrash_mgr: Failover, rolling restart, random fail [if enabled]
     │   ├── thrash_mds: Failover, rolling restart, random fail [if enabled]
     │   ├── thrash_nfs_fio: Mount/FIO/FS ops/unmount cycles on NFS exports [if enabled]
+    │   ├── thrash_nfs_daemon_failover: NFS daemon kill/recovery loops [if enabled]
+    │   ├── nfs protocol state threads: client/export/admin churn [if enabled]
+    │   ├── thrash_smb: SMB daemon chaos loops [if enabled]
+    │   ├── thrash_smb_client_io: SMB client operations under chaos [if enabled]
     │   └── thrash_cephfs_subvolumes: Create/ops/delete subvolume groups+subvols [if enabled]
     │
     ├── VALIDATION PHASE
     │   ├── Wait for cluster stabilization (active+clean PGs)
     │   ├── Check cluster health
+    │   ├── If NFS thrashing: post-thrash NFS verification
+    │   │   ├── Daemon health: all NFS daemons must be running
+    │   │   ├── Mount health: pre-thrash integrity mounts must not be stale
+    │   │   ├── Data integrity: fio --verify re-check (mismatch = test failure)
+    │   │   ├── Export accessibility: mount/ls/unmount each export
+    │   │   └── RADOS config integrity: validate each cluster's config object
+    │   ├── If SMB thrashing: post-thrash SMB verification
+    │   │   ├── RADOS config: check for corruption (if enable_smb_rados_config_check)
+    │   │   ├── Endpoint accessibility: smbclient -L on each share
+    │   │   └── CTDB health: verify all nodes healthy, none banned
     │   ├── If destructive MDS injection:
     │   │   ├── Validate MDS crashes match CDentry::check_corruption signature
     │   │   ├── Attempt repair workflow (mds repaired -> damage ls -> scrub repair -> damage rm)
     │   │   └── Log repair outcome (diagnostic only, does not affect pass/fail)
-    │   ├── Else: Check for crashes (ceph crash ls-new) and fail if detected
+    │   ├── Else: Check for crashes (ceph crash + daemon logs) and fail if detected
+    │   │   └── NFS+OSD exception: if all NFS daemons recovered, downgrade to warning
     │   └── Report findings
     │
     └── CLEANUP PHASE
@@ -66,6 +175,9 @@ TEST WORKFLOW:
         ├── Force log rotation on all OSD hosts (parallel)
         ├── Unmount and cleanup CephFS and RBD
         ├── Cleanup NFS clusters and exports (if enabled)
+        ├── Cleanup SMB clusters and shares (if enabled)
+        ├── Unmount pre-thrash NFS integrity mounts
+        ├── Re-enable firewall on NFS nodes
         └── Delete test pools and EC profiles
 
 CONFIGURATION OPTIONS:
@@ -104,6 +216,16 @@ CONFIGURATION OPTIONS:
 - enable_nfsv3: Pass --enable-nfsv3 to ceph nfs cluster create (default: False)
 - nfs_placement_label: Prefer orch hosts with this **ceph orch host label**. If no host
   has the label, fallback uses all orch hosts.
+- enable_nfs_daemon_thrashing: Enable NFS daemon kill/recovery cycles (default: False)
+- nfs_daemon_kill_method: NFS daemon kill method (pkill | orch_stop | systemctl)
+- enable_nfs_data_integrity: Enable pre/post-thrash NFS data integrity verification (default: False)
+- enable_nfs_protocol_state_thrash: Enable NFS state churn threads (default: False)
+- enable_smb_thrashing: Enable SMB daemon chaos + client IO workflows (default: False)
+- smb_cluster_ids: SMB cluster IDs for thrash workflows (default: [])
+- smb_auth_mode: SMB auth mode used for setup/endpoint checks (default: user)
+- smb_num_shares: Number of SMB shares per cluster for setup (default: 4)
+- smb_user_name / smb_user_password: SMB credentials for client IO checks
+- enable_smb_rados_config_check: Validate SMB RADOS metadata post-thrash (default: False)
 - enable_esb_verification: Enable BlueStore ESB Bug #70390 verification (default: False).
   Sets bluestore_elastic_shared_blobs=true, bluestore_write_v2=false, bluestore_onode_segment_size=0,
   bluestore_debug_extent_map_encode_check=true, debug_bluestore=5/5.
@@ -117,8 +239,6 @@ CONFIGURATION OPTIONS:
 import concurrent.futures as cf
 import random
 import time
-import uuid
-from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -139,6 +259,22 @@ from ceph.rados.utils import get_cluster_timestamp
 from tests.rados.monitor_configurations import MonConfigMethods, MonElectionStrategies
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_four_node_ecpool import create_comprehensive_test_objects
+from tests.rados.thrash_helpers import (
+    NfsThrashWorkflows,
+    SmbThrashWorkflows,
+    _nfs_client_mount_option_string,
+    _nfs_export_mount_targets,
+    _nfs_mount_context,
+    check_mount_health,
+    thrash_nfs_admin_ops,
+    thrash_nfs_client_churn,
+    thrash_nfs_daemon_failover,
+    thrash_nfs_export_churn,
+    thrash_smb,
+    thrash_smb_client_io,
+    verify_data_integrity,
+    write_integrity_baseline,
+)
 from utility.log import Log
 from utility.utils import extract_ceph_version
 
@@ -216,8 +352,27 @@ def run(ceph_cluster, **kw):
     Main test execution for OSD thrashing with concurrent I/O workload.
 
     This test creates pools (EC and/or replicated) and performs aggressive OSD
-    thrashing with concurrent I/O to verify cluster stability. Any crashes
-    detected during the test are reported and cause test failure.
+    thrashing with concurrent I/O to verify cluster stability. Execution
+    proceeds through five phases:
+
+    1. **Setup** -- Create pools, NFS/SMB/RGW resources, apply injection
+       configs, and configure recovery settings.
+    2. **Pre-thrash** (``enable_nfs_data_integrity`` only) -- Mount NFS
+       exports, write ``fio --verify=crc32c`` baseline files, and run an
+       initial verification pass on the healthy cluster.  Failure here
+       aborts the test immediately.
+    3. **Thrash** -- Launch parallel chaos + I/O threads for ``duration``
+       seconds.  NFS and SMB workflow errors are *expected* under chaos
+       and are logged as warnings only (see ``_warn_checks``).  The sole
+       hard-fail is an NFS data integrity checksum mismatch.
+    4. **Validation** -- After recovery, verify daemon health, NFS mount
+       staleness, data integrity, export accessibility, NFS/SMB RADOS
+       config integrity, SMB endpoint/CTDB health, and crash status.
+       Failures here set ``test_failed = True``.  When both NFS and OSD
+       thrashing are active, NFS crashes where all daemons have recovered
+       are downgraded to warnings (cascading OSD pool degradation).
+    5. **Cleanup** -- Unmount filesystems, delete pools, re-enable
+       firewalls, and remove injection configs.
 
     Test Args (in config):
         pool_configs (list): List of pool configurations to create (REQUIRED)
@@ -262,13 +417,49 @@ def run(ceph_cluster, **kw):
         enable_nfsv3 (bool): Pass --enable-nfsv3 to ceph nfs cluster create (default: False)
         nfs_placement_label (str|None): Prefer orch hosts with this label; if no
             matches, use all orch hosts (default: None).
+        enable_nfs_daemon_thrashing (bool): Enable NFS daemon kill/restart cycles (default: False)
+        nfs_daemon_kill_method (str): pkill | orch_stop | systemctl (default: pkill)
+        nfs_daemon_thrash_interval (int): Seconds between kill cycles (default: 60)
+        nfs_daemon_recovery_timeout (int): Seconds to wait for daemon recovery (default: 180)
+        enable_nfs_data_integrity (bool): Run fio --verify=crc32c on NFS mounts (default: False)
+        enable_nfs_protocol_state_thrash (bool): Client/export/admin churn threads (default: False)
+        nfs_client_churn_rate (int): Client ops per 10s window (default: 5)
+        nfs_export_churn_enabled (bool): Export create/delete/modify cycles (default: False)
+        nfs_admin_interleave_enabled (bool): Admin op interleaving (default: False)
+        enable_smb_thrashing (bool): Enable SMB daemon thrashing (default: False)
+        smb_cluster_ids (list): SMB cluster IDs to thrash (default: [])
+        smb_auth_mode (str): user | active-directory (default: user)
+        smb_num_shares (int): Number of SMB shares per cluster (default: 4)
+        smb_user_name (str): SMB username for endpoint/client IO checks
+            (default: smbuser)
+        smb_user_password (str): SMB password for endpoint/client IO checks
+            (default: smbpassword)
+        enable_smb_rados_config_check (bool): RADOS config integrity for SMB (default: False)
         error_injection (dict): Suite-driven error injection config (default: None).
             Supports profile, profile_overrides, configs, ec_write_errors,
             ec_read_errors, admin_socket. See CephErrorInjector for schema.
 
     Returns:
-        0: Test passed - No crashes detected, cluster remained stable
-        1: Test failed - Crashes detected or unexpected error occurred
+        int: 0 if test passed, 1 if test failed.
+
+    Failure conditions (``test_failed = True``):
+        - Daemon crashes detected via ``ceph crash`` or daemon logs (unless
+          NFS+OSD recovery downgrade applies).
+        - Post-thrash NFS daemon not running, stale mount, data integrity
+          error (mismatch or unreadable file), export inaccessible, or
+          RADOS config invalid.
+        - Post-thrash SMB RADOS config corruption, endpoint failure,
+          unhealthy CTDB nodes, or SMB integrity md5 mismatch.
+        - Pre-thrash baseline write failure or verification error (cluster
+          broken before chaos begins).
+        - Inconsistent PGs with ``inconsistent_object_fail`` enabled.
+        - Unhandled exceptions during any phase.
+
+    Warning-only conditions (logged, do not cause failure):
+        - NFS/SMB workflow errors during the thrash phase (recovery
+          failures, kill failures, churn errors, timeouts).
+        - NFS crashes when OSD thrashing is active and all NFS daemons
+          have recovered post-thrash.
     """
     log.info(run.__doc__)
     config = kw["config"]
@@ -325,6 +516,18 @@ def run(ceph_cluster, **kw):
     enable_election_strategy_thrash = config.get(
         "enable_election_strategy_thrash", True
     )
+
+    # NFS enhanced thrashing parameters
+    enable_nfs_daemon_thrashing = config.get("enable_nfs_daemon_thrashing", False)
+    enable_nfs_data_integrity = config.get("enable_nfs_data_integrity", False)
+    enable_nfs_protocol_state_thrash = config.get(
+        "enable_nfs_protocol_state_thrash", False
+    )
+
+    # SMB thrashing parameters
+    enable_smb_thrashing = config.get("enable_smb_thrashing", False)
+    smb_cluster_ids = config.get("smb_cluster_ids", [])
+    enable_smb_rados_config_check = config.get("enable_smb_rados_config_check", False)
     enable_fast_ec_config_params = config.get("enable_fast_ec_config_params", True)
     enable_esb_verification = config.get("enable_esb_verification", False)
     disabled_ec_optimizations = False
@@ -419,6 +622,12 @@ def run(ceph_cluster, **kw):
         f"  Fast EC config params: {enable_fast_ec_config_params}\n"
         f"  ESB verification (Bug #70390): {enable_esb_verification}\n"
         f"  Inconsistent object fail (no repair): {inconsistent_object_fail}\n"
+        f"  NFS daemon thrashing: {enable_nfs_daemon_thrashing}\n"
+        f"  NFS data integrity (fio verify): {enable_nfs_data_integrity}\n"
+        f"  NFS protocol state thrash: {enable_nfs_protocol_state_thrash}\n"
+        f"  SMB thrashing: {enable_smb_thrashing}\n"
+        + (f"  SMB cluster IDs: {smb_cluster_ids}\n" if enable_smb_thrashing else "")
+        + f"  SMB RADOS config check: {enable_smb_rados_config_check}\n"
     )
     _ei_config = config.get("error_injection", {})
     if _ei_config:
@@ -467,6 +676,9 @@ def run(ceph_cluster, **kw):
     rbd_mount_path = None
     rbd_device_path = None
     nfs_config = None
+    smb_config = None
+    nfs_integrity_mounts = []  # Pre-thrash NFS mounts for integrity baseline
+    smb_integrity_baselines = {}  # Pre-thrash SMB per-share md5 baselines
     nfs_firewall_disabled_nodes = []  # Track nodes where firewall was disabled for NFS
 
     try:
@@ -484,6 +696,7 @@ def run(ceph_cluster, **kw):
             + (1 if enable_rbd_pools else 0)
             + (1 if enable_rgw_thrashing else 0)
             + (1 if enable_nfs_thrashing else 0)
+            + (1 if enable_smb_thrashing else 0)
         )
         with cf.ThreadPoolExecutor(max_workers=pool_workers) as pool_executor:
             log.info("Creating pools in parallel...")
@@ -541,6 +754,19 @@ def run(ceph_cluster, **kw):
                     rdma_port=nfs_rdma_port,
                     enable_nfsv3=enable_nfsv3,
                     nfs_placement_label=nfs_placement_label,
+                )
+
+            smb_future = None
+            smb_wf = None
+            if enable_smb_thrashing and smb_cluster_ids:
+                log.info(
+                    "SMB workflows enabled - creating %s SMB cluster(s) for thrashing",
+                    len(smb_cluster_ids),
+                )
+                smb_wf = SmbThrashWorkflows(cephadm.installer, ceph_cluster, rados_obj)
+                smb_future = pool_executor.submit(
+                    smb_wf.create_clusters_and_shares,
+                    config,
                 )
 
             # Collect results
@@ -618,38 +844,47 @@ def run(ceph_cluster, **kw):
                             "xargs -r systemctl restart 2>/dev/null || true"
                         )
                         for cluster_info in nfs_config.get("clusters", []):
-                            hostname = cluster_info.get("host")
-                            if not hostname or hostname in configured_hosts:
-                                continue
-                            configured_hosts.add(hostname)
-                            host_node = next(
-                                (n for n in all_nodes if n.hostname == hostname),
-                                None,
-                            )
-                            if not host_node:
-                                log.warning(f"  {hostname}: Node not found, skipping")
-                                continue
-                            try:
-                                fw = (
-                                    "systemctl stop firewalld 2>/dev/null || true; "
-                                    "systemctl disable firewalld 2>/dev/null || true"
+                            cluster_hosts = cluster_info.get("hosts")
+                            if isinstance(cluster_hosts, str):
+                                cluster_hosts = [cluster_hosts]
+                            if not cluster_hosts:
+                                cluster_hosts = [cluster_info.get("host")]
+                            for hostname in cluster_hosts:
+                                if not hostname or hostname in configured_hosts:
+                                    continue
+                                configured_hosts.add(hostname)
+                                host_node = next(
+                                    (n for n in all_nodes if n.hostname == hostname),
+                                    None,
                                 )
-                                if nfs_config.get("enable_nfsv3"):
-                                    cmd = fw + "; " + v3_extra
-                                    log_note = "firewall disabled + NFSv3 prerequisites"
-                                else:
-                                    cmd = fw
-                                    log_note = "firewall disabled for NFS/RDMA"
-                                host_node.exec_command(
-                                    cmd=cmd,
-                                    sudo=True,
-                                    timeout=180,
-                                    check_ec=False,
-                                )
-                                nfs_firewall_disabled_nodes.append(host_node)
-                                log.info(f"  {hostname}: {log_note}")
-                            except Exception as e:
-                                log.warning(f"  {hostname}: Failed - {e}")
+                                if not host_node:
+                                    log.warning(
+                                        "  %s: Node not found, skipping", hostname
+                                    )
+                                    continue
+                                try:
+                                    fw = (
+                                        "systemctl stop firewalld 2>/dev/null || true; "
+                                        "systemctl disable firewalld 2>/dev/null || true"
+                                    )
+                                    if nfs_config.get("enable_nfsv3"):
+                                        cmd = fw + "; " + v3_extra
+                                        log_note = (
+                                            "firewall disabled + NFSv3 prerequisites"
+                                        )
+                                    else:
+                                        cmd = fw
+                                        log_note = "firewall disabled for NFS/RDMA"
+                                    host_node.exec_command(
+                                        cmd=cmd,
+                                        sudo=True,
+                                        timeout=180,
+                                        check_ec=False,
+                                    )
+                                    nfs_firewall_disabled_nodes.append(host_node)
+                                    log.info("  %s: %s", hostname, log_note)
+                                except Exception as e:
+                                    log.warning("  %s: Failed - %s", hostname, e)
 
                         # Also disable firewall on client node for NFS access
                         try:
@@ -673,6 +908,21 @@ def run(ceph_cluster, **kw):
                         )
                 else:
                     log.info("NFS setup skipped (NFS thrashing not enabled)")
+
+                if smb_future:
+                    smb_config = smb_future.result()
+                    if smb_config:
+                        log.info(
+                            "Created SMB setup: %s cluster(s), %s share(s)",
+                            len(smb_config.get("cluster_ids", [])),
+                            len(smb_config.get("smb_shares", [])),
+                        )
+                    else:
+                        raise Exception(
+                            "SMB thrashing enabled but setup returned no config"
+                        )
+                else:
+                    log.info("SMB setup skipped (SMB thrashing not enabled)")
             except Exception as e:
                 log.error(f"Failed to create pools: {e}")
                 raise
@@ -894,6 +1144,234 @@ def run(ceph_cluster, **kw):
 
         log.info("Setup phase completed successfully")
 
+        # ── Pre-thrash setup phase ──
+        #
+        # Before any chaos begins, establish an NFS data-integrity baseline
+        # on the healthy cluster (gated by enable_nfs_data_integrity).
+        #
+        # Steps:
+        #   1. Resolve NFS export mount targets via _nfs_export_mount_targets().
+        #   2. Mount each target to /mnt/nfs-integrity-pre-<N> using NFSv4.1.
+        #   3. Write 10 fio --verify=crc32c baseline files (4K-64M, varying block sizes).
+        #   4. Run a pre-thrash verify pass to confirm zero errors on a clean cluster.
+        #   5. Check mount health -- stale mounts here mean the cluster is already
+        #      degraded, so the test aborts with an exception.
+        #
+        # These mounts stay up through the thrash phase and are re-verified
+        # post-thrash in the validation phase.  They are cleaned up in the
+        # finally block regardless of cleanup_pools setting.
+        if enable_nfs_data_integrity and nfs_config:
+            log.info(
+                f"\n{'-' * 60}\n"
+                "Pre-thrash NFS integrity baseline setup\n"
+                f"{'-' * 60}"
+            )
+            targets = _nfs_export_mount_targets(nfs_config)
+            if targets:
+                for idx, target in enumerate(targets):
+                    mp = f"/mnt/nfs-integrity-pre-{idx}"
+                    try:
+                        hosts = target.get("hosts") or (
+                            [target.get("host")] if target.get("host") else []
+                        )
+                        if not hosts:
+                            raise RuntimeError(
+                                f"No NFS hosts for cluster "
+                                f"{target.get('cluster_id')}"
+                            )
+                        nfs_host = hosts[idx % len(hosts)]
+                        mount_opts = _nfs_client_mount_option_string(
+                            nfs_config,
+                            target["cluster_id"],
+                            "nfsvers=4.1",
+                        )
+                        client_node.exec_command(
+                            sudo=True, cmd=f"mkdir -p {mp}", timeout=15
+                        )
+                        client_node.exec_command(
+                            sudo=True,
+                            cmd=f"mount -t nfs -o {mount_opts} "
+                            f"{nfs_host}:{target['pseudo_path']} {mp}",
+                            timeout=45,
+                        )
+                        nfs_integrity_mounts.append(mp)
+                        log.info(
+                            "  Mounted %s:%s -> %s", nfs_host, target["pseudo_path"], mp
+                        )
+                    except Exception as e:
+                        log.warning(
+                            "  Failed to mount integrity target %s: %s", target, e
+                        )
+
+                if nfs_integrity_mounts:
+                    log.info(
+                        "  Writing integrity baseline to %s mount(s)...",
+                        len(nfs_integrity_mounts),
+                    )
+                    baseline = write_integrity_baseline(
+                        client_node, nfs_integrity_mounts
+                    )
+                    if not baseline["files_written"]:
+                        raise Exception(
+                            "Pre-thrash baseline write failed on all mounts "
+                            "— cluster broken before thrashing"
+                        )
+
+                    log.info("  Running pre-thrash verify pass...")
+                    pre_verify = verify_data_integrity(
+                        client_node, nfs_integrity_mounts
+                    )
+                    if pre_verify["errors"] or pre_verify["mismatches"]:
+                        raise Exception(
+                            f"Pre-thrash verify FAILED: {pre_verify} — "
+                            "cluster has integrity issues before thrashing"
+                        )
+                    log.info(
+                        "  Pre-thrash verify passed: %s file(s) clean",
+                        pre_verify["files_checked"],
+                    )
+
+                    if nfs_integrity_mounts:
+                        mount_health = check_mount_health(
+                            client_node, nfs_integrity_mounts, proto="nfs"
+                        )
+                        if mount_health.get("stale"):
+                            log.error(
+                                "[pre-thrash] Stale NFS mounts before thrashing: %s",
+                                mount_health["stale"],
+                            )
+                            raise Exception(
+                                "Pre-thrash NFS mount health check failed — "
+                                "cluster has issues before thrashing"
+                            )
+                        else:
+                            log.info(
+                                "[pre-thrash] NFS mount health OK: %s healthy mounts",
+                                len(mount_health.get("healthy", [])),
+                            )
+                else:
+                    log.warning(
+                        "  No NFS mounts succeeded — " "integrity baseline skipped"
+                    )
+            else:
+                log.warning(
+                    "  No NFS export targets found — " "integrity baseline skipped"
+                )
+
+        # ── Pre-thrash SMB integrity baseline ──
+        #
+        # For each SMB share, upload a 4MB test file via smbclient and
+        # record its md5 checksum.  After the thrash phase, the same files
+        # are downloaded and their checksums compared to detect silent
+        # data corruption.
+        #
+        # Unlike NFS, SMB setup is more variable so failures here are
+        # logged as warnings rather than aborting the test.
+        if enable_smb_thrashing and smb_config:
+            log.info(
+                f"\n{'-' * 60}\n"
+                "Pre-thrash SMB integrity baseline setup\n"
+                f"{'-' * 60}"
+            )
+            try:
+                smb_user = smb_config.get("smb_user_name", "")
+                smb_password = smb_config.get("smb_user_password", "")
+                smb_shares = smb_config.get("smb_shares", [])
+
+                smb_target = None
+                public_addrs = smb_config.get("public_addrs")
+                if public_addrs:
+                    smb_target = (
+                        public_addrs[0]
+                        if isinstance(public_addrs, list)
+                        else public_addrs
+                    )
+                if not smb_target:
+                    smb_nodes = smb_config.get("smb_nodes", [])
+                    if smb_nodes:
+                        node = smb_nodes[0]
+                        smb_target = (
+                            node.ip_address
+                            if hasattr(node, "ip_address")
+                            else str(node)
+                        )
+
+                if not smb_target:
+                    log.warning(
+                        "  No SMB target IP found — " "integrity baseline skipped"
+                    )
+                elif not smb_shares:
+                    log.warning(
+                        "  No SMB shares configured — " "integrity baseline skipped"
+                    )
+                elif not smb_user:
+                    log.warning(
+                        "  No SMB user configured — " "integrity baseline skipped"
+                    )
+                else:
+                    for share in smb_shares:
+                        share_name = (
+                            share if isinstance(share, str) else share.get("name", "")
+                        )
+                        if not share_name:
+                            continue
+                        local_file = f"/tmp/smb_integrity_{share_name}.dat"
+                        try:
+                            client_node.exec_command(
+                                cmd=(
+                                    f"dd if=/dev/urandom of={local_file} "
+                                    "bs=1M count=4 2>/dev/null"
+                                ),
+                                timeout=30,
+                            )
+                            out, _ = client_node.exec_command(
+                                cmd=f"md5sum {local_file}",
+                                timeout=15,
+                            )
+                            md5hash = out.strip().split()[0]
+
+                            client_node.exec_command(
+                                cmd=(
+                                    f"smbclient -U {smb_user}%{smb_password} "
+                                    f"//{smb_target}/{share_name} "
+                                    f"-c 'put {local_file} smb_integrity_test.dat'"
+                                ),
+                                timeout=60,
+                            )
+                            smb_integrity_baselines[share_name] = md5hash
+                            log.info(
+                                "  SMB integrity baseline written: share=%s md5=%s",
+                                share_name,
+                                md5hash,
+                            )
+                        except Exception as e:
+                            log.warning(
+                                "  Failed to write SMB integrity baseline "
+                                "for share %s: %s",
+                                share_name,
+                                e,
+                            )
+
+                    if smb_integrity_baselines:
+                        log.info(
+                            "  SMB integrity baselines recorded for %s share(s)",
+                            len(smb_integrity_baselines),
+                        )
+                    else:
+                        log.warning(
+                            "  No SMB integrity baselines succeeded — "
+                            "post-thrash verification will be skipped"
+                        )
+            except Exception as e:
+                log.warning("  SMB integrity baseline setup failed: %s", e)
+
+        # TODO: Add pre-thrash/post-thrash integrity baselines for other client types:
+        #   - CephFS: fio --verify=crc32c on kernel/fuse mount before thrash,
+        #     verify post-thrash on same mount points
+        #   - RBD: fio --verify=crc32c on mapped block device before thrash,
+        #     verify post-thrash
+        #   - RGW: S3 PUT with checksums before thrash, S3 GET + verify post-thrash
+
         log.info(f"\n{'=' * 60}\nTHRASHING PHASE\n{'=' * 60}")
 
         # Stop flag for coordinated shutdown of background threads
@@ -921,7 +1399,18 @@ def run(ceph_cluster, **kw):
         max_workers += 1 if enable_mds_thrashing else 0
         max_workers += 4 if (enable_nfs_thrashing and nfs_config) else 0
         max_workers += 1 if (enable_cephfs_subvolume_thrashing and fs_names) else 0
-        log.debug(f"ThreadPoolExecutor max_workers: {max_workers}")
+        # NFS enhanced thrashing threads
+        max_workers += 1 if (enable_nfs_daemon_thrashing and nfs_config) else 0
+        if enable_nfs_protocol_state_thrash and nfs_config:
+            max_workers += 1  # client churn
+            max_workers += 1 if config.get("nfs_export_churn_enabled") else 0
+            max_workers += 1 if config.get("nfs_admin_interleave_enabled") else 0
+        # SMB thrashing threads
+        max_workers += 1 if (enable_smb_thrashing and smb_config) else 0  # smb_daemon
+        max_workers += (
+            1 if (enable_smb_thrashing and smb_config) else 0
+        )  # smb_client_io
+        log.debug("ThreadPoolExecutor max_workers: %s", max_workers)
 
         with cf.ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = []
@@ -1218,6 +1707,94 @@ def run(ceph_cluster, **kw):
                     "CephFS subvolume thrashing enabled but no filesystems available"
                 )
 
+            # NFS daemon failover thrashing (kill/restart cycles)
+            if enable_nfs_daemon_thrashing and nfs_config:
+                log.info("NFS daemon failover thrashing enabled")
+                futures.append(
+                    executor.submit(
+                        thrash_nfs_daemon_failover,
+                        installer=cephadm.installer,
+                        nfs_config=nfs_config,
+                        rados_obj=rados_obj,
+                        ceph_cluster=ceph_cluster,
+                        client_node=client_node,
+                        duration=duration,
+                        stop_flag=stop_flag,
+                        config=config,
+                    )
+                )
+            elif enable_nfs_daemon_thrashing:
+                log.warning("NFS daemon thrashing enabled but no NFS config available")
+
+            # NFS protocol state thrash threads
+            if enable_nfs_protocol_state_thrash and nfs_config:
+                log.info("NFS protocol state thrash threads enabled")
+                futures.append(
+                    executor.submit(
+                        thrash_nfs_client_churn,
+                        client_node=client_node,
+                        nfs_config=nfs_config,
+                        duration=duration,
+                        stop_flag=stop_flag,
+                        churn_rate=config.get("nfs_client_churn_rate", 5),
+                    )
+                )
+                if config.get("nfs_export_churn_enabled"):
+                    futures.append(
+                        executor.submit(
+                            thrash_nfs_export_churn,
+                            installer=cephadm.installer,
+                            nfs_config=nfs_config,
+                            duration=duration,
+                            stop_flag=stop_flag,
+                            rados_obj=rados_obj,
+                        )
+                    )
+                if config.get("nfs_admin_interleave_enabled"):
+                    futures.append(
+                        executor.submit(
+                            thrash_nfs_admin_ops,
+                            installer=cephadm.installer,
+                            nfs_config=nfs_config,
+                            duration=duration,
+                            stop_flag=stop_flag,
+                            rados_obj=rados_obj,
+                        )
+                    )
+            elif enable_nfs_protocol_state_thrash:
+                log.warning(
+                    "NFS protocol state thrash enabled but no NFS config available"
+                )
+
+            # SMB daemon thrashing
+            if enable_smb_thrashing and smb_config:
+                log.info(
+                    "SMB daemon thrashing enabled for %s",
+                    smb_config.get("cluster_ids", []),
+                )
+                futures.append(
+                    executor.submit(
+                        thrash_smb,
+                        installer=cephadm.installer,
+                        smb_config=smb_config,
+                        ceph_cluster=ceph_cluster,
+                        rados_obj=rados_obj,
+                        duration=duration,
+                        stop_flag=stop_flag,
+                    )
+                )
+                futures.append(
+                    executor.submit(
+                        thrash_smb_client_io,
+                        client_node=client_node,
+                        smb_config=smb_config,
+                        duration=duration,
+                        stop_flag=stop_flag,
+                    )
+                )
+            elif enable_smb_thrashing:
+                log.warning("SMB thrashing enabled but no SMB config available")
+
             log.info(f"Thrashing operations in progress (max duration: {duration}s)...")
             try:
                 for future in cf.as_completed(futures, timeout=duration):
@@ -1275,6 +1852,13 @@ def run(ceph_cluster, **kw):
                 "nfs_rootsquash": None,
                 "nfs_fsops_extended": None,
                 "cephfs_subvolume_thrashing": None,
+                "scrub_thrashing": None,
+                "nfs_daemon_failover": None,
+                "nfs_client_churn": None,
+                "nfs_export_churn": None,
+                "nfs_admin_ops": None,
+                "smb_daemon_thrashing": None,
+                "smb_client_io": None,
             }
             # Map futures to workflow names based on their index
             workflow_order = []
@@ -1319,6 +1903,17 @@ def run(ceph_cluster, **kw):
                 workflow_order.append("nfs_fsops_extended")
             if enable_cephfs_subvolume_thrashing and fs_names:
                 workflow_order.append("cephfs_subvolume_thrashing")
+            if enable_nfs_daemon_thrashing and nfs_config:
+                workflow_order.append("nfs_daemon_failover")
+            if enable_nfs_protocol_state_thrash and nfs_config:
+                workflow_order.append("nfs_client_churn")
+                if config.get("nfs_export_churn_enabled"):
+                    workflow_order.append("nfs_export_churn")
+                if config.get("nfs_admin_interleave_enabled"):
+                    workflow_order.append("nfs_admin_ops")
+            if enable_smb_thrashing and smb_config:
+                workflow_order.append("smb_daemon_thrashing")
+                workflow_order.append("smb_client_io")
 
             for idx, future in enumerate(futures):
                 workflow_name = (
@@ -1334,10 +1929,116 @@ def run(ceph_cluster, **kw):
                             f"  {workflow_name}: {result} iterations/operations completed"
                         )
                     else:
+                        workflow_results[workflow_name] = {"timeout": True}
                         log.info(f"  {workflow_name}: Did not complete in time")
                 except Exception as e:
                     log.info(f"  {workflow_name}: Failed with exception - {e}")
             log.info(f"{'=' * 60}")
+
+            # ----------------------------------------------------------
+            # During-thrash workflow result evaluation (warn-only)
+            #
+            # NFS and SMB workflows operate under active daemon chaos,
+            # so transient errors (recovery failures, kill failures,
+            # mount timeouts, client I/O errors) are *expected* and
+            # must not fail the test.  Each workflow returns a dict
+            # with counters (e.g. "errors", "recovery_failures").
+            #
+            # This block inspects those counters and emits warnings
+            # for any non-zero values.  The only hard-fail condition
+            # during the thrash phase is an NFS data integrity
+            # *mismatch* (corrupted file content), which is detected
+            # separately in the post-thrash verification.
+            #
+            # Workflow timeouts (the thread did not finish before
+            # stop_flag was set) are also warn-only for NFS/SMB
+            # workflows listed in _timeout_warn_workflows.
+            # ----------------------------------------------------------
+
+            # _warn_checks: maps workflow name -> list of
+            # (condition_fn, message_fn) tuples evaluated against the
+            # workflow result dict.
+            _warn_checks = {
+                "nfs_daemon_failover": [
+                    (
+                        lambda r: r.get("recovery_failures", 0),
+                        lambda r: f"NFS daemon recovery failures: {r['recovery_failures']}",
+                    ),
+                    (
+                        lambda r: r.get("kill_failures", 0),
+                        lambda r: f"NFS daemon kill failures: {r['kill_failures']}",
+                    ),
+                ],
+                "nfs_client_churn": [
+                    (
+                        lambda r: r.get("errors", 0),
+                        lambda r: f"nfs_client_churn errors: {r['errors']}",
+                    ),
+                ],
+                "nfs_export_churn": [
+                    (
+                        lambda r: r.get("errors", 0),
+                        lambda r: f"nfs_export_churn errors: {r['errors']}",
+                    ),
+                ],
+                "nfs_admin_ops": [
+                    (
+                        lambda r: r.get("errors", 0),
+                        lambda r: f"nfs_admin_ops errors: {r['errors']}",
+                    ),
+                ],
+                "smb_daemon_thrashing": [
+                    (
+                        lambda r: r.get("recovery_failures", 0),
+                        lambda r: f"SMB daemon recovery failures: {r['recovery_failures']}",
+                    ),
+                    (
+                        lambda r: r.get("errors", 0),
+                        lambda r: f"SMB daemon thrash errors: {r['errors']}",
+                    ),
+                ],
+                "smb_client_io": [
+                    (
+                        lambda r: r.get("errors", 0),
+                        lambda r: f"SMB client IO errors: {r['errors']}",
+                    ),
+                    (
+                        lambda r: r.get("io_ops", 0) == 0,
+                        lambda r: "SMB client IO completed zero operations",
+                    ),
+                ],
+            }
+
+            thrash_warnings = []
+            for wf_name, checks in _warn_checks.items():
+                wf_result = workflow_results.get(wf_name)
+                if not isinstance(wf_result, dict):
+                    continue
+                for cond_fn, msg_fn in checks:
+                    if cond_fn(wf_result):
+                        thrash_warnings.append(msg_fn(wf_result))
+
+            # NFS/SMB workflow timeouts are also warn-only.
+            _timeout_warn_workflows = [
+                "nfs_daemon_failover",
+                "nfs_client_churn",
+                "nfs_export_churn",
+                "nfs_admin_ops",
+                "smb_daemon_thrashing",
+                "smb_client_io",
+            ]
+            for wf_name in _timeout_warn_workflows:
+                wf_result = workflow_results.get(wf_name)
+                if isinstance(wf_result, dict) and wf_result.get("timeout"):
+                    thrash_warnings.append(f"{wf_name} timed out during stop/drain")
+
+            if thrash_warnings:
+                log.warning(
+                    "[thrash_validation] During-thrash workflow warnings (%s):",
+                    len(thrash_warnings),
+                )
+                for warn_msg in thrash_warnings:
+                    log.warning("  WARN: %s", warn_msg)
 
         log.info(
             "Thrashing phase completed\n Sleeping for 60 seconds to allow for recovery..."
@@ -1428,6 +2129,349 @@ def run(ceph_cluster, **kw):
                 raise Exception("Not all PGs are active+clean")
 
         rados_obj.log_cluster_health()
+
+        # ── Post-thrash NFS verification ──
+        #
+        # After thrash threads have stopped and PGs are active+clean,
+        # validate the NFS subsystem end-to-end.  Every check that
+        # fails sets test_failed = True (these are hard failures).
+        #
+        # Checks performed (in order):
+        #   1. Daemon health: every nfs.<daemon_id> must report "running"
+        #      via ceph orch.
+        #   2. Mount health: pre-thrash integrity mounts (if any) must
+        #      not be stale (stat returns EIO/ESTALE).
+        #   3. Data integrity: re-run fio --verify=crc32c on pre-thrash
+        #      mounts.  A *mismatch* (corrupted data) is a hard failure.
+        #      I/O errors that are not mismatches are warn-only.
+        #   4. Export accessibility: mount each export via
+        #      _nfs_mount_context, run ``ls``, unmount.  Any mount or
+        #      ls failure is a hard failure.
+        #   5. RADOS config integrity: for each NFS cluster, read the
+        #      conf-nfs.<cluster_id> RADOS object and validate it
+        #      parses correctly.  Corruption is a hard failure.
+        if enable_nfs_thrashing and nfs_config:
+            log.info("Running post-thrash NFS verification...")
+            nfs_wf = NfsThrashWorkflows(
+                cephadm.installer, nfs_config, rados_obj, ceph_cluster
+            )
+
+            # NFS daemon health: all daemons must be running
+            try:
+                nfs_daemon_healthy = True
+                for cluster in nfs_config.get("clusters", []):
+                    cluster_id = cluster.get("cluster_id", "")
+                    if not cluster_id:
+                        continue
+                    svc_name = f"nfs.{cluster_id}"
+                    daemon_ids = rados_obj.get_service_spec_daemons(
+                        service_name=svc_name
+                    )
+                    if not daemon_ids:
+                        log.error("[post-thrash NFS] No daemons found for %s", svc_name)
+                        nfs_daemon_healthy = False
+                        continue
+                    for daemon_id in daemon_ids:
+                        daemon_id = str(daemon_id)
+                        status = rados_obj.get_daemon_status(
+                            daemon_type="nfs", daemon_id=daemon_id
+                        )
+                        status_desc = status[1] if status else "unknown"
+                        if status_desc != "running":
+                            log.error(
+                                "[post-thrash NFS] Daemon nfs.%s "
+                                "status=%s (expected running)",
+                                daemon_id,
+                                status_desc,
+                            )
+                            nfs_daemon_healthy = False
+                        else:
+                            log.debug("[post-thrash NFS] nfs.%s running", daemon_id)
+                if nfs_daemon_healthy:
+                    log.info("Post-thrash NFS daemon health verified")
+                else:
+                    test_failed = True
+            except Exception as e:
+                log.error("[post-thrash NFS] Daemon health check failed: %s", e)
+                test_failed = True
+
+            # NFS mount health check on pre-thrash integrity mounts
+            if nfs_integrity_mounts:
+                try:
+                    mount_health = check_mount_health(
+                        client_node, nfs_integrity_mounts, proto="nfs"
+                    )
+                    if mount_health.get("stale"):
+                        log.error(
+                            "[post-thrash NFS] Stale mounts detected: %s",
+                            mount_health["stale"],
+                        )
+                        test_failed = True
+                    else:
+                        log.info(
+                            "[post-thrash NFS] Mount health OK: %s healthy",
+                            len(mount_health.get("healthy", [])),
+                        )
+                except Exception as e:
+                    log.error("[post-thrash NFS] Mount health check failed: %s", e)
+                    test_failed = True
+
+            # Post-thrash data integrity verification on pre-mounted paths
+            if nfs_integrity_mounts:
+                try:
+                    log.info(
+                        "[post-thrash NFS] Verifying data integrity on "
+                        "%s pre-thrash mount(s)...",
+                        len(nfs_integrity_mounts),
+                    )
+                    post_verify = verify_data_integrity(
+                        client_node, nfs_integrity_mounts
+                    )
+                    if post_verify.get("mismatches"):
+                        log.error(
+                            "[post-thrash NFS] Data integrity MISMATCH: %s",
+                            post_verify["mismatches"],
+                        )
+                        test_failed = True
+                    elif post_verify.get("errors"):
+                        log.error(
+                            "[post-thrash NFS] Data integrity errors on "
+                            "stable cluster: %s (file unreadable = potential data loss)",
+                            post_verify["errors"],
+                        )
+                        test_failed = True
+                    else:
+                        log.info(
+                            "[post-thrash NFS] Data integrity verified: "
+                            "%s file(s) clean",
+                            post_verify.get("files_checked", 0),
+                        )
+                except Exception as e:
+                    log.error(
+                        "[post-thrash NFS] Data integrity verification failed: %s", e
+                    )
+                    test_failed = True
+
+            # NFS export accessibility: mount each export, verify ls, unmount
+            try:
+                nfs_exports_ok = True
+                for idx, export in enumerate(nfs_config.get("exports", [])):
+                    cluster_id = export.get("cluster_id", "")
+                    pseudo_path = export.get("pseudo_path", "")
+                    if not cluster_id or not pseudo_path:
+                        continue
+                    try:
+                        with _nfs_mount_context(
+                            client_node,
+                            nfs_config,
+                            "/mnt/post-thrash-nfs-verify",
+                            index=idx,
+                        ) as (exp_info, mount_point):
+                            if exp_info is None or mount_point is None:
+                                log.error(
+                                    "[post-thrash NFS] Mount failed for export %s",
+                                    pseudo_path,
+                                )
+                                nfs_exports_ok = False
+                                continue
+                            client_node.exec_command(
+                                sudo=True,
+                                cmd=f"ls {mount_point}/",
+                                timeout=30,
+                            )
+                            log.debug(
+                                "[post-thrash NFS] Export %s accessible at %s",
+                                pseudo_path,
+                                mount_point,
+                            )
+                    except Exception as e:
+                        log.error(
+                            "[post-thrash NFS] Export %s access failed: %s",
+                            pseudo_path,
+                            e,
+                        )
+                        nfs_exports_ok = False
+                if nfs_exports_ok:
+                    log.info("Post-thrash NFS export accessibility verified")
+                else:
+                    test_failed = True
+            except Exception as e:
+                log.error("[post-thrash NFS] Export accessibility check failed: %s", e)
+                test_failed = True
+
+            # NFS RADOS config integrity: verify each cluster's config object
+            try:
+                nfs_rados_ok = True
+                for cluster in nfs_config.get("clusters", []):
+                    cluster_id = cluster.get("cluster_id", "")
+                    if not cluster_id:
+                        continue
+                    rados_result = nfs_wf.check_rados_config(cluster_id)
+                    if not rados_result.get("valid"):
+                        log.error(
+                            "[post-thrash NFS] RADOS config invalid for %s: %s",
+                            cluster_id,
+                            rados_result.get("error"),
+                        )
+                        nfs_rados_ok = False
+                    else:
+                        log.debug(
+                            "[post-thrash NFS] RADOS config OK for %s (%s bytes)",
+                            cluster_id,
+                            rados_result["size"],
+                        )
+                if nfs_rados_ok:
+                    log.info("Post-thrash NFS RADOS config integrity verified")
+                else:
+                    test_failed = True
+            except Exception as e:
+                log.error("[post-thrash NFS] RADOS config check failed: %s", e)
+                test_failed = True
+
+        # ── Post-thrash SMB verification ──
+        #
+        # When SMB thrashing is enabled, verify the SMB subsystem after
+        # chaos threads have stopped.  All failures here are hard
+        # failures (set test_failed = True).
+        #
+        # Checks performed (in order):
+        #   1. RADOS config integrity (if enable_smb_rados_config_check):
+        #      verify_rados_config() reads each SMB cluster's metadata
+        #      object from the RADOS pool and checks for corruption.
+        #   2. Endpoint accessibility: verify_endpoints() runs
+        #      ``smbclient -L`` against each share and confirms the
+        #      share is listed in the output.
+        #   3. CTDB health: verify_ctdb_health() checks that all CTDB
+        #      cluster nodes are healthy and none are banned.
+        if enable_smb_thrashing and smb_config:
+            log.info("Running post-thrash SMB verification...")
+            if smb_wf is None:
+                smb_wf = SmbThrashWorkflows(cephadm.installer, ceph_cluster, rados_obj)
+            if enable_smb_rados_config_check:
+                smb_rados_result = smb_wf.verify_rados_config(
+                    smb_config.get("cluster_ids", [])
+                )
+                if smb_rados_result.get("corrupted"):
+                    log.error(
+                        "SMB RADOS config corruption detected: %s",
+                        smb_rados_result["corrupted"],
+                    )
+                    test_failed = True
+                else:
+                    log.info("SMB RADOS config integrity verified")
+
+            smb_endpoint_result = smb_wf.verify_endpoints(client_node, smb_config)
+            if smb_endpoint_result.get("failed"):
+                log.error("SMB endpoint failures: %s", smb_endpoint_result["failed"])
+                test_failed = True
+            else:
+                log.info(
+                    "All %s SMB endpoints accessible",
+                    len(smb_endpoint_result.get("accessible", [])),
+                )
+
+            ctdb_result = smb_wf.verify_ctdb_health(
+                smb_config.get("smb_nodes", []),
+                smb_config.get("cluster_ids", []),
+            )
+            if not ctdb_result.get("healthy", False):
+                log.error(
+                    "CTDB health check failed: banned=%s", ctdb_result.get("banned", [])
+                )
+                test_failed = True
+            else:
+                log.info(
+                    "CTDB health verified: %s/%s nodes OK",
+                    ctdb_result.get("nodes_ok"),
+                    ctdb_result.get("nodes_total"),
+                )
+
+        # ── Post-thrash SMB data integrity verification ──
+        #
+        # Download each pre-thrash test file and compare its md5 checksum
+        # against the stored baseline.  A mismatch indicates silent data
+        # corruption during the thrash phase.
+        if smb_integrity_baselines and smb_config:
+            log.info("Running post-thrash SMB integrity verification...")
+            try:
+                smb_user = smb_config.get("smb_user_name", "")
+                smb_password = smb_config.get("smb_user_password", "")
+
+                smb_target = None
+                public_addrs = smb_config.get("public_addrs")
+                if public_addrs:
+                    smb_target = (
+                        public_addrs[0]
+                        if isinstance(public_addrs, list)
+                        else public_addrs
+                    )
+                if not smb_target:
+                    smb_nodes = smb_config.get("smb_nodes", [])
+                    if smb_nodes:
+                        node = smb_nodes[0]
+                        smb_target = (
+                            node.ip_address
+                            if hasattr(node, "ip_address")
+                            else str(node)
+                        )
+
+                if not smb_target:
+                    log.warning(
+                        "No SMB target IP for post-thrash verification — skipped"
+                    )
+                else:
+                    for share_name, expected_md5 in smb_integrity_baselines.items():
+                        verify_file = f"/tmp/smb_integrity_verify_{share_name}.dat"
+                        try:
+                            client_node.exec_command(
+                                cmd=(
+                                    f"smbclient -U {smb_user}%{smb_password} "
+                                    f"//{smb_target}/{share_name} "
+                                    f"-c 'get smb_integrity_test.dat {verify_file}'"
+                                ),
+                                timeout=60,
+                            )
+                            out, _ = client_node.exec_command(
+                                cmd=f"md5sum {verify_file}",
+                                timeout=15,
+                            )
+                            actual_md5 = out.strip().split()[0]
+
+                            if actual_md5 != expected_md5:
+                                log.error(
+                                    "SMB integrity MISMATCH on share %s: "
+                                    "expected=%s actual=%s",
+                                    share_name,
+                                    expected_md5,
+                                    actual_md5,
+                                )
+                                test_failed = True
+                            else:
+                                log.info(
+                                    "SMB integrity verified: share=%s md5=%s",
+                                    share_name,
+                                    actual_md5,
+                                )
+                        except Exception as e:
+                            log.error(
+                                "SMB integrity check failed for share %s: %s",
+                                share_name,
+                                e,
+                            )
+                            test_failed = True
+                        finally:
+                            client_node.exec_command(
+                                cmd=f"rm -f {verify_file}",
+                                timeout=10,
+                                check_ec=False,
+                            )
+            except Exception as e:
+                log.error("Post-thrash SMB integrity verification failed: %s", e)
+                test_failed = True
+
+        # TODO: Add post-thrash integrity verification for CephFS, RBD, and RGW
+        #   clients (pre-thrash baselines must be written first — see pre-thrash
+        #   setup phase TODO)
 
         log.info("\nValidation phase completed")
 
@@ -1580,15 +2624,62 @@ def run(ceph_cluster, **kw):
                     )
                     test_failed = True
             else:
+                # NFS+OSD crash recovery downgrade:
+                # When both NFS and OSD thrashing are active, OSD pool
+                # degradation (.nfs RADOS pool) can cascade into NFS
+                # daemon crashes.  If crashes are detected but all NFS
+                # daemons have since recovered to "running" state, the
+                # crash is downgraded to a warning rather than failing
+                # the test.  This avoids false negatives caused by the
+                # expected OSD->NFS failure cascade.
                 if rados_obj.check_crash_status(
                     start_time=start_time,
                     end_time=test_end_time,
                     check_mds=enable_mds_thrashing,
                     check_nfs=enable_nfs_thrashing,
                     check_rgw=enable_rgw_thrashing,
+                    check_smb=enable_smb_thrashing,
                 ):
-                    log.error("Test failed due to crash detected")
-                    test_failed = True
+                    if enable_nfs_thrashing and enable_osd_thrashing:
+                        all_nfs_recovered = True
+                        try:
+                            for cluster in (nfs_config or {}).get("clusters", []):
+                                cid = cluster.get("cluster_id", "")
+                                if not cid:
+                                    continue
+                                svc_name = f"nfs.{cid}"
+                                daemon_ids = rados_obj.get_service_spec_daemons(
+                                    service_name=svc_name
+                                )
+                                for did in daemon_ids or []:
+                                    status = rados_obj.get_daemon_status(
+                                        daemon_type="nfs", daemon_id=str(did)
+                                    )
+                                    status_desc = status[1] if status else "unknown"
+                                    if status_desc != "running":
+                                        all_nfs_recovered = False
+                                        break
+                                if not all_nfs_recovered:
+                                    break
+                        except Exception as nfs_check_err:
+                            log.warning("NFS recovery check failed: %s", nfs_check_err)
+                            all_nfs_recovered = False
+
+                        if all_nfs_recovered:
+                            log.warning(
+                                "Crash detected but all NFS daemons have recovered. "
+                                "Likely cascading effect from OSD thrashing degrading "
+                                "the .nfs RADOS pool. Downgrading to warning."
+                            )
+                        else:
+                            log.error(
+                                "Test failed due to crash detected "
+                                "(NFS daemons not fully recovered)"
+                            )
+                            test_failed = True
+                    else:
+                        log.error("Test failed due to crash detected")
+                        test_failed = True
         except Exception as e:
             log.error(f"Crash check failed: {e}")
             test_failed = True
@@ -1656,26 +2747,6 @@ def run(ceph_cluster, **kw):
                     except Exception as e:
                         log.warning(f"{name} cleanup failed: {e}")
 
-            # Re-enable firewall on nodes where it was disabled for NFS
-            if nfs_firewall_disabled_nodes:
-                log.info(
-                    f"Re-enabling firewall on {len(nfs_firewall_disabled_nodes)} node(s)..."
-                )
-                for node in nfs_firewall_disabled_nodes:
-                    try:
-                        node.exec_command(
-                            cmd="systemctl enable firewalld 2>/dev/null || true; "
-                            "systemctl start firewalld 2>/dev/null || true",
-                            sudo=True,
-                            timeout=30,
-                            check_ec=False,
-                        )
-                        log.info(f"  {node.hostname}: firewall re-enabled")
-                    except Exception as e:
-                        log.warning(
-                            f"  {node.hostname}: Failed to re-enable firewall - {e}"
-                        )
-
             # Phase 2: Delete tracked pools
             if created_pools:
                 log.info(f"Deleting {len(created_pools)} tracked pool(s)...")
@@ -1700,6 +2771,95 @@ def run(ceph_cluster, **kw):
             log.info("Pool cleanup completed")
         else:
             log.info("Skipping cleanup (cleanup_pools=False)")
+
+        # Unmount pre-thrash NFS integrity mounts (infrastructure cleanup,
+        # runs regardless of cleanup_pools setting)
+        if nfs_integrity_mounts:
+            log.info(
+                "Unmounting %s pre-thrash NFS integrity mount(s)...",
+                len(nfs_integrity_mounts),
+            )
+            for mp in nfs_integrity_mounts:
+                try:
+                    client_node.exec_command(
+                        sudo=True,
+                        cmd=f"umount -l {mp} 2>/dev/null; " f"rmdir {mp} 2>/dev/null",
+                        timeout=20,
+                        check_ec=False,
+                    )
+                    log.info("  Unmounted: %s", mp)
+                except Exception as e:
+                    log.warning("  Failed to unmount %s: %s", mp, e)
+
+        # Clean up SMB integrity temp files (runs regardless of cleanup_pools)
+        if smb_integrity_baselines:
+            log.info("Cleaning up SMB integrity temp files...")
+            try:
+                client_node.exec_command(
+                    cmd="rm -f /tmp/smb_integrity_*.dat",
+                    timeout=15,
+                    check_ec=False,
+                )
+                log.info("  SMB integrity temp files removed")
+            except Exception as e:
+                log.warning("  SMB integrity temp file cleanup failed: %s", e)
+
+        # Clean up SMB clusters/shares and the dedicated CephFS volume
+        # (runs regardless of cleanup_pools to prevent leftover resources
+        # from blocking subsequent runs)
+        if smb_config and smb_config.get("cluster_ids"):
+            log.info("Cleaning up SMB resources (unconditional)...")
+            try:
+                if smb_wf is None:
+                    smb_wf = SmbThrashWorkflows(
+                        cephadm.installer, ceph_cluster, rados_obj
+                    )
+                smb_wf.cleanup(smb_config)
+                log.info("  SMB clusters and shares removed")
+            except Exception as e:
+                log.warning("  SMB cluster/share cleanup failed: %s", e)
+            smb_vol = smb_config.get("cephfs_vol", "")
+            if smb_vol:
+                try:
+                    cephadm.installer.exec_command(
+                        sudo=True,
+                        cmd=f"ceph orch rm mds.{smb_vol}",
+                        timeout=60,
+                        check_ec=False,
+                    )
+                    log.info("  MDS service for '%s' removed", smb_vol)
+                except Exception as e:
+                    log.warning("  MDS service removal failed: %s", e)
+                try:
+                    cephadm.installer.exec_command(
+                        sudo=True,
+                        cmd=(f"ceph fs volume rm" f" {smb_vol} --yes-i-really-mean-it"),
+                        timeout=120,
+                    )
+                    log.info("  SMB CephFS volume '%s' removed", smb_vol)
+                except Exception as e:
+                    log.warning("  SMB CephFS volume removal failed: %s", e)
+
+        # Re-enable firewall on nodes where it was disabled for NFS
+        if nfs_firewall_disabled_nodes:
+            log.info(
+                "Re-enabling firewall on %s node(s)...",
+                len(nfs_firewall_disabled_nodes),
+            )
+            for node in nfs_firewall_disabled_nodes:
+                try:
+                    node.exec_command(
+                        cmd="systemctl enable firewalld 2>/dev/null || true; "
+                        "systemctl start firewalld 2>/dev/null || true",
+                        sudo=True,
+                        timeout=30,
+                        check_ec=False,
+                    )
+                    log.info("  %s: firewall re-enabled", node.hostname)
+                except Exception as e:
+                    log.warning(
+                        "  %s: Failed to re-enable firewall - %s", node.hostname, e
+                    )
 
         if enable_debug_logs:
             log.info("Forcing log rotation on OSD nodes...")
@@ -4429,24 +5589,35 @@ def thrash_nfs_fio(
     stop_flag: Dict,
 ) -> Dict[str, int]:
     """
-    Thrash NFS exports with mount -> FIO -> unmount cycles.
+    Thrash NFS exports with mount -> FIO -> FS ops -> unmount cycles.
 
-    Continuously cycles through:
-    1. Mount all NFS exports (cycling NFSv4.0/4.1/4.2, and NFSv3 only if the
-       cluster was created with enable_nfsv3)
-    2. Run NFS export info/ls commands on 2 random exports
-    3. Run FIO workloads on all mounted exports (cycling through I/O patterns)
-    4. Unmount all exports
-    5. Repeat until duration expires or stop_flag is set
+    Resolves mount targets via ``_nfs_export_mount_targets()`` (handles
+    multi-host NFS clusters), distributes them across up to 5 parallel
+    worker threads, and continuously cycles through:
+
+    1. Mount all assigned exports (cycling NFSv4.0/4.1/4.2; NFSv3 only
+       if the cluster was created with ``enable_nfsv3``).  Multi-host
+       clusters rotate the active host per cycle for load distribution.
+    2. Run ``ceph nfs export info`` / ``ls`` on a random mounted export.
+    3. Run FIO workloads on all mounted exports (cycling through I/O
+       patterns: seq_write, seq_read, rand_write, rand_read, mixed_rw).
+    4. Run filesystem operations (dd, stat, chmod, symlink, hardlink,
+       remount, rename, touch) on each mounted export.
+    5. Unmount all exports.
+    6. Repeat until ``duration`` expires or ``stop_flag["stop"]`` is set.
 
     Args:
-        client_node: Client node to mount/unmount and run FIO
-        nfs_config: NFS configuration dict from create_nfs_clusters_and_exports
-        duration: Total duration in seconds
-        stop_flag: Dict with 'stop' key to signal early termination
+        client_node: Client node to mount/unmount and run FIO.
+        nfs_config: NFS configuration dict from
+            ``create_nfs_clusters_and_exports``.  Must contain ``exports``
+            and ``clusters`` lists; may contain ``enable_rdma``,
+            ``enable_nfsv3``, and per-cluster ``rdma_port`` entries.
+        duration: Total duration in seconds.
+        stop_flag: Dict with ``stop`` key to signal early termination.
 
     Returns:
-        Total number of completed mount-FIO-unmount cycles across all workers
+        dict: ``{"cycles": int, "failures": int}`` aggregated across all
+        worker threads.
     """
     nfs_versions_v4 = (
         ("4.0", "nfsvers=4.0"),
@@ -4466,24 +5637,27 @@ def thrash_nfs_fio(
 
     log.info("Starting NFS FIO thrashing (5 parallel workers)")
 
-    clusters = nfs_config.get("clusters", [])
     exports = nfs_config.get("exports", [])
 
     if not exports:
         log.warning("No NFS exports available for thrashing")
-        return 0
+        return {"cycles": 0, "failures": 0}
 
-    cluster_host_map = {c["cluster_id"]: c["host"] for c in clusters}
-    cluster_port_map = {c["cluster_id"]: c["port"] for c in clusters}
+    mount_targets = _nfs_export_mount_targets(nfs_config)
+    if not mount_targets:
+        log.warning("No valid NFS mount targets available for thrashing")
+        return {"cycles": 0, "failures": 0}
 
-    num_workers = min(5, len(exports))
-    export_groups = [[] for _ in range(num_workers)]
-    for idx, export in enumerate(exports):
-        export_groups[idx % num_workers].append((idx, export))
+    num_workers = min(5, len(mount_targets))
+    target_groups = [[] for _ in range(num_workers)]
+    for idx, target in enumerate(mount_targets):
+        target_groups[idx % num_workers].append((idx, target))
 
     log.info(
-        f"Distributing {len(exports)} exports across {num_workers} workers: "
-        f"{[len(g) for g in export_groups]}"
+        "Distributing %s exports across %s workers: %s",
+        len(mount_targets),
+        num_workers,
+        [len(g) for g in target_groups],
     )
 
     # Log NFS version assignments
@@ -4497,17 +5671,15 @@ def thrash_nfs_fio(
     total_failures = 0
     with cf.ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures = []
-        for worker_id, export_group in enumerate(export_groups):
-            if export_group:
+        for worker_id, target_group in enumerate(target_groups):
+            if target_group:
                 assigned_nfs_version = nfs_versions[worker_id % len(nfs_versions)]
                 futures.append(
                     executor.submit(
                         _nfs_worker_thread,
                         client_node=client_node,
                         worker_id=worker_id,
-                        export_group=export_group,
-                        cluster_host_map=cluster_host_map,
-                        cluster_port_map=cluster_port_map,
+                        target_group=target_group,
                         nfs_version=assigned_nfs_version,
                         duration=duration,
                         stop_flag=stop_flag,
@@ -4538,9 +5710,7 @@ def thrash_nfs_fio(
 def _nfs_worker_thread(
     client_node,
     worker_id: int,
-    export_group: List[tuple],
-    cluster_host_map: Dict[str, str],
-    cluster_port_map: Dict[str, int],
+    target_group: List[tuple],
     nfs_version: tuple,
     duration: int,
     stop_flag: Dict,
@@ -4549,15 +5719,13 @@ def _nfs_worker_thread(
     """
     Worker thread for NFS FIO thrashing.
 
-    Each worker handles a subset of exports using a specific NFS version:
-    mount -> NFS info commands -> FIO -> unmount
+    Each worker handles a subset of pre-resolved mount targets using a specific
+    NFS version: mount -> NFS info commands -> FIO -> unmount
 
     Args:
         client_node: Client node for commands
         worker_id: Unique worker identifier
-        export_group: List of (idx, export_dict) tuples assigned to this worker
-        cluster_host_map: Cluster ID to host mapping
-        cluster_port_map: Cluster ID to TCP NFS port mapping (informational)
+        target_group: List of (idx, target_dict) from _nfs_export_mount_targets
         nfs_version: Tuple of (version_str, mount_options) e.g. ("4.1", "nfsvers=4.1")
         duration: Total duration in seconds
         stop_flag: Stop signal dict
@@ -4582,20 +5750,17 @@ def _nfs_worker_thread(
     base_mount_dir = f"/mnt/nfs-thrash-w{worker_id}"
     num_patterns = len(fio_patterns)
 
-    # Pre-build export info with mount points to avoid repeated lookups
     export_info = []
-    for idx, export in export_group:
-        cluster_id = export["cluster_id"]
-        nfs_host = cluster_host_map.get(cluster_id)
-        nfs_port = cluster_port_map.get(cluster_id)
-        if nfs_host and nfs_port:
+    for idx, target in target_group:
+        if target.get("hosts") and target.get("port") is not None:
             export_info.append(
                 {
                     "mount_point": f"{base_mount_dir}/export_{idx}",
-                    "cluster_id": cluster_id,
-                    "pseudo_path": export["pseudo_path"],
-                    "host": nfs_host,
-                    "port": nfs_port,
+                    "cluster_id": target["cluster_id"],
+                    "pseudo_path": target["pseudo_path"],
+                    "host": target["host"],
+                    "hosts": target["hosts"],
+                    "port": target["port"],
                 }
             )
 
@@ -4619,25 +5784,43 @@ def _nfs_worker_thread(
             # Step 2: Mount all exports assigned to this worker
             for exp in export_info:
                 mount_point = exp["mount_point"]
+                active_host = ""
                 try:
+                    hosts = exp.get("hosts") or (
+                        [exp.get("host")] if exp.get("host") else []
+                    )
+                    if not hosts:
+                        raise RuntimeError(
+                            f"No NFS hosts available for cluster {exp['cluster_id']}"
+                        )
+                    host_idx = (cycle_count - 1 + worker_id) % len(hosts)
+                    active_host = hosts[host_idx]
+
                     client_node.exec_command(cmd=f"mkdir -p {mount_point}", sudo=True)
                     mount_opts = _nfs_client_mount_option_string(
                         nfs_config, exp["cluster_id"], nfs_options
                     )
                     mount_cmd = (
                         f"mount -t nfs -o {mount_opts} "
-                        f"{exp['host']}:{exp['pseudo_path']} {mount_point}"
+                        f"{active_host}:{exp['pseudo_path']} {mount_point}"
                     )
                     client_node.exec_command(cmd=mount_cmd, sudo=True, timeout=60)
-                    mounted_exports.append(exp)
+                    mounted_exports.append((exp, active_host))
                 except Exception as e:
                     err_type = type(e).__name__
                     log.warning(
-                        f"Worker {worker_id}: MOUNT FAILED\n"
-                        f"  Export: {exp['host']}:{exp['pseudo_path']}\n"
-                        f"  Mount point: {mount_point}\n"
-                        f"  NFS version: {nfs_ver_str}\n"
-                        f"  Error: {err_type}: {e}"
+                        "Worker %s: MOUNT FAILED\n"
+                        "  Export: %s:%s\n"
+                        "  Mount point: %s\n"
+                        "  NFS version: %s\n"
+                        "  Error: %s: %s",
+                        worker_id,
+                        active_host,
+                        exp["pseudo_path"],
+                        mount_point,
+                        nfs_ver_str,
+                        err_type,
+                        e,
                     )
                     failures += 1
 
@@ -4649,7 +5832,7 @@ def _nfs_worker_thread(
                 continue
 
             # Step 2.5: Run NFS export info on one random export per cycle
-            exp = random.choice(mounted_exports)
+            exp, _host = random.choice(mounted_exports)
             cid, ppath = exp["cluster_id"], exp["pseudo_path"]
             try:
                 client_node.exec_command(
@@ -4665,7 +5848,7 @@ def _nfs_worker_thread(
                 failures += 1
 
             # Step 3: Run FIO on all mounted exports
-            for exp in mounted_exports:
+            for exp, exp_active_host in mounted_exports:
                 if stop_flag.get("stop"):
                     break
 
@@ -4682,16 +5865,25 @@ def _nfs_worker_thread(
                 except Exception as e:
                     err_type = type(e).__name__
                     log.warning(
-                        f"Worker {worker_id}: FIO FAILED\n"
-                        f"  Pattern: {p_name} (rw={p_rw}, bs={p_bs})\n"
-                        f"  Work dir: {work_dir}\n"
-                        f"  Export: {exp['host']}:{exp['pseudo_path']}\n"
-                        f"  Error: {err_type}: {e}"
+                        "Worker %s: FIO FAILED\n"
+                        "  Pattern: %s (rw=%s, bs=%s)\n"
+                        "  Work dir: %s\n"
+                        "  Export: %s:%s\n"
+                        "  Error: %s: %s",
+                        worker_id,
+                        p_name,
+                        p_rw,
+                        p_bs,
+                        work_dir,
+                        exp_active_host,
+                        exp["pseudo_path"],
+                        err_type,
+                        e,
                     )
                     failures += 1
 
             # Step 4: Additional filesystem operations on mounted NFS
-            for exp in mounted_exports:
+            for exp, exp_active_host in mounted_exports:
                 if stop_flag.get("stop"):
                     break
 
@@ -4743,7 +5935,7 @@ FSOPS_WORKER
                     client_node.exec_command(
                         cmd=f"umount -lf {mount_point} && sleep 1 && "
                         f"mount -t nfs -o {remount_opts} "
-                        f"{exp['host']}:{exp['pseudo_path']} {mount_point}",
+                        f"{exp_active_host}:{exp['pseudo_path']} {mount_point}",
                         sudo=True,
                         timeout=60,
                     )
@@ -4760,10 +5952,16 @@ FSOPS_WORKER
                 except Exception as e:
                     err_type = type(e).__name__
                     log.warning(
-                        f"Worker {worker_id}: FS OPS FAILED\n"
-                        f"  Work dir: {work_dir}\n"
-                        f"  Export: {exp['host']}:{exp['pseudo_path']}\n"
-                        f"  Error: {err_type}: {e}"
+                        "Worker %s: FS OPS FAILED\n"
+                        "  Work dir: %s\n"
+                        "  Export: %s:%s\n"
+                        "  Error: %s: %s",
+                        worker_id,
+                        work_dir,
+                        exp_active_host,
+                        exp["pseudo_path"],
+                        err_type,
+                        e,
                     )
                     failures += 1
 
@@ -4776,7 +5974,7 @@ FSOPS_WORKER
 
         finally:
             if mounted_exports:
-                mount_paths = " ".join(e["mount_point"] for e in mounted_exports)
+                mount_paths = " ".join(e["mount_point"] for e, _h in mounted_exports)
                 try:
                     client_node.exec_command(
                         cmd=f"umount -lf {mount_paths}", sudo=True, check_ec=False
@@ -4797,115 +5995,6 @@ FSOPS_WORKER
         f"Worker {worker_id}: Completed {cycle_count} cycles (failures={failures})"
     )
     return {"cycles": cycle_count, "failures": failures}
-
-
-def _nfs_client_mount_option_string(
-    nfs_config: Dict[str, Any],
-    cluster_id: str,
-    nfs_options_base: str,
-) -> str:
-    """
-    Build mount -o string for NFS client: nfsvers/... plus port= and optional rdma.
-
-    When nfs_config['enable_rdma'] is True, uses per-cluster rdma_port from
-    create_nfs_clusters_and_exports and appends the rdma mount option.
-    """
-    clusters = nfs_config.get("clusters", [])
-    port = None
-    for c in clusters:
-        if c["cluster_id"] == cluster_id:
-            if nfs_config.get("enable_rdma") and c.get("rdma_port") is not None:
-                port = c["rdma_port"]
-                return f"{nfs_options_base},rdma,port={port}"
-            port = c.get("port")
-            break
-    if port is None:
-        log.warning(
-            "_nfs_client_mount_option_string: no port for cluster_id=%s", cluster_id
-        )
-        return nfs_options_base
-    return f"{nfs_options_base},port={port}"
-
-
-def _pick_nfs_endpoint(nfs_config: Dict[str, Any], index: int = 0):
-    """Helper to pick NFS export endpoint by index with cached lookups."""
-    exports = nfs_config.get("exports", [])
-    clusters = nfs_config.get("clusters", [])
-    if not exports or not clusters:
-        return None, None, None
-
-    # Cache cluster maps to avoid rebuilding on every call
-    if "_cluster_host_map" not in nfs_config:
-        nfs_config["_cluster_host_map"] = {c["cluster_id"]: c["host"] for c in clusters}
-        nfs_config["_cluster_port_map"] = {c["cluster_id"]: c["port"] for c in clusters}
-
-    exp = exports[index % len(exports)]
-    host = nfs_config["_cluster_host_map"].get(exp["cluster_id"])
-    cid = exp["cluster_id"]
-    if nfs_config.get("enable_rdma"):
-        if "_cluster_rdma_port_map" not in nfs_config:
-            nfs_config["_cluster_rdma_port_map"] = {
-                c["cluster_id"]: c.get("rdma_port") for c in clusters
-            }
-        port = nfs_config["_cluster_rdma_port_map"].get(cid)
-    else:
-        port = nfs_config["_cluster_port_map"].get(cid)
-    return exp, host, port
-
-
-@contextmanager
-def _nfs_mount_context(
-    client_node,
-    nfs_config: Dict[str, Any],
-    mount_base: str,
-    index: int = 0,
-    nfs_ver: str = "4.1",
-):
-    """
-    Context manager for NFS mount/unmount with automatic cleanup.
-
-    Args:
-        client_node: SSH client node
-        nfs_config: NFS configuration dictionary
-        mount_base: Base name for mount point (unique suffix added automatically)
-        index: Export index to use
-        nfs_ver: NFS version string (e.g., "4.1", "4.2")
-
-    Yields:
-        Tuple of (export_info, mount_point) or (None, None) if setup fails
-    """
-    exp, host, port = _pick_nfs_endpoint(nfs_config, index=index)
-    if not exp or not host or not port:
-        yield None, None
-        return
-
-    # Use unique mount point to avoid collisions in parallel runs
-    unique_suffix = uuid.uuid4().hex[:8]
-    mount_point = f"{mount_base}-{unique_suffix}"
-
-    mount_opts = _nfs_client_mount_option_string(
-        nfs_config, exp["cluster_id"], f"nfsvers={nfs_ver}"
-    )
-    mount_cmd = (
-        f"mount -t nfs -o {mount_opts} " f"{host}:{exp['pseudo_path']} {mount_point}"
-    )
-    try:
-        client_node.exec_command(cmd=f"mkdir -p {mount_point}", sudo=True)
-        client_node.exec_command(cmd=mount_cmd, sudo=True, timeout=60)
-        yield exp, mount_point
-    except Exception as e:
-        log.warning(f"NFS mount FAILED: {host}:{exp['pseudo_path']} NFSv{nfs_ver}: {e}")
-        yield None, None
-    finally:
-        try:
-            client_node.exec_command(
-                cmd=f"umount -lf {mount_point}", sudo=True, check_ec=False
-            )
-            client_node.exec_command(
-                cmd=f"rm -rf {mount_point}", sudo=True, check_ec=False
-            )
-        except Exception:
-            pass
 
 
 def thrash_nfs_locking(

--- a/tests/rados/thrash_helpers.py
+++ b/tests/rados/thrash_helpers.py
@@ -1,0 +1,1937 @@
+"""
+General-purpose thrash helpers for daemon failure injection and verification.
+
+Provides shared verification utilities and component-specific thrash workflows
+for NFS and SMB. Used by test_osd_thrashing.py thread submissions.
+
+Components:
+    - Shared: data integrity (write_integrity_baseline, verify_data_integrity,
+      check_mount_health) -- called in pre-thrash / post-thrash phases
+    - Shared: wait_for_service_daemons_running -- daemon-type-agnostic polling
+      used by both NFS and SMB wait methods
+    - NFS: NfsThrashWorkflows class -- daemon kill, recovery, RADOS config
+    - SMB: SmbThrashWorkflows class -- daemon lifecycle, kill methods, CTDB/VIP
+    - NFS protocol state: client churn, export churn, admin op interleaving
+"""
+
+import json
+import random
+import re
+import shlex
+import time
+import uuid
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional, Tuple
+
+from ceph.waiter import WaitUntil
+from cli.utilities.utils import reboot_node
+from utility.log import Log
+
+log = Log(__name__)
+
+
+# ---------------------------------------------------------------------------
+#  Shared Verification Layer
+# ---------------------------------------------------------------------------
+
+
+_INTEGRITY_FILE_SPECS = [
+    ("integrity_4k", "4k", "4k"),
+    ("integrity_64k", "64k", "4k"),
+    ("integrity_256k", "256k", "4k"),
+    ("integrity_1m", "1M", "16k"),
+    ("integrity_4m", "4M", "64k"),
+    ("integrity_8m", "8M", "64k"),
+    ("integrity_16m", "16M", "128k"),
+    ("integrity_32m", "32M", "128k"),
+    ("integrity_48m", "48M", "256k"),
+    ("integrity_64m", "64M", "256k"),
+]
+"""(job_name, file_size, block_size) tuples for integrity baseline files."""
+
+
+def write_integrity_baseline(
+    client_node,
+    mount_points: List[str],
+) -> Dict[str, Any]:
+    """Write 10 fio files with CRC32C checksums to establish a verification baseline.
+
+    Creates a ``thrash_integrity/`` directory under each mount point and writes
+    10 files of varying sizes (4K to 64M) using ``--verify=crc32c --do_verify=0``
+    (write-only). Each file uses a different block size for IO pattern diversity.
+    File sizes and block sizes are defined by ``_INTEGRITY_FILE_SPECS``.
+
+    Args:
+        client_node: CephNode with the mount points accessible.
+        mount_points: Absolute paths to mounted NFS or CIFS filesystems.
+
+    Returns:
+        Dict with ``files_written`` (int) and ``paths`` (list of integrity dirs
+        that were successfully written).
+    """
+    result = {"files_written": 0, "paths": []}
+    for mp in mount_points:
+        integrity_dir = f"{mp}/thrash_integrity"
+        try:
+            client_node.exec_command(
+                sudo=True, cmd=f"mkdir -p {integrity_dir}", timeout=15
+            )
+            files_ok = 0
+            for job_name, fsize, bs in _INTEGRITY_FILE_SPECS:
+                fio_cmd = (
+                    f"fio --name={job_name} --directory={integrity_dir} "
+                    f"--size={fsize} --bs={bs} --rw=write --numjobs=1 "
+                    f"--verify=crc32c --verify_dump=1 --do_verify=0 "
+                    f"--ioengine=libaio --direct=1"
+                )
+                client_node.exec_command(sudo=True, cmd=fio_cmd, timeout=120)
+                files_ok += 1
+            result["files_written"] += files_ok
+            result["paths"].append(integrity_dir)
+            log.info(
+                "[integrity] Baseline written: %s (%s files, 4K-64M)",
+                integrity_dir,
+                files_ok,
+            )
+        except Exception as e:
+            log.warning("[integrity] Failed to write baseline at %s: %s", mp, e)
+    return result
+
+
+def verify_data_integrity(
+    client_node,
+    mount_points: List[str],
+) -> Dict[str, Any]:
+    """Re-run fio verify pass on all integrity files written by the baseline.
+
+    Reads each file created by ``write_integrity_baseline`` with
+    ``--do_verify=1`` and checks CRC32C checksums.
+
+    This function returns results without raising; callers decide the
+    severity. Typical usage:
+
+    * **Pre-thrash** (healthy cluster): any error → abort test.
+    * **Post-thrash** (recovered cluster): ``mismatches`` → test failure
+      (data corruption); ``errors`` without mismatches → warning
+      (transient I/O issue).
+
+    Args:
+        client_node: CephNode with the mount points accessible.
+        mount_points: Same mount paths passed to ``write_integrity_baseline``.
+
+    Returns:
+        Dict with ``files_checked`` (int), ``errors`` (int), and
+        ``mismatches`` (list of mount paths with CRC32C verification failures).
+    """
+    result = {"files_checked": 0, "errors": 0, "mismatches": []}
+    for mp in mount_points:
+        integrity_dir = f"{mp}/thrash_integrity"
+        mp_mismatched = False
+        for job_name, fsize, bs in _INTEGRITY_FILE_SPECS:
+            try:
+                fio_cmd = (
+                    f"fio --name={job_name} --directory={integrity_dir} "
+                    f"--size={fsize} --bs={bs} --rw=read --numjobs=1 "
+                    f"--verify=crc32c --do_verify=1 "
+                    f"--ioengine=libaio --direct=1"
+                )
+                out, err = client_node.exec_command(
+                    sudo=True, cmd=fio_cmd, timeout=120, check_ec=False
+                )
+                result["files_checked"] += 1
+                err_lower = (err or "").lower()
+                if "verify" in err_lower and "error" in err_lower:
+                    result["errors"] += 1
+                    mp_mismatched = True
+                    log.error(
+                        "[integrity] VERIFY MISMATCH: %s/%s (%s)",
+                        integrity_dir,
+                        job_name,
+                        fsize,
+                    )
+            except Exception as e:
+                log.warning(
+                    "[integrity] Verify failed: %s/%s: %s", integrity_dir, job_name, e
+                )
+                result["errors"] += 1
+        if mp_mismatched:
+            result["mismatches"].append(mp)
+        else:
+            log.info(
+                "[integrity] Verify passed: %s (%s files)",
+                integrity_dir,
+                len(_INTEGRITY_FILE_SPECS),
+            )
+    return result
+
+
+def check_mount_health(
+    client_node,
+    mount_points: List[str],
+    proto: str = "nfs",
+) -> Dict[str, Any]:
+    """Detect stale or hung mounts via ``stat`` and ``df`` with a 10-second timeout.
+
+    Any mount that fails either command is classified as stale. For SMB mounts,
+    "cifs vfs" is added to the stale-indicator pattern list.
+
+    Args:
+        client_node: CephNode with the mount points accessible.
+        mount_points: Absolute paths to check.
+        proto: ``"nfs"`` or ``"smb"`` -- controls stale-error pattern matching.
+
+    Returns:
+        Dict with ``healthy`` (list of responsive mount paths) and ``stale``
+        (list of unresponsive mount paths).
+    """
+    result = {"healthy": [], "stale": []}
+    stale_indicators = [
+        "stale file handle",
+        "transport endpoint",
+        "no route to host",
+        "connection timed out",
+        "timed out",
+    ]
+    if proto == "smb":
+        stale_indicators.append("cifs vfs")
+    for mp in mount_points:
+        try:
+            client_node.exec_command(
+                sudo=True, cmd=f"timeout 10 stat {mp}/.", timeout=15
+            )
+            client_node.exec_command(sudo=True, cmd=f"timeout 10 df {mp}", timeout=15)
+            result["healthy"].append(mp)
+        except Exception as e:
+            err_str = str(e).lower()
+            if any(ind in err_str for ind in stale_indicators):
+                log.warning("[mount_health] Stale mount detected: %s", mp)
+            else:
+                log.warning("[mount_health] Mount check failed for %s: %s", mp, e)
+            result["stale"].append(mp)
+    return result
+
+
+# ---------------------------------------------------------------------------
+#  Shared Daemon Wait Helper
+# ---------------------------------------------------------------------------
+
+
+def wait_for_service_daemons_running(
+    rados_obj,
+    daemon_type: str,
+    cluster_ids: List[str],
+    timeout: int = 300,
+) -> bool:
+    """Poll until all daemons of the given type across clusters are running.
+
+    Uses ``get_service_spec_daemons`` + ``get_daemon_status`` in a
+    ``WaitUntil`` loop with a 10-second polling interval.
+
+    Args:
+        rados_obj: RadosOrchestrator instance.
+        daemon_type: Daemon type (``"nfs"``, ``"smb"``, etc.).
+        cluster_ids: Cluster identifiers (service name =
+            ``"{daemon_type}.{cluster_id}"``).
+        timeout: Max seconds to wait.
+
+    Returns:
+        True if all daemons are running within timeout, False otherwise.
+    """
+    svc_names = [f"{daemon_type}.{cid}" for cid in cluster_ids]
+    for _ in WaitUntil(timeout=timeout, interval=10):
+        try:
+            all_running = True
+            for svc_name in svc_names:
+                daemon_ids = rados_obj.get_service_spec_daemons(service_name=svc_name)
+                if not daemon_ids:
+                    all_running = False
+                    break
+                for did in daemon_ids:
+                    status = rados_obj.get_daemon_status(daemon_type, str(did))
+                    if not status or status[1] != "running":
+                        all_running = False
+                        break
+                if not all_running:
+                    break
+            if all_running:
+                log.info(
+                    "[daemon_wait] All daemons running for %s", ", ".join(svc_names)
+                )
+                return True
+        except Exception as e:
+            log.debug("[daemon_wait] Polling %s: %s", svc_names, e)
+    log.error(
+        "[daemon_wait] Timeout (%ss) waiting for daemons: %s",
+        timeout,
+        ", ".join(svc_names),
+    )
+    return False
+
+
+# ---------------------------------------------------------------------------
+#  NFS Thrash Workflows
+# ---------------------------------------------------------------------------
+
+
+class NfsThrashWorkflows:
+    """NFS daemon failover helpers for thrash testing.
+
+    Follows the pattern of MonitorWorkflows / MgrWorkflows. Each method has
+    a single responsibility. Uses ``rados_obj`` (RadosOrchestrator) for
+    daemon discovery, status polling, and kill actions instead of maintaining
+    its own topology cache.
+    """
+
+    def __init__(self, installer, nfs_config, rados_obj, ceph_cluster):
+        """Initialize NFS thrash workflow context.
+
+        Args:
+            installer: CephNode with ``ceph`` CLI access (typically the installer node).
+            nfs_config: Dict produced by ``create_nfs_clusters_and_exports`` containing
+                ``clusters`` (list of cluster dicts with ``cluster_id``).
+            rados_obj: RadosOrchestrator instance for daemon/host queries.
+            ceph_cluster: CephCluster object for node lookups.
+        """
+        self.installer = installer
+        self.nfs_config = nfs_config
+        self.rados_obj = rados_obj
+        self.ceph_cluster = ceph_cluster
+
+    # -- Daemon Discovery (via rados_obj) --
+
+    def _get_cluster_ids(self) -> List[str]:
+        """Extract NFS cluster IDs from ``self.nfs_config["clusters"]``.
+
+        Returns:
+            List of non-empty ``cluster_id`` strings.
+        """
+        clusters = self.nfs_config.get("clusters", [])
+        return [c.get("cluster_id", "") for c in clusters if c.get("cluster_id")]
+
+    def get_daemon_for_cluster(self, cluster_id: str) -> Optional[Dict]:
+        """Select a random running daemon for the given NFS cluster.
+
+        Delegates to ``RadosOrchestrator.get_service_spec_daemons``,
+        ``fetch_host_node``, and ``get_daemon_status`` for discovery.
+
+        Args:
+            cluster_id: NFS cluster identifier (e.g. ``"nfs-cluster-1"``).
+
+        Returns:
+            Dict with ``daemon_name``, ``hostname``, ``host_node``, and ``status``.
+            Returns ``None`` if no daemons are found or on error.
+        """
+        svc_name = f"nfs.{cluster_id}"
+        try:
+            daemon_ids = self.rados_obj.get_service_spec_daemons(service_name=svc_name)
+            if not daemon_ids:
+                return None
+            daemon_id = str(random.choice(daemon_ids))
+            daemon_name = f"nfs.{daemon_id}"
+            host_node = self.rados_obj.fetch_host_node(
+                daemon_type="nfs", daemon_id=daemon_id
+            )
+            daemon_status = self.rados_obj.get_daemon_status(
+                daemon_type="nfs", daemon_id=daemon_id
+            )
+            status_desc = daemon_status[1] if daemon_status else "unknown"
+            hostname = host_node.hostname if host_node else ""
+            return {
+                "daemon_name": daemon_name,
+                "hostname": hostname,
+                "host_node": host_node,
+                "status": status_desc,
+            }
+        except Exception as e:
+            log.warning("[nfs_topo] Failed to get daemon for %s: %s", cluster_id, e)
+            return None
+
+    # -- Kill Methods --
+
+    def kill_daemon_pkill(self, host_node, daemon_name: str) -> bool:
+        """Kill ganesha.nfsd inside its container via ``cephadm enter``.
+
+        NFS-Ganesha runs inside a cephadm-managed container, so a host-level
+        ``pkill`` won't reach the process. This method enters the container
+        and sends SIGKILL to ganesha.nfsd, simulating an unexpected crash.
+        Cephadm detects the dead process and restarts the container.
+
+        Args:
+            host_node: CephNode hosting the NFS daemon container.
+            daemon_name: Full daemon name (e.g. ``"nfs.nfs-cluster-1.0.0.grim031.abc"``).
+
+        Returns:
+            True if kill succeeded, False on error.
+        """
+        try:
+            host_node.exec_command(
+                sudo=True,
+                cmd=f"cephadm enter -n {daemon_name} -- sh -c 'kill -9 $(pidof ganesha.nfsd) 2>/dev/null || true'",
+                timeout=15,
+            )
+            log.info(
+                "[nfs_kill] Killed ganesha.nfsd inside %s on %s",
+                daemon_name,
+                host_node.hostname,
+            )
+            return True
+        except Exception as e:
+            log.warning(
+                "[nfs_kill] pkill failed for %s on %s: %s",
+                daemon_name,
+                host_node.hostname,
+                e,
+            )
+            return False
+
+    def kill_daemon(self, host_node, daemon_name: str, method: str) -> bool:
+        """Dispatch to the appropriate daemon kill method.
+
+        Supported methods:
+            - ``"pkill"``: ``kill_daemon_pkill`` (SIGKILL ganesha.nfsd).
+            - ``"orch_stop"``: ``RadosOrchestrator.change_daemon_orch_state``.
+            - ``"systemctl"``: ``RadosOrchestrator.change_daemon_systemctl_state``
+              (builds systemd unit from FSID, performs reset-failed, stops daemon).
+
+        Args:
+            host_node: CephNode hosting the daemon (used by pkill path).
+            daemon_name: Full daemon name (e.g. ``"nfs.12345"``).
+            method: One of ``"pkill"``, ``"orch_stop"``, ``"systemctl"``.
+
+        Returns:
+            True if the kill action succeeded, False otherwise.
+        """
+        if method == "pkill":
+            return self.kill_daemon_pkill(host_node, daemon_name)
+        elif method in ("orch_stop", "systemctl"):
+            daemon_id = daemon_name.removeprefix("nfs.")
+            try:
+                fn = (
+                    self.rados_obj.change_daemon_orch_state
+                    if method == "orch_stop"
+                    else self.rados_obj.change_daemon_systemctl_state
+                )
+                return fn(action="stop", daemon_type="nfs", daemon_id=daemon_id)
+            except Exception as e:
+                log.warning(
+                    "[nfs_kill] %s stop failed for %s: %s", method, daemon_name, e
+                )
+                return False
+        else:
+            log.warning("[nfs_kill] Unknown kill method: %s", method)
+            return False
+
+    # -- Recovery Checks --
+
+    def wait_for_daemon_running(self, cluster_id: str, timeout: int = 180) -> bool:
+        """Poll until all NFS daemons in the cluster report running state.
+
+        Delegates to the shared ``wait_for_service_daemons_running`` helper.
+
+        Args:
+            cluster_id: NFS cluster identifier.
+            timeout: Maximum seconds to wait before returning False.
+
+        Returns:
+            True if all daemons reach ``"running"`` within timeout, False otherwise.
+        """
+        return wait_for_service_daemons_running(
+            self.rados_obj, "nfs", [cluster_id], timeout=timeout
+        )
+
+    def verify_vip_floated(self, vip: str, nfs_hosts: List) -> Optional[str]:
+        """Check which host currently holds the virtual IP address.
+
+        Runs ``ip addr show`` on each host and greps for the VIP (without
+        CIDR prefix). Intended for post-thrash validation of NFS HA clusters
+        deployed with ``--ingress --virtual_ip``.
+
+        .. note:: **Not yet called in thrash workflows (TODO)**
+
+           Once VIP/ingress support is added to ``create_nfs_clusters_and_exports``
+           (via ``nfs_enable_ingress`` and ``nfs_virtual_ip`` config params),
+           this method should be called in the post-thrash NFS verification
+           phase to confirm the VIP migrated to a healthy host after daemon
+           kills. The VIP address would come from ``nfs_config["clusters"][i]["virtual_ip"]``.
+
+        Args:
+            vip: Virtual IP address, optionally with CIDR suffix (e.g. ``"10.0.0.5/24"``).
+            nfs_hosts: List of CephNode objects to scan.
+
+        Returns:
+            Hostname of the node holding the VIP, or ``None`` if not found.
+        """
+        for node in nfs_hosts:
+            try:
+                out = node.exec_command(
+                    sudo=True,
+                    cmd=f"ip addr show | grep '{vip.split('/')[0]}'",
+                    timeout=10,
+                    check_ec=False,
+                )
+                if out[0].strip():
+                    log.info("[nfs_vip] VIP %s found on %s", vip, node.hostname)
+                    return node.hostname
+            except Exception:
+                pass
+        log.warning("[nfs_vip] VIP %s not found on any host", vip)
+        return None
+
+    # -- RADOS Config Check --
+
+    def check_rados_config(self, cluster_id: str) -> Dict[str, Any]:
+        """Check the NFS RADOS config object (``conf-nfs.<cluster_id>``) for corruption.
+
+        Reads the object from the ``.nfs`` pool and flags it as invalid if the
+        content is empty or fewer than 10 bytes.
+
+        Args:
+            cluster_id: NFS cluster identifier.
+
+        Returns:
+            Dict with ``valid`` (bool), ``error`` (str or None), and ``size`` (int).
+        """
+        result = {"valid": False, "error": None, "size": 0}
+        try:
+            out = self.installer.exec_command(
+                sudo=True,
+                cmd=f"rados get -p .nfs -N {cluster_id} "
+                f"conf-nfs.{cluster_id} /dev/stdout 2>/dev/null",
+                timeout=15,
+            )
+            content = out[0]
+            result["size"] = len(content) if content else 0
+            if result["size"] < 10:
+                result["error"] = "empty or truncated"
+                log.error(
+                    "[nfs_rados] Config for %s is empty/truncated (%s bytes)",
+                    cluster_id,
+                    result["size"],
+                )
+            else:
+                result["valid"] = True
+                log.debug(
+                    "[nfs_rados] Config for %s: %s bytes, valid",
+                    cluster_id,
+                    result["size"],
+                )
+        except Exception as e:
+            result["error"] = str(e)
+            log.warning("[nfs_rados] Failed to read config for %s: %s", cluster_id, e)
+        return result
+
+    # -- Composite Operations --
+
+    def daemon_kill_cycle(
+        self,
+        cluster_id: str,
+        method: str = "pkill",
+        timeout: int = 180,
+    ) -> Dict[str, Any]:
+        """Execute one kill-and-recover cycle for a random daemon in the cluster.
+
+        Selects a random daemon via ``get_daemon_for_cluster``, kills it using
+        ``kill_daemon``, waits 5 seconds, then polls for recovery.
+
+        Args:
+            cluster_id: NFS cluster identifier.
+            method: Kill method forwarded to ``kill_daemon``.
+            timeout: Seconds to wait for daemon recovery after the kill.
+
+        Returns:
+            Dict with ``killed`` (bool) and ``recovered`` (bool).
+        """
+        result = {"killed": False, "recovered": False}
+
+        target = self.get_daemon_for_cluster(cluster_id)
+        if not target:
+            log.warning("[nfs_cycle] No daemon found for cluster %s", cluster_id)
+            return result
+
+        host_node = target.get("host_node")
+        daemon_name = target.get("daemon_name", "")
+        if not host_node:
+            log.warning("[nfs_cycle] No host node for daemon %s", daemon_name)
+            return result
+
+        log.info(
+            "[nfs_cycle] Killing %s on %s via %s",
+            daemon_name,
+            host_node.hostname,
+            method,
+        )
+        result["killed"] = self.kill_daemon(host_node, daemon_name, method)
+
+        time.sleep(5)
+        result["recovered"] = self.wait_for_daemon_running(cluster_id, timeout)
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+#  SMB Thrash Workflows
+# ---------------------------------------------------------------------------
+
+
+class SmbThrashWorkflows:
+    """SMB daemon lifecycle and verification helpers for thrash testing.
+
+    Consolidates daemon discovery, kill methods (orch restart, ctdb kill, smbd
+    kill, node reboot), endpoint verification, RADOS config checks, and CTDB
+    health into a single class. Uses ``rados_obj`` (RadosOrchestrator) for
+    daemon discovery where applicable.
+    """
+
+    def __init__(self, installer, ceph_cluster, rados_obj):
+        """Initialize SMB thrash workflow context.
+
+        Args:
+            installer: CephNode with ``ceph`` CLI access.
+            ceph_cluster: CephCluster object for node lookups.
+            rados_obj: RadosOrchestrator instance for daemon/host queries.
+        """
+        self.installer = installer
+        self.ceph_cluster = ceph_cluster
+        self.rados_obj = rados_obj
+
+    # -- Daemon Info --
+
+    def get_daemon_info(self, cluster_id: str) -> List[Dict[str, Any]]:
+        """Get SMB daemon IDs/hosts/status for a cluster via rados helpers.
+
+        Returns:
+            List of dicts with daemon_name, daemon_id, hostname, status.
+        """
+        svc_name = f"smb.{cluster_id}"
+        try:
+            daemon_ids = self.rados_obj.get_service_spec_daemons(service_name=svc_name)
+            result = []
+            for daemon_id in daemon_ids or []:
+                daemon_id = str(daemon_id)
+                daemon_name = f"smb.{daemon_id}"
+                host_node = self.rados_obj.fetch_host_node(
+                    daemon_type="smb", daemon_id=daemon_id
+                )
+                daemon_status = self.rados_obj.get_daemon_status(
+                    daemon_type="smb", daemon_id=daemon_id
+                )
+                result.append(
+                    {
+                        "daemon_name": daemon_name,
+                        "daemon_id": daemon_id,
+                        "hostname": host_node.hostname if host_node else "",
+                        "status": daemon_status[1] if daemon_status else "unknown",
+                    }
+                )
+            log.info("[smb_info] Found %s daemon(s) for %s", len(result), svc_name)
+            return result
+        except Exception as e:
+            log.error("[smb_info] Failed to query %s: %s", svc_name, e)
+            return []
+
+    def wait_for_daemons_running(
+        self,
+        cluster_ids: List[str],
+        timeout: int = 300,
+    ) -> bool:
+        """Poll until all SMB daemons across the given clusters report running.
+
+        Delegates to the shared ``wait_for_service_daemons_running`` helper.
+
+        Args:
+            cluster_ids: List of SMB cluster identifiers to monitor.
+            timeout: Maximum seconds to wait before returning False.
+
+        Returns:
+            True if every daemon in every cluster is running, False on timeout.
+        """
+        return wait_for_service_daemons_running(
+            self.rados_obj, "smb", cluster_ids, timeout=timeout
+        )
+
+    def get_daemon_name(self, node, cluster_id: str) -> Optional[str]:
+        """Resolve a single SMB daemon name for a cluster.
+
+        Primary path uses ``get_daemon_info`` (rados-based discovery).
+        Falls back to ``cephadm ls`` + ``jq`` for compatibility with older
+        environments where rados-based discovery is not available.
+
+        Args:
+            node: CephNode used only by the ``cephadm ls`` fallback path.
+            cluster_id: SMB cluster identifier.
+
+        Returns:
+            Daemon name string (e.g. ``"smb.12345"``) or ``None``.
+        """
+        daemons = self.get_daemon_info(cluster_id)
+        if daemons:
+            return daemons[0].get("daemon_name")
+
+        # Fallback to cephadm ls (kept for compatibility with older flows).
+        try:
+            cmd = (
+                f"cephadm ls --no-detail | "
+                f"jq -r 'map(select(.name | startswith("
+                f'"smb.{cluster_id}")))[-1].name\''
+            )
+            out = node.exec_command(sudo=True, cmd=cmd, timeout=15)
+            name = out[0].strip()
+            if name and name != "null":
+                return name
+        except Exception as e:
+            log.warning("[smb_name] Failed to resolve daemon name: %s", e)
+        return None
+
+    # -- Kill Methods --
+
+    def kill_orch_service_restart(self, cluster_id: str) -> bool:
+        """Restart all SMB services via orch.
+
+        Delegates to RadosOrchestrator.restart_daemon_services which restarts
+        all SMB services (not scoped to a single cluster) and verifies each
+        daemon has restarted. ``cluster_id`` is accepted for interface
+        consistency and logging only.
+        """
+        try:
+            return self.rados_obj.restart_daemon_services(daemon="smb")
+        except Exception as e:
+            log.warning("[smb_kill] orch restart failed for smb.%s: %s", cluster_id, e)
+            return False
+
+    def _kill_process_in_container(
+        self, node, cluster_id: str, process_name: str, tag: str
+    ) -> bool:
+        """Kill a process inside its cephadm-managed SMB container.
+
+        SMB daemons (smbd, ctdbd) run inside containers, so host-level
+        ``pgrep``/``kill`` won't reach them. This method finds the SMB
+        daemon name for the given node and cluster, then uses
+        ``cephadm enter`` to send SIGKILL to the target process inside
+        the container.
+
+        Args:
+            node: CephNode hosting the SMB container.
+            cluster_id: SMB cluster identifier (to resolve daemon name).
+            process_name: Process to kill inside the container (e.g.
+                ``"ctdbd"``, ``"smbd"``).
+            tag: Log tag prefix for messages.
+
+        Returns:
+            True if the process was killed, False otherwise.
+        """
+        try:
+            daemons = self.get_daemon_info(cluster_id)
+            daemon_name = next(
+                (
+                    d["daemon_name"]
+                    for d in daemons
+                    if d.get("hostname") == node.hostname
+                ),
+                None,
+            )
+            if not daemon_name:
+                log.warning(
+                    "[%s] No SMB daemon for cluster %s on %s",
+                    tag,
+                    cluster_id,
+                    node.hostname,
+                )
+                return False
+            node.exec_command(
+                sudo=True,
+                cmd=(
+                    f"cephadm enter -n {daemon_name} -- "
+                    f"sh -c 'kill -9 $(pidof {process_name}) 2>/dev/null || true'"
+                ),
+                timeout=15,
+            )
+            log.info(
+                "[%s] Killed %s inside %s on %s",
+                tag,
+                process_name,
+                daemon_name,
+                node.hostname,
+            )
+            return True
+        except Exception as e:
+            log.warning(
+                "[%s] %s kill failed on %s: %s", tag, process_name, node.hostname, e
+            )
+            return False
+
+    def kill_ctdb(self, node, cluster_id: str) -> bool:
+        """Kill ctdbd process inside the SMB container on a node."""
+        return self._kill_process_in_container(node, cluster_id, "ctdbd", "smb_kill")
+
+    def kill_smbd(self, node, cluster_id: str) -> bool:
+        """Kill smbd process inside the SMB container on a node."""
+        return self._kill_process_in_container(node, cluster_id, "smbd", "smb_kill")
+
+    def kill_node_reboot(self, node) -> bool:
+        """Reboot an SMB node via ``reboot_node`` from cli.utilities.utils.
+
+        Args:
+            node: CephNode to reboot.
+
+        Returns:
+            True if the reboot command succeeded, False on error.
+        """
+        try:
+            reboot_node(node)
+            log.info("[smb_kill] Rebooted %s", node.hostname)
+            return True
+        except Exception as e:
+            log.warning("[smb_kill] Reboot failed for %s: %s", node.hostname, e)
+            return False
+
+    # -- Verification --
+
+    def verify_endpoints(self, client_node, smb_config: Dict) -> Dict[str, Any]:
+        """Verify SMB shares are accessible via ``smbclient -c ls``.
+
+        Iterates over every target-IP / share combination. Uses
+        ``public_addrs`` (VIPs) when present; falls back to ``smb_nodes``
+        IP addresses.
+
+        Args:
+            client_node: CephNode with ``smbclient`` installed.
+            smb_config: Dict with ``smb_user_name``, ``smb_user_password``,
+                ``smb_shares``, ``smb_nodes``, and optional ``public_addrs``.
+
+        Returns:
+            Dict with ``accessible`` (list of ``"<ip>/<share>"`` strings) and
+            ``failed`` (list of same format for unreachable shares).
+        """
+        result = {"accessible": [], "failed": []}
+        user = smb_config.get("smb_user_name", "")
+        password = smb_config.get("smb_user_password", "")
+        shares = smb_config.get("smb_shares", [])
+        nodes = smb_config.get("smb_nodes", [])
+
+        public_addrs = smb_config.get("public_addrs", [])
+        if public_addrs:
+            targets = [addr.split("/")[0] for addr in public_addrs]
+        else:
+            targets = [n.ip_address for n in nodes]
+
+        for target in targets:
+            for share in shares:
+                try:
+                    cmd = f"smbclient -U {user}%{password} //{target}/{share} -c ls"
+                    client_node.exec_command(sudo=True, cmd=cmd, timeout=30)
+                    result["accessible"].append(f"{target}/{share}")
+                except Exception as e:
+                    log.warning("[smb_verify] Failed: //%s/%s - %s", target, share, e)
+                    result["failed"].append(f"{target}/{share}")
+        return result
+
+    def verify_rados_config(self, cluster_ids: List[str]) -> Dict[str, Any]:
+        """Check ``.smb`` pool metadata for corruption.
+
+        Reads ``cluster.meta.json`` from the ``.smb`` RADOS pool for each
+        cluster and verifies it parses as valid JSON.
+
+        Args:
+            cluster_ids: SMB cluster identifiers to verify.
+
+        Returns:
+            Dict with ``valid`` (list), ``corrupted`` (list), and
+            ``details`` (per-cluster info or error string).
+        """
+        result = {"valid": [], "corrupted": [], "details": {}}
+        for cid in cluster_ids:
+            try:
+                out = self.installer.exec_command(
+                    sudo=True,
+                    cmd=f"rados --pool=.smb -N {cid} get cluster.meta.json /dev/stdout",
+                    timeout=15,
+                )
+                meta = json.loads(out[0].strip() or "{}")
+                nodes = meta.get("nodes", [])
+                result["valid"].append(cid)
+                result["details"][cid] = f"{len(nodes)} nodes"
+                log.info("[smb_rados] %s: %s nodes, valid", cid, len(nodes))
+            except (json.JSONDecodeError, Exception) as e:
+                result["corrupted"].append(cid)
+                result["details"][cid] = str(e)
+                log.error("[smb_rados] %s: config check failed: %s", cid, e)
+        return result
+
+    def verify_ctdb_health(
+        self,
+        smb_nodes: List,
+        cluster_ids: List[str],
+    ) -> Dict[str, Any]:
+        """Verify CTDB cluster health via ``cephadm enter ... ctdb status``.
+
+        Runs ``ctdb status`` inside the first daemon's container for each
+        cluster. Checks all nodes report ``OK``; flags ``BANNED`` or
+        ``DISCONNECTED`` nodes.
+
+        Args:
+            smb_nodes: CephNode objects in the SMB cluster (fallback host).
+            cluster_ids: SMB cluster identifiers.
+
+        Returns:
+            Dict with ``healthy`` (bool), ``nodes_ok`` (int),
+            ``nodes_total`` (int), and ``banned`` (list).
+        """
+        result = {"healthy": True, "nodes_ok": 0, "nodes_total": 0, "banned": []}
+        for cid in cluster_ids:
+            try:
+                daemons = self.get_daemon_info(cid)
+                if not daemons:
+                    result["healthy"] = False
+                    log.warning("[ctdb_health] No daemons for %s", cid)
+                    continue
+
+                daemon_name = daemons[0]["daemon_name"]
+                hostname = daemons[0].get("hostname", "")
+                ctdb_node = next(
+                    (n for n in smb_nodes if n.hostname == hostname),
+                    smb_nodes[0],
+                )
+
+                out = ctdb_node.exec_command(
+                    sudo=True,
+                    cmd=f"cephadm enter -n {daemon_name} ctdb status",
+                    timeout=30,
+                )
+                status_text = out[0]
+
+                num_match = re.search(r"Number of nodes:\s*(\d+)", status_text)
+                total = int(num_match.group(1)) if num_match else 0
+                ok_count = len(re.findall(r"pnn:\d+ \S+ *OK", status_text))
+                banned = [
+                    ln.strip()
+                    for ln in status_text.splitlines()
+                    if "pnn:" in ln and ("BANNED" in ln or "DISCONNECTED" in ln)
+                ]
+
+                result["nodes_ok"] += ok_count
+                result["nodes_total"] += total
+                result["banned"].extend(banned)
+                if banned:
+                    result["healthy"] = False
+                log.info("[ctdb_health] %s: %s/%s nodes OK", cid, ok_count, total)
+            except Exception as e:
+                result["healthy"] = False
+                log.warning("[ctdb_health] Check failed for %s: %s", cid, e)
+        return result
+
+    # -- Setup / Cleanup --
+
+    def create_clusters_and_shares(self, config: Dict) -> Dict[str, Any]:
+        """Deploy SMB cluster + CephFS + subvolumes + shares.
+
+        Uses smb_operations imports internally.
+
+        Args:
+            config: Dict with smb_cluster_ids, smb_auth_mode, etc.
+
+        Returns:
+            smb_config dict with cluster_ids, shares, nodes, and credentials.
+        """
+        import sys
+
+        if "tests/smb" not in sys.path:
+            sys.path.insert(0, "tests/smb")
+        from smb_operations import (
+            create_smb_cluster,
+            create_smb_share,
+            create_vol_smb_subvol,
+            enable_smb_module,
+        )
+
+        smb_config = {
+            "cluster_ids": config.get("smb_cluster_ids", ["smb-thrash1"]),
+            "smb_shares": [],
+            "smb_nodes": [],
+            "smb_user_name": config.get("smb_user_name", "smbuser"),
+            "smb_user_password": config.get("smb_user_password", "smbpassword"),
+            "cephfs_vol": "smb_thrash_vol",
+            "smb_subvol_group": "smb_thrash_group",
+        }
+
+        # smb_nodes will be resolved after daemons are running (see below)
+        smb_config["smb_nodes"] = []
+
+        num_shares = config.get("smb_num_shares", 4)
+        auth_mode = config.get("smb_auth_mode", "user")
+        domain_realm = config.get("smb_domain_realm", "")
+        custom_dns = config.get("smb_custom_dns", "")
+        clustering = config.get("smb_clustering", "default")
+
+        try:
+            subvols = [f"smb_thrash_sv{i}" for i in range(num_shares)]
+            create_vol_smb_subvol(
+                self.installer,
+                smb_config["cephfs_vol"],
+                smb_config["smb_subvol_group"],
+                subvols,
+                "0777",
+            )
+
+            all_shares = []
+            for cluster_id in smb_config["cluster_ids"]:
+                enable_smb_module(self.installer, cluster_id)
+                create_smb_cluster(
+                    self.installer,
+                    cluster_id,
+                    auth_mode,
+                    domain_realm,
+                    smb_config["smb_user_name"],
+                    smb_config["smb_user_password"],
+                    custom_dns,
+                    clustering,
+                )
+
+                share_names = [f"share{i}" for i in range(num_shares)]
+                path = "/"
+                create_smb_share(
+                    self.installer,
+                    share_names,
+                    cluster_id,
+                    smb_config["cephfs_vol"],
+                    path,
+                    smb_config["smb_subvol_group"],
+                    subvols,
+                )
+                all_shares.extend(share_names)
+
+            smb_config["smb_shares"] = all_shares
+
+            # Wait for SMB daemons to be running (replaces verify_smb_service
+            # which crashes on empty orch ls output before daemons deploy)
+            if not self.wait_for_daemons_running(
+                smb_config["cluster_ids"], timeout=300
+            ):
+                raise RuntimeError(
+                    "[smb_setup] SMB daemons did not reach running state "
+                    f"for clusters {smb_config['cluster_ids']}"
+                )
+
+            # Resolve smb_nodes from actual daemon hostnames so endpoint
+            # verification targets the correct IPs (not guessed from roles).
+            all_nodes = self.ceph_cluster.get_nodes()
+            smb_hostnames = set()
+            for cluster_id in smb_config["cluster_ids"]:
+                for d in self.get_daemon_info(cluster_id):
+                    if d.get("hostname"):
+                        smb_hostnames.add(d["hostname"])
+            smb_config["smb_nodes"] = [
+                n for n in all_nodes if n.hostname in smb_hostnames
+            ]
+            log.info(
+                "[smb_setup] SMB daemon hosts resolved: %s",
+                [n.hostname for n in smb_config["smb_nodes"]],
+            )
+
+            log.info(
+                "[smb_setup] Created %s cluster(s) with %s share(s) each",
+                len(smb_config["cluster_ids"]),
+                num_shares,
+            )
+        except Exception as e:
+            log.error("[smb_setup] SMB setup failed: %s", e)
+            raise
+
+        return smb_config
+
+    def cleanup(self, smb_config: Dict):
+        """Tear down SMB thrash resources via ``smb_operations.smb_cleanup``.
+
+        Args:
+            smb_config: Dict returned by ``create_clusters_and_shares``.
+        """
+        import sys
+
+        if "tests/smb" not in sys.path:
+            sys.path.insert(0, "tests/smb")
+        from smb_operations import smb_cleanup
+
+        try:
+            for cluster_id in smb_config.get("cluster_ids", []):
+                smb_cleanup(
+                    self.installer,
+                    smb_config.get("smb_shares", []),
+                    cluster_id,
+                    smb_config.get("cephfs_vol", ""),
+                    smb_config.get("smb_subvol_group", ""),
+                )
+            log.info("[smb_cleanup] SMB thrash resources cleaned up")
+        except Exception as e:
+            log.warning("[smb_cleanup] Cleanup failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+#  NFS Protocol State Thrash Threads
+# ---------------------------------------------------------------------------
+
+
+def _list_cluster_exports(rados_obj, cluster_id: str) -> List:
+    """Fetch the NFS export list for a cluster, returning [] on non-list results."""
+    exports = rados_obj.run_ceph_command(
+        cmd=f"ceph nfs export ls {cluster_id}", timeout=15
+    )
+    return exports if isinstance(exports, list) else []
+
+
+def _export_pseudo(export_entry) -> str:
+    """Resolve the pseudo path from a str or dict export entry."""
+    return (
+        export_entry
+        if isinstance(export_entry, str)
+        else export_entry.get("pseudo", "")
+    )
+
+
+def _nfs_export_mount_targets(nfs_config: Dict) -> List[Dict[str, Any]]:
+    """Build mount targets from ``nfs_config`` with multi-host fallback support.
+
+    Merges cluster endpoint info (hosts, port) with each export's pseudo_path.
+    When ``enable_rdma`` is set in ``nfs_config``, the RDMA port is selected
+    instead of the TCP port.
+
+    .. note:: **VIP / Ingress support (TODO)**
+
+       When NFS clusters are deployed with ``--ingress --virtual_ip``, the
+       client mount endpoint is the VIP, not individual daemon host IPs.
+       To support this:
+
+       1. ``create_nfs_clusters_and_exports`` should accept ``nfs_virtual_ip``
+          and ``nfs_enable_ingress`` params, pass them to
+          ``ceph nfs cluster create``, and store ``virtual_ip`` in the
+          cluster entry dict.
+       2. This function should check ``cluster.get("virtual_ip")``; when
+          present, use the VIP as the sole ``host`` (overriding daemon
+          hostnames) and use the ingress port for TCP mounts.
+       3. ``verify_vip_floated`` in ``NfsThrashWorkflows`` can then be used
+          post-thrash to confirm the VIP migrated correctly after daemon kills.
+
+    Args:
+        nfs_config: Dict with ``clusters`` (list of cluster dicts containing
+            ``cluster_id``, ``hosts``/``host``, ``port``, ``rdma_port``) and
+            ``exports`` (list of export dicts with ``cluster_id``,
+            ``pseudo_path``).
+
+    Returns:
+        List of dicts, each with ``cluster_id``, ``host`` (primary),
+        ``hosts`` (all), ``port``, and ``pseudo_path``.
+    """
+    use_rdma_port = bool(nfs_config.get("enable_rdma"))
+    cluster_endpoint_map: Dict[str, Dict[str, Any]] = {}
+    for cluster in nfs_config.get("clusters", []):
+        cluster_id = cluster.get("cluster_id")
+        if not cluster_id:
+            continue
+        # TODO: When virtual_ip is present in cluster dict (VIP/ingress
+        # deployment), use it as the mount endpoint instead of daemon hosts.
+        # vip = cluster.get("virtual_ip")
+        # if vip:
+        #     hosts = [vip.split("/")[0]]  # strip CIDR if present
+        # else:
+        hosts = cluster.get("hosts") or (
+            [cluster.get("host")] if cluster.get("host") else []
+        )
+        hosts = [host for host in hosts if host]
+        if not hosts:
+            continue
+        cluster_endpoint_map[cluster_id] = {
+            "host": hosts[0],
+            "hosts": hosts,
+            "port": cluster.get("rdma_port") if use_rdma_port else cluster.get("port"),
+        }
+
+    targets = []
+    for export in nfs_config.get("exports", []):
+        cluster_id = export.get("cluster_id")
+        endpoint = cluster_endpoint_map.get(cluster_id, {})
+        host = endpoint.get("host")
+        hosts = endpoint.get("hosts", [])
+        port = endpoint.get("port")
+        pseudo_path = export.get("pseudo_path")
+        if cluster_id and host and pseudo_path:
+            targets.append(
+                {
+                    "cluster_id": cluster_id,
+                    "host": host,
+                    "hosts": hosts,
+                    "port": port,
+                    "pseudo_path": pseudo_path,
+                }
+            )
+    return targets
+
+
+def _nfs_client_mount_option_string(
+    nfs_config: Dict[str, Any],
+    cluster_id: str,
+    nfs_options_base: str,
+) -> str:
+    """Build a ``mount -o`` option string with port and optional RDMA flag.
+
+    Uses ``_nfs_export_mount_targets`` (cached in ``nfs_config["_mount_targets"]``)
+    as the single source of truth for port resolution, handling RDMA vs TCP
+    transparently.
+
+    Args:
+        nfs_config: Full NFS config dict; ``_mount_targets`` is lazily populated.
+        cluster_id: Cluster to resolve the port for.
+        nfs_options_base: Base options string (e.g. ``"nfsvers=4.1"``).
+
+    Returns:
+        Comma-separated option string suitable for ``mount -o``.
+        Falls back to ``nfs_options_base`` if no port is found.
+    """
+    if "_mount_targets" not in nfs_config:
+        nfs_config["_mount_targets"] = _nfs_export_mount_targets(nfs_config)
+    port = None
+    for t in nfs_config["_mount_targets"]:
+        if t["cluster_id"] == cluster_id and t.get("port") is not None:
+            port = t["port"]
+            break
+    if port is None:
+        log.warning(
+            "_nfs_client_mount_option_string: no port for cluster_id=%s",
+            cluster_id,
+        )
+        return nfs_options_base
+    if nfs_config.get("enable_rdma"):
+        return f"{nfs_options_base},rdma,port={port}"
+    return f"{nfs_options_base},port={port}"
+
+
+def _pick_nfs_endpoint(
+    nfs_config: Dict[str, Any], index: int = 0
+) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int]]:
+    """Pick an NFS export endpoint by index with wrap-around.
+
+    Delegates to ``_nfs_export_mount_targets`` (cached) and selects a target
+    and host using modular indexing for round-robin distribution.
+
+    Args:
+        nfs_config: Full NFS config dict.
+        index: Selector index; wraps around available targets and hosts.
+
+    Returns:
+        Tuple of ``(export_info, host, port)`` where ``export_info`` is a dict
+        with ``cluster_id`` and ``pseudo_path``. Returns ``(None, None, None)``
+        if no targets exist.
+    """
+    if "_mount_targets" not in nfs_config:
+        nfs_config["_mount_targets"] = _nfs_export_mount_targets(nfs_config)
+    targets = nfs_config["_mount_targets"]
+    if not targets:
+        return None, None, None
+    target = targets[index % len(targets)]
+    hosts = target.get("hosts", [])
+    host = hosts[index % len(hosts)] if hosts else target.get("host")
+    port = target.get("port")
+    exp = {"cluster_id": target["cluster_id"], "pseudo_path": target["pseudo_path"]}
+    return exp, host, port
+
+
+@contextmanager
+def _nfs_mount_context(
+    client_node,
+    nfs_config: Dict[str, Any],
+    mount_base: str,
+    index: int = 0,
+    nfs_ver: str = "4.1",
+):
+    """Context manager that mounts an NFS export and unmounts on exit.
+
+    Creates a unique mount point (``<mount_base>-<uuid8>``), mounts via
+    ``_pick_nfs_endpoint`` and ``_nfs_client_mount_option_string``, and
+    performs lazy unmount + cleanup in the finally block.
+
+    Args:
+        client_node: CephNode to mount on.
+        nfs_config: Full NFS config dict.
+        mount_base: Path prefix for the mount directory.
+        index: Passed to ``_pick_nfs_endpoint`` for target selection.
+        nfs_ver: NFS protocol version string (e.g. ``"4.1"``).
+
+    Yields:
+        ``(export_info, mount_point)`` on success, or ``(None, None)`` if
+        endpoint selection or mount fails.
+    """
+    exp, host, port = _pick_nfs_endpoint(nfs_config, index=index)
+    if not exp or not host or not port:
+        yield None, None
+        return
+
+    unique_suffix = uuid.uuid4().hex[:8]
+    mount_point = f"{mount_base}-{unique_suffix}"
+
+    mount_opts = _nfs_client_mount_option_string(
+        nfs_config, exp["cluster_id"], f"nfsvers={nfs_ver}"
+    )
+    mount_cmd = (
+        f"mount -t nfs -o {mount_opts} {host}:{exp['pseudo_path']} {mount_point}"
+    )
+    try:
+        client_node.exec_command(cmd=f"mkdir -p {mount_point}", sudo=True)
+        client_node.exec_command(cmd=mount_cmd, sudo=True, timeout=60)
+        yield exp, mount_point
+    except Exception as e:
+        log.warning(
+            "NFS mount FAILED: %s:%s NFSv%s: %s", host, exp["pseudo_path"], nfs_ver, e
+        )
+        yield None, None
+    finally:
+        try:
+            client_node.exec_command(
+                cmd=f"umount -lf {mount_point}",
+                sudo=True,
+                check_ec=False,
+            )
+            client_node.exec_command(
+                cmd=f"rm -rf {mount_point}",
+                sudo=True,
+                check_ec=False,
+            )
+        except Exception:
+            pass
+
+
+def _sleep_with_stop(stop_flag: Dict, total_seconds: int, step: int = 2) -> None:
+    """Sleep in small increments, exiting early if ``stop_flag["stop"]`` is set.
+
+    Args:
+        stop_flag: Dict checked each iteration; returns immediately when
+            ``stop_flag["stop"]`` is truthy.
+        total_seconds: Total sleep duration in seconds.
+        step: Maximum seconds per sleep chunk.
+    """
+    remaining = max(0, int(total_seconds))
+    while remaining > 0 and not stop_flag.get("stop"):
+        this_sleep = min(step, remaining)
+        time.sleep(this_sleep)
+        remaining -= this_sleep
+
+
+def thrash_nfs_client_churn(
+    client_node,
+    nfs_config: Dict,
+    duration: int,
+    stop_flag: Dict,
+    churn_rate: int = 5,
+) -> Dict[str, int]:
+    """Random client mount/unmount/open/lock cycles to stress NFS state management.
+
+    Designed to run as a background thread alongside daemon kill threads.
+    Operations are randomly chosen each iteration: mount a new NFS export,
+    unmount an existing one, write a small file (open_hold), or acquire an
+    ``flock`` lock. All churn mounts are lazy-unmounted in the finally block.
+
+    Args:
+        client_node: CephNode to perform mounts and I/O on.
+        nfs_config: NFS config dict with ``clusters`` and ``exports``.
+        duration: Total runtime in seconds.
+        stop_flag: Dict with ``"stop"`` key; set to True to terminate early.
+        churn_rate: Number of operations per 10-second window.
+
+    Returns:
+        Dict with ``mounts``, ``unmounts``, ``opens``, ``locks``, and
+        ``errors`` counts.
+    """
+    result = {"mounts": 0, "unmounts": 0, "opens": 0, "locks": 0, "errors": 0}
+    end_time = time.time() + duration
+    export_targets = _nfs_export_mount_targets(nfs_config)
+    if not export_targets:
+        log.warning("[client_churn] No NFS exports configured")
+        result["errors"] += 1
+        return result
+
+    churn_mounts = []
+    mount_base = "/mnt/thrash_churn"
+    mount_idx = 0
+
+    try:
+        while time.time() < end_time and not stop_flag.get("stop"):
+            for _ in range(churn_rate):
+                if stop_flag.get("stop"):
+                    break
+
+                op = random.choice(["mount", "unmount", "open_hold", "lock"])
+
+                if op == "mount" and len(churn_mounts) < 20:
+                    target = random.choice(export_targets)
+                    mp = f"{mount_base}_{mount_idx}"
+                    mount_idx += 1
+                    hosts = target.get("hosts") or (
+                        [target.get("host")] if target.get("host") else []
+                    )
+                    if not hosts:
+                        result["errors"] += 1
+                        continue
+                    nfs_server = random.choice(hosts)
+                    pseudo = target.get("pseudo_path", "")
+                    try:
+                        client_node.exec_command(
+                            sudo=True, cmd=f"mkdir -p {mp}", timeout=10
+                        )
+                        nfs_ver = random.choice(["4.0", "4.1", "4.2"])
+                        mount_opts = _nfs_client_mount_option_string(
+                            nfs_config,
+                            target["cluster_id"],
+                            f"nfsvers={nfs_ver}",
+                        )
+                        client_node.exec_command(
+                            sudo=True,
+                            cmd=f"mount -t nfs -o {mount_opts} {nfs_server}:{pseudo} {mp}",
+                            timeout=30,
+                        )
+                        churn_mounts.append(mp)
+                        result["mounts"] += 1
+                    except Exception:
+                        result["errors"] += 1
+
+                elif op == "unmount" and churn_mounts:
+                    mp = random.choice(churn_mounts)
+                    try:
+                        client_node.exec_command(
+                            sudo=True,
+                            cmd=f"umount -l {mp} 2>/dev/null; rmdir {mp}",
+                            timeout=15,
+                            check_ec=False,
+                        )
+                        churn_mounts.remove(mp)
+                        result["unmounts"] += 1
+                    except Exception:
+                        result["errors"] += 1
+
+                elif op == "open_hold" and churn_mounts:
+                    mp = random.choice(churn_mounts)
+                    try:
+                        client_node.exec_command(
+                            sudo=True,
+                            cmd=f"dd if=/dev/urandom "
+                            f"of={mp}/churn_file_{random.randint(0, 999)} "
+                            f"bs=4k count=1 2>/dev/null",
+                            timeout=15,
+                        )
+                        result["opens"] += 1
+                    except Exception:
+                        result["errors"] += 1
+
+                elif op == "lock" and churn_mounts:
+                    mp = random.choice(churn_mounts)
+                    try:
+                        lock_file = f"{mp}/churn_lock_{random.randint(0, 99)}"
+                        client_node.exec_command(
+                            sudo=True,
+                            cmd=f"touch {lock_file} && "
+                            f"flock -x -w 2 {lock_file} -c 'sleep 1' "
+                            f"2>/dev/null",
+                            timeout=15,
+                            check_ec=False,
+                        )
+                        result["locks"] += 1
+                    except Exception:
+                        result["errors"] += 1
+
+            _sleep_with_stop(stop_flag, total_seconds=10, step=2)
+    finally:
+        for mp in churn_mounts:
+            try:
+                client_node.exec_command(
+                    sudo=True,
+                    cmd=f"umount -l {mp} 2>/dev/null; rmdir {mp} 2>/dev/null",
+                    timeout=15,
+                    check_ec=False,
+                )
+            except Exception:
+                pass
+
+    log.info(
+        "[client_churn] Completed: mounts=%s, unmounts=%s, opens=%s, "
+        "locks=%s, errors=%s",
+        result["mounts"],
+        result["unmounts"],
+        result["opens"],
+        result["locks"],
+        result["errors"],
+    )
+    return result
+
+
+def thrash_nfs_export_churn(
+    installer,
+    nfs_config: Dict,
+    duration: int,
+    stop_flag: Dict,
+    rados_obj,
+) -> Dict[str, int]:
+    """Rapid NFS export create/delete/modify to stress RADOS config updates.
+
+    Randomly selects one of three operations each cycle:
+        - ``create``: create a new churn export then immediately delete it.
+        - ``delete_recreate``: delete a non-churn export and recreate it.
+        - ``modify_access``: toggle ``access_type`` between RW and RO via
+          ``ceph nfs export apply``.
+
+    Args:
+        installer: CephNode with ``ceph`` CLI access.
+        nfs_config: NFS config dict with ``clusters`` and ``fs_name``.
+        duration: Total runtime in seconds.
+        stop_flag: Dict with ``"stop"`` key for early termination.
+        rados_obj: RadosOrchestrator used for ``run_ceph_command`` calls.
+
+    Returns:
+        Dict with ``creates``, ``deletes``, ``modifies``, and ``errors`` counts.
+    """
+    result = {"creates": 0, "deletes": 0, "modifies": 0, "errors": 0}
+    end_time = time.time() + duration
+    clusters = nfs_config.get("clusters", [])
+    fs_name = nfs_config.get("fs_name", "nfs-cephfs")
+    if not clusters:
+        log.warning("[export_churn] No NFS clusters in config")
+        return result
+
+    churn_export_idx = 100
+
+    while time.time() < end_time and not stop_flag.get("stop"):
+        cluster = random.choice(clusters)
+        cluster_id = cluster.get("cluster_id", "")
+        op = random.choice(["create", "delete_recreate", "modify_access"])
+
+        try:
+            if op == "create":
+                pseudo = f"/churn_export_{churn_export_idx}"
+                churn_export_idx += 1
+                installer.exec_command(
+                    sudo=True,
+                    cmd=f"ceph nfs export create cephfs {cluster_id} "
+                    f"{pseudo} {fs_name} --path=/",
+                    timeout=30,
+                )
+                result["creates"] += 1
+                _sleep_with_stop(stop_flag, total_seconds=3, step=1)
+                installer.exec_command(
+                    sudo=True,
+                    cmd=f"ceph nfs export rm {cluster_id} {pseudo}",
+                    timeout=30,
+                    check_ec=False,
+                )
+                result["deletes"] += 1
+
+            elif op == "delete_recreate":
+                exports = _list_cluster_exports(rados_obj, cluster_id)
+                churn_exports = [e for e in exports if "churn" not in str(e)]
+                if churn_exports:
+                    target = random.choice(churn_exports)
+                    pseudo = _export_pseudo(target)
+                    if pseudo:
+                        installer.exec_command(
+                            sudo=True,
+                            cmd=f"ceph nfs export rm {cluster_id} {pseudo}",
+                            timeout=30,
+                            check_ec=False,
+                        )
+                        result["deletes"] += 1
+                        _sleep_with_stop(stop_flag, total_seconds=2, step=1)
+                        installer.exec_command(
+                            sudo=True,
+                            cmd=f"ceph nfs export create cephfs {cluster_id} "
+                            f"{pseudo} {fs_name} --path=/",
+                            timeout=30,
+                        )
+                        result["creates"] += 1
+
+            elif op == "modify_access":
+                exports = _list_cluster_exports(rados_obj, cluster_id)
+                if exports:
+                    target_pseudo = _export_pseudo(exports[0])
+                    if target_pseudo:
+                        try:
+                            export_info = rados_obj.run_ceph_command(
+                                cmd=f"ceph nfs export info "
+                                f"{cluster_id} {target_pseudo}",
+                                timeout=15,
+                            )
+                            current_access = export_info.get("access_type", "RW")
+                            new_access = "RO" if current_access == "RW" else "RW"
+                            export_info["access_type"] = new_access
+                            payload = shlex.quote(json.dumps(export_info))
+                            installer.exec_command(
+                                sudo=True,
+                                cmd=f"printf %s {payload} | "
+                                f"ceph nfs export apply {cluster_id} -i -",
+                                timeout=30,
+                            )
+                            result["modifies"] += 1
+                        except Exception:
+                            result["errors"] += 1
+        except Exception as e:
+            log.debug("[export_churn] Operation %s failed: %s", op, e)
+            result["errors"] += 1
+
+        _sleep_with_stop(stop_flag, total_seconds=random.randint(5, 15), step=2)
+
+    log.info(
+        "[export_churn] Completed: creates=%s, deletes=%s, modifies=%s, " "errors=%s",
+        result["creates"],
+        result["deletes"],
+        result["modifies"],
+        result["errors"],
+    )
+    return result
+
+
+def thrash_nfs_admin_ops(
+    installer,
+    nfs_config: Dict,
+    duration: int,
+    stop_flag: Dict,
+    rados_obj,
+) -> Dict[str, int]:
+    """Interleave NFS admin operations with client I/O running in parallel.
+
+    Randomly selects operations each cycle:
+        - ``orch_restart``: restart all NFS daemons via
+          ``RadosOrchestrator.restart_daemon_services``, then sleeps 30s.
+        - ``export_reload``: re-apply an existing export's config unchanged
+          via ``ceph nfs export apply`` to exercise config reload paths.
+
+    Args:
+        installer: CephNode with ``ceph`` CLI access.
+        nfs_config: NFS config dict with ``clusters``.
+        duration: Total runtime in seconds.
+        stop_flag: Dict with ``"stop"`` key for early termination.
+        rados_obj: RadosOrchestrator for ``restart_daemon_services`` and
+            ``run_ceph_command``.
+
+    Returns:
+        Dict with ``restarts``, ``reloads``, and ``errors`` counts.
+    """
+    result = {"restarts": 0, "reloads": 0, "errors": 0}
+    end_time = time.time() + duration
+    clusters = nfs_config.get("clusters", [])
+    if not clusters:
+        log.warning("[admin_ops] No NFS clusters in config")
+        return result
+
+    while time.time() < end_time and not stop_flag.get("stop"):
+        cluster = random.choice(clusters)
+        cluster_id = cluster.get("cluster_id", "")
+        op = random.choice(["orch_restart", "export_reload"])
+
+        try:
+            if op == "orch_restart":
+                rados_obj.restart_daemon_services(daemon="nfs")
+                result["restarts"] += 1
+                _sleep_with_stop(stop_flag, total_seconds=30, step=3)
+
+            elif op == "export_reload":
+                exports = _list_cluster_exports(rados_obj, cluster_id)
+                if exports:
+                    target = _export_pseudo(exports[0])
+                    if target:
+                        try:
+                            export_info = rados_obj.run_ceph_command(
+                                cmd=f"ceph nfs export info {cluster_id} {target}",
+                                timeout=15,
+                            )
+                            payload = shlex.quote(json.dumps(export_info))
+                            installer.exec_command(
+                                sudo=True,
+                                cmd=f"printf %s {payload} | "
+                                f"ceph nfs export apply {cluster_id} -i -",
+                                timeout=30,
+                            )
+                            result["reloads"] += 1
+                        except Exception:
+                            result["errors"] += 1
+        except Exception as e:
+            log.debug("[admin_ops] Operation %s failed: %s", op, e)
+            result["errors"] += 1
+
+        _sleep_with_stop(stop_flag, total_seconds=random.randint(20, 40), step=3)
+
+    log.info(
+        "[admin_ops] Completed: restarts=%s, reloads=%s, errors=%s",
+        result["restarts"],
+        result["reloads"],
+        result["errors"],
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+#  Thin Orchestrator Functions (called from test_osd_thrashing.py)
+# ---------------------------------------------------------------------------
+
+
+def thrash_nfs_daemon_failover(
+    installer,
+    nfs_config: Dict,
+    rados_obj,
+    ceph_cluster,
+    client_node,
+    duration: int,
+    stop_flag: Dict,
+    config: Dict,
+) -> Dict[str, Any]:
+    """Kill NFS daemons cyclically and validate recovery.
+
+    Called from ``test_osd_thrashing.py`` thread submissions. Instantiates
+    ``NfsThrashWorkflows`` and loops ``daemon_kill_cycle`` on random clusters
+    until ``duration`` expires or ``stop_flag`` is set.
+
+    Config keys read from ``config``:
+        - ``nfs_daemon_kill_method``: Kill method string (default ``"pkill"``).
+        - ``nfs_daemon_thrash_interval``: Seconds between cycles (default 60).
+        - ``nfs_daemon_recovery_timeout``: Seconds for recovery poll (default 180).
+
+    Args:
+        installer: CephNode with ``ceph`` CLI access.
+        nfs_config: NFS config dict with cluster definitions.
+        rados_obj: RadosOrchestrator instance.
+        ceph_cluster: CephCluster object.
+        client_node: CephNode (unused directly; reserved for future I/O checks).
+        duration: Total runtime in seconds.
+        stop_flag: Dict with ``"stop"`` key for early termination.
+        config: Test config dict with thrash tuning parameters.
+
+    Returns:
+        Dict with ``cycles`` (int), ``kill_failures`` (int), and
+        ``recovery_failures`` (int).
+    """
+    wf = NfsThrashWorkflows(installer, nfs_config, rados_obj, ceph_cluster)
+
+    method = config.get("nfs_daemon_kill_method", "pkill")
+    interval = config.get("nfs_daemon_thrash_interval", 60)
+    timeout = config.get("nfs_daemon_recovery_timeout", 180)
+    clusters = wf._get_cluster_ids()
+    end_time = time.time() + duration
+    results = {"cycles": 0, "kill_failures": 0, "recovery_failures": 0}
+
+    if not clusters:
+        log.warning("[nfs_failover] No NFS clusters discovered")
+        return results
+
+    while time.time() < end_time and not stop_flag.get("stop"):
+        cluster_id = random.choice(clusters)
+        cycle_result = wf.daemon_kill_cycle(cluster_id, method, timeout)
+        results["cycles"] += 1
+        if not cycle_result.get("killed"):
+            results["kill_failures"] += 1
+        if not cycle_result.get("recovered"):
+            results["recovery_failures"] += 1
+
+        _sleep_with_stop(stop_flag, total_seconds=interval, step=3)
+
+    log.info(
+        "[nfs_failover] Completed %s cycles, kill_failures=%s, " "recovery_failures=%s",
+        results["cycles"],
+        results["kill_failures"],
+        results["recovery_failures"],
+    )
+    return results
+
+
+def thrash_smb(
+    installer,
+    smb_config: Dict,
+    ceph_cluster,
+    rados_obj,
+    duration: int,
+    stop_flag: Dict,
+) -> Dict[str, int]:
+    """SMB daemon-level chaos: randomly kill/restart SMB components.
+
+    Called from ``test_osd_thrashing.py`` thread submissions. Instantiates
+    ``SmbThrashWorkflows`` and randomly selects from four operations each
+    cycle: ``orch_daemon_restart``, ``orch_service_restart``, ``ctdb_kill``,
+    ``smbd_kill``. Waits for daemon recovery after each kill.
+
+    Args:
+        installer: CephNode with ``ceph`` CLI access.
+        smb_config: Dict with ``cluster_ids``, ``smb_nodes``, and related
+            SMB configuration produced by ``create_clusters_and_shares``.
+        ceph_cluster: CephCluster object.
+        rados_obj: RadosOrchestrator instance.
+        duration: Total runtime in seconds.
+        stop_flag: Dict with ``"stop"`` key for early termination.
+
+    Returns:
+        Dict with ``cycles``, ``kills``, ``recovery_failures``, and ``errors``
+        counts.
+    """
+    smb_wf = SmbThrashWorkflows(installer, ceph_cluster, rados_obj)
+    result = {"cycles": 0, "kills": 0, "recovery_failures": 0, "errors": 0}
+    end_time = time.time() + duration
+    cluster_ids = smb_config.get("cluster_ids", [])
+    smb_nodes = smb_config.get("smb_nodes", [])
+
+    if not cluster_ids or not smb_nodes:
+        log.warning("[smb_thrash] No clusters or nodes configured")
+        return result
+
+    operations = [
+        "orch_daemon_restart",
+        "orch_service_restart",
+        "ctdb_kill",
+        "smbd_kill",
+    ]
+
+    while time.time() < end_time and not stop_flag.get("stop"):
+        cluster_id = random.choice(cluster_ids)
+        op = random.choice(operations)
+        node = random.choice(smb_nodes)
+        result["cycles"] += 1
+
+        log.info(
+            "[smb_thrash] Iteration %s: op=%s, node=%s",
+            result["cycles"],
+            op,
+            node.hostname,
+        )
+
+        try:
+            killed = False
+            if op == "orch_daemon_restart":
+                daemons = smb_wf.get_daemon_info(cluster_id)
+                if daemons:
+                    daemon = random.choice(daemons)
+                    daemon_id = daemon["daemon_name"].removeprefix("smb.")
+                    killed = smb_wf.rados_obj.change_daemon_orch_state(
+                        action="restart", daemon_type="smb", daemon_id=daemon_id
+                    )
+            elif op == "orch_service_restart":
+                killed = smb_wf.kill_orch_service_restart(cluster_id)
+            elif op == "ctdb_kill":
+                killed = smb_wf.kill_ctdb(node, cluster_id)
+            elif op == "smbd_kill":
+                killed = smb_wf.kill_smbd(node, cluster_id)
+
+            if killed:
+                result["kills"] += 1
+
+            _sleep_with_stop(stop_flag, total_seconds=10, step=2)
+
+            if not smb_wf.wait_for_daemons_running(cluster_ids, timeout=120):
+                result["recovery_failures"] += 1
+                log.warning("[smb_thrash] Recovery failed after %s", op)
+
+        except Exception as e:
+            result["errors"] += 1
+            log.warning("[smb_thrash] Error during %s: %s", op, e)
+
+        _sleep_with_stop(stop_flag, total_seconds=15, step=2)
+
+    log.info(
+        "[smb_thrash] Completed %s cycles, kills=%s, " "recovery_failures=%s",
+        result["cycles"],
+        result["kills"],
+        result["recovery_failures"],
+    )
+    return result
+
+
+def thrash_smb_client_io(
+    client_node,
+    smb_config: Dict,
+    duration: int,
+    stop_flag: Dict,
+) -> Dict[str, int]:
+    """Run smbclient read/write/list loops to generate I/O during SMB daemon chaos.
+
+    Called from ``test_osd_thrashing.py`` thread submissions. Each iteration
+    randomly picks a target IP and share, then performs one of: ``smbclient ls``,
+    ``smbclient put`` (4 MB file), or ``smbclient get``. Uses ``public_addrs``
+    (VIPs) when present; falls back to ``smb_nodes`` IP addresses. Temp files
+    are cleaned up in the finally block.
+
+    Args:
+        client_node: CephNode with ``smbclient`` installed.
+        smb_config: Dict with ``smb_shares``, ``smb_user_name``,
+            ``smb_user_password``, ``smb_nodes``, and optional ``public_addrs``.
+        duration: Total runtime in seconds.
+        stop_flag: Dict with ``"stop"`` key for early termination.
+
+    Returns:
+        Dict with ``io_ops`` (int) and ``errors`` (int) counts.
+    """
+    result = {"io_ops": 0, "errors": 0}
+    end_time = time.time() + duration
+    shares = smb_config.get("smb_shares", [])
+    user = smb_config.get("smb_user_name", "")
+    password = smb_config.get("smb_user_password", "")
+    smb_nodes = smb_config.get("smb_nodes", [])
+
+    if not shares or not smb_nodes:
+        log.warning("[smb_io] No shares or nodes configured")
+        return result
+
+    public_addrs = smb_config.get("public_addrs", [])
+    targets = (
+        [addr.split("/")[0] for addr in public_addrs]
+        if public_addrs
+        else [n.ip_address for n in smb_nodes]
+    )
+
+    try:
+        while time.time() < end_time and not stop_flag.get("stop"):
+            target = random.choice(targets)
+            share = random.choice(shares)
+            op = random.choice(["smbclient_ls", "smbclient_write", "smbclient_read"])
+
+            try:
+                if op == "smbclient_ls":
+                    client_node.exec_command(
+                        sudo=True,
+                        cmd=f"smbclient -U {user}%{password} "
+                        f"//{target}/{share} -c ls",
+                        timeout=30,
+                    )
+                    result["io_ops"] += 1
+
+                elif op == "smbclient_write":
+                    fname = f"thrash_io_{random.randint(0, 999)}.dat"
+                    client_node.exec_command(
+                        sudo=True,
+                        cmd=f"dd if=/dev/urandom of=/tmp/{fname} bs=1M count=4 "
+                        f"2>/dev/null && "
+                        f"smbclient -U {user}%{password} "
+                        f"//{target}/{share} "
+                        f"-c 'put /tmp/{fname} {fname}'; "
+                        f"rc=$?; rm -f /tmp/{fname}; exit $rc",
+                        timeout=30,
+                    )
+                    result["io_ops"] += 1
+
+                elif op == "smbclient_read":
+                    fname = f"thrash_io_{random.randint(0, 999)}.dat"
+                    client_node.exec_command(
+                        sudo=True,
+                        cmd=f"smbclient -U {user}%{password} "
+                        f"//{target}/{share} "
+                        f"-c 'get {fname} /dev/null' 2>/dev/null",
+                        timeout=30,
+                        check_ec=False,
+                    )
+                    result["io_ops"] += 1
+
+            except Exception:
+                result["errors"] += 1
+
+            _sleep_with_stop(stop_flag, total_seconds=2, step=1)
+    finally:
+        try:
+            client_node.exec_command(
+                sudo=True,
+                cmd="rm -f /tmp/thrash_io_*.dat 2>/dev/null",
+                timeout=15,
+                check_ec=False,
+            )
+        except Exception:
+            pass
+
+    log.info(
+        "[smb_io] Completed: io_ops=%s, errors=%s", result["io_ops"], result["errors"]
+    )
+    return result


### PR DESCRIPTION
Introduce comprehensive NFS and SMB daemon chaos testing alongside existing OSD thrashing. The test is restructured into five phases: setup, pre-thrash baseline, thrash, post-thrash validation, and cleanup.

New module tests/rados/thrash_helpers.py centralizes:
- NfsThrashWorkflows: daemon kill (pkill/orch/systemctl), recovery polling, RADOS config integrity, VIP float checks
- SmbThrashWorkflows: daemon lifecycle, CTDB/smbd process kills, endpoint and CTDB health verification
- NFS protocol state threads: client churn, export churn, admin ops
- Shared verification: fio integrity baselines, mount health checks
- Consolidated NFS mount helpers with multi-host endpoint resolution

Key design decisions:
- During-thrash errors are warn-only (timeouts expected under chaos)
- Pre-thrash baselines written on healthy cluster, verified post-thrash
- Only data integrity mismatches (fio crc32c, smb md5) cause test failure
- Post-thrash checks (daemon health, export accessibility, RADOS config, CTDB health) run after PGs reach active+clean

core_workflows.py additions:
- change_daemon_orch_state(): general-purpose orch daemon stop/start/restart with state polling and confirmation
- NFS cluster placement fix: round-robin multi-host distribution when placement > 1, with validation and hosts list in cluster metadata
- check_crash_status() extended with check_smb parameter

Thrash helpers reuse RadosOrchestrator methods throughout: get_service_spec_daemons, get_daemon_status, fetch_host_node, change_daemon_systemctl_state, restart_daemon_services, run_ceph_command.