### PR TITLE
[tfa] stretch mode warning STRETCH_MODE_BUCKET_WEIGHT_IMBALANCE

### DIFF
--- a/tests/rados/test_stretch_deployment_with_placement.py
+++ b/tests/rados/test_stretch_deployment_with_placement.py
@@ -190,7 +190,7 @@ def run(ceph_cluster, **kw):
         loc_absent = False
         mons = rados_obj.run_ceph_command(mon_dump_cmd)
         for mon in mons["mons"]:
-            if mon["crush_location"] == "{}":
+            if mon["crush_location"] == "{}" or mon["crush_location"] == []:
                 log.debug(f"Mon location attributes not present on mon : {mon}")
                 loc_absent = True
 
@@ -218,7 +218,10 @@ def run(ceph_cluster, **kw):
                 tiebreaker_mon = [
                     entry["name"]
                     for entry in mons["mons"]
-                    if entry.get("crush_location") == "{}"
+                    if (
+                        entry.get("crush_location") == "{}"
+                        or entry.get("crush_location") == []
+                    )
                 ][0]
                 # Setting up CRUSH location on the final tiebreaker mon
                 tiebreaker_cmd = f"ceph mon set_location {tiebreaker_mon} datacenter={tiebreaker_mon_site_name}"

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -129,7 +129,9 @@ def run(ceph_cluster, **kw):
         return False
 
     def validate_osd_removal_scenario(
-        dc_1_osds_to_remove: list, dc_2_osds_to_remove: list
+        dc_1_osds_to_remove: list,
+        dc_2_osds_to_remove: list,
+        check_bucket_weight_imbalance_warning=False,
     ):
         """
         Method to perform osd removal scenario in stretch mode.
@@ -208,9 +210,21 @@ def run(ceph_cluster, **kw):
         log.info(
             "Proceeding to perform Check (3) Health warning - UNEVEN_WEIGHTS_STRETCH_MODE post OSD removal"
         )
-        if float(rhbuild.split("-")[0]) >= 7.1 and len(dc_1_osds_to_remove) != len(
-            dc_2_osds_to_remove
-        ):
+        # Extract version float safely (e.g., "9.1-12345" -> 9.1)
+        version_num = float(rhbuild.split("-")[0])
+        osd_counts_unequal = len(dc_1_osds_to_remove) != len(dc_2_osds_to_remove)
+
+        should_check_warning = False
+
+        if osd_counts_unequal:
+            # Covers 7.1, 8.0, 9.0
+            if 7.1 <= version_num < 9.1:
+                should_check_warning = True
+            # Covers 9.1+ (Fixed variable mismatch here)
+            elif version_num >= 9.1 and check_bucket_weight_imbalance_warning:
+                should_check_warning = True
+
+        if should_check_warning:
             endtime = datetime.datetime.now() + datetime.timedelta(seconds=300)
             while endtime > datetime.datetime.now():
                 if check_stretch_health_warning():
@@ -355,14 +369,19 @@ def run(ceph_cluster, **kw):
             f"Successfully wrote {pool_stat['stats']['objects']} on pool {pool_name}"
         )
 
-    def validate_host_removal_scenario(dc_1_hosts_to_remove, dc_2_hosts_to_remove):
+    def validate_host_removal_scenario(
+        dc_1_hosts_to_remove,
+        dc_2_hosts_to_remove,
+        check_bucket_weight_imbalance_warning=False,
+    ):
         """
         1) Drain osd host - ceph orch host drain
         2) Wait until all process are drained
         3) Check osd rm status
         4) Once hosts are drained host is removed
         5) Checks are performed once host is removed from cluster
-            - Health warning - UNEVEN_WEIGHTS_STRETCH_MODE
+            - Health warning - UNEVEN_WEIGHTS_STRETCH_MODE (7.1 <= version < 9.1)
+                              or STRETCH_MODE_BUCKET_WEIGHT_IMBALANCE (version >= 9.1)
             - PG has 2 OSD from datacenter DC1 and 2 OSD from datacenter DC2
             - PGs should reach active+clean state
             - Pool sanity checks should be successful
@@ -370,7 +389,8 @@ def run(ceph_cluster, **kw):
             - Write IO should succeed
         6) Add removed hosts back to the cluster
         7) Checks are performed once removed hosts are added back
-            - Health warning - UNEVEN_WEIGHTS_STRETCH_MODE
+            - Health warning - UNEVEN_WEIGHTS_STRETCH_MODE (7.1 <= version < 9.1)
+                              or STRETCH_MODE_BUCKET_WEIGHT_IMBALANCE (version >= 9.1)
             - PG has 2 OSD from datacenter DC1 and 2 OSD from datacenter DC2
             - PGs should reach active+clean state
             - Pool sanity checks should be successful
@@ -439,10 +459,21 @@ def run(ceph_cluster, **kw):
         log.info(
             "Proceeding to perform Check (6) Health warning - UNEVEN_WEIGHTS_STRETCH_MODE post OSD Host removal"
         )
-        # Checking if the expected health warning about the different site weights is displayed post removal of OSD host
-        if float(rhbuild.split("-")[0]) >= 7.1 and len(dc_1_hosts_to_remove) != len(
-            dc_1_hosts_to_remove
-        ):
+        # Extract version float safely (e.g., "9.1-12345" -> 9.1)
+        version_num = float(rhbuild.split("-")[0])
+        host_counts_unequal = len(dc_1_hosts_to_remove) != len(dc_2_hosts_to_remove)
+
+        should_check_warning = False
+
+        if host_counts_unequal:
+            # Covers 7.1, 8.0, 9.0
+            if 7.1 <= version_num < 9.1:
+                should_check_warning = True
+            # Covers 9.1+
+            elif version_num >= 9.1 and check_bucket_weight_imbalance_warning:
+                should_check_warning = True
+
+        if should_check_warning:
             endtime = datetime.datetime.now() + datetime.timedelta(seconds=300)
             while endtime > datetime.datetime.now():
                 if check_stretch_health_warning():
@@ -771,8 +802,12 @@ def run(ceph_cluster, **kw):
             # Waiting for recovery to post OSD host removal
             method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
 
-            # Checking if the expected health warning about the different site weights are seen.
-            if float(rhbuild.split("-")[0]) >= 7.1:
+            # In 9.1, we will not see the warning generated here as The two dividing buckets
+            #  must have weights within a fractional difference when
+            # stretch mode is enabled. This is determined by the configuration option
+            # mon_stretch_max_bucket_weight_delta  (default: 0.1)
+            version = float(rhbuild.split("-")[0])
+            if 7.1 <= version < 9.1:
                 endtime = datetime.datetime.now() + datetime.timedelta(seconds=300)
                 while endtime > datetime.datetime.now():
                     if check_stretch_health_warning():
@@ -1051,7 +1086,11 @@ def run(ceph_cluster, **kw):
 
             log.info(f"{dc_1_name} osds to remove are {dc_1_osds_to_remove}")
             log.info(f"{dc_2_name} osds to remove are {dc_2_osds_to_remove}")
-            validate_osd_removal_scenario(dc_1_osds_to_remove, dc_2_osds_to_remove)
+            validate_osd_removal_scenario(
+                dc_1_osds_to_remove,
+                dc_2_osds_to_remove,
+                check_bucket_weight_imbalance_warning=True,
+            )
 
         if "scenario-5" in scenarios_to_run:
             log.info(
@@ -1092,7 +1131,11 @@ def run(ceph_cluster, **kw):
 
             log.info(f"{dc_1_name} osds to remove are {dc_1_osds_to_remove}")
             log.info(f"{dc_2_name} osds to remove are {dc_2_osds_to_remove}")
-            validate_osd_removal_scenario(dc_1_osds_to_remove, dc_2_osds_to_remove)
+            validate_osd_removal_scenario(
+                dc_1_osds_to_remove,
+                dc_2_osds_to_remove,
+                check_bucket_weight_imbalance_warning=True,
+            )
 
         if "scenario-7" in scenarios_to_run:
             log.info(
@@ -1100,8 +1143,10 @@ def run(ceph_cluster, **kw):
             )
             dc_1_hosts_to_remove = [random.choice(dc_1_hosts)]
             dc_2_hosts_to_remove = [random.choice(dc_2_hosts)]
-            validate_host_removal_scenario(dc_1_hosts_to_remove, dc_2_hosts_to_remove)
-
+            validate_host_removal_scenario(
+                dc_1_hosts_to_remove,
+                dc_2_hosts_to_remove,
+            )
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)


### PR DESCRIPTION
TFA fixes for scenarios to adapt test modules to 9.1 stretch mode bucket warning changes
STRETCH_MODE_BUCKET_WEIGHT_IMBALANCE 

BUG :- https://redhat.atlassian.net/browse/DFBUGS-3712 




# STRETCH_MODE_BUCKET_WEIGHT_IMBALANCE Warning Analysis

**The check:**

```
WARNING if:  |W_DC1 - W_DC2|  >  delta × min(W_DC1, W_DC2)
```

Where `delta` = `mon_stretch_max_bucket_weight_delta` (default `0.1`).
---

### Baseline Weights

| Parameter | Value |
|-----------|-------|
| OSD weight | **0.01459** TiB (15 GiB disk) |
| Host weight | **0.05835** (4 × 0.01459 ≈ 0.05836) |
| DC1 total weight | **0.29175** (5 hosts × 0.05835) |
| DC2 total weight | **0.29175** (5 hosts × 0.05835) |
| Total OSDs per DC | **20** |
| Initial imbalance | **0** (perfectly balanced) |

---


## Summary Table

| Scenario | Description | OSDs Removed (DC1/DC2) | Difference | Threshold (0.1×min) | Warning? |
|----------|-------------|------------------------|------------|---------------------|----------|
| 1 | 1 OSD removed | 1 / 0 | 0.01459 | 0.02772 | **No** |
| 2 | 1 host (4 OSDs) removed | 4 / 0 | 0.05835 | 0.02334 | **Yes** |
| 3 | 1 OSD from each DC | 1 / 1 | 0.00000 | 0.02772 | **No** |
| 4 | 1 OSD from each DC1 host | 5 / 0 | 0.07295 | 0.02188 | **Yes** |
| 5 | 1 OSD from each host (both) | 5 / 5 | 0 (final) | 0.02188 | **Transient** |
| 6 | All OSDs from 1 DC1 host | 4 / 0 | 0.05836 | 0.02334 | **Yes** |
| 7 | 1 host from each DC | 4 / 4 | 0 (final) | 0.02334 | **Transient** |





# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
