### PR TITLE
Fix Vault init KeyError: use REST API field name keys_base64

### DIFF
--- a/tests/misc_env/install_vault.py
+++ b/tests/misc_env/install_vault.py
@@ -173,25 +173,28 @@ def _initialize_vault(vault: Vault, config: Dict) -> Dict:
     """Initialize Vault and configure Transit engine via REST API."""
     LOG.info("Initializing Vault server")
 
-    status = vault.operator.init_status()
     try:
+        status = vault.operator.init_status()
         if status.get("initialized"):
             LOG.info("Vault already initialized, retrieving existing credentials")
-            if isinstance(vault.ctx, list):
-                node = vault.ctx[0]
-            else:
-                node = vault.ctx
+            node = vault.ctx[0] if isinstance(vault.ctx, list) else vault.ctx
             creds_out, _ = node.exec_command(
                 sudo=True, cmd="cat /vault/credentials.json", check_ec=False
             )
             if creds_out:
                 return json.loads(creds_out)
     except Exception:
-        pass
+        LOG.info("Vault not yet initialized, proceeding with init")
 
     init_data = vault.operator.init(**{"secret-shares": 5, "secret-threshold": 3})
 
-    unseal_keys = init_data["unseal_keys_b64"]
+    if "keys_base64" not in init_data:
+        LOG.error(f"Unexpected init response: {init_data}")
+        raise RuntimeError(
+            f"Vault init failed: {init_data.get('errors', 'unknown error')}"
+        )
+
+    unseal_keys = init_data["keys_base64"]
     root_token = init_data["root_token"]
     LOG.info("Vault initialized")
 


### PR DESCRIPTION
The failure happens because in different test suites we have defined  install_vault.py in a different way  (it's from before, not because of the new changes).

But the new changes only address one kind of cephci test suite format, which is why it failed for the other format.

For example, in the test suite https://github.com/red-hat-storage/cephci/blob/5b39488ee382e82e85e109a2d0c54ba3770c4165/suites/tentacle/rgw/tier-1_rgw_upgrade_71GA_to_9x_latest.yaml#L253, the test will pass because no clusters are defined.

However, in the test suite, https://github.com/red-hat-storage/cephci/blob/5b39488ee382e82e85e109a2d0c54ba3770c4165/suites/squid/rgw/tier-2_rgw_cloud_transition.yaml#L210, it will fail

This PR addresses the solution so that it passes for both

passed log 
1. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D29FMM
2. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GMRQ8S/
