### PR TITLE
[TFA] fixing bucket_logging failures in s3tests by adding the service2_sdk_extras which are prereq for boto3 client

### DIFF
--- a/suites/tentacle/rgw/test_granular_s3test.yaml
+++ b/suites/tentacle/rgw/test_granular_s3test.yaml
@@ -106,6 +106,7 @@ tests:
         execute_granular: true
         path: test_s3
         skip_setup : false
+        add_service2_sdk: true
       desc: Run the Granular external S3test suites test s3
       destroy-cluster: false
       module: test_s3.py

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -135,6 +135,10 @@ def run(**kw):
     if not skip_setup:
         execute_setup(cluster, config)
 
+    add_service2_sdk = config.get("add_service2_sdk", False)
+    if add_service2_sdk:
+        add_sevice2_sdk_extras(client_node)
+
     if not host:
         _, secure, _ = get_rgw_frontend(cluster)
 
@@ -398,7 +402,6 @@ def create_s3_user(node: CephNode, user_prefix: str, data: Dict) -> None:
             f"--display_name={display_name} --email={display_name}@foo.bar"
         )
     else:
-
         cmd = f"radosgw-admin user create --uid={uid} --display_name={display_name}"
         cmd += " --email={email}@foo.bar".format(email=uid)
 
@@ -677,3 +680,28 @@ def _rgw_lc_debug(cluster: Ceph, add: bool = True) -> None:
 
     # Restart can take time
     sleep(30)
+
+
+def add_sevice2_sdk_extras(node: CephNode) -> None:
+    """
+    download service-2.sdk-extras.json into aws path
+
+    Args:
+        node        The node from which the test execution is triggered.
+
+    Returns:
+        None
+    """
+
+    log.info(
+        "downloading service-2.sdk-extras.json to enable extra functionality supported by Ceph Extension"
+    )
+    out, err = node.exec_command(sudo=True, cmd="mkdir -p ~/.aws/models/s3/2006-03-01/")
+    extras_json_path = "~/.aws/models/s3/2006-03-01/service-2.sdk-extras.json"
+    sdk_github = "https://github.com/boto/botocore/blob/develop/botocore/data/s3/2006-03-01/service-2.json?raw=true"
+    out, err = node.exec_command(
+        sudo=True, cmd=f"sudo curl -o {extras_json_path} -L {sdk_github}"
+    )
+    log.info(f"service-2.sdk-extras.json is downloaded to {extras_json_path}")
+    log.info("sleeping for 5 seconds")
+    sleep(5)


### PR DESCRIPTION
this PR is to fix s3tests bucket_logging testcase failures
the issue was because of service_sdks_extras not configured which are required for s3client put/get bucket logging api requests.
so adding it in test_s3.py if the config is set in the test of the suite.

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_s3tests_add_bucket_logging_prereq/cephci-run-MJ93RW/

all of the bucket logging tests passed but the below failed with some different errors. will investigate them and fix in a separate PR

```2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - =========================== short test summary info ============================
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILED s3tests/functional/test_s3.py::test_bucket_policy_tenanted_bucket - bo...
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILED s3tests/functional/test_s3.py::test_bucket_logging_put_and_flush - Ass...
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILED s3tests/functional/test_s3.py::test_put_bucket_logging_tenant_s - boto...
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILED s3tests/functional/test_s3.py::test_put_bucket_logging_tenant_j - boto...
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILED s3tests/functional/test_s3.py::test_bucket_logging_cleanup_disabling_s_single
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILED s3tests/functional/test_s3.py::test_bucket_logging_cleanup_updating_s
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - FAILE
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - D s3tests/functional/test_s3.py::test_bucket_logging_conf_concurrent_updating_roll_j
2026-06-29 23:36:29,594 - cephci - ceph:1212 - DEBUG - = 7 failed, 636 passed, 13 skipped, 76 deselected, 3 warnings in 2145.76s (0:35:45) =
```

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
