### PR TITLE
TFA fixes for system test

### DIFF
--- a/conf/baremetal/cephfs_bruuni_6node_system_scale_test.yaml
+++ b/conf/baremetal/cephfs_bruuni_6node_system_scale_test.yaml
@@ -1,0 +1,129 @@
+---
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.0.0.0/8']
+      nodes:
+        -
+          hostname: bruuni001
+          id: node1
+          ip: 10.64.0.220
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - node-exporter
+            - alertmanager
+            - grafana
+            - prometheus
+            - crash
+        -
+          hostname: bruuni002
+          id: node2
+          ip: 10.64.0.221
+          root_password: passwd
+          role:
+            - mon
+            - mgr
+            - mds
+            - node-exporter
+            - alertmanager
+            - crash
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: bruuni003
+          id: node3
+          ip: 10.64.0.222
+          root_password: passwd
+          role:
+            - mon
+            - mds
+            - node-exporter
+            - crash
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: bruuni004
+          id: node4
+          ip: 10.64.0.223
+          root_password: passwd
+          role:
+            - mds
+            - node-exporter
+            - crash
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: bruuni005
+          id: node5
+          ip: 10.64.0.224
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+            - node-exporter
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: bruuni006
+          id: node6
+          ip: 10.64.0.225
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+            - node-exporter
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        - hostname: cephfs-client-vm01
+          id: node7
+          ip: 10.64.26.238
+          role:
+          - client
+          root_password: passwd
+        - hostname: cephfs-client-vm02
+          id: node8
+          ip: 10.64.26.125
+          role:
+          - client
+          root_password: passwd
+        - hostname: cephfs-client-vm03
+          id: node9
+          ip: 10.64.26.201
+          role:
+          - client
+          root_password: passwd
+        - hostname: cephfs-client-vm04
+          id: node10
+          ip: 10.64.27.93
+          role:
+          - client
+          root_password: passwd
+        - hostname: cephfs-client-vm05
+          id: node11
+          ip: 10.64.26.162
+          role:
+          - client
+          root_password: passwd

--- a/suites/tentacle/cephfs/tier-4_cephfs_system_scale_baremetal.yaml
+++ b/suites/tentacle/cephfs/tier-4_cephfs_system_scale_baremetal.yaml
@@ -1268,7 +1268,15 @@ tests:
         crash_setup : 1
         daemon_list : ['mds','osd','mgr','mon']
 
-
+  ### Add all disks of same type to OSD
+  -
+    test:
+      abort-on-fail: true
+      desc: Add all disks of same type to OSD
+      module: cephfs_system.cephfs_systest_disruptive_tests.py
+      name: "Add all disks of same type to OSD"
+      config:
+        test_name: "add_all_disks_same_type"
 ### Scale Tests
 
   - test:
@@ -1544,6 +1552,13 @@ tests:
             desc: Run MDS ops
             module: cephfs_system.cephfs_systest_mds_ops.py
             name: "CephFS System Test MDS ops"
+        -
+          test:
+            abort-on-fail: false
+            desc: Run FS recovery with large mds log
+            module: cephfs_bugs.test_fs_recovery_with_large_mds_log.py
+            name: "CephFS System Test FS recovery with large mds log"
+            polarion-id: CEPH-83632603
         -
           test:
             abort-on-fail: true

--- a/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
@@ -12,6 +12,7 @@ from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from tests.cephfs.lib.cephfs_subvol_metric_utils import MDSMetricsHelper
 from utility.log import Log
+from utility.retry import retry
 
 log = Log(__name__)
 
@@ -311,6 +312,15 @@ def run(ceph_cluster, **kw):
             fs_util.deamon_op(active_mds_node, rf"mds\.{fs_name}\.", "restart")
             log.info("Restarted active MDS daemon on host %s", active_host)
 
+            @retry(RuntimeError, tries=6, delay=10)
+            def _wait_for_active_mds():
+                active_mds = FsUtils.get_active_mdss(client, fs_name=fs_name)
+                if not active_mds:
+                    raise RuntimeError("No active MDS found after restart operation")
+                return 0
+
+            _wait_for_active_mds()
+
         def _restart_active_mgr_daemon():
             client.exec_command(sudo=True, cmd="ceph orch restart mgr")
             log.info("Restarted active MGR daemon: mgr")
@@ -372,9 +382,15 @@ def run(ceph_cluster, **kw):
                 sudo=True,
                 cmd=f"ceph orch apply mds {fs_name} --placement='{len(fs_hosts)} {full_placement}'",
             )
+
             if _wait_for_mds_daemon_count(
                 client, fs_name, expected_count=len(fs_hosts)
             ):
+                out, _ = client.exec_command(
+                    sudo=True,
+                    cmd=f"ceph fs status {fs_name}",
+                )
+                log.info("FS status: %s", out)
                 raise RuntimeError("MDS count did not converge after add operation")
 
             log.info("Completed MDS service remove/add for fs %s", fs_name)

--- a/tests/cephfs/cephfs_system/cephfs_config_update.py
+++ b/tests/cephfs/cephfs_system/cephfs_config_update.py
@@ -29,6 +29,7 @@ def run(ceph_cluster, **kw):
 
     """
     try:
+        global log_base_dir
         sys_lib = CephFSSystemUtils(ceph_cluster)
         config = kw.get("config")
         config_name = config.get("config_name", "all")
@@ -36,12 +37,14 @@ def run(ceph_cluster, **kw):
         update_interval = config.get(
             "conf_update_interval", 1
         )  # hrs,set to '0' if NO iteration required
-        run_time = config.get("run_time_hrs", 4)
+        run_time = config.get("run_time_hrs", 8)
         chk_clus = config.get(
             "check_cluster", 1
         )  # Required for system testing only,0 for other tests
 
         client = ceph_cluster.get_ceph_objects("client")[0]
+        run_config = kw.get("run_config")
+        log_base_dir = run_config.get("log_dir")
         mds_config = {
             "mds_cache_memory_limit": {
                 "default": "4G",
@@ -149,8 +152,7 @@ def mds_config_test(
 ):
     # Log configuration
     log_name = "mds_config_test"
-    log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-    log_path = f"{log_base_dir}/config_subtests"
+    log_path = f"{log_base_dir}/mds_config_subtests"
     try:
         os.mkdir(log_path)
     except BaseException as ex:

--- a/tests/cephfs/cephfs_system/cephfs_systest_client_io.py
+++ b/tests/cephfs/cephfs_system/cephfs_systest_client_io.py
@@ -47,10 +47,11 @@ def run(ceph_cluster, **kw):
 
     """
     try:
-        global byok_run
+        global byok_run, clients_orig
         fs_system_utils = CephFSSystemUtils(ceph_cluster)
         fs_io = FSIO(ceph_cluster)
         config = kw.get("config")
+        run_config = kw.get("run_config")
         cephfs_config = {}
         run_time = config.get("run_time_hrs", 8)
         byok_run = config.get("byok_run", 0)
@@ -61,7 +62,7 @@ def run(ceph_cluster, **kw):
         fs_util_v1.prepare_clients(clients, build)
         file = "cephfs_systest_data.json"
 
-        client1 = clients[0]
+        client1 = clients_orig[0]
 
         f = client1.remote_file(
             sudo=True,
@@ -94,8 +95,7 @@ def run(ceph_cluster, **kw):
         proc_status_list = []
         write_procs = []
         io_test_fail = 0
-        # log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-        log_base_dir = config.get("log-dir")
+        log_base_dir = run_config.get("log_dir")
         log_path = f"{log_base_dir}/client_io_subtests"
         try:
             os.mkdir(log_path)
@@ -323,11 +323,10 @@ def io_test_workflow_1(
                     file_path2 = (
                         f"{dir_path2}/io_test_dir_{child_dir}/wf1_file_{rand_str}"
                     )
-                    read_cmd = f"fio --name={file_path2} --ioengine=libaio --size 10M --rw=read --direct=0"
-                    read_cmd += " --startdelay=1"
                     file_ops = {
                         "write": f"fio --name={file_path1} --ioengine=libaio --size 10M --rw=write --direct=0",
-                        "read": read_cmd,
+                        "read": f"fio --name={file_path2} --ioengine=libaio --size 10M --rw=read --direct=0 "
+                        "--startdelay=1",
                     }
                     get_attr_cmds1 = "sleep 2;"
                     get_attr_cmds2 = "sleep 2;"
@@ -367,7 +366,7 @@ def io_test_workflow_1(
                     log1.info(f"Running cmd {cmd}")
                     p.spawn(run_cmd, cmd, client2, log1)
         time.sleep(30)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
 
     log1.info("io_test_workflow_1 completed")
@@ -452,7 +451,7 @@ def io_test_workflow_2(
                     sudo=True, cmd=f"rm -rf /var/tmp/smallfile_dir_{rand_str}"
                 )
         log1.info("Completed test iteration")
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
         if cleanup == 1:
             with parallel() as p:
@@ -553,7 +552,7 @@ def io_test_workflow_3(
                     if cleanup == 1:
                         cmd = f"rm -rf {dir_path1}"
                         p.spawn(run_cmd, cmd, client1, log1)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     log1.info("io_test_workflow_3 completed")
     return 0
@@ -634,7 +633,7 @@ def io_test_workflow_4(
                     cmd = f"rm -f {dir_path}/io_test_workflow_4*"
                     log1.info(f"Executing cmd {cmd}")
                     p.spawn(run_cmd, cmd, client, log1)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     log1.info("io_test_workflow_4 completed")
     return 0
@@ -706,7 +705,7 @@ def io_test_workflow_5(
                 frag_list.append(y)
         log1.info(f"Maximum Fragmentation seen across OSDs : {max(frag_list)}")
         time.sleep(10)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     if cleanup == 1:
         with parallel() as p:
@@ -782,7 +781,7 @@ def io_test_workflow_6(
                     cmd = f"rm -rf {dir_path}"
                     log1.info(f"Executing cmd {cmd}")
                     p.spawn(run_cmd, cmd, client, log1)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     log1.info("io_test_workflow_6 completed")
     return 0
@@ -870,7 +869,7 @@ def io_test_workflow_7(
                         p.spawn(run_cmd, cmd, client, log1)
 
             retry_cnt += 1
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
 
     if mds_req_limit.value == 0:
@@ -990,7 +989,7 @@ def io_test_workflow_8(
                 client.exec_command(sudo=True, cmd=cmd)
             except BaseException as ex:
                 log.info(ex)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     if cleanup == 1:
         with parallel() as p:
@@ -1095,7 +1094,7 @@ def io_test_workflow_9(run_time, log_path, cleanup, clients, fs_system_utils, sv
         except BaseException as ex:
             log1.info(ex)
         time.sleep(10)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     log1.info(f"cleanup:{cleanup}")
     log1.info("io_test_workflow_9 completed")
@@ -1150,10 +1149,10 @@ def io_test_workflow_10(
                 client = sv_info_objs[sv_name]["client"]
                 for i in range(15):
                     dir_path_tmp = f"{dir_path}/io_test_dir_{i}"
-                    cmd = "for i in create read append read delete create overwrite rename delete-renamed mkdir"
-                    cmd += f" rmdir create symlink stat chmod ls-l delete cleanup ;do {smallfile_cmd} --operation $i"
-                    cmd += " --thread 2 --file-size 2048 --files 10000 --dirs-per-dir 50 --same-dir false"
-                    cmd += f" --top {dir_path_tmp}; done"
+                    cmd = "for i in create read append read delete create overwrite rename delete-renamed mkdir "
+                    cmd += f"rmdir create symlink stat chmod ls-l delete cleanup ;do {smallfile_cmd} --operation $i "
+                    cmd += "--thread 2 --file-size 2048 --files 10000 --dirs-per-dir 50 --same-dir false --top "
+                    cmd += f"{dir_path_tmp}; done"
                     log1.info(f"Executing cmd {cmd}")
                     p.spawn(run_cmd, cmd, client, log1)
         if cleanup == 1:
@@ -1164,12 +1163,12 @@ def io_test_workflow_10(
                     client = sv_info_objs[sv_name]["client"]
                     for i in range(15):
                         dir_path_tmp = f"{dir_path}/io_test_dir_{i}"
-                        cmd = f"{smallfile_cmd} --operation cleanup --thread 2 --file-size 2048 --files 10000"
+                        cmd = f"{smallfile_cmd} --operation cleanup --thread 2 --file-size 2048 --files 10000 "
                         cmd += (
-                            f" --dirs-per-dir 50 --same-dir false --top {dir_path_tmp}"
+                            f"--dirs-per-dir 50 --same-dir false --top {dir_path_tmp}"
                         )
                         p.spawn(run_cmd, cmd, client, log1)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     log1.info("io_test_workflow_10 completed")
     return 0
@@ -1202,8 +1201,7 @@ def io_test_workflow_11(run_time, log_path, cleanup, clients, fs_system_utils, s
         dir_path = f"{mnt_pt}/io_test_workflow_11_{rand_str}"
         cmd = f"mkdir {dir_path};touch {dir_path}/tmp_workflow11_data"
         client.exec_command(sudo=True, cmd=cmd)
-        cmd = f"cd {dir_path};wget -O linux.tar.xz http://download.ceph.com/qa/linux-5.4.tar.gz"
-        cmd += " > tmp_workflow11_data"
+        cmd = f"cd {dir_path};wget -O linux.tar.xz http://download.ceph.com/qa/linux-5.4.tar.gz > tmp_workflow11_data"
         log1.info(f"Executing cmd {cmd}")
         client.exec_command(
             sudo=True,
@@ -1213,7 +1211,7 @@ def io_test_workflow_11(run_time, log_path, cleanup, clients, fs_system_utils, s
         if cleanup == 1:
             cmd = f"rm -rf {dir_path}"
             client.exec_command(sudo=True, cmd=cmd)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
     log1.info("io_test_workflow_11 completed")
     return 0
@@ -1279,7 +1277,7 @@ def io_test_workflow_12(
                     cmd = f"rm -rf {dir_path}"
                     p.spawn(run_cmd, cmd, client, log1)
         time.sleep(30)
-        cluster_healthy = is_cluster_healthy(clients[0])
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health{cluster_healthy}")
 
     log1.info("io_test_workflow_12 completed")

--- a/tests/cephfs/cephfs_system/cephfs_systest_data.json
+++ b/tests/cephfs/cephfs_system/cephfs_systest_data.json
@@ -1,15 +1,15 @@
 {
-    "cephfs": {
+    "cephfs-scale": {
         "group": {
             "default": {
                 "shared": {"sv_prefix": "cephfs_systest_def_shared", "sv_cnt": "10"},
-                "unique": {"sv_prefix": "cephfs_systest_def", "sv_cnt": "15"},
+                "unique": {"sv_prefix": "cephfs_systest_def", "sv_cnt": "15"}
             },
             "svg1": {
                 "shared": {"sv_prefix": "cephfs_systest_def_shared", "sv_cnt": "10"},
-                "unique": {"sv_prefix": "cephfs_systest_def", "sv_cnt": "15"},
-            },
+                "unique": {"sv_prefix": "cephfs_systest_def", "sv_cnt": "15"}
+            }
         },
-        "mds": {"active": 3, "standby_replay": "true"},
+        "mds": {"active": 3, "standby_replay": "true"}
     }
 }

--- a/tests/cephfs/cephfs_system/cephfs_systest_disruptive_tests.py
+++ b/tests/cephfs/cephfs_system/cephfs_systest_disruptive_tests.py
@@ -29,27 +29,25 @@ def run(ceph_cluster, **kw):
 
     1. Add OSD and run snapshot creation parallel, verify snapshot create suceeds
     2. Remove OSD and run snapshot creation parallel, verify snapshot create suceeds
+    3. Verify all disks of same disk type are added to cluster, else add them.
     """
     try:
         fs_system_utils = CephFSSystemUtils(ceph_cluster)
         cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
         config = kw.get("config")
+        run_config = kw.get("run_config")
         cephfs_config = {}
         run_time = config.get("run_time_hrs", 8)
         # Derive OSD usage limit to trigger OSD removal
         osd_rm_limit_def = random.randrange(5, 26)
         osd_rm_limit = config.get("osd_rm_limit", osd_rm_limit_def)
-        clients = ceph_cluster.get_ceph_objects("client")
+        clients_orig = ceph_cluster.get_ceph_objects("client")
+        clients_cnt = len(clients_orig)
+        # Skipping client.0 as it is used for monitoring and execution
+        clients = clients_orig[1:clients_cnt]
         file = "cephfs_systest_data.json"
-        client1 = clients[0]
+        client1 = clients_orig[0]
 
-        f = client1.remote_file(
-            sudo=True,
-            file_name=f"/home/cephuser/{file}",
-            file_mode="r",
-        )
-        cephfs_config = json.load(f)
-        log.info("cephfs_config:%s", cephfs_config)
         nearfull_ratio = config.get("nearfull_ratio", 0.5)
         nearfull_cmd = f"ceph osd set-nearfull-ratio {nearfull_ratio}"
         log.info("Set OSD nearfull ratio to %s", nearfull_ratio)
@@ -57,17 +55,19 @@ def run(ceph_cluster, **kw):
         disruptive_tests = {
             "add_osd_during_systest": "Add OSD and run snapshot create on test subvolumes in parallel",
             "remove_osd_during_systest": "Remove OSD and run snapshot create on test subvolumes in parallel",
+            "add_all_disks_same_type": "Add all disks of same type to cluster",
         }
         test_case_name = config.get("test_name", "all_tests")
         if test_case_name in disruptive_tests:
             test_list = [test_case_name]
         else:
             test_list = disruptive_tests.keys()
+            # This test is not supported in disruptive tests,it needs to be run as setup test
+            test_list.remove("add_all_disks_same_type")
         proc_status_list = []
         write_procs = []
         mds_test_fail = 0
-        # log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-        log_base_dir = config.get("log-dir")
+        log_base_dir = run_config.get("log_dir")
         log_path = f"{log_base_dir}/disruptive_subtests"
         try:
             os.mkdir(log_path)
@@ -78,24 +78,33 @@ def run(ceph_cluster, **kw):
 
         for test_name in test_list:
             log.info("Running %s : %s", test_name, disruptive_tests[test_name])
-            test_proc_check_status = Value("i", 0)
-            proc_status_list.append(test_proc_check_status)
-            p = Thread(
-                target=disruptive_test_runner,
-                args=(
-                    test_proc_check_status,
-                    test_name,
-                    run_time,
-                    osd_rm_limit,
-                    log_path,
-                    clients,
-                    cephfs_common_utils,
-                    fs_system_utils,
-                    cephfs_config,
-                ),
-            )
-            p.start()
-            write_procs.append(p)
+            if test_name == "add_all_disks_same_type":
+                mds_test_fail = add_all_disks_same_type(client1, ceph_cluster)
+            else:
+                f = client1.remote_file(
+                    sudo=True,
+                    file_name=f"/home/cephuser/{file}",
+                    file_mode="r",
+                )
+                cephfs_config = json.load(f)
+                test_proc_check_status = Value("i", 0)
+                proc_status_list.append(test_proc_check_status)
+                p = Thread(
+                    target=disruptive_test_runner,
+                    args=(
+                        test_proc_check_status,
+                        test_name,
+                        run_time,
+                        osd_rm_limit,
+                        log_path,
+                        clients,
+                        cephfs_common_utils,
+                        fs_system_utils,
+                        cephfs_config,
+                    ),
+                )
+                p.start()
+                write_procs.append(p)
         for write_proc in write_procs:
             write_proc.join()
         for proc_status in proc_status_list:
@@ -164,6 +173,70 @@ def disruptive_test_runner(
             cephfs_config,
         )
     log.info("%s status after test : %s", test_name, test_proc_check_status.value)
+
+
+def add_all_disks_same_type(client, ceph_cluster):
+    """
+    This method is used for test case "Add all disks of same type to cluster", ideally before running the test.
+    Params:
+    Required -
+    client : client object
+    ceph_cluster : ceph cluster object
+    """
+    # Get disk type from currently assigned OSD nodes
+    cmd = "ceph osd tree --format json"
+    out, _ = client.exec_command(sudo=True, cmd=cmd)
+    parsed_data = json.loads(out)
+    disk_type_list = [
+        node["device_class"]
+        for node in parsed_data.get("nodes", [])
+        if node.get("type") == "osd" and node.get("device_class")
+    ]
+    log.info("Disk types from ceph osd tree: %s", disk_type_list)
+    if not disk_type_list:
+        log.error("No device_class found in ceph osd tree output")
+        return 1
+    disk_type = list(set(disk_type_list))[0]
+    # Get disk size of any existing osd node
+    cmd = "ceph orch device ls --refresh --f json"
+    out, _ = client.exec_command(sudo=True, cmd=cmd)
+    host_devices = json.loads(out)
+    device_list = {}
+    for host_entry in host_devices:
+        hostname = host_entry.get("name") or host_entry.get("addr")
+        if not hostname:
+            continue
+        device_list.setdefault(hostname, [])
+        for device in host_entry.get("devices", []):
+            if (
+                device.get("available")
+                and device.get("human_readable_type") == disk_type
+            ):
+                device_list[hostname].append(device["path"])
+    log.info("Available %s disks per host: %s", disk_type, device_list)
+    if not any(device_list.values()):
+        log.info("No available %s disks found on any host", disk_type)
+        return 0
+    max_osd_id = get_max_osd_id(client)
+    osd_procs = []
+    try:
+        for hostname, device_paths in device_list.items():
+            for device_path in device_paths:
+                max_osd_id += 1
+                p = Thread(
+                    target=add_osd,
+                    args=(ceph_cluster, hostname, device_path, max_osd_id),
+                )
+                p.start()
+                osd_procs.append(p)
+        for p in osd_procs:
+            p.join()
+        log.info("All disks of same type added to cluster")
+        return 0
+    except Exception as e:
+        log.error("Error adding all disks of same type to cluster: %s", e)
+        log.error(traceback.format_exc())
+        return 1
 
 
 def add_osd_during_systest(
@@ -304,7 +377,7 @@ def remove_osd_during_systest(
                 osd_node_name = osd_node.node.hostname
                 osd_id_list = non_available_disks[osd_node_name]
                 osd_id = max(osd_id_list)
-                if len(non_available_disks[osd_node_name]) >= 3:
+                if len(non_available_disks[osd_node_name]) >= 2:
                     sv_info_list = get_sv_list(cephfs_config, fs_system_utils)
                     rand_str = "".join(
                         random.choice(string.ascii_lowercase + string.digits)

--- a/tests/cephfs/cephfs_system/cephfs_systest_mds_ops.py
+++ b/tests/cephfs/cephfs_system/cephfs_systest_mds_ops.py
@@ -30,9 +30,11 @@ def run(ceph_cluster, **kw):
 
     """
     try:
+        global clients_orig
         fs_system_utils = CephFSSystemUtils(ceph_cluster)
         fs_util = FsUtilsV1(ceph_cluster)
         config = kw.get("config")
+        run_config = kw.get("run_config")
         cephfs_config = {}
         run_time = config.get("run_time_hrs", 8)
         replay_interval = config.get("replay_interval_hrs", 1)
@@ -41,7 +43,7 @@ def run(ceph_cluster, **kw):
         clients = clients_orig[1:11]
         file = "cephfs_systest_data.json"
 
-        client1 = clients[0]
+        client1 = clients_orig[0]
 
         f = client1.remote_file(
             sudo=True,
@@ -63,8 +65,7 @@ def run(ceph_cluster, **kw):
         proc_status_list = []
         write_procs = []
         mds_test_fail = 0
-        # log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-        log_base_dir = config.get("log-dir")
+        log_base_dir = run_config.get("log_dir")
         log_path = f"{log_base_dir}/mds_subtests"
         try:
             os.mkdir(log_path)
@@ -203,11 +204,11 @@ def mds_test_workflow_1(
         log1.info(
             f"Ceph status after MDS failover: {json.dumps(ceph_status, indent=4)}"
         )
-        if "HEALTH_OK" not in ceph_status["health"]["status"]:
-            log1.error(f"Ceph Health is NOT OK after mds{mds} failover")
+        if "HEALTH_ERR" in ceph_status["health"]["status"]:
+            log1.error(f"Ceph Health is in ERR state after mds{mds} failover")
             return 1
 
-        cluster_healthy = is_cluster_healthy(client)
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health {cluster_healthy}")
     log1.info("mds_test_workflow_1 completed")
     return 0
@@ -279,7 +280,7 @@ def mds_test_workflow_2(
 
             if (
                 mds_perf_after_flush[mds_rank]["expos"]
-                == mds_perf_before_flush[mds_rank]["wrpos"]
+                >= mds_perf_before_flush[mds_rank]["wrpos"]
             ):
                 log1.info(f"Journal flush Validated for MDS {mds_rank}")
             else:
@@ -297,7 +298,7 @@ def mds_test_workflow_2(
                     "Journal flush validation failed, please check journal stats before and after flush above"
                 )
                 test_fail += 1
-        cluster_healthy = is_cluster_healthy(client)
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
 
     log1.info("mds_test_workflow_2 completed")
     if test_fail > 0:

--- a/tests/cephfs/cephfs_system/cephfs_systest_monitor.py
+++ b/tests/cephfs/cephfs_system/cephfs_systest_monitor.py
@@ -29,20 +29,19 @@ def run(ceph_cluster, **kw):
         fs_util_v1 = FsUtilsV1(ceph_cluster)
         fs_scale_utils = CephfsScaleUtils(ceph_cluster)
         config = kw.get("config")
+        run_config = kw.get("run_config")
         clients = ceph_cluster.get_ceph_objects("client")
 
         mds_nodes = ceph_cluster.get_ceph_objects("mds")
         mem_limit = config.get("mds_mem_limit", 95)
-        cpu_limit = config.get("mds_cpu_limit", 180)
+        cpu_limit = config.get("mds_cpu_limit", 400)
         disk_limit = config.get("disk_limit", 80)
         client = clients[0]
         update_system_status(clients, "NA")
         mds_names_hostname = []
         for mds in mds_nodes:
             mds_names_hostname.append(mds.node.hostname)
-
-        # log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-        log_base_dir = config.get("log-dir")
+        log_base_dir = run_config.get("log_dir")
         mds_list = fs_scale_utils.get_daemon_names(clients[0], "mds")
         cmd_list = [
             "ceph mgr module enable stats",
@@ -54,7 +53,7 @@ def run(ceph_cluster, **kw):
         for daemon in mds_list:
             cmd_list.append(f"ceph tell {daemon} perf dump --format json")
         log.info(f"Ceph commands to run at an interval : {cmd_list}")
-        log_dir = f"{log_base_dir}/ceph_monitor_logs"
+        log_dir = f"{log_base_dir}/cephfs_systest_monitor_logs"
 
         try:
             os.mkdir(log_dir)

--- a/tests/cephfs/cephfs_system/cephfs_systest_setup.py
+++ b/tests/cephfs/cephfs_system/cephfs_systest_setup.py
@@ -1,11 +1,8 @@
 import json
-
-# import os
+import os
 import random
 import secrets
 import string
-
-# import time
 import traceback
 
 from tests.cephfs.cephfs_scale.cephfs_scale_utils import CephfsScaleUtils
@@ -41,16 +38,15 @@ def run(ceph_cluster, **kw):
         snap_util = SnapUtils(ceph_cluster)
         cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
         config = kw.get("config")
+        run_config = kw.get("run_config")
         cephfs_config = {}
         build = config.get("build", config.get("rhbuild"))
-        # systest_monitor = config.get("systest_monitor", 1)
+        byok_setup = config.get("byok_setup", 1)
         clients_orig = ceph_cluster.get_ceph_objects("client")
-        clients_tmp = clients_orig[1:11]
-        clients = []
-        for client_tmp in clients_tmp:
-            if "osv-vm-master07" in client_tmp.node.hostname:
-                continue
-            clients.append(client_tmp)
+        clients_cnt = len(clients_orig)
+        # Skipping client.0 as it is used for monitoring and execution
+        clients = clients_orig[1:clients_cnt]
+
         nfs_nodes = ceph_cluster.get_nodes("nfs")
         installer = ceph_cluster.get_nodes(role="installer")[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -58,9 +54,10 @@ def run(ceph_cluster, **kw):
         fs_util_v1.auth_list(clients)
         file = "cephfs_systest_data.json"
         mnt_type_list = ["kernel", "fuse", "nfs"]
-        client1 = clients[0]
+        client1 = clients_orig[0]
         ephemeral_pin = config.get("ephemeral_pin", 1)
-        nfs_name = "cephfs_systest_nfs_byok"
+        mds_cache_limit = config.get("mds_cache_limit_gb", 24)
+        nfs_name = "cephfs_systest_nfs"
         client1.upload_file(
             sudo=True,
             src=f"tests/cephfs/cephfs_system/{file}",
@@ -72,51 +69,59 @@ def run(ceph_cluster, **kw):
             file_mode="r",
         )
         cephfs_config = json.load(f)
-        # BYOK Setup
-        # ------------------- Retrieving GKLM DATA -------------------
-        custom_data = kw.get("test_data", None)
-        rand_str = "".join(secrets.choice(string.digits) for i in range(3))
-        gklm_client_name = f"cephfs_systest_byok_client_{rand_str}"
-        gklm_cert_alias = f"cephfs_systest_byok_client_cert_{rand_str}"
-        #
-        gklm_params = load_gklm_config(custom_data, config, cephci_data)
         nfs_nodes_1 = get_free_nodes_for_nfs(client1, nfs_nodes)
-        # nfs_nodes_1 = nfs_nodes
-        for nfs_node in nfs_nodes_1:
-            log.info(nfs_node.hostname)
-        byok_setup_params = {
-            "gklm_ip": gklm_params["gklm_ip"],
-            "gklm_user": gklm_params["gklm_user"],
-            "gklm_password": gklm_params["gklm_password"],
-            "gklm_node_user": gklm_params["gklm_node_username"],
-            "gklm_node_password": gklm_params["gklm_node_password"],
-            "gklm_hostname": gklm_params["gklm_hostname"],
-            "gklm_client_name": gklm_client_name,
-            "gklm_cert_alias": gklm_cert_alias,
-            "nfs_nodes": nfs_nodes_1,
-            "installer": installer,
-            "nfs_name": nfs_name,
-        }
-        _, enctag, _, _ = nfs_byok_test_setup(byok_setup_params)
-        nfs_node = byok_setup_params["nfs_nodes"][0]
-        nfs_server = nfs_node.hostname
         nfs_node = nfs_nodes_1[0]
         nfs_server = nfs_node.hostname
-        fs_util_v1.create_nfs(
-            client1,
-            nfs_cluster_name=nfs_name,
-            nfs_server_name=nfs_server,
-        )
+        nfs_server = nfs_server.replace("'", "")
+        log.info(f"nfs_server: {nfs_server}")
+        if byok_setup == 1:
+            # BYOK Setup
+            # ------------------- Retrieving GKLM DATA -------------------
+            custom_data = kw.get("test_data", None)
+            rand_str = "".join(secrets.choice(string.digits) for i in range(3))
+            gklm_client_name = f"cephfs_systest_byok_client_{rand_str}"
+            gklm_cert_alias = f"cephfs_systest_byok_client_cert_{rand_str}"
+
+            gklm_params = load_gklm_config(custom_data, config, cephci_data)
+
+            for nfs_node in nfs_nodes_1:
+                log.info(nfs_node.hostname)
+
+            byok_setup_params = {
+                "gklm_ip": gklm_params["gklm_ip"],
+                "gklm_user": gklm_params["gklm_user"],
+                "gklm_password": gklm_params["gklm_password"],
+                "gklm_node_user": gklm_params["gklm_node_username"],
+                "gklm_node_password": gklm_params["gklm_node_password"],
+                "gklm_hostname": gklm_params["gklm_hostname"],
+                "gklm_client_name": gklm_client_name,
+                "gklm_cert_alias": gklm_cert_alias,
+                "nfs_nodes": nfs_nodes_1,
+                "installer": installer,
+                "nfs_name": nfs_name,
+            }
+            _, enctag, _, _ = nfs_byok_test_setup(byok_setup_params)
+        else:
+            fs_util_v1.create_nfs(
+                client1,
+                nfs_cluster_name=nfs_name,
+                nfs_server_name=nfs_server,
+            )
         for i in cephfs_config:
             cephfs_config[i].update(
                 {
-                    "byok": {
-                        "gklm_client_name": gklm_client_name,
-                        "gklm_cert_alias": gklm_cert_alias,
-                    },
                     "nfs": {"nfs_name": nfs_name},
                 }
             )
+            if byok_setup == 1:
+                cephfs_config[i].update(
+                    {
+                        "byok": {
+                            "gklm_client_name": gklm_client_name,
+                            "gklm_cert_alias": gklm_cert_alias,
+                        },
+                    }
+                )
 
         if wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             log.info("ceph nfs cluster created successfully")
@@ -128,7 +133,9 @@ def run(ceph_cluster, **kw):
             log.info("Setup Ephemeral Distributed pinning")
             cmd = "ceph config set mds mds_export_ephemeral_distributed true"
             client1.exec_command(sudo=True, cmd=cmd)
-
+        log.info("Increasing MDS Cache Memory Limit to %s", mds_cache_limit)
+        cmd = f"ceph config set mds mds_cache_memory_limit {mds_cache_limit * 1024 * 1024 * 1024}"
+        client1.exec_command(sudo=True, cmd=cmd)
         log.info("Enable snap-schedule config")
         snap_util.enable_snap_schedule(client1)
         snap_util.allow_minutely_schedule(client1)
@@ -174,16 +181,18 @@ def run(ceph_cluster, **kw):
                             f"Creating subvolume {sv_name} in {j} group in FS volume {i}"
                         )
                         fs_util_v1.create_subvolume(client1, **sv_iter)
-                        if "unique" in type:
-                            # Apply enctag
-                            enc_args = {
-                                "enc_tag": enctag,
-                                "group_name": sv_iter.get("group_name", None),
-                                "fs_name": sv_iter["vol_name"],
-                            }
-                            cephfs_common_utils.enc_tag(
-                                client1, "set", sv_iter["subvol_name"], **enc_args
-                            )
+                        if byok_setup == 1:
+                            if "unique" in type:
+                                enc_args = {
+                                    "enc_tag": enctag,
+                                    "group_name": sv_iter.get("group_name", None),
+                                    "fs_name": sv_iter["vol_name"],
+                                    "add_suffix": False,
+                                }
+                                cephfs_common_utils.enc_tag(
+                                    client1, "set", sv_iter["subvol_name"], **enc_args
+                                )
+
                         cephfs_config[i]["group"][j][type].update({sv_name: {}})
                         mnt_client1 = random.choice(clients)
                         mnt_client2 = random.choice(clients)
@@ -210,9 +219,15 @@ def run(ceph_cluster, **kw):
                         sched_list = ["10m", "1h"]
                         for sched_val in sched_list:
                             snap_test_params.update({"sched": sched_val})
-                            snap_util.create_snap_schedule(snap_test_params)
+                            try:
+                                snap_util.create_snap_schedule(snap_test_params)
+                            except Exception as ex:
+                                log.error(f"Error creating snap schedule: {ex}")
                         snap_test_params.update({"retention": "6m4h"})
-                        snap_util.create_snap_retention(snap_test_params)
+                        try:
+                            snap_util.create_snap_retention(snap_test_params)
+                        except Exception as ex:
+                            log.error(f"Error creating snap retention: {ex}")
                         mount_params = {
                             "fs_util": fs_util_v1,
                             "mnt_path": mnt_path,
@@ -230,8 +245,9 @@ def run(ceph_cluster, **kw):
                                     "nfs_server": nfs_server,
                                 }
                             )
-                            if "unique" in type:
-                                mount_params.update({"kmip_key_id": enctag})
+                            if byok_setup == 1:
+                                if "unique" in type:
+                                    mount_params.update({"kmip_key_id": enctag})
                         log.info(f"Perform {mnt_type} mount of {sv_name}")
                         mount_params.update({"client": mnt_client1})
                         mounting_dir1, _ = fs_util_v1.mount_ceph(mnt_type, mount_params)
@@ -256,7 +272,7 @@ def run(ceph_cluster, **kw):
                             )
 
         log.info(f"CephFS System Test config : {cephfs_config}")
-        for client in clients:
+        for client in clients_orig:
             f = client.remote_file(
                 sudo=True,
                 file_name=f"/home/cephuser/{file}",
@@ -266,19 +282,17 @@ def run(ceph_cluster, **kw):
             f.write("\n")
             f.flush()
 
-        # log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-        """
-        log_base_dir = config.get("log-dir")
+        log_base_dir = run_config.get("log_dir")
         log_dir = f"{log_base_dir}/cephfs_systest_data"
         file_path = f"{log_dir}/cephfs_systest_config.json"
         os.mkdir(log_dir)
         cmd = f"touch {file_path}"
         os.system(cmd)
+
         src_path = f"/home/cephuser/{file}"
         dst_path = file_path
         client1.download_file(src=src_path, dst=dst_path, sudo=True)
         log.info(f"Downloaded {src_path} to {dst_path}")
-        """
         return 0
     except Exception as e:
         log.error(e)

--- a/tests/cephfs/cephfs_system/cephfs_systest_sv_clone_ops.py
+++ b/tests/cephfs/cephfs_system/cephfs_systest_sv_clone_ops.py
@@ -36,19 +36,21 @@ def run(ceph_cluster, **kw):
 
     """
     try:
-        global common_util, nested_dir
+        global common_util, nested_dir, clients_orig
         fs_system_utils = CephFSSystemUtils(ceph_cluster)
         fs_util = FsUtilsV1(ceph_cluster)
         common_util = CephFSCommonUtils(ceph_cluster)
         config = kw.get("config")
+        run_config = kw.get("run_config")
         cephfs_config = {}
         run_time = config.get("run_time_hrs", 8)
         nested_dir = config.get("nested_dir", True)
         sv_cnt = config.get("sv_cnt", 100)
         clone_cnt = config.get("clone_cnt", 10)
-        clients = ceph_cluster.get_ceph_objects("client")
+        clients_orig = ceph_cluster.get_ceph_objects("client")
+        clients = clients_orig[1:11]
         file = "cephfs_systest_data.json"
-        client1 = clients[0]
+        client1 = clients_orig[0]
         f = client1.remote_file(
             sudo=True,
             file_name=f"/home/cephuser/{file}",
@@ -69,8 +71,7 @@ def run(ceph_cluster, **kw):
         proc_status_list = []
         write_procs = []
         io_test_fail = 0
-        # log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
-        log_base_dir = config.get("log-dir")
+        log_base_dir = run_config.get("log_dir")
         log_path = f"{log_base_dir}/sv_clone_subtests"
         try:
             os.mkdir(log_path)
@@ -78,7 +79,7 @@ def run(ceph_cluster, **kw):
             log.info(ex)
             if "File exists" not in str(ex):
                 return 1
-
+        clone_cnt = max(10, int(clone_cnt))
         set_verify_clone_config(client1, clone_cnt)
         for io_test in test_list:
             log.info(f"Running {io_test} : {io_tests[io_test]}")
@@ -197,9 +198,13 @@ def sv_test_workflow_1(
             "subvol_name": sv_name,
             "group_name": group_name,
         }
-        fs_util.create_subvolume(client, **subvolume, validate=False)
-        log1.info(f"Created {sv_name} on {group_name}")
-        sv_rm_list.append(sv_name)
+        try:
+            fs_util.create_subvolume(client, **subvolume, validate=False)
+            log1.info(f"Created {sv_name} on {group_name}")
+            sv_rm_list.append(sv_name)
+        except Exception as e:
+            if "already exists" not in str(e):
+                log1.error(f"Error creating {sv_name}: {e}")
         k += 1
 
     end_time = datetime.datetime.now() + datetime.timedelta(hours=run_time)
@@ -217,28 +222,40 @@ def sv_test_workflow_1(
                         "subvol_name": sv_name,
                         "group_name": group_name,
                     }
-                    p.spawn(
-                        fs_util.remove_subvolume, client, **subvolume, validate=True
-                    )
-                    log1.info(f"started {sv_name} remove")
+                    try:
+                        p.spawn(
+                            fs_util.remove_subvolume, client, **subvolume, validate=True
+                        )
+                        log1.info(f"started {sv_name} remove")
+                    except Exception as e:
+                        if "does not exist" not in str(e):
+                            log1.error(f"Error removing {sv_name}: {e}")
                     rand_str = "".join(
                         random.choice(string.ascii_lowercase + string.digits)
                         for _ in list(range(3))
                     )
-                    sv_name = f"systest_sv_{rand_str}"
+                    sv_name_1 = f"systest_sv_{rand_str}"
                     subvolume1 = {
                         "vol_name": fs_name,
-                        "subvol_name": sv_name,
+                        "subvol_name": sv_name_1,
                         "group_name": group_name,
                     }
-                    p.spawn(
-                        fs_util.create_subvolume, client, **subvolume1, validate=False
-                    )
-                    log1.info(f"started {sv_name} create")
-                    sv_rm_list.append(sv_name)
+                    try:
+                        p.spawn(
+                            fs_util.create_subvolume,
+                            client,
+                            **subvolume1,
+                            validate=False,
+                        )
+                        log1.info(f"started {sv_name_1} create")
+                        sv_rm_list.append(sv_name_1)
+                    except Exception as e:
+                        if "already exists" not in str(e):
+                            log1.error(f"Error creating {sv_name_1}: {e}")
+
             i += 100
         time.sleep(30)
-        cluster_healthy = is_cluster_healthy(client)
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
         log1.info(f"cluster_health {cluster_healthy}")
 
     log1.info("sv_test_workflow_1 completed")
@@ -273,12 +290,12 @@ def clone_test_workflow_2(
         fs_util.create_snapshot(client, **snapshot, validate=False)
         log1.info(f"Snapshot {snap_name} created on {sv_name}")
         sv_info[sv_name].update({"snap_name": snap_name})
-    k = 0
+    k = 1
     clone_rm_list = []
-    while k <= int(clone_cnt):
+    while k <= (int(clone_cnt) - 1):
         with parallel() as p:
             for sv_info in sv_info_list:
-                if k <= int(clone_cnt):
+                if k <= (int(clone_cnt) - 1):
                     for i in sv_info:
                         sv_name = i
                     snap_name = sv_info[sv_name]["snap_name"]
@@ -307,6 +324,37 @@ def clone_test_workflow_2(
                     log1.info(f"Started {clone_name} on {sv_name}")
                     k += 1
                     clone_rm_list.append(clone_obj)
+
+    def wait_for_clone(client, fs_util, fs_name, clone_name, group_name=None):
+        max_wait_time = 1800
+        start_time = time.time()
+        while time.time() - start_time < max_wait_time:
+            out, _ = fs_util.get_clone_status(
+                client, fs_name, clone_name, group_name=group_name
+            )
+            status_json = json.loads(out)
+            state = status_json.get("status", {}).get("state", "")
+            if state == "complete":
+                return 0
+            elif state == "failed":
+                return 1
+            time.sleep(1)
+        if state == "in-progress":
+            log1.info(f"Clone {clone_name} is in progress, waiting for it to complete")
+            return 1
+        return 0
+
+    with parallel() as p:
+        for clone_obj in clone_rm_list:
+            p.spawn(
+                wait_for_clone,
+                client,
+                fs_util,
+                fs_name,
+                clone_obj["clone_name"],
+                group_name=clone_obj.get("group_name", None),
+            )
+            log1.info(f"Waiting for {clone_obj['clone_name']} to complete")
     if nested_dir:
         mount_params = {
             "client": client,
@@ -326,7 +374,11 @@ def clone_test_workflow_2(
             sv_path = common_util.subvolume_get_path(client, fs_name, **sv_args)
             mount_params.update({"mnt_path": sv_path})
             mnt_path, _ = fs_util.mount_ceph("fuse", mount_params)
-            fs_system_utils.add_nested_dirs(client, mnt_path)
+            try:
+                fs_system_utils.add_nested_dirs(client, mnt_path)
+            except Exception as e:
+                log.error(f"Error adding nested dirs: {e}")
+                continue
             client.exec_command(sudo=True, cmd=f"umount -l {mnt_path}", check_ec=False)
 
     end_time = datetime.datetime.now() + datetime.timedelta(hours=run_time)
@@ -334,7 +386,7 @@ def clone_test_workflow_2(
     while datetime.datetime.now() < end_time and cluster_healthy:
         rm_cmd_list = []
         clone_cmd_list = []
-        for i in range(0, clone_cnt):
+        for i in range(0, int(clone_cnt) - 1):
             clone_obj = clone_rm_list.pop(0)
             sv_name = clone_obj["sv_name"]
             clone_rm = {
@@ -372,9 +424,20 @@ def clone_test_workflow_2(
                 p.spawn(fs_util.create_clone, client, **clone_create, validate=False)
                 log1.info(f"Creating {clone_create['subvol_name']}")
         time.sleep(30)
+        with parallel() as p:
+            for clone_obj in clone_rm_list:
+                p.spawn(
+                    wait_for_clone,
+                    client,
+                    fs_util,
+                    fs_name,
+                    clone_obj["clone_name"],
+                    group_name=clone_obj.get("group_name", None),
+                )
+                log1.info(f"Waiting for {clone_obj['clone_name']} to complete")
         log1.info(f"clone_test_workflow_1 iteration {iter_cnt} complete")
         iter_cnt += 1
-        cluster_healthy = is_cluster_healthy(client)
+        cluster_healthy = is_cluster_healthy(clients_orig[0])
 
     log1.info("clone_test_workflow_2 completed")
     return 0

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -201,7 +201,7 @@ def run(ceph_cluster, **kw):
             log.info(f"Mount subvolume {subvolume_name}_3 on NFS Client")
             nfs_servers = ceph_cluster.get_ceph_objects("nfs")
             nfs_server = nfs_servers[0].node.hostname
-            nfs_name = "cephfs-nfs"
+            nfs_name = config.get("nfs_name", "cephfs_systest_nfs")
 
             fs_util.create_nfs(
                 client1,

--- a/tests/misc_env/homogenous_osd_cluster.py
+++ b/tests/misc_env/homogenous_osd_cluster.py
@@ -29,14 +29,8 @@ def generate_osd_list(ceph_cluster: Ceph):
         None
     """
     installer = ceph_cluster.get_ceph_object("installer")
-    ceph_osds = ceph_cluster.get_ceph_objects("osd")
-    osd_nodes = set()
-    for osd in ceph_osds:
-        osd_nodes.add(osd.node.vmshortname)
-    osd_node_list = list(osd_nodes)
-    log.info(osd_node_list)
-    out, rc = installer.exec_command(
-        cmd=f"sudo cephadm shell -- ceph orch device ls --hostname= {' '.join(osd_node_list)} --format json"
+    out, _ = installer.exec_command(
+        cmd="sudo cephadm shell -- ceph orch device ls --format json"
     )
     grouped_data, desired_size, min_disk_count = get_osd_size_count(json.loads(out))
     with parallel() as p:


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

Jira: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-24279

Fixes done:
Latest: 
subvol metrics disruptive test: metrics not reported after mds restart was the issue. Added code to wait for mds to become active, thats when IO resumes and metrics can be reported.
Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-B2ZPRT
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-77JA4J

Previous:
Setup : Enable for byok by default, and make it run when its non-byok
SV_clone_ops : Fix Clone ops failure with wait_for_clone, and reduce clone count by 1. Check for Clone complete before fuse mount
mds_ops: Exit when HEALTH_ERR after failover, not for HEALTH_WARN
monitor : Update status on all clients inclluding clients[0]
cephfs_vol_mgmt_fs_create_delete_loop : Run it for NFS server used in system test by default
homogenous_osd_cluster : Remove hostname param from orch device ls cmd
log_base_dir : Change log_dir fetch approach across all system test scripts
cephfs_systest_data.json : remove syntax issue
cephfs_systest_client_io.py : use clients[0] for executor, but use it for config update
cephfs_config_update.py : change runtime

Logs: http://10.64.24.74/logs/archive/ceph-qe-user-logs/sumar/cephfs_sys_tfa_9.1z1/

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
