### PR TITLE
Fix 7x-to-8x upgrade bootstrap on released pipelines

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -280,10 +280,17 @@ class BootstrapMixin:
             custom_image = False
             self.cluster.use_cdn = True
             self.set_cdn_tool_repo(_ceph_version, manifest_obj)
-        elif build_type == "released" and base_url == manifest_obj.repository:
+        elif (
+            build_type == "released"
+            and base_url == manifest_obj.repository
+            and manifest_obj.build_info.get("repo_ids", {}).get(manifest_obj.platform)
+            and cloud_type != "ibmc"
+            and not self.config.get("skip_subscription", False)
+            and not _ceph_version
+        ):
             custom_image = False
             self.cluster.use_cdn = True
-            self.set_cdn_tool_repo(manifest_obj)
+            self.set_cdn_tool_repo(ctm=manifest_obj)
         elif custom_repo:
             self.set_tool_repo(repo=custom_repo)
         else:

--- a/suites/squid/upgrades/tier1-upgrade-rhcs-7x-to-8x.yaml
+++ b/suites/squid/upgrades/tier1-upgrade-rhcs-7x-to-8x.yaml
@@ -31,7 +31,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -398,17 +398,38 @@ def setup_ibmc_qe_lab_os_repos(ceph, distro_ver):
 
     Live IBM inventories may not define yum_repos in cloud-init. Mirror the
     repository layout used by conf/inventory/ibm-eu-rhel-*.yaml inventories.
+
+    Repo files must use the standard names (appstream.repo, baseos.repo,
+    crb.repo) so they survive remove_repos() during cephadm upgrade tests.
     """
     version_parts = distro_ver.split(".")
     major = version_parts[0]
     minor = version_parts[1] if len(version_parts) > 1 else "0"
     base_url = f"{IBM_QE_LAB_REPO_MIRROR}/{major}/{minor}"
-    pkg = Package(ceph)
 
-    for repo_name in ("AppStream", "BaseOS", "CRB"):
-        repo_url = f"{base_url}/{repo_name}/"
+    repo_defs = {
+        "appstream.repo": ("appstream", "AppStream", "AppStream"),
+        "baseos.repo": ("baseos", "BaseOS", "BaseOS"),
+        "crb.repo": ("crb", "codeready-builder", "CRB"),
+    }
+
+    for repo_file, (repo_id, repo_name, repo_path) in repo_defs.items():
+        repo_url = f"{base_url}/{repo_path}/"
         log.info("Adding IBM QE lab repository %s", repo_url)
-        pkg.add_repo(repo_url)
+        repo_content = (
+            f"[{repo_id}]\n"
+            f"name={repo_name}\n"
+            f"baseurl={repo_url}\n"
+            f"enabled=1\n"
+            f"gpgcheck=0\n"
+        )
+        repo = ceph.remote_file(
+            sudo=True,
+            file_name=f"/etc/yum.repos.d/{repo_file}",
+            file_mode="w",
+        )
+        repo.write(repo_content)
+        repo.flush()
 
     ceph.exec_command(sudo=True, cmd="dnf clean metadata", check_ec=False)
     log.info("Added IBM QE lab RHEL repositories successfully")

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -219,6 +219,12 @@ def install_prereq(
             else:
                 enable_rhel_rpms(ceph, distro_ver)
 
+        elif cloud_type.lower() == "ibmc" and not has_enabled_repositories(ceph):
+            log.info(
+                "Enabling QE lab RHEL repositories for IBM cloud skip-subscription"
+            )
+            setup_ibmc_qe_lab_os_repos(ceph, distro_ver)
+
         if repo:
             setup_addition_repo(ceph, repo)
 
@@ -369,6 +375,43 @@ def subscription_manager_status(ceph):
         raise SubscriptionManagerError("Unexpected subscription manager status")
 
     return match.group(0)
+
+
+IBM_QE_LAB_REPO_MIRROR = "http://nginx-vm-01.qe.ceph.lab/repos"
+
+
+def has_enabled_repositories(ceph):
+    """Return True when the node has at least one enabled yum/dnf repository."""
+    out, _ = ceph.exec_command(
+        sudo=True,
+        cmd="dnf repolist --enabled -q 2>/dev/null | tail -n +2 | wc -l",
+        check_ec=False,
+    )
+    try:
+        return int(out.strip()) > 0
+    except ValueError:
+        return False
+
+
+def setup_ibmc_qe_lab_os_repos(ceph, distro_ver):
+    """Configure QE lab OS mirrors for unregistered IBM cloud nodes.
+
+    Live IBM inventories may not define yum_repos in cloud-init. Mirror the
+    repository layout used by conf/inventory/ibm-eu-rhel-*.yaml inventories.
+    """
+    version_parts = distro_ver.split(".")
+    major = version_parts[0]
+    minor = version_parts[1] if len(version_parts) > 1 else "0"
+    base_url = f"{IBM_QE_LAB_REPO_MIRROR}/{major}/{minor}"
+    pkg = Package(ceph)
+
+    for repo_name in ("AppStream", "BaseOS", "CRB"):
+        repo_url = f"{base_url}/{repo_name}/"
+        log.info("Adding IBM QE lab repository %s", repo_url)
+        pkg.add_repo(repo_url)
+
+    ceph.exec_command(sudo=True, cmd="dnf clean metadata", check_ec=False)
+    log.info("Added IBM QE lab RHEL repositories successfully")
 
 
 def setup_local_repos(ceph):


### PR DESCRIPTION
Use the baseline manifest when enabling CDN tool repos and only take the
CDN path when repo_ids exist. Bootstrap tier1-upgrade-rhcs-7x-to-8x from
7.1 GA (released) instead of rc.