### PR TITLE
Add latest inventory file for rgw

### DIFF
--- a/conf/inventory/ibm-eu-rhel-10-latest-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-10-latest-rgw.yaml
@@ -1,0 +1,1 @@
+ibm-eu-rhel-10.2-rgw.yaml

--- a/conf/inventory/ibm-eu-rhel-9-latest-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-9-latest-rgw.yaml
@@ -1,0 +1,1 @@
+ibm-eu-rhel-9.8-rgw.yaml


### PR DESCRIPTION
# Description
Add latest inventory file for rgw

Since currently we are having only rhel version specific inventory files for rgw .
this is reffered in our metadata.
i.e, Ex: ibm-eu-rhel-10.1-rgw.yaml , ibm-eu-rhel-9.7-rgw.yaml

This makes us make changes to metadata every time when there is a new rhel versions.

Hence adding [ibm-rhel-10-latest-rgw.yaml] [ibm-rhel-9-latest-rgw.yaml]
which will be referring to latest rhel inventory file.
So that we can just make changes to ibm-rhel-10-latest-rgw.yaml file for the every new rhel version.




Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
