### PR TITLE
Add NFS state lifecycle test module with dual-layer fault injection

### DIFF
--- a/suites/tentacle/nfs/tier-2_nfs_state_lifecycle.yaml
+++ b/suites/tentacle/nfs/tier-2_nfs_state_lifecycle.yaml
@@ -1,0 +1,759 @@
+#===============================================================================================
+#---    Test Suite: NFS State Lifecycle Validation Under Fault Injection   ---
+#===============================================================================================
+# Conf: conf/tentacle/nfs/1admin-7node-3client.yaml
+#
+# Purpose:
+#   Validates NFS-Ganesha client state lifecycle — identity management, lease
+#   handling, state table integrity, churn resilience, export reorganization,
+#   admin interleaving, observability, and reconnect storms — across three
+#   injection layers to isolate where state corruption originates.
+#
+# Layout (3 sections after bootstrap):
+#
+#   Section 1 — Layer 1 (injection_layer: nfs_protocol)
+#     Pure NFS protocol-level scenarios with no backend fault injection.
+#     Validates that NFS-Ganesha's own state machine handles lifecycle
+#     transitions correctly in a healthy backend environment.
+#
+#   Section 2 — Layer 2 (injection_layer: mds_backend)
+#     Same 10 scenarios but with Ceph debug fault injection configs targeting
+#     MDS sessions, client caps, socket failures, and network chaos.
+#     Validates NFS-Ganesha state coherence when the CephFS backend is degraded.
+#
+#   Section 3 — Combined (injection_layer: combined)
+#     Same 10 scenarios with both NFS-layer and MDS-backend faults active
+#     simultaneously. Validates end-to-end state resilience under cascading
+#     failures across all layers.
+#
+#===============================================================================================
+tests:
+
+  #---------------------------------------------------------------------------------------------
+  # Bootstrap: Cluster deployment, CephFS, MDS, and client setup
+  # Note: NFS clusters are created per-scenario by the test code (not here).
+  #---------------------------------------------------------------------------------------------
+
+  - test:
+      name: Install ceph pre-requisites
+      desc: Install software pre-requisites for cluster deployment
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Deploy cluster using cephadm
+      desc: Bootstrap Ceph cluster with MON, MGR, OSD, CephFS, and MDS services
+      module: test_cephadm.py
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              command: apply
+              service: mds
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+
+  - test:
+      name: Configure client 1
+      desc: Configure NFS client on node5
+      module: test_client.py
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node5
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+
+  - test:
+      name: Configure client 2
+      desc: Configure NFS client on node6
+      module: test_client.py
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2
+        node: node6
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+
+  - test:
+      name: Configure client 3
+      desc: Configure NFS client on node7
+      module: test_client.py
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3
+        node: node7
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+
+  #=============================================================================================
+  #  SECTION 1 — Layer 1: NFS Protocol-Level State Lifecycle (injection_layer: nfs_protocol)
+  #=============================================================================================
+  #
+  #  What this section tests:
+  #    Each scenario exercises a distinct aspect of NFS-Ganesha's client state
+  #    lifecycle — identity, leases, cardinality, churn, export mutations, admin
+  #    operations, observability, and reconnect storms — using ONLY NFS protocol
+  #    layer operations. No backend fault injection is applied.
+  #
+  #  How chaos is induced:
+  #    Purely through NFS client behavior: rapid mount/unmount, concurrent I/O,
+  #    export CRUD during active sessions, randomized operation sequences, and
+  #    burst reconnection patterns. The CephFS/MDS backend remains healthy.
+  #
+  #  What a failure means:
+  #    A failure here indicates a bug in NFS-Ganesha's own state machine —
+  #    incorrect identity handling, lease logic errors, state table corruption,
+  #    or resource leaks — independent of any backend issues.
+  #
+  #  Validation approach:
+  #    NFS client state verification, mount availability checks, export
+  #    accessibility probes, daemon counter assertions, and data integrity
+  #    checksums after each lifecycle transition.
+  #
+  #=============================================================================================
+
+  # Scenario 1: Validate that client identities are created on mount, refreshed
+  # on reconnect, and cleanly torn down on unmount with no residual state.
+  - test:
+      name: "L1 - Client Identity Lifecycle"
+      desc: "Validate client identity creation, credential refresh, and clean teardown through NFS mount lifecycle"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: client_identity_lifecycle
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        num_clients: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 2: Verify lease expiry and renewal correctness when multiple
+  # clients sustain parallel I/O that keeps leases alive under pressure.
+  - test:
+      name: "L1 - Lease Expiry Under Load"
+      desc: "Verify lease expiry and renewal under sustained parallel I/O from multiple clients"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: lease_expiry_under_load
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 3: Push state table cardinality to limits with a high number of
+  # concurrent clients and exports to detect overflow or degradation.
+  - test:
+      name: "L1 - State Cardinality Stress"
+      desc: "Stress NFS state tables with high client and export counts to detect cardinality limits"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: state_cardinality_stress
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 10
+        duration: 300
+        num_clients: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 4: Rapid mount/unmount churn cycles to validate that state cleanup
+  # is complete and resources are reclaimed without leaks.
+  - test:
+      name: "L1 - Client State Churn"
+      desc: "Rapid client mount/unmount cycles to validate state cleanup and resource reclamation"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: client_state_churn
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        churn_rate: 5
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 5: Add, remove, and modify exports while clients hold active state
+  # and I/O, verifying no state corruption or orphaned entries.
+  - test:
+      name: "L1 - Export Reorg State Integrity"
+      desc: "Add, remove, and modify exports while clients hold active state and I/O"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: export_reorg_state_integrity
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 6: Randomized client operation sequences using a seeded generator
+  # to discover unexpected state transitions or crashes.
+  - test:
+      name: "L1 - Generative Client Behavior"
+      desc: "Randomized client operation sequences to discover unexpected state transitions"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: generative_client_behavior
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 7: Interleave admin operations (export create/delete, cluster
+  # reconfiguration) with active client I/O to detect race conditions.
+  - test:
+      name: "L1 - Admin Op Interleave"
+      desc: "Interleave admin operations with active client I/O to detect state races"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: admin_op_interleave
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 8: Verify that NFS daemon metrics, counters, and health check
+  # outputs accurately reflect the current client and export state.
+  # Note: S8 keeps the full 5x60s memory check (default) since it is the
+  # primary leak-detection scenario.
+  - test:
+      name: "L1 - Observability Validation"
+      desc: "Verify NFS metrics, daemon counters, and health checks reflect actual state"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: observability_validation
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+
+  # Scenario 9: Burst reconnection patterns simulating network flap where many
+  # clients disconnect and reconnect simultaneously.
+  - test:
+      name: "L1 - Rapid Reconnect Storms"
+      desc: "Burst reconnection patterns simulating network flap and client migration"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: rapid_reconnect_storms
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  # Scenario 10: Maximum state pressure by combining client churn with export
+  # reorganization and concurrent I/O on all remaining mounts.
+  - test:
+      name: "L1 - Combined Churn Failure"
+      desc: "Combined client churn with export reorganization for maximum state pressure"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: combined_churn_failure
+        injection_layer: nfs_protocol
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        churn_rate: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+
+  #=============================================================================================
+  #  SECTION 2 — Layer 2: MDS Backend Fault Injection (injection_layer: mds_backend)
+  #=============================================================================================
+  #
+  #  What this section tests:
+  #    The same 10 state lifecycle scenarios from Section 1, but now with Ceph
+  #    debug fault injection configs targeting MDS sessions, client caps, socket
+  #    transport, and network paths. This isolates whether NFS-Ganesha can
+  #    maintain state coherence when its CephFS backend is degraded.
+  #
+  #  How chaos is induced:
+  #    Via Ceph config injection parameters: client_inject_fixed_oldest_tid,
+  #    client_inject_release_failure, ms_inject_socket_failures,
+  #    ms_inject_delay_probability, client_debug_inject_tick_delay, and
+  #    objecter_inject_no_watch_ping. Additionally, named profiles
+  #    (client_session_stress, network_chaos, mds_chaos, network_latency,
+  #    multi_layer_chaos) apply coordinated fault sets.
+  #
+  #  What a failure means:
+  #    A failure here indicates NFS-Ganesha cannot maintain client state
+  #    integrity when MDS sessions stall, caps are not released, sockets fail,
+  #    or messages are delayed. The NFS protocol layer itself is correct (proven
+  #    by Section 1), so the root cause is backend fault propagation.
+  #
+  #  Validation approach:
+  #    Data integrity checksums, state recovery verification after fault
+  #    clearance, lease coherence checks, MDS session state cross-referencing
+  #    with NFS client state, and client I/O resumption timing.
+  #
+  #=============================================================================================
+
+  # Scenario 1: Client identity lifecycle under MDS fault injection — oldest TID
+  # is pinned and sockets are intermittently dropped to disrupt cap renewal.
+  - test:
+      name: "L2 - Client Identity Lifecycle"
+      desc: "Client identity lifecycle under MDS backend fault injection with fixed oldest TID and socket failures"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: client_identity_lifecycle
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        num_clients: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          configs:
+            client_inject_fixed_oldest_tid: true
+            ms_inject_socket_failures: 500
+
+  # Scenario 2: Lease expiry under MDS session stress with a reduced lease
+  # lifetime to accelerate expiry/renewal cycles and expose timing bugs.
+  - test:
+      name: "L2 - Lease Expiry Under Load"
+      desc: "Lease expiry under MDS session stress with reduced lease lifetime"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: lease_expiry_under_load
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: client_session_stress
+          lease_lifetime: 15
+
+  # Scenario 3: State cardinality stress with injected client cap release
+  # failures forcing the MDS to accumulate stale capabilities.
+  - test:
+      name: "L2 - State Cardinality Stress"
+      desc: "State cardinality stress with injected client release failures in MDS backend"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: state_cardinality_stress
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 10
+        duration: 300
+        num_clients: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          configs:
+            client_inject_release_failure: true
+
+  # Scenario 4: Client state churn under network chaos affecting MDS
+  # communication paths to simulate unstable datacenter interconnects.
+  - test:
+      name: "L2 - Client State Churn"
+      desc: "Client state churn under network chaos affecting MDS communication"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: client_state_churn
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        churn_rate: 5
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: network_chaos
+
+  # Scenario 5: Export reorganization under MDS daemon chaos — MDS restarts and
+  # failovers during active export mutations to test state recovery.
+  - test:
+      name: "L2 - Export Reorg State Integrity"
+      desc: "Export reorganization integrity with MDS daemon chaos injection"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: export_reorg_state_integrity
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: mds_chaos
+
+  # Scenario 6: Generative client behavior under network latency injection with
+  # tick delay to slow MDS heartbeat processing and expose race windows.
+  - test:
+      name: "L2 - Generative Client Behavior"
+      desc: "Generative client behavior under network latency and tick delay injection"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: generative_client_behavior
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: network_latency
+          configs:
+            client_debug_inject_tick_delay: 5
+
+  # Scenario 7: Admin operations interleaved with MDS chaos and random message
+  # delays to trigger admin/state-machine race conditions.
+  - test:
+      name: "L2 - Admin Op Interleave"
+      desc: "Admin operations interleaved with MDS chaos and message delay injection"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: admin_op_interleave
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: mds_chaos
+          configs:
+            ms_inject_delay_probability: 0.03
+
+  # Scenario 8: Observability validation under client session stress to verify
+  # that metrics remain accurate when backend sessions are disrupted.
+  # Note: S8 keeps the full 5x60s memory check (default) since it is the
+  # primary leak-detection scenario.
+  - test:
+      name: "L2 - Observability Validation"
+      desc: "Observability validation under client session stress in MDS backend"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: observability_validation
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        error_injection:
+          profile: client_session_stress
+
+  # Scenario 9: Rapid reconnect storms with socket failures and suppressed watch
+  # pings to simulate clients losing backend connectivity mid-reconnect.
+  - test:
+      name: "L2 - Rapid Reconnect Storms"
+      desc: "Rapid reconnect storms with socket failures and watch ping suppression"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: rapid_reconnect_storms
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          configs:
+            ms_inject_socket_failures: 200
+            objecter_inject_no_watch_ping: true
+
+  # Scenario 10: Combined churn and failure under multi-layer chaos that
+  # activates all injection profiles simultaneously for worst-case validation.
+  - test:
+      name: "L2 - Combined Churn Failure"
+      desc: "Combined churn and failure under multi-layer chaos affecting all backends"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: combined_churn_failure
+        injection_layer: mds_backend
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        churn_rate: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: multi_layer_chaos
+
+  #=============================================================================================
+  #  SECTION 3 — Combined: NFS Protocol + MDS Backend (injection_layer: combined)
+  #=============================================================================================
+  #
+  #  What this section tests:
+  #    The same 10 state lifecycle scenarios with BOTH NFS protocol-level chaos
+  #    and MDS backend fault injection active simultaneously. This is the most
+  #    aggressive layer — it validates that NFS-Ganesha can maintain end-to-end
+  #    state integrity when faults cascade across all layers concurrently.
+  #
+  #  How chaos is induced:
+  #    The test harness applies NFS client-side chaos (rapid mounts, churn,
+  #    export mutations) at the same time as backend injection configs
+  #    (socket failures, cap release failures, MDS chaos, network latency).
+  #    This creates realistic multi-layer fault scenarios.
+  #
+  #  What a failure means:
+  #    A failure here indicates cascading state corruption — faults at one layer
+  #    amplify into unrecoverable states at another. Section 1 and 2 passing
+  #    while Section 3 fails pinpoints cross-layer interaction bugs that only
+  #    manifest under combined stress.
+  #
+  #  Validation approach:
+  #    End-to-end data integrity (checksum verification), state convergence
+  #    after fault clearance, client transparency timing (I/O resumption
+  #    targets), cross-layer state consistency (NFS client count matches MDS
+  #    session count), and zero resource leaks post-recovery.
+  #
+  #=============================================================================================
+
+  # Scenario 1: Client identity lifecycle under combined NFS and MDS faults —
+  # protocol-level churn plus oldest TID pinning and socket disruption.
+  - test:
+      name: "Combined - Client Identity Lifecycle"
+      desc: "Client identity lifecycle under combined NFS protocol and MDS backend fault injection"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: client_identity_lifecycle
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        num_clients: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          configs:
+            client_inject_fixed_oldest_tid: true
+            ms_inject_socket_failures: 500
+
+  # Scenario 2: Lease expiry under combined NFS load and MDS session stress with
+  # reduced lease lifetime to maximize expiry/renewal contention.
+  - test:
+      name: "Combined - Lease Expiry Under Load"
+      desc: "Lease expiry under combined NFS protocol load and MDS session stress"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: lease_expiry_under_load
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: client_session_stress
+          lease_lifetime: 15
+
+  # Scenario 3: State cardinality stress under combined faults with cap release
+  # failures amplifying the high-cardinality state table pressure.
+  - test:
+      name: "Combined - State Cardinality Stress"
+      desc: "State cardinality stress under combined faults with client release failures"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: state_cardinality_stress
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 10
+        duration: 300
+        num_clients: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          configs:
+            client_inject_release_failure: true
+
+  # Scenario 4: Client state churn under combined NFS reconnect pressure and
+  # MDS network chaos to simulate real-world unstable environments.
+  - test:
+      name: "Combined - Client State Churn"
+      desc: "Client state churn under combined NFS reconnect pressure and network chaos"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: client_state_churn
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        churn_rate: 5
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: network_chaos
+
+  # Scenario 5: Export reorganization under combined NFS export mutations and
+  # MDS daemon chaos to stress state recovery across both layers.
+  - test:
+      name: "Combined - Export Reorg State Integrity"
+      desc: "Export reorganization under combined NFS mutations and MDS daemon chaos"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: export_reorg_state_integrity
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: mds_chaos
+
+  # Scenario 6: Generative client behavior under combined NFS randomization and
+  # MDS network latency with tick delay to widen race windows.
+  - test:
+      name: "Combined - Generative Client Behavior"
+      desc: "Generative client behavior under combined NFS randomization and network latency"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: generative_client_behavior
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: network_latency
+          configs:
+            client_debug_inject_tick_delay: 5
+
+  # Scenario 7: Admin operations under combined NFS interleaving and MDS chaos
+  # with message delays to maximize admin/state-machine race exposure.
+  - test:
+      name: "Combined - Admin Op Interleave"
+      desc: "Admin operations under combined NFS interleaving and MDS chaos with message delays"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: admin_op_interleave
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: mds_chaos
+          configs:
+            ms_inject_delay_probability: 0.03
+
+  # Scenario 8: Observability validation under combined NFS state transitions
+  # and MDS session stress to verify metrics under worst-case conditions.
+  # Note: S8 keeps the full 5x60s memory check (default) since it is the
+  # primary leak-detection scenario.
+  - test:
+      name: "Combined - Observability Validation"
+      desc: "Observability validation under combined NFS state transitions and session stress"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: observability_validation
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        error_injection:
+          profile: client_session_stress
+
+  # Scenario 9: Rapid reconnect storms under combined NFS burst reconnections
+  # and MDS socket failures with suppressed watch pings.
+  - test:
+      name: "Combined - Rapid Reconnect Storms"
+      desc: "Rapid reconnect storms under combined NFS burst reconnections and MDS socket failures"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: rapid_reconnect_storms
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          configs:
+            ms_inject_socket_failures: 200
+            objecter_inject_no_watch_ping: true
+
+  # Scenario 10: Combined churn and failure under multi-layer chaos across both
+  # NFS and MDS layers for ultimate state resilience validation.
+  - test:
+      name: "Combined - Combined Churn Failure"
+      desc: "Combined churn and failure under multi-layer chaos across all layers"
+      module: nfs_state_lifecycle.test_nfs_state_lifecycle.py
+      abort-on-fail: false
+      config:
+        test_scenario: combined_churn_failure
+        injection_layer: combined
+        fs_name: cephfs
+        num_exports: 3
+        duration: 300
+        churn_rate: 3
+        mem_check_samples: 3
+        mem_check_interval: 30
+        error_injection:
+          profile: multi_layer_chaos

--- a/tests/nfs/nfs_state_lifecycle/nfs_state_lifecycle_workflows.py
+++ b/tests/nfs/nfs_state_lifecycle/nfs_state_lifecycle_workflows.py
@@ -1,0 +1,1596 @@
+"""
+NFS State Lifecycle Workflow Helpers
+====================================
+
+Provides the NfsStateLifecycleWorkflows class with building blocks for
+dual-layer chaos testing of NFS-Ganesha state management.
+
+Components:
+    - Phase Infrastructure: health checks, crash/coredump detection,
+      background health monitoring, crash archive
+    - Ganesha Config Management: Lease_Lifetime override via config-key
+      template modification + orch redeploy (follows set_cluster_delegation
+      pattern from nfs_delegation_operations.py)
+    - Client Identity: gRPC GetClientIds/GetSessionIds queries via
+      grpcurl (reuses test_nfs_grpc.py patterns)
+    - State Tracking: Ganesha container log parsing for _state_add_impl,
+      dec_nfs4_state_ref, cid_refcount patterns at STATE=FULL_DEBUG
+    - Churn Generation: Wraps thrash_nfs_client_churn with state sampling
+    - Network Manipulation: iptables INPUT+OUTPUT block, tc netem delay
+    - Error Injection: CephErrorInjector wrapper for L2 scenarios
+    - Behavioral Roles: Probabilistic op generator per client role
+
+All helpers are designed to work with 1..N clients via round-robin
+assignment.  Scenarios degrade gracefully when fewer clients are available.
+"""
+
+import json
+import random
+import time
+from datetime import datetime
+from threading import Thread
+
+from ceph.rados.ceph_error_injector import CephErrorInjector
+from ceph.rados.utils import get_cluster_timestamp
+from utility.log import Log
+
+log = Log(__name__)
+
+GRPC_PORT = 50051
+_PHASE_SEP = "-" * 70
+
+_L2_DEFAULTS = {
+    "client_identity_lifecycle": {
+        "configs": {
+            "client_inject_fixed_oldest_tid": True,
+            "ms_inject_socket_failures": 500,
+        }
+    },
+    "lease_expiry_under_load": {"profile": "client_session_stress"},
+    "state_cardinality_stress": {"configs": {"client_inject_release_failure": True}},
+    "client_state_churn": {"profile": "network_chaos"},
+    "export_reorg_state_integrity": {"profile": "mds_chaos"},
+    "generative_client_behavior": {
+        "profile": "network_latency",
+        "configs": {"client_debug_inject_tick_delay": 5},
+    },
+    "admin_op_interleave": {
+        "profile": "mds_chaos",
+        "configs": {"ms_inject_delay_probability": 0.03},
+    },
+    "observability_validation": {"profile": "client_session_stress"},
+    "rapid_reconnect_storms": {
+        "configs": {
+            "ms_inject_socket_failures": 200,
+            "objecter_inject_no_watch_ping": True,
+        }
+    },
+    "combined_churn_failure": {"profile": "multi_layer_chaos"},
+}
+
+# Behavioral profiles for Scenario 6 (generative_client_behavior).
+# Each profile controls the mix of NFS operations a client performs
+# and what failure mode it simulates.
+#
+# Operation weights (read, write, lock, metadata) are probabilities
+# passed to random.choices() inside run_churn_on_mount().
+ROLE_PROFILES = {
+    "reader_heavy": {
+        "read": 0.80,
+        "write": 0.05,
+        "lock": 0.05,
+        "metadata": 0.10,
+    },
+    "lock_heavy": {
+        "read": 0.10,
+        "write": 0.20,
+        "lock": 0.60,
+        "metadata": 0.10,
+    },
+    "metadata_heavy": {
+        "read": 0.05,
+        "write": 0.05,
+        "lock": 0.05,
+        "metadata": 0.85,
+    },
+    "flaky": {
+        "read": 0.20,
+        "write": 0.20,
+        "lock": 0.10,
+        "metadata": 0.10,
+        "iptables_block_interval": (15, 30),
+        "iptables_block_duration": (3, 10),
+    },
+    "slow_renew": {
+        "read": 0.30,
+        "write": 0.30,
+        "lock": 0.20,
+        "metadata": 0.20,
+        "tc_delay_ms": 5000,
+        "tc_jitter_ms": 3000,
+    },
+}
+
+
+def _log_phase(number, title):
+    """Log a phase separator banner with phase number and title."""
+    log.info(f"\n{_PHASE_SEP}")
+    log.info(f"  PHASE {number}: {title}")
+    log.info(_PHASE_SEP)
+
+
+def _sleep_with_stop(stop_event, total_seconds, step=2):
+    """Sleep for ``total_seconds`` in increments of ``step``.
+
+    Checks ``stop_event`` between each increment and returns early
+    if the event is set.  Used by background threads for cooperative
+    shutdown.
+
+    Args:
+        stop_event: threading.Event checked between sleep increments.
+        total_seconds: Total time to sleep (seconds).
+        step: Sleep increment size (seconds, default 2).
+    """
+    elapsed = 0
+    while elapsed < total_seconds:
+        if stop_event.is_set():
+            return
+        time.sleep(min(step, total_seconds - elapsed))
+        elapsed += step
+
+
+def _round_robin(items, index):
+    """Select an item from ``items`` using round-robin by ``index``.
+
+    Returns None if ``items`` is empty.  With 1 item and any index,
+    always returns that item (all assignments go to the single client).
+
+    Args:
+        items: List to select from.
+        index: Integer index (wraps via modulo).
+    """
+    if not items:
+        return None
+    return items[index % len(items)]
+
+
+class NfsStateLifecycleWorkflows:
+    """Workflow orchestrator for NFS state lifecycle scenarios.
+
+    Instantiated once per scenario with cluster objects.  Provides
+    phase-level building blocks that each scenario composes.
+
+    All methods that accept ``clients`` work with any number of clients
+    (1..N) via round-robin assignment.
+    """
+
+    def __init__(self, installer, nfs_nodes, clients, rados_obj, ceph_cluster):
+        """Initialize workflows with cluster objects.
+
+        Args:
+            installer: CephNode with admin/installer role (runs ceph CLI).
+            nfs_nodes: List of CephNodes with the nfs role (Ganesha hosts).
+            clients: List of CephNodes with the client role (NFS clients).
+            rados_obj: RadosOrchestrator instance for cluster operations.
+            ceph_cluster: CephCluster object for node discovery.
+        """
+        self.installer = installer
+        self.nfs_nodes = nfs_nodes
+        self.clients = clients
+        self.rados_obj = rados_obj
+        self.ceph_cluster = ceph_cluster
+        self._start_time = None
+        self._template_backup_exists = False
+        self._template_backed_up = False
+        self._debug_logging_enabled = False
+        self._grpc_enabled = False
+
+    # ------------------------------------------------------------------
+    #  Phase Infrastructure
+    # ------------------------------------------------------------------
+
+    def archive_crash_state(self):
+        """Archive existing crashes and record start timestamp.
+
+        Runs ``ceph crash archive-all`` to clear prior crash records,
+        then captures the cluster timestamp for scoping future crash
+        checks to this test run only.
+
+        Returns:
+            str: Cluster timestamp string for use with check_crash_status.
+        """
+        try:
+            self.rados_obj.run_ceph_command(
+                cmd="ceph crash archive-all", client_exec=True
+            )
+        except Exception as e:
+            log.warning("Failed to archive crashes: %s", e)
+        self._start_time = get_cluster_timestamp(self.rados_obj.node)
+        log.info("Crash state archived, start_time=%s", self._start_time)
+        return self._start_time
+
+    def log_cluster_health(self):
+        """Log ceph health detail + ceph -s."""
+        try:
+            self.rados_obj.log_cluster_health()
+        except Exception as e:
+            log.warning("Failed to log cluster health: %s", e)
+
+    def check_crashes(self, phase_name):
+        """Check for crashes since test start via core_workflows.
+
+        Uses RadosOrchestrator.check_crash_status() which performs:
+        1. ``ceph crash ls`` -- queries the MON crash database (reliable,
+           survives daemon restarts and container redeploys).
+        2. Daemon log scanning for crash patterns across mon, mgr, osd,
+           mds, and nfs daemons (when check_nfs=True).
+
+        Args:
+            phase_name: Label for log messages (e.g. "VALIDATION", "CLEANUP").
+
+        Returns:
+            bool: True if any crash was found.
+        """
+        end_time = get_cluster_timestamp(self.rados_obj.node)
+        try:
+            if self.rados_obj.check_crash_status(
+                start_time=self._start_time,
+                end_time=end_time,
+                check_nfs=True,
+            ):
+                log.error("[%s] Crash detected", phase_name)
+                return True
+        except Exception as e:
+            log.warning("[%s] Crash check failed: %s", phase_name, e)
+        return False
+
+    def start_health_monitor(self, stop_event, interval=30):
+        """Start a daemon thread that logs cluster health periodically.
+
+        Logs ``ceph health detail``, ``ceph -s``, and Ganesha RSS memory
+        every ``interval`` seconds until ``stop_event`` is set.
+
+        Args:
+            stop_event: threading.Event to signal shutdown.
+            interval: Seconds between health snapshots (default 30).
+
+        Returns:
+            Thread: The started daemon thread (auto-cleaned on process exit).
+        """
+
+        def _monitor():
+            count = 0
+            while not stop_event.is_set():
+                count += 1
+                log.info(
+                    "\n%s\nHEALTH MONITOR #%d | %s\n%s",
+                    "=" * 60,
+                    count,
+                    datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    "=" * 60,
+                )
+                self.log_cluster_health()
+                try:
+                    rss = self.get_ganesha_memory_rss()
+                    log.info("[health_monitor] Ganesha RSS: %s KB", rss)
+                except Exception:
+                    pass
+                _sleep_with_stop(stop_event, interval, step=5)
+
+        t = Thread(target=_monitor, daemon=True)
+        t.start()
+        return t
+
+    # ------------------------------------------------------------------
+    #  Ganesha Config Management (template + redeploy)
+    # ------------------------------------------------------------------
+
+    def _apply_lease_to_template(self, seconds):
+        """Modify Lease_Lifetime in the config-key template (no redeploy).
+
+        Called by apply_all_configs to fold the lease change into the
+        same redeploy cycle as gRPC and debug logging.  The template
+        must already be in config-key (written by enable_ganesha_debug_logging
+        or a prior apply_all_configs call).
+        """
+        from nfs_delegation_operations import run_cephadm_shell
+
+        work_file = "/tmp/_nfs_lease_template.conf"
+        conf_key = "mgr/cephadm/services/nfs/ganesha.conf"
+        fallback_path = (
+            "/usr/share/ceph/mgr/cephadm/templates/services/nfs/ganesha.conf.j2"
+        )
+
+        run_cephadm_shell(
+            self.installer,
+            f"ceph config-key get {conf_key} > {work_file}",
+            check_ec=False,
+        )
+        size_out, _ = self.installer.exec_command(
+            sudo=True, cmd=f"wc -c < {work_file}", check_ec=False
+        )
+        if int(size_out.strip() or "0") < 10:
+            run_cephadm_shell(
+                self.installer,
+                f"cat {fallback_path} > {work_file}",
+            )
+
+        lease_line = f"Lease_Lifetime = {seconds};"
+        self.installer.exec_command(
+            sudo=True,
+            cmd=(
+                f"grep -q 'Lease_Lifetime' {work_file} && "
+                f"sed -i 's/Lease_Lifetime.*=.*[0-9].*;/{lease_line}/' {work_file} || "
+                f"sed -i '/NFSv4 {{/a\\    {lease_line}' {work_file}"
+            ),
+        )
+
+        mounted_path = "/var/lib/ceph/ganesha.conf"
+        self.installer.exec_command(
+            sudo=True,
+            cmd=(
+                f"cephadm shell --mount {work_file}:{mounted_path} "
+                f"-- ceph config-key set {conf_key} -i {mounted_path}"
+            ),
+            timeout=60,
+        )
+        log.info("Lease_Lifetime set to %ds in template (pending redeploy)", seconds)
+
+    def restore_all_config(self, nfs_name):
+        """Restore original Ganesha template (undoes both lease and debug changes).
+
+        Writes the backed-up template to config-key but does NOT
+        redeploy.  The NFS cluster is deleted immediately after this
+        call in cleanup, so a redeploy would be wasted (~60s).  The
+        restored template is picked up by the next scenario's
+        create_nfs_cluster + apply_all_configs cycle.
+
+        Uses the correct backup path depending on which method took the
+        initial backup: enable_ganesha_debug_logging saves to
+        LOG_TEMPLATE_BACKUP_PATH, backup_ganesha_template saves to
+        BACKUP_TEMPLATE_PATH.
+        """
+        if not self._template_backed_up:
+            return
+        from nfs_delegation_operations import (
+            BACKUP_TEMPLATE_PATH,
+            LOG_TEMPLATE_BACKUP_PATH,
+            restore_ganesha_template,
+        )
+
+        backup_path = (
+            LOG_TEMPLATE_BACKUP_PATH
+            if self._debug_logging_enabled
+            else BACKUP_TEMPLATE_PATH
+        )
+        try:
+            restore_ganesha_template(
+                self.installer,
+                self._template_backup_exists,
+                backup_path=backup_path,
+            )
+            self._template_backed_up = False
+            self._debug_logging_enabled = False
+            log.info("Ganesha template restored in config-key (no redeploy)")
+        except Exception as e:
+            log.error("Failed to restore Ganesha template: %s", e)
+
+    def _redeploy_nfs(self, nfs_name, timeout=300):
+        """Redeploy NFS cluster via ``ceph orch redeploy`` and wait.
+
+        Recreates all NFS daemon containers for the cluster, picking up
+        any template changes made via config-key set.  Waits for all
+        daemons to reach ``running`` state.
+
+        Args:
+            nfs_name: NFS cluster name (e.g. ``lc-a3f2b1c4``).
+            timeout: Max seconds to wait for daemons (default 300).
+        """
+        self.installer.exec_command(
+            sudo=True,
+            cmd=f"ceph orch redeploy nfs.{nfs_name}",
+            timeout=60,
+        )
+        time.sleep(10)
+        from nfs_operations import verify_nfs_ganesha_service
+
+        verify_nfs_ganesha_service(node=self.installer, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    #  gRPC Server Enablement
+    # ------------------------------------------------------------------
+
+    def apply_all_configs(self, nfs_name, lease_lifetime=None):
+        """Apply gRPC + debug logging + optional lease configs with a single redeploy.
+
+        1. Writes ``GRPC {}`` block to the .nfs RADOS pool
+        2. Opens the gRPC firewall port
+        3. Applies STATE+NFS4 debug logging to the config-key template
+        4. If lease_lifetime is set, modifies Lease_Lifetime in the
+           same config-key template (before redeploy)
+        5. Single redeploy picks up all changes
+        6. Verifies gRPC port is listening + installs grpcurl
+
+        Args:
+            nfs_name: NFS cluster name (e.g. ``lc-a3f2b1c4``).
+            lease_lifetime: Optional Lease_Lifetime override in seconds.
+                If provided, the Ganesha template is modified to set
+                this value before the single redeploy.
+        """
+        grpc_conf = "/tmp/_nfs_grpc_enable.conf"
+        grpc_block = "GRPC {\\n    Grpc_Enable = true;\\n    Grpc_Port = 50051;\\n}"
+        self.installer.exec_command(
+            sudo=True, cmd=f"printf '{grpc_block}\\n' > {grpc_conf}"
+        )
+        self.installer.exec_command(
+            sudo=True,
+            cmd=f"ceph nfs cluster config set {nfs_name} -i {grpc_conf}",
+            timeout=60,
+        )
+
+        nfs_node = self.nfs_nodes[0]
+        nfs_node.exec_command(
+            sudo=True,
+            cmd=f"firewall-cmd --permanent --add-port={GRPC_PORT}/tcp",
+            check_ec=False,
+        )
+        nfs_node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+
+        from nfs_delegation_operations import enable_ganesha_debug_logging
+
+        if not self._template_backed_up:
+            self._template_backup_exists = enable_ganesha_debug_logging(
+                cmd_host=self.installer,
+            )
+            self._template_backed_up = True
+        else:
+            enable_ganesha_debug_logging(cmd_host=self.installer)
+        self._debug_logging_enabled = True
+
+        if lease_lifetime is not None:
+            self._apply_lease_to_template(int(lease_lifetime))
+
+        log.info(
+            "gRPC + STATE debug logging%s applied to %s, single redeploy...",
+            f" + Lease_Lifetime={lease_lifetime}s" if lease_lifetime else "",
+            nfs_name,
+        )
+        self._redeploy_nfs(nfs_name)
+
+        from test_nfs_grpc import verify_grpc_port_availability
+
+        nfs_ip = self.get_nfs_server_ip()
+        for attempt in range(3):
+            if verify_grpc_port_availability(nfs_node, nfs_ip):
+                self._grpc_enabled = True
+                log.info("gRPC server enabled on port %d", GRPC_PORT)
+                break
+            if attempt < 2:
+                log.info(
+                    "gRPC port not yet listening (attempt %d/3), retrying...",
+                    attempt + 1,
+                )
+                time.sleep(10)
+        else:
+            log.warning(
+                "gRPC port %d not listening after redeploy; "
+                "gRPC queries will return empty results",
+                GRPC_PORT,
+            )
+
+        try:
+            self.install_grpcurl()
+        except Exception as e:
+            log.warning("grpcurl install failed (gRPC checks will be skipped): %s", e)
+        log.info("All cluster configs applied for %s", nfs_name)
+
+    # ------------------------------------------------------------------
+    #  Client Identity via gRPC
+    # ------------------------------------------------------------------
+
+    def install_grpcurl(self):
+        """Install grpcurl on the first client (driver node).
+
+        Downloads grpcurl v1.8.9 from GitHub.  Requires internet access
+        on the client node.  Skips if already installed.
+        """
+        from test_nfs_grpc import install_grpcurl
+
+        install_grpcurl(self.clients[0])
+
+    def get_nfs_server_ip(self):
+        """Resolve IP of the first NFS node."""
+        return self.nfs_nodes[0].ip_address
+
+    def get_client_ids(self):
+        """Query active NFS client IDs via gRPC GetClientIds.
+
+        Delegates to ``test_nfs_grpc.get_client_ids()``.
+
+        Returns:
+            tuple: (success: bool, client_ids: list of str).
+            Returns (False, []) if grpcurl is not installed or gRPC fails.
+        """
+        from test_nfs_grpc import get_client_ids
+
+        return get_client_ids(self.clients[0], self.get_nfs_server_ip())
+
+    def get_session_ids(self):
+        """Query active NFS session IDs via gRPC GetSessionIds.
+
+        Delegates to ``test_nfs_grpc.get_session_ids()``.
+
+        Returns:
+            tuple: (success: bool, session_ids: list of str).
+            Returns (False, []) if grpcurl is not installed or gRPC fails.
+        """
+        from test_nfs_grpc import get_session_ids
+
+        return get_session_ids(self.clients[0], self.get_nfs_server_ip())
+
+    # ------------------------------------------------------------------
+    #  State Tracking via Log Parsing
+    # ------------------------------------------------------------------
+
+    def _resolve_daemon_id(self, nfs_node, nfs_name=""):
+        """Resolve NFS daemon ID for a node, with per-instance caching.
+
+        The daemon ID is stable for the lifetime of a scenario (between
+        create_nfs_cluster and delete_nfs_cluster).  Caching avoids
+        redundant ``get_service_spec_daemons`` calls during the
+        validation phase where multiple log-grep methods are called
+        in quick succession.
+        """
+        cache_key = (nfs_node.hostname, nfs_name)
+        if hasattr(self, "_daemon_id_cache") and cache_key in self._daemon_id_cache:
+            return self._daemon_id_cache[cache_key]
+
+        daemon_id = ""
+        svc = f"nfs.{nfs_name}" if nfs_name else "nfs"
+        try:
+            all_ids = self.rados_obj.get_service_spec_daemons(service_name=svc)
+            for did in all_ids:
+                if nfs_node.hostname in str(did):
+                    daemon_id = str(did)
+                    break
+            if not daemon_id and all_ids:
+                daemon_id = str(all_ids[0])
+        except Exception:
+            pass
+
+        if not hasattr(self, "_daemon_id_cache"):
+            self._daemon_id_cache = {}
+        if daemon_id:
+            self._daemon_id_cache[cache_key] = daemon_id
+        return daemon_id
+
+    def _invalidate_daemon_cache(self):
+        """Clear cached daemon IDs (call after cluster create/delete)."""
+        self._daemon_id_cache = {}
+
+    def _grep_ganesha_log(self, nfs_node, pattern, nfs_name=""):
+        """Grep Ganesha logs for a pattern via cephadm logs.
+
+        Resolves the daemon ID (cached) then uses ``cephadm logs
+        --name nfs.<daemon_id>`` which goes through journalctl and
+        survives container restarts/redeploys.  Returns match count.
+        """
+        daemon_id = self._resolve_daemon_id(nfs_node, nfs_name)
+        if not daemon_id:
+            log.warning("No NFS daemon found on %s", nfs_node.hostname)
+            return 0
+
+        cmd = (
+            f"cephadm logs --name nfs.{daemon_id} "
+            f"-- --no-pager 2>/dev/null | grep -c '{pattern}'"
+        )
+        out, _ = nfs_node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        try:
+            return int(out.strip())
+        except (ValueError, TypeError):
+            return 0
+
+    def count_state_add(self, nfs_name=""):
+        """Count state object creation events in Ganesha logs.
+
+        Searches for ``_state_add_impl`` in Ganesha debug logs across all
+        NFS nodes.  Requires STATE=FULL_DEBUG to be enabled.
+        """
+        total = 0
+        for node in self.nfs_nodes:
+            total += self._grep_ganesha_log(node, "_state_add_impl", nfs_name)
+        return total
+
+    def count_state_deleted(self, nfs_name=""):
+        """Count state objects actually freed in Ganesha logs.
+
+        Ganesha's log format includes the calling function name on every
+        line.  ``dec_nfs4_state_ref()`` emits ``"Deleted <stateid>"``
+        only when the refcount reaches 0 and the object is freed:
+
+            :dec_nfs4_state_ref :sal_functions.c-NNN :Deleted State 0x...
+
+        This is a 1:1 match with ``_state_add_impl`` (one log per state
+        object creation).  The intermediate ``dec_nfs4_state_ref`` lines
+        (refcount > 0) are NOT matched by this pattern -- those are
+        temporary reference releases that occur many times per object
+        lifetime.
+
+        Requires STATE=FULL_DEBUG to be enabled (via
+        apply_all_configs).  Returns 0 if debug logging is not active.
+        """
+        total = 0
+        for node in self.nfs_nodes:
+            total += self._grep_ganesha_log(
+                node, "dec_nfs4_state_ref.*Deleted", nfs_name
+            )
+        return total
+
+    def check_cid_refcount_negative(self, nfs_name=""):
+        """Check for negative client ID refcount values in Ganesha logs.
+
+        A negative cid_refcount indicates a refcount underflow bug in
+        Ganesha's state management.  This is always a test failure.
+
+        Returns:
+            bool: True if negative refcount detected.
+        """
+        for node in self.nfs_nodes:
+            count = self._grep_ganesha_log(node, "cid_refcount.*= *-", nfs_name)
+            if count > 0:
+                log.error("Negative cid_refcount on %s (%d hits)", node.hostname, count)
+                return True
+        return False
+
+    def check_ibmceph_13072_flooding(self, nfs_name="", threshold=100):
+        """Check for IBMCEPH-13072: excessive expired-state log flooding.
+
+        After lease expiry, Ganesha may log the same expired-state message
+        repeatedly.  If the count exceeds ``threshold``, this indicates
+        the known log flooding bug.
+
+        Args:
+            nfs_name: NFS cluster name for daemon ID resolution.
+            threshold: Max acceptable expired-state log lines (default 100).
+
+        Returns:
+            bool: True if flooding detected.
+        """
+        for node in self.nfs_nodes:
+            count = self._grep_ganesha_log(node, "expired.*state", nfs_name)
+            if count > threshold:
+                log.error(
+                    "IBMCEPH-13072: %d expired state lines on %s (threshold %d)",
+                    count,
+                    node.hostname,
+                    threshold,
+                )
+                return True
+        return False
+
+    def sample_state_snapshot(self, nfs_name=""):
+        """Capture a composite state snapshot for convergence analysis.
+
+        Collects: gRPC client/session counts (if gRPC is enabled),
+        Ganesha log-based state add/deleted counters, and Ganesha
+        process RSS memory.
+
+        Returns:
+            dict with keys: timestamp, client_count, session_count,
+            state_add, state_deleted, rss_kb.
+        """
+        if self._grpc_enabled:
+            ok_c, client_ids = self.get_client_ids()
+            ok_s, session_ids = self.get_session_ids()
+        else:
+            ok_c, client_ids = False, []
+            ok_s, session_ids = False, []
+        return {
+            "timestamp": time.time(),
+            "client_count": len(client_ids) if ok_c else -1,
+            "session_count": len(session_ids) if ok_s else -1,
+            "state_add": self.count_state_add(nfs_name),
+            "state_deleted": self.count_state_deleted(nfs_name),
+            "rss_kb": self.get_ganesha_memory_rss(),
+        }
+
+    def verify_state_convergence(self, baseline, current):
+        """Compare two state snapshots for convergence.
+
+        Fails if:
+        - gRPC was enabled but client query failed in the current snapshot.
+
+        RSS growth is logged for visibility but does NOT fail the test.
+        Leak detection is handled entirely by ``check_memory_stabilization``
+        which monitors RSS trends after I/O ceases.
+
+        When gRPC is not enabled (``_grpc_enabled`` is False), client/session
+        counts of -1 are expected and do not cause failure.
+
+        Args:
+            baseline: Snapshot from pre-thrash phase.
+            current: Snapshot from post-thrash validation.
+
+        Returns:
+            bool: True if all convergence checks pass.
+        """
+        issues = []
+        if self._grpc_enabled and current["client_count"] < 0:
+            issues.append("gRPC client query failed")
+        elif not self._grpc_enabled and current["client_count"] < 0:
+            log.info("[convergence] gRPC not enabled; skipping client count check")
+        if baseline["rss_kb"] > 0 and current["rss_kb"] > 0:
+            growth = (current["rss_kb"] - baseline["rss_kb"]) / baseline["rss_kb"]
+            log.info(
+                "[convergence] RSS growth: %+.1f%% (%dKB -> %dKB) "
+                "[informational -- leak detection via check_memory_stabilization]",
+                growth * 100,
+                baseline["rss_kb"],
+                current["rss_kb"],
+            )
+        if issues:
+            for msg in issues:
+                log.error("[convergence] %s", msg)
+            return False
+        log.info("[convergence] State converged")
+        return True
+
+    # ------------------------------------------------------------------
+    #  Ganesha Memory
+    # ------------------------------------------------------------------
+
+    def get_ganesha_memory_rss(self):
+        """Get RSS of the nfs-ganesha process on the first NFS node.
+
+        Tries nfs_operations.get_nfs_pid_and_memory() first, falls back
+        to ``ps -C ganesha.nfsd -o rss=`` if the import fails.
+
+        Returns:
+            int: RSS in KB, or 0 if unavailable.
+        """
+        try:
+            from nfs_operations import get_nfs_pid_and_memory
+
+            result = get_nfs_pid_and_memory(self.nfs_nodes[:1])
+            if result:
+                hostname = self.nfs_nodes[0].hostname
+                if hostname in result:
+                    return int(result[hostname][1])
+        except Exception:
+            pass
+        try:
+            out, _ = self.nfs_nodes[0].exec_command(
+                sudo=True,
+                cmd="ps -C ganesha.nfsd -o rss= | head -1",
+                check_ec=False,
+            )
+            return int(out.strip()) if out.strip() else 0
+        except Exception:
+            return 0
+
+    def check_memory_stabilization(self, samples=5, interval=60, margin_kb=2048):
+        """Check whether Ganesha RSS is stabilizing or still growing.
+
+        After I/O stops, Ganesha's RSS should flatten (warm cache, malloc
+        arenas) or decline (LRU eviction, cap release).  A monotonically
+        increasing trend indicates a potential memory leak.
+
+        Collects ``samples`` RSS readings at ``interval`` second gaps.
+        Computes consecutive deltas.  Fails if ALL deltas are positive
+        and exceed ``margin_kb``.
+
+        The margin accounts for background jitter (MDCACHE LRU churn,
+        MDS cap renewal, malloc arena overhead).  Observed steady-state
+        jitter on VMs is ~170 KB; 2 MB (2048 KB) gives ~10x headroom.
+        On baremetal with more cores/NUMA, jitter may be higher; margin
+        is floored at ``margin_kb`` or 1% of the first sample's RSS,
+        whichever is larger, to scale with hardware.
+
+        Args:
+            samples: Number of RSS samples to collect (default 5).
+            interval: Seconds between samples (default 60).
+            margin_kb: Minimum growth per interval to count as
+                increasing (default 2048 KB = 2 MB).
+
+        Returns:
+            bool: True if memory is stabilized (no leak).  False if a
+            monotonic upward trend was detected.
+        """
+        readings = []
+        for i in range(samples):
+            rss = self.get_ganesha_memory_rss()
+            readings.append(rss)
+            log.info(
+                "[mem_stabilization] Sample %d/%d: RSS = %d KB",
+                i + 1,
+                samples,
+                rss,
+            )
+            if i < samples - 1:
+                time.sleep(interval)
+
+        if readings[0] > 0:
+            effective_margin = max(margin_kb, int(readings[0] * 0.01))
+        else:
+            effective_margin = margin_kb
+
+        deltas = [readings[i + 1] - readings[i] for i in range(len(readings) - 1)]
+        if len(deltas) < 2:
+            log.info(
+                "[mem_stabilization] Too few samples (%d) for trend analysis; "
+                "assuming stabilized",
+                len(readings),
+            )
+            return True
+
+        log.info(
+            "[mem_stabilization] Deltas (KB): %s (margin: %d KB)",
+            deltas,
+            effective_margin,
+        )
+
+        all_growing = all(d > effective_margin for d in deltas)
+        if all_growing:
+            total_growth = readings[-1] - readings[0]
+            log.error(
+                "[mem_stabilization] LEAK SUSPECTED: RSS grew monotonically "
+                "across all %d intervals (%d KB -> %d KB, +%d KB total, "
+                "all deltas > %d KB margin)",
+                len(deltas),
+                readings[0],
+                readings[-1],
+                total_growth,
+                effective_margin,
+            )
+            return False
+
+        stable_count = sum(1 for d in deltas if d <= effective_margin)
+        log.info(
+            "[mem_stabilization] RSS stabilized: %d/%d intervals flat or "
+            "declining (%d KB -> %d KB)",
+            stable_count,
+            len(deltas),
+            readings[0],
+            readings[-1],
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    #  NFS Cluster Lifecycle
+    # ------------------------------------------------------------------
+
+    def create_nfs_cluster(self, nfs_name, placement=None):
+        """Create an NFS-Ganesha cluster and wait for daemons to start.
+
+        Each test scenario calls this to spin up an isolated NFS cluster
+        so that state from one scenario cannot leak into the next.
+
+        Args:
+            nfs_name: Unique cluster name (e.g. ``lc-a3f2b1c4``).
+            placement: Hostname(s) for daemon placement.  Accepts a
+                single hostname string or a list.  Defaults to the
+                first NFS node's hostname.
+
+        Raises:
+            RuntimeError: If daemons do not reach ``running`` within 300s.
+        """
+        if placement is None:
+            placement = self.nfs_nodes[0].hostname
+
+        cmd = f"ceph nfs cluster create {nfs_name} {placement}"
+        log.info("Creating NFS cluster: %s", cmd)
+        self.installer.exec_command(sudo=True, cmd=cmd, timeout=60)
+
+        from nfs_operations import verify_nfs_ganesha_service
+
+        verify_nfs_ganesha_service(node=self.installer, timeout=300)
+        self._invalidate_daemon_cache()
+        log.info("NFS cluster %s is running", nfs_name)
+
+    def delete_nfs_cluster(self, nfs_name):
+        """Delete an NFS-Ganesha cluster and wait for daemons to be removed.
+
+        Uses ``ceph nfs cluster rm`` (non-deprecated form).  Waits up
+        to 300s for ``ceph orch ls --service-type=nfs`` to confirm no
+        daemons remain for this cluster.
+
+        Args:
+            nfs_name: Name of the NFS cluster to delete.
+        """
+        try:
+            self.installer.exec_command(
+                sudo=True,
+                cmd=f"ceph nfs cluster rm {nfs_name}",
+                timeout=30,
+            )
+        except Exception as e:
+            log.warning("Cluster rm for %s: %s", nfs_name, e)
+
+        for attempt in range(30):
+            time.sleep(10)
+            try:
+                out, _ = self.installer.exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch ps --service_name nfs.{nfs_name} -f json",
+                    check_ec=False,
+                )
+                daemons = json.loads(out.strip()) if out.strip() else []
+                if not daemons:
+                    log.info("NFS cluster %s: all daemons removed", nfs_name)
+                    self._invalidate_daemon_cache()
+                    return
+            except (json.JSONDecodeError, ValueError):
+                log.info("NFS cluster %s: daemons removed", nfs_name)
+                self._invalidate_daemon_cache()
+                return
+        log.warning("NFS cluster %s: daemons may still remain after 300s", nfs_name)
+        self._invalidate_daemon_cache()
+
+    # ------------------------------------------------------------------
+    #  NFS Export & Mount Helpers (round-robin across clients)
+    # ------------------------------------------------------------------
+
+    def create_exports(self, nfs_name, fs_name, num_exports, subvol_group=None):
+        """Create N NFS exports via ``ceph nfs export create cephfs``.
+
+        Each export gets a pseudo path ``/export_lifecycle_<i>`` backed
+        by the root of the CephFS filesystem.
+
+        Args:
+            nfs_name: NFS cluster name.
+            fs_name: CephFS filesystem name.
+            num_exports: Number of exports to create.
+            subvol_group: Unused, reserved for future subvolume support.
+
+        Returns:
+            list of dict: [{pseudo, path, index}, ...] for each created export.
+        """
+        from cli.ceph.ceph import Ceph
+
+        exports = []
+        for i in range(num_exports):
+            pseudo = f"/export_lifecycle_{i}"
+            try:
+                Ceph(self.installer).nfs.export.create(
+                    fs_name=fs_name,
+                    nfs_name=nfs_name,
+                    nfs_export=pseudo,
+                    fs=fs_name,
+                )
+                exports.append({"pseudo": pseudo, "path": "/", "index": i})
+                log.info("Created export %s on %s", pseudo, nfs_name)
+            except Exception as e:
+                log.error("Failed to create export %s: %s", pseudo, e)
+        return exports
+
+    def mount_exports_round_robin(
+        self, exports, nfs_name, nfs_server, port="2049", version="4.2"
+    ):
+        """Mount exports across clients round-robin.
+
+        Works with any number of clients (1..N).  Returns list of
+        assignment dicts: [{client, mount_point, export, index}, ...]
+        """
+        from nfs_operations import mount_retry
+
+        assignments = []
+        for i, exp in enumerate(exports):
+            client = _round_robin(self.clients, i)
+            mp = f"/mnt/lifecycle_{nfs_name}_{i}"
+            try:
+                client.exec_command(sudo=True, cmd=f"mkdir -p {mp}", timeout=10)
+                mount_retry(
+                    client,
+                    mp,
+                    version,
+                    port,
+                    nfs_server,
+                    exp["pseudo"],
+                )
+                assignments.append(
+                    {
+                        "client": client,
+                        "mount_point": mp,
+                        "export": exp,
+                        "index": i,
+                    }
+                )
+                log.info(
+                    "Mounted %s:%s on %s -> %s",
+                    nfs_server,
+                    exp["pseudo"],
+                    client.hostname,
+                    mp,
+                )
+            except Exception as e:
+                log.error("Failed to mount %s: %s", exp["pseudo"], e)
+        return assignments
+
+    def unmount_all(self, assignments):
+        """Lazy-unmount (``umount -l``) and remove all mount directories.
+
+        Errors are silently ignored since mounts may already be stale.
+        """
+        for a in assignments:
+            try:
+                a["client"].exec_command(
+                    sudo=True,
+                    cmd=f"umount -l {a['mount_point']}",
+                    check_ec=False,
+                    timeout=30,
+                )
+                a["client"].exec_command(
+                    sudo=True,
+                    cmd=f"rm -rf {a['mount_point']}",
+                    check_ec=False,
+                    timeout=10,
+                )
+            except Exception:
+                pass
+
+    def delete_exports(self, nfs_name, exports):
+        """Delete all NFS exports via ``ceph nfs export rm``."""
+        from cli.ceph.ceph import Ceph
+
+        for exp in exports:
+            try:
+                Ceph(self.installer).nfs.export.delete(nfs_name, exp["pseudo"])
+            except Exception as e:
+                log.debug("Export delete %s: %s", exp["pseudo"], e)
+
+    # ------------------------------------------------------------------
+    #  Data Integrity
+    # ------------------------------------------------------------------
+
+    _INTEGRITY_FILE_SPECS = [
+        ("integrity_4k", "4k", "4k"),
+        ("integrity_64k", "64k", "4k"),
+        ("integrity_256k", "256k", "4k"),
+        ("integrity_1m", "1M", "16k"),
+        ("integrity_4m", "4M", "64k"),
+    ]
+
+    def write_integrity_baseline(self, assignments):
+        """Write fio baseline files with CRC32C checksums on each mount.
+
+        Creates a ``thrash_integrity/`` directory under each mount point
+        and writes files of varying sizes (4K to 4M) using
+        ``fio --verify=crc32c --do_verify=0`` (write-only pass).
+        The verify pass is done separately by verify_data_integrity().
+        """
+        for a in assignments:
+            client = a["client"]
+            idir = f"{a['mount_point']}/thrash_integrity"
+            try:
+                client.exec_command(sudo=True, cmd=f"mkdir -p {idir}", timeout=15)
+                for name, fsize, bs in self._INTEGRITY_FILE_SPECS:
+                    client.exec_command(
+                        sudo=True,
+                        cmd=(
+                            f"fio --name={name} --directory={idir} "
+                            f"--size={fsize} --bs={bs} --rw=write --numjobs=1 "
+                            f"--verify=crc32c --verify_dump=1 --do_verify=0 "
+                            f"--ioengine=libaio --direct=1"
+                        ),
+                        timeout=120,
+                    )
+                log.info("[integrity] Baseline written: %s", idir)
+            except Exception as e:
+                log.warning("[integrity] Baseline failed at %s: %s", idir, e)
+
+    def verify_data_integrity(self, assignments):
+        """Re-read and verify CRC32C checksums on integrity baseline files.
+
+        Runs ``fio --verify=crc32c --do_verify=1`` on each file written
+        by write_integrity_baseline().  A checksum mismatch indicates
+        data corruption (test failure).
+
+        Returns:
+            bool: True if all files verified OK, False on any mismatch.
+        """
+        all_ok = True
+        for a in assignments:
+            client = a["client"]
+            idir = f"{a['mount_point']}/thrash_integrity"
+            for name, fsize, bs in self._INTEGRITY_FILE_SPECS:
+                try:
+                    client.exec_command(
+                        sudo=True,
+                        cmd=(
+                            f"fio --name={name} --directory={idir} "
+                            f"--size={fsize} --bs={bs} --rw=read --numjobs=1 "
+                            f"--verify=crc32c --verify_dump=1 --do_verify=1 "
+                            f"--ioengine=libaio --direct=1"
+                        ),
+                        timeout=120,
+                    )
+                except Exception as e:
+                    log.error(
+                        "[integrity] Verify FAILED on %s/%s: %s",
+                        a["mount_point"],
+                        name,
+                        e,
+                    )
+                    all_ok = False
+        return all_ok
+
+    def check_mount_health(self, assignments):
+        """Check for stale mounts via stat.  Returns list of stale mount points."""
+        stale = []
+        for a in assignments:
+            try:
+                a["client"].exec_command(
+                    sudo=True,
+                    cmd=f"stat {a['mount_point']} && ls {a['mount_point']}",
+                    timeout=10,
+                )
+            except Exception:
+                stale.append(a["mount_point"])
+                log.warning("[mount_health] Stale: %s", a["mount_point"])
+        return stale
+
+    def heal_stale_mounts(self, assignments, stale_mps, nfs_server, nfs_name):
+        """Attempt to recover stale mounts via lazy unmount + remount.
+
+        After chaos scenarios (iptables cycling, orch restarts), the
+        kernel NFS client may mark mounts as stale even after the
+        network and server are healthy.  A remount is the only way to
+        recover -- the kernel won't auto-heal a stale NFS handle.
+
+        Retries up to 3 times with increasing wait intervals (15s,
+        30s, 45s) to handle Combined injection scenarios where the
+        backend may still be draining faults when the first attempt
+        runs.
+
+        Args:
+            assignments: Full list of mount assignment dicts.
+            stale_mps: List of stale mount point paths (from check_mount_health).
+            nfs_server: NFS server hostname for remount.
+            nfs_name: NFS cluster name (for logging).
+
+        Returns:
+            list: Mount points that remain stale after all recovery attempts.
+        """
+        from nfs_operations import mount_retry
+
+        still_stale = list(stale_mps)
+        max_attempts = 3
+        wait_intervals = [15, 30, 45]
+
+        for attempt in range(1, max_attempts + 1):
+            stale_assignments = [
+                a for a in assignments if a["mount_point"] in still_stale
+            ]
+            if not stale_assignments:
+                break
+
+            log.info(
+                "[heal_mounts] Attempt %d/%d: recovering %d stale mount(s)",
+                attempt,
+                max_attempts,
+                len(stale_assignments),
+            )
+            for a in stale_assignments:
+                client = a["client"]
+                mp = a["mount_point"]
+                pseudo = a["export"]["pseudo"]
+                try:
+                    client.exec_command(
+                        sudo=True,
+                        cmd=f"umount -l {mp}",
+                        check_ec=False,
+                        timeout=30,
+                    )
+                    time.sleep(5)
+                    client.exec_command(sudo=True, cmd=f"mkdir -p {mp}", timeout=10)
+                    mount_retry(client, mp, "4.2", "2049", nfs_server, pseudo)
+                    log.info("[heal_mounts] Recovered: %s on %s", mp, client.hostname)
+                except Exception as e:
+                    log.warning("[heal_mounts] Recovery failed for %s: %s", mp, e)
+
+            wait = wait_intervals[attempt - 1]
+            log.info("[heal_mounts] Waiting %ds before recheck...", wait)
+            time.sleep(wait)
+            still_stale = self.check_mount_health(assignments)
+
+            if not still_stale:
+                log.info("[heal_mounts] All mounts recovered on attempt %d", attempt)
+                return []
+
+        if still_stale:
+            log.warning(
+                "[heal_mounts] %d mount(s) still stale after %d attempts: %s",
+                len(still_stale),
+                max_attempts,
+                still_stale,
+            )
+        return still_stale
+
+    # ------------------------------------------------------------------
+    #  Network Manipulation
+    # ------------------------------------------------------------------
+
+    def block_client_nfs_traffic(self, client, seconds):
+        """Block NFS traffic on a client for ``seconds``, then unblock.
+
+        Adds iptables DROP rules on both OUTPUT (to server port 2049)
+        and INPUT (from server port 2049) to simulate full network loss
+        from the NFS server's perspective.  After sleeping, removes the
+        rules via _flush_iptables_client().
+
+        Args:
+            client: CephNode to block.
+            seconds: Duration of the block in seconds.
+        """
+        log.info("Blocking NFS traffic on %s for %ds", client.hostname, seconds)
+        client.exec_command(
+            sudo=True,
+            cmd=(
+                "iptables -A OUTPUT -p tcp --dport 2049 -j DROP && "
+                "iptables -A INPUT -p tcp --sport 2049 -j DROP"
+            ),
+            check_ec=False,
+        )
+        time.sleep(seconds)
+        self._flush_iptables_client(client)
+
+    def block_all_clients_simultaneously(self, stagger_map):
+        """Block all clients simultaneously, then unblock with stagger.
+
+        Simulates a thundering-herd reconnect scenario.  All clients are
+        blocked at the same instant, then unblocked at different times
+        to test staggered reconnection behavior.
+
+        Args:
+            stagger_map: dict of {client_index: unblock_delay_seconds}.
+                Delays are absolute from the block time, not relative to
+                each other.  Example: {0: 3, 1: 5, 2: 8} unblocks client
+                0 at +3s, client 1 at +5s, client 2 at +8s.
+        """
+        for client in self.clients:
+            client.exec_command(
+                sudo=True,
+                cmd=(
+                    "iptables -A OUTPUT -p tcp --dport 2049 -j DROP && "
+                    "iptables -A INPUT -p tcp --sport 2049 -j DROP"
+                ),
+                check_ec=False,
+            )
+        block_time = time.time()
+        log.info("All %d clients blocked", len(self.clients))
+
+        for idx, delay in sorted(stagger_map.items(), key=lambda x: x[1]):
+            elapsed = time.time() - block_time
+            remaining = delay - elapsed
+            if remaining > 0:
+                time.sleep(remaining)
+            client = _round_robin(self.clients, idx)
+            if client:
+                self._flush_iptables_client(client)
+                log.info(
+                    "Unblocked %s at +%ds",
+                    client.hostname,
+                    int(time.time() - block_time),
+                )
+
+    def _flush_iptables_client(self, client):
+        """Remove NFS-specific iptables rules added by this test."""
+        client.exec_command(
+            sudo=True,
+            cmd=(
+                "iptables -D OUTPUT -p tcp --dport 2049 -j DROP 2>/dev/null; "
+                "iptables -D INPUT -p tcp --sport 2049 -j DROP 2>/dev/null; "
+                "true"
+            ),
+            check_ec=False,
+        )
+
+    def add_client_latency(self, client, delay_ms, jitter_ms=0):
+        """Add network latency on a client via ``tc qdisc add netem delay``.
+
+        Applied to the default network interface.  Used by the slow_renew
+        role to simulate a client whose lease renewals arrive late.
+
+        Args:
+            client: CephNode to add latency on.
+            delay_ms: Base delay in milliseconds.
+            jitter_ms: Jitter (+/-) in ms with normal distribution (default 0).
+        """
+        iface = self._get_default_iface(client)
+        jitter_part = f" {jitter_ms}ms distribution normal" if jitter_ms else ""
+        client.exec_command(
+            sudo=True,
+            cmd=(
+                f"tc qdisc add dev {iface} root netem "
+                f"delay {delay_ms}ms{jitter_part}"
+            ),
+            check_ec=False,
+        )
+        log.info(
+            "Added %dms (+/-%dms) latency on %s:%s",
+            delay_ms,
+            jitter_ms,
+            client.hostname,
+            iface,
+        )
+
+    def remove_client_latency(self, client):
+        """Remove tc netem qdisc from client's default interface."""
+        iface = self._get_default_iface(client)
+        client.exec_command(
+            sudo=True,
+            cmd=f"tc qdisc del dev {iface} root",
+            check_ec=False,
+        )
+
+    def _get_default_iface(self, node):
+        """Get the default network interface name."""
+        out, _ = node.exec_command(
+            sudo=True,
+            cmd="ip route | grep default | awk '{print $5}' | head -1",
+            check_ec=False,
+        )
+        return out.strip() or "eth0"
+
+    def flush_iptables_all(self):
+        """Safety cleanup: flush all iptables rules on all test nodes.
+
+        Uses full flush (-F) intentionally to guarantee no leftover rules
+        from any code path.  Called only during test cleanup phase.
+        """
+        for node in self.clients + self.nfs_nodes:
+            try:
+                node.exec_command(sudo=True, cmd="iptables -F", check_ec=False)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    #  Error Injection (Layer 2)
+    # ------------------------------------------------------------------
+
+    def create_injector(self):
+        """Create a CephErrorInjector for Layer 2 error injection.
+
+        Returns:
+            CephErrorInjector: Instance bound to this cluster's RadosOrchestrator.
+        """
+        return CephErrorInjector(rados_obj=self.rados_obj)
+
+    def get_l2_defaults(self, scenario_name):
+        """Get default Layer 2 error injection config for a scenario.
+
+        Returns the CephErrorInjector config dict from _L2_DEFAULTS,
+        or empty dict if the scenario has no default injection.
+        """
+        return _L2_DEFAULTS.get(scenario_name, {})
+
+    def apply_scenario_injection(self, injector, scenario_name, config):
+        """Apply Layer 2 error injection for a scenario.
+
+        Uses the ``error_injection`` key from config if present,
+        otherwise falls back to the scenario's default from _L2_DEFAULTS.
+
+        Args:
+            injector: CephErrorInjector instance.
+            scenario_name: Key into _L2_DEFAULTS.
+            config: Test config dict (may contain ``error_injection`` override).
+        """
+        ei_config = config.get("error_injection")
+        if ei_config is None:
+            ei_config = self.get_l2_defaults(scenario_name)
+        if ei_config:
+            injector.apply_from_config(ei_config)
+            log.info(
+                "L2 error injection active for %s: %s",
+                scenario_name,
+                ei_config,
+            )
+
+    def cleanup_injection(self, injector):
+        """Remove all active error injections and wait for cluster recovery.
+
+        Calls ``injector.cleanup_all()`` to remove all MON config-key
+        injections, then sleeps 30s for the cluster to stabilize.
+        Safe to call multiple times (idempotent).
+        """
+        if injector:
+            try:
+                injector.cleanup_all()
+                log.info("L2 error injection removed, waiting 30s for recovery")
+                time.sleep(30)
+            except Exception as e:
+                log.warning("Injection cleanup failed: %s", e)
+
+    # ------------------------------------------------------------------
+    #  Churn Generation
+    # ------------------------------------------------------------------
+
+    def run_churn_on_mount(
+        self, client, mount_point, stop_event, churn_rate=5, role=None
+    ):
+        """Single-client churn loop: random file ops on a mount point.
+
+        Operations weighted by role profile from ROLE_PROFILES.
+        If no role specified, uses equal probability.
+        Runs until stop_event is set.
+        """
+        ops = {"creates": 0, "writes": 0, "reads": 0, "locks": 0, "errors": 0}
+        idx = 0
+
+        op_choices = ["read", "create", "lock", "write"]
+        if role and role in ROLE_PROFILES:
+            p = ROLE_PROFILES[role]
+            weights = [
+                p.get("read", 0.25),
+                p.get("write", 0.25),
+                p.get("lock", 0.25),
+                p.get("metadata", 0.25),
+            ]
+        else:
+            weights = [0.25, 0.25, 0.25, 0.25]
+
+        while not stop_event.is_set():
+            for _ in range(churn_rate):
+                if stop_event.is_set():
+                    break
+                idx += 1
+                fname = f"{mount_point}/churn_{idx}"
+                op = random.choices(op_choices, weights=weights, k=1)[0]
+                try:
+                    if op == "create":
+                        client.exec_command(
+                            sudo=True,
+                            cmd=f"dd if=/dev/urandom of={fname} bs=4k count=1 2>/dev/null",
+                            check_ec=False,
+                            timeout=15,
+                        )
+                        ops["creates"] += 1
+                    elif op == "write":
+                        client.exec_command(
+                            sudo=True,
+                            cmd=f"echo 'data' >> {fname}",
+                            check_ec=False,
+                            timeout=10,
+                        )
+                        ops["writes"] += 1
+                    elif op == "read":
+                        client.exec_command(
+                            sudo=True,
+                            cmd=f"cat {fname} > /dev/null 2>&1",
+                            check_ec=False,
+                            timeout=10,
+                        )
+                        ops["reads"] += 1
+                    elif op == "lock":
+                        lock_cmd = (
+                            f'python3 -c "import fcntl,time;'
+                            f"f=open('{fname}','a');"
+                            f"fcntl.flock(f,fcntl.LOCK_EX|fcntl.LOCK_NB);"
+                            f"time.sleep(1);"
+                            f'fcntl.flock(f,fcntl.LOCK_UN)"'
+                        )
+                        client.exec_command(
+                            sudo=True,
+                            cmd=lock_cmd,
+                            check_ec=False,
+                            timeout=15,
+                        )
+                        ops["locks"] += 1
+                except Exception:
+                    ops["errors"] += 1
+            _sleep_with_stop(stop_event, 10, step=2)
+        return ops
+
+    # ------------------------------------------------------------------
+    #  Admin Operations
+    # ------------------------------------------------------------------
+
+    def run_admin_ops(self, nfs_name, fs_name, duration, stop_event):
+        """Run random NFS admin operations for ``duration`` seconds.
+
+        Randomly selects one of three operations each cycle:
+        - export_create: create a temporary export, then delete it.
+        - export_delete: no-op (avoids deleting test exports).
+        - restart: ``ceph orch restart nfs.<cluster>``, then wait 30s.
+
+        Args:
+            nfs_name: NFS cluster name.
+            fs_name: CephFS filesystem name for new exports.
+            duration: Total runtime in seconds.
+            stop_event: threading.Event for early termination.
+
+        Returns:
+            dict: Operation counts {creates, deletes, restarts, errors}.
+        """
+        from cli.ceph.ceph import Ceph
+
+        ops = {"creates": 0, "deletes": 0, "restarts": 0, "errors": 0}
+        end_time = time.time() + duration
+        churn_idx = 100
+
+        while time.time() < end_time and not stop_event.is_set():
+            op = random.choice(["export_create", "export_delete", "restart"])
+            try:
+                if op == "export_create":
+                    pseudo = f"/churn_admin_{churn_idx}"
+                    churn_idx += 1
+                    Ceph(self.installer).nfs.export.create(
+                        fs_name=fs_name,
+                        nfs_name=nfs_name,
+                        nfs_export=pseudo,
+                        fs=fs_name,
+                    )
+                    ops["creates"] += 1
+                    _sleep_with_stop(stop_event, 3, step=1)
+                    Ceph(self.installer).nfs.export.delete(nfs_name, pseudo)
+                    ops["deletes"] += 1
+
+                elif op == "export_delete":
+                    pass  # no-op to avoid deleting test exports
+
+                elif op == "restart":
+                    self.installer.exec_command(
+                        sudo=True,
+                        cmd=f"ceph orch restart nfs.{nfs_name}",
+                        timeout=60,
+                    )
+                    ops["restarts"] += 1
+                    _sleep_with_stop(stop_event, 30, step=5)
+
+            except Exception as e:
+                log.debug("[admin_ops] %s failed: %s", op, e)
+                ops["errors"] += 1
+
+            _sleep_with_stop(stop_event, 10, step=3)
+
+        log.info("[admin_ops] Summary: %s", ops)
+        return ops
+
+    # ------------------------------------------------------------------
+    #  FIO on Mounts
+    # ------------------------------------------------------------------
+
+    def run_fio_on_assignments(self, assignments, fio_params, stop_event=None):
+        """Run fio sequentially on each mount assignment.
+
+        Mounts are fio'd one at a time intentionally.  Parallel fio on
+        multiple NFS mounts through a single Ganesha daemon creates I/O
+        contention that obscures the chaos signal we're trying to measure.
+        For L2-only paths, ``_l2_soak_with_io`` passes ``assignments[:1]``
+        to avoid multiplying soak time.  For L1 paths,
+        ``_start_background_io`` wraps this in a daemon thread that loops
+        30s bursts, so the sequential nature is transparent.
+
+        Args:
+            assignments: List of mount assignment dicts.
+            fio_params: dict with keys bs, size, runtime.
+            stop_event: Optional threading.Event for early stop
+                (checked between assignments, not mid-fio).
+
+        Returns:
+            bool: True if all fio runs succeeded.
+        """
+        all_ok = True
+        for a in assignments:
+            if stop_event and stop_event.is_set():
+                break
+            mp = a["mount_point"]
+            client = a["client"]
+            bs = fio_params.get("bs", "1M")
+            size = fio_params.get("size", "128M")
+            runtime = fio_params.get("runtime", 30)
+            try:
+                client.exec_command(
+                    sudo=True,
+                    cmd=(
+                        f"fio --name=lifecycle_io --directory={mp} "
+                        f"--size={size} --bs={bs} --rw=randrw "
+                        f"--numjobs=2 --time_based --runtime={runtime} "
+                        f"--ioengine=libaio --direct=1 --group_reporting"
+                    ),
+                    timeout=runtime + 120,
+                )
+            except Exception as e:
+                log.warning("[fio] Failed on %s:%s: %s", client.hostname, mp, e)
+                all_ok = False
+        return all_ok

--- a/tests/nfs/nfs_state_lifecycle/test_nfs_state_lifecycle.py
+++ b/tests/nfs/nfs_state_lifecycle/test_nfs_state_lifecycle.py
@@ -1,0 +1,1660 @@
+"""
+Test Module: NFS State Lifecycle & Robustness
+==============================================
+
+This module validates NFS-Ganesha state management under controlled stress
+at two independent failure layers, individually and combined:
+
+Layer 1 (NFS Protocol): Catches bugs in Ganesha's own state machine --
+    clientid management, lease handling, delegation lifecycle, export binding.
+    Chaos is induced organically at the NFS protocol boundary via iptables
+    port blocking, tc netem latency, mount/unmount cycles, and export CRUD.
+    If something breaks here, it is a Ganesha state machine bug.
+
+Layer 2 (MDS/FSAL Backend): Catches bugs in how Ganesha handles backend
+    failures -- cap revocation, MDS session loss, RADOS timeouts.  Chaos
+    is injected at the Ceph daemon layer via CephErrorInjector (MON config
+    database).  If something breaks here, it is a Ganesha resilience bug
+    or a Ceph bug surfaced through NFS.
+
+Layer 1+2 (Combined): Catches interaction bugs -- the most realistic
+    failure mode.  NFS client disconnects while Ganesha is simultaneously
+    losing caps to MDS.  These are the hardest bugs to reproduce.
+
+The injection layer is selected per test via ``config["injection_layer"]``:
+    - ``nfs_protocol``  -- Layer 1 only (default)
+    - ``mds_backend``   -- Layer 2 only
+    - ``combined``      -- Both layers active
+
+Each scenario is organized into five sequential phases:
+
+1. **Setup** -- Create a dedicated NFS cluster (unique name per run),
+   apply gRPC + STATE debug logging via apply_all_configs (single
+   redeploy), create exports/mounts, optionally set Lease_Lifetime,
+   archive crash state, optionally create CephErrorInjector.
+2. **Pre-thrash** -- Write fio integrity baselines, snapshot state via gRPC
+   (GetClientIds/GetSessionIds), snapshot Ganesha memory.  If L2: apply
+   error injection AFTER baseline capture.  Abort if cluster unhealthy.
+3. **Thrash** -- Launch scenario-specific chaos threads.  L1: iptables, tc,
+   mount/unmount, export/admin churn.  L2: CephErrorInjector configs active.
+   Background health monitor logs cluster state every 30s.
+4. **Validation** -- Remove L2 injections (if active), flush iptables and
+   tc netem on all nodes, wait 60s for recovery.  Heal stale NFS mounts
+   via lazy-unmount + remount (repeated iptables cycling poisons the
+   kernel NFS client beyond auto-recovery).  Verify: PG health, daemon
+   health, fio integrity on healed mounts, gRPC state convergence,
+   memory stabilization (5 RSS samples at 60s intervals for monotonic
+   growth detection), negative cid_refcount, no IBMCEPH-13072 log
+   flooding, no crashes (ceph crash ls-new + daemon log scan).
+5. **Cleanup** -- Flush iptables and tc qdisc, unmount, delete exports,
+   delete the per-scenario NFS cluster, restore Ganesha template, final
+   crash check.
+
+Failure Stack Diagram
+---------------------
+    NFS Client (mount/unmount/IO)
+        |
+        +-- [L1] iptables block/unblock port 2049
+        +-- [L1] tc netem delay/jitter
+        +-- [L1] mount/unmount/open/lock cycles
+        +-- [L1] export CRUD (create/delete/apply)
+        +-- [L1] ceph orch restart/redeploy
+        |
+        v
+    NFS-Ganesha
+        +-- State Machine (clientid, sessions, locks, delegations)
+        |       ^ validated by gRPC GetClientIds/GetSessionIds
+        |       ^ validated by Ganesha log counters
+        |
+        +-- FSAL_CEPH (libcephfs)
+                |
+                +-- [L2] client_inject_release_failure (cap release fails)
+                +-- [L2] client_inject_fixed_oldest_tid (stale TID)
+                +-- [L2] client_debug_inject_tick_delay (slow renewals)
+                +-- [L2] ms_inject_socket_failures (connection drops)
+                +-- [L2] ms_inject_delay_probability (message delays)
+                +-- [L2] mds_inject_traceless_reply (missing traces)
+                +-- [L2] mds_inject_migrator_session_race (migration)
+                +-- [L2] objecter_inject_no_watch_ping (blocklist risk)
+                |
+                v
+            MDS / OSD / RADOS
+
+Implemented Scenarios
+---------------------
+client_identity_lifecycle
+    Model NFSv4 client lifecycle: EXCHANGE_ID, clientid reuse, reconnect
+    before/after lease expiry, rapid reconnect loops, grace reclaim.
+
+lease_expiry_under_load
+    Shortened Lease_Lifetime with active IO, locks, delegations.  Induce
+    expiry via iptables (L1) or cap release failure (L2).
+
+state_cardinality_stress
+    Scale matrix: clients x exports x states.  Incremental ramp-up,
+    bulk-close, cleanup ordering.  Cap pressure at extreme cardinality (L2).
+
+client_state_churn
+    Random mount/unmount/open/lock churn overlapping lease expiry, server
+    restart with grace reclaim, and export reload.  BM repro pattern.
+
+export_reorg_state_integrity
+    Export apply/delete/recreate during active IO.  Same-path reuse,
+    export ID reuse.  MDS subtree migration race (L2).
+
+generative_client_behavior
+    Role-based probabilistic ops: reader-heavy, lock-heavy, metadata-heavy,
+    flaky (iptables L1 / N/A L2), slow-renew (tc netem L1 / tick delay L2).
+
+admin_op_interleave
+    Admin ops (export CRUD, orch restart/redeploy, config set) interleaved
+    with active IO.  Grace reclaim verification.
+
+observability_validation
+    Continuous state sampling via gRPC + Ganesha log parsing.  Fail on:
+    state non-convergence, negative refcounts, memory leak, IBMCEPH-13072.
+
+rapid_reconnect_storms
+    All clients simultaneously disconnect and reconnect with staggered
+    timing.  Thundering herd at NFS level (L1) and RADOS level (L2).
+
+combined_churn_failure
+    Full integration: client churn + admin ops + lease stress + backend
+    chaos.  Chaos budget limits concurrent generators.
+
+CONFIGURATION OPTIONS:
+======================
+- test_scenario: Scenario name from _SCENARIOS dispatch table (REQUIRED)
+- injection_layer: nfs_protocol | mds_backend | combined (default: nfs_protocol)
+- duration: Thrash phase duration in seconds (default: 300)
+- fs_name: CephFS filesystem name (default: cephfs)
+- num_clients: Max client nodes to use; actual count capped by available (default: 3)
+- num_exports: Number of NFS exports to create (default: 3)
+- lease_lifetime: Ganesha Lease_Lifetime override in seconds (default: None, no change)
+- reconnect_cycles: Rapid reconnect loop count for S1/S9 (default: 20)
+- churn_rate: Client ops per 10s window for churn scenarios (default: 5)
+- error_injection: CephErrorInjector config dict for L2 (default: scenario-specific)
+    Supports: profile, profile_overrides, configs -- see ceph_error_injector.py
+- fio_bs: FIO block size (default: 1M)
+- fio_size: FIO file size (default: 128M)
+- fio_runtime: FIO runtime in seconds (default: 30)
+- mem_check_samples: Number of RSS samples for memory stabilization (default: 5)
+- mem_check_interval: Seconds between RSS samples (default: 60)
+
+Note: NFS cluster name is auto-generated (``lc-<hex8>``) per scenario.
+Each run creates and tears down its own NFS cluster.  The backing
+CephFS filesystem is shared across all scenarios.
+"""
+
+import random
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Event, Thread
+
+from nfs_state_lifecycle.nfs_state_lifecycle_workflows import (
+    NfsStateLifecycleWorkflows,
+    _log_phase,
+    _round_robin,
+    _sleep_with_stop,
+)
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from cli.exceptions import ConfigError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def _l2_soak_with_io(wf, cfg, assignments, stop_event):
+    """Run fio on first mount during L2 injection soak period.
+
+    Without active IO, backend error injection has nothing to disrupt
+    and the test produces trivially-passing results.  Uses only the
+    first mount to avoid sequential fio multiplying the soak time.
+    """
+    duration = cfg["duration"]
+    log.info("L2 soak: running IO for %ds while injection active", duration)
+    if assignments:
+        wf.run_fio_on_assignments(
+            assignments[:1],
+            {**cfg["fio_params"], "runtime": duration},
+            stop_event,
+        )
+
+
+def _start_background_io(wf, assignments, fio_params, stop_event):
+    """Start a daemon thread running short fio cycles during L1 thrash.
+
+    Runs 30-second fio bursts in a loop, checking ``stop_event`` between
+    cycles.  Returns the Thread object.  The thread is daemonic so it
+    will not block test exit even if a fio command is mid-flight when
+    ``stop_event`` is set.
+
+    Args:
+        wf: NfsStateLifecycleWorkflows instance.
+        assignments: Mount assignments to run fio on.
+        fio_params: Base fio parameters dict (bs, size).
+        stop_event: threading.Event -- loop exits when set.
+
+    Returns:
+        Thread: The started daemon thread.
+    """
+    if not assignments:
+        return None
+
+    def _io_loop():
+        short_params = {**fio_params, "runtime": 30}
+        log.info("Background IO: started on %d mount(s)", len(assignments))
+        while not stop_event.is_set():
+            wf.run_fio_on_assignments(assignments, short_params, stop_event)
+        log.info("Background IO: stopped")
+
+    t = Thread(target=_io_loop, daemon=True)
+    t.start()
+    return t
+
+
+def _parse_config(config, ceph_cluster):
+    """Parse and validate config, resolve cluster objects.
+
+    Note: ``nfs_name`` is NOT read from config.  Each scenario creates
+    its own NFS cluster with a unique name generated in _common_setup.
+    """
+    fs_name = config.get("fs_name", "cephfs")
+    duration = int(config.get("duration", 300))
+    num_exports = int(config.get("num_exports", 3))
+    max_clients = int(config.get("num_clients", 3))
+
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    installers = ceph_cluster.get_nodes("installer")
+
+    if not clients:
+        raise ConfigError("At least one client node required")
+    if not nfs_nodes:
+        raise ConfigError("At least one NFS node required")
+    if not installers:
+        raise ConfigError("Installer node required")
+
+    clients = clients[:max_clients]
+    installer = installers[0]
+    nfs_server = nfs_nodes[0].hostname
+    nfs_ip = nfs_nodes[0].ip_address
+
+    layer = config.get("injection_layer", "nfs_protocol")
+    enable_l1 = layer in ("nfs_protocol", "combined")
+    enable_l2 = layer in ("mds_backend", "combined")
+
+    fio_params = {
+        "bs": config.get("fio_bs", "1M"),
+        "size": config.get("fio_size", "128M"),
+        "runtime": int(config.get("fio_runtime", 30)),
+    }
+
+    return {
+        "nfs_name": None,
+        "fs_name": fs_name,
+        "duration": duration,
+        "num_exports": num_exports,
+        "clients": clients,
+        "nfs_nodes": nfs_nodes,
+        "installer": installer,
+        "nfs_server": nfs_server,
+        "nfs_ip": nfs_ip,
+        "enable_l1": enable_l1,
+        "enable_l2": enable_l2,
+        "layer": layer,
+        "fio_params": fio_params,
+    }
+
+
+def _common_setup(config, ceph_cluster, scenario_name, lease_lifetime=None):
+    """Common setup for all scenarios.  Returns (wf, cfg, rados_obj, injector).
+
+    Creates a dedicated NFS cluster for this scenario run.  The cluster
+    name is ``lc-<8-hex-chars>`` to keep it short and collision-free
+    across parallel runs.  The backing CephFS filesystem is shared.
+
+    If ``lease_lifetime`` is provided, it is folded into the single
+    ``apply_all_configs`` redeploy to avoid a second redeploy cycle.
+    """
+    cfg = _parse_config(config, ceph_cluster)
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+
+    wf = NfsStateLifecycleWorkflows(
+        installer=cfg["installer"],
+        nfs_nodes=cfg["nfs_nodes"],
+        clients=cfg["clients"],
+        rados_obj=rados_obj,
+        ceph_cluster=ceph_cluster,
+    )
+
+    nfs_name = f"lc-{uuid.uuid4().hex[:8]}"
+    cfg["nfs_name"] = nfs_name
+
+    log.info(
+        "\n%s\nNFS STATE LIFECYCLE TEST\n%s\n"
+        "Scenario: %s\n"
+        "Injection layer: %s (L1=%s, L2=%s)\n"
+        "Clients: %d / NFS nodes: %d / Exports: %d\n"
+        "Duration: %ds / NFS cluster: %s (created per-scenario)\n%s",
+        "=" * 60,
+        "=" * 60,
+        scenario_name,
+        cfg["layer"],
+        cfg["enable_l1"],
+        cfg["enable_l2"],
+        len(cfg["clients"]),
+        len(cfg["nfs_nodes"]),
+        cfg["num_exports"],
+        cfg["duration"],
+        nfs_name,
+        "=" * 60,
+    )
+
+    injector = None
+    try:
+        wf.create_nfs_cluster(nfs_name, cfg["nfs_server"])
+        wf.apply_all_configs(nfs_name, lease_lifetime=lease_lifetime)
+        if cfg["enable_l2"]:
+            injector = wf.create_injector()
+    except Exception:
+        log.error("Setup failed; attempting cleanup for NFS cluster %s", nfs_name)
+        try:
+            wf.delete_nfs_cluster(nfs_name)
+        except Exception:
+            pass
+        raise
+
+    return wf, cfg, rados_obj, injector
+
+
+def _common_validation(wf, cfg, config, injector, assignments, baseline_snap):
+    """Common validation logic for all scenarios.  Returns test_failed.
+
+    If an injector is provided and still has active injections, they are
+    cleaned up here to allow the cluster to recover before validation.
+
+    Network chaos (iptables, tc) is flushed before the recovery wait to
+    ensure mounts have a clean network path.  Stale mounts are healed
+    via remount before integrity checks -- repeated iptables cycling can
+    poison the kernel NFS client beyond auto-recovery.
+    """
+    test_failed = False
+
+    if injector:
+        wf.cleanup_injection(injector)
+        injector._cleaned = True
+
+    wf.flush_iptables_all()
+    for client in cfg["clients"]:
+        wf.remove_client_latency(client)
+
+    time.sleep(60)
+    wf.log_cluster_health()
+
+    stale = wf.check_mount_health(assignments)
+    if stale:
+        log.warning(
+            "[validation] %d stale mount(s) detected, attempting recovery: %s",
+            len(stale),
+            stale,
+        )
+        still_stale = wf.heal_stale_mounts(
+            assignments, stale, cfg["nfs_server"], cfg["nfs_name"]
+        )
+        if still_stale:
+            log.error(
+                "[validation] %d mount(s) still stale after recovery: %s",
+                len(still_stale),
+                still_stale,
+            )
+            test_failed = True
+
+    if not wf.verify_data_integrity(assignments):
+        log.error("[validation] Data integrity check failed")
+        test_failed = True
+
+    if baseline_snap:
+        current_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+        if not wf.verify_state_convergence(baseline_snap, current_snap):
+            test_failed = True
+
+    mem_samples = int(config.get("mem_check_samples", 5))
+    mem_interval = int(config.get("mem_check_interval", 60))
+    if not wf.check_memory_stabilization(samples=mem_samples, interval=mem_interval):
+        log.error("[validation] Memory leak suspected (RSS growing after I/O stopped)")
+        test_failed = True
+
+    if wf.check_cid_refcount_negative(cfg["nfs_name"]):
+        log.error("[validation] Negative cid_refcount detected")
+        test_failed = True
+
+    if wf.check_ibmceph_13072_flooding(cfg["nfs_name"]):
+        log.error("[validation] IBMCEPH-13072 log flooding detected")
+        test_failed = True
+
+    if wf.check_crashes("VALIDATION"):
+        test_failed = True
+
+    return test_failed
+
+
+def _common_cleanup(wf, cfg, config, injector, assignments, exports):
+    """Common cleanup for all scenarios.
+
+    Tears down in reverse order: injection -> network -> mounts ->
+    exports -> template restore (no redeploy) -> crash check -> NFS
+    cluster deletion.  Template restore writes the original config
+    back to config-key; the next scenario's apply_all_configs picks
+    it up.  Crash check runs while the cluster and its daemons still
+    exist so logs are accessible.  The NFS cluster created by
+    _common_setup is deleted last.
+    """
+    if not wf or not cfg:
+        return
+    if injector and not getattr(injector, "_cleaned", False):
+        wf.cleanup_injection(injector)
+
+    wf.flush_iptables_all()
+    for client in cfg["clients"]:
+        wf.remove_client_latency(client)
+
+    wf.unmount_all(assignments)
+    if cfg["nfs_name"]:
+        wf.delete_exports(cfg["nfs_name"], exports)
+        wf.restore_all_config(cfg["nfs_name"])
+        if wf.check_crashes("CLEANUP"):
+            log.error("[cleanup] Crash detected during cleanup")
+        wf.delete_nfs_cluster(cfg["nfs_name"])
+    wf.log_cluster_health()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Client Identity Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _scenario_client_identity_lifecycle(config, ceph_cluster):
+    """Validate NFSv4 client identity lifecycle through EXCHANGE_ID.
+
+    Layer 1 (nfs_protocol):
+        Reconnect tests via iptables block/unblock and mount/unmount
+        cycles.  Validates clientid reuse on same-verifier reconnect,
+        new clientid on different-verifier (reboot), session cleanup
+        after lease expiry, and rapid reconnect loop stability.
+
+    Layer 2 (mds_backend):
+        client_inject_fixed_oldest_tid forces MDS to see Ganesha as
+        stuck.  ms_inject_socket_failures causes intermittent FSAL
+        disconnects.  Tests clientid state after MDS session loss.
+
+    Combined:
+        NFS clients reconnecting while Ganesha's own MDS session is
+        being disrupted by backend injection.
+
+    Config keys:
+        reconnect_cycles (int): Rapid loop iterations (default: 20)
+        lease_lifetime (int): Shortened lease in seconds (default: 30)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    lease_lt = config.get("lease_lifetime", 30)
+    wf, cfg, rados_obj, injector = _common_setup(
+        config,
+        ceph_cluster,
+        "client_identity_lifecycle",
+        lease_lifetime=lease_lt,
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        if not assignments:
+            raise ConfigError("No mounts established")
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+        log.info("Baseline: %s", baseline_snap)
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "client_identity_lifecycle", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+        cycles = int(config.get("reconnect_cycles", 20))
+
+        if cfg["enable_l1"]:
+            from nfs_operations import mount_retry
+
+            _io_thread = _start_background_io(  # noqa: F841
+                wf,
+                assignments[1:],
+                cfg["fio_params"],
+                stop_event,
+            )
+
+            test_client = cfg["clients"][0]
+            test_mp = assignments[0]["mount_point"]
+            test_export = assignments[0]["export"]["pseudo"]
+
+            log.info("--- Reconnect before lease expiry ---")
+            for i in range(min(3, cycles)):
+                test_client.exec_command(
+                    sudo=True, cmd=f"umount -l {test_mp}", check_ec=False
+                )
+                time.sleep(2)
+                mount_retry(
+                    test_client,
+                    test_mp,
+                    "4.2",
+                    "2049",
+                    cfg["nfs_server"],
+                    test_export,
+                )
+                log.info("Reconnect cycle %d/%d OK", i + 1, 3)
+
+            log.info("--- Reconnect after lease expiry ---")
+            wf.block_client_nfs_traffic(test_client, lease_lt + 10)
+            test_client.exec_command(
+                sudo=True, cmd=f"umount -l {test_mp}", check_ec=False
+            )
+            time.sleep(5)
+            mount_retry(
+                test_client,
+                test_mp,
+                "4.2",
+                "2049",
+                cfg["nfs_server"],
+                test_export,
+            )
+            log.info("Post-expiry reconnect OK")
+
+            log.info("--- Rapid reconnect loop (%d cycles) ---", cycles)
+            for i in range(cycles):
+                test_client.exec_command(
+                    sudo=True, cmd=f"umount -l {test_mp}", check_ec=False
+                )
+                mount_retry(
+                    test_client,
+                    test_mp,
+                    "4.2",
+                    "2049",
+                    cfg["nfs_server"],
+                    test_export,
+                )
+            log.info("Rapid reconnect loop complete")
+
+        if cfg["enable_l2"]:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+
+        stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO client_identity_lifecycle: PASSED ***")
+        else:
+            log.error("*** SCENARIO client_identity_lifecycle: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED with exception: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Lease Expiry Under Load
+# ---------------------------------------------------------------------------
+
+
+def _scenario_lease_expiry_under_load(config, ceph_cluster):
+    """Validate NFS state cleanup when leases expire under realistic load.
+
+    Layer 1 (nfs_protocol):
+        Blocks NFS traffic on one client via iptables INPUT+OUTPUT on
+        port 2049 for lease_time + 5s.  Other clients continue IO.
+
+    Layer 2 (mds_backend):
+        Applies client_session_stress profile: cap release failures
+        cause caps to accumulate, risking MDS session eviction.
+
+    Combined:
+        NFS clients blocked while Ganesha's caps are failing to release.
+
+    Config keys:
+        lease_lifetime (int): Shortened lease in seconds (default: 15)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    lease_lt = int(config.get("lease_lifetime", 15))
+    wf, cfg, rados_obj, injector = _common_setup(
+        config,
+        ceph_cluster,
+        "lease_expiry_under_load",
+        lease_lifetime=lease_lt,
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        wf.run_fio_on_assignments(assignments, cfg["fio_params"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "lease_expiry_under_load", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+
+        if cfg["enable_l1"]:
+            _io_thread = _start_background_io(  # noqa: F841
+                wf,
+                assignments,
+                cfg["fio_params"],
+                stop_event,
+            )
+
+            delays = [
+                ("before_expiry", max(1, lease_lt - 5)),
+                ("at_expiry", lease_lt + 5),
+                ("well_past", lease_lt * 2),
+            ]
+            for label, block_time in delays:
+                target_client = _round_robin(cfg["clients"], 0)
+                log.info(
+                    "--- Lease test: %s (block %ds, lease %ds) ---",
+                    label,
+                    block_time,
+                    lease_lt,
+                )
+                wf.block_client_nfs_traffic(target_client, block_time)
+                time.sleep(10)
+
+        if cfg["enable_l2"]:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+
+        stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO lease_expiry_under_load: PASSED ***")
+        else:
+            log.error("*** SCENARIO lease_expiry_under_load: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: State Cardinality Stress
+# ---------------------------------------------------------------------------
+
+
+def _scenario_state_cardinality_stress(config, ceph_cluster):
+    """Scale matrix: clients x exports x states per client.
+
+    Layer 1 (nfs_protocol):
+        Incremental ramp-up of file opens and locks across all clients
+        and exports.  Tests refcount correctness at scale.
+
+    Layer 2 (mds_backend):
+        client_inject_release_failure at extreme cardinality pushes
+        cap pressure toward MDS eviction threshold.
+
+    Config keys:
+        num_exports (int): Export count axis (default: 3)
+        states_per_client (str): low | medium | extreme (default: medium)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    wf, cfg, rados_obj, injector = _common_setup(
+        config, ceph_cluster, "state_cardinality_stress"
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+        wf.write_integrity_baseline(assignments)
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "state_cardinality_stress", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        cardinality = config.get("states_per_client", "medium")
+        file_counts = {"low": 5, "medium": 20, "extreme": 50}
+        num_files = file_counts.get(cardinality, 20)
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+
+        if cfg["enable_l1"]:
+            log.info(
+                "--- Ramp-up: %d files per mount, %d mounts ---",
+                num_files,
+                len(assignments),
+            )
+            for step in range(1, num_files + 1, max(1, num_files // 5)):
+                actual = min(step, num_files)
+                for a in assignments:
+                    client = a["client"]
+                    mp = a["mount_point"]
+                    for f_idx in range(actual):
+                        fname = f"{mp}/card_{f_idx}"
+                        try:
+                            client.exec_command(
+                                sudo=True,
+                                cmd=f"dd if=/dev/zero of={fname} bs=4k count=1 2>/dev/null",
+                                check_ec=False,
+                                timeout=30,
+                            )
+                        except Exception:
+                            log.warning(
+                                "[cardinality] dd timed out on %s (expected under combined injection)",
+                                fname,
+                            )
+                snap = wf.sample_state_snapshot(cfg["nfs_name"])
+                log.info("Step %d/%d state: %s", actual, num_files, snap)
+
+            log.info("--- Bulk close (unlink all) ---")
+            for a in assignments:
+                try:
+                    a["client"].exec_command(
+                        sudo=True,
+                        cmd=f"rm -f {a['mount_point']}/card_*",
+                        check_ec=False,
+                        timeout=60,
+                    )
+                except Exception:
+                    log.warning(
+                        "[cardinality] rm timed out on %s (expected under combined injection)",
+                        a["mount_point"],
+                    )
+            time.sleep(30)
+
+        if cfg["enable_l2"]:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+
+        stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO state_cardinality_stress: PASSED ***")
+        else:
+            log.error("*** SCENARIO state_cardinality_stress: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Client State Churn
+# ---------------------------------------------------------------------------
+
+
+def _scenario_client_state_churn(config, ceph_cluster):
+    """Random client state churn overlapping with lease expiry and restarts.
+
+    Layer 1 (nfs_protocol):
+        Per-client churn threads: random file create/write/read/lock
+        cycles.  Overlaps with shortened lease and orch restart.
+
+    Layer 2 (mds_backend):
+        network_chaos profile: socket failures + message delays amplify
+        churn-induced state instability at the FSAL layer.
+
+    Config keys:
+        churn_rate (int): Ops per 10s window per mount (default: 5)
+        lease_lifetime (int): Shortened lease (default: 30)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    lease_lt = config.get("lease_lifetime")
+    wf, cfg, rados_obj, injector = _common_setup(
+        config,
+        ceph_cluster,
+        "client_state_churn",
+        lease_lifetime=int(lease_lt) if lease_lt else None,
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "client_state_churn", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+        churn_rate = int(config.get("churn_rate", 5))
+
+        futures = []
+        if cfg["enable_l1"]:
+            with ThreadPoolExecutor(max_workers=min(len(assignments), 5)) as executor:
+                for a in assignments:
+                    futures.append(
+                        executor.submit(
+                            wf.run_churn_on_mount,
+                            a["client"],
+                            a["mount_point"],
+                            stop_event,
+                            churn_rate,
+                        )
+                    )
+                _sleep_with_stop(stop_event, cfg["duration"], step=10)
+                stop_event.set()
+                for f in as_completed(futures, timeout=60):
+                    try:
+                        result = f.result()
+                        log.info("[churn] Thread result: %s", result)
+                    except Exception as e:
+                        log.warning("[churn] Thread error: %s", e)
+        else:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+            stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO client_state_churn: PASSED ***")
+        else:
+            log.error("*** SCENARIO client_state_churn: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Export Reorg & State Integrity
+# ---------------------------------------------------------------------------
+
+
+def _scenario_export_reorg_state_integrity(config, ceph_cluster):
+    """Export lifecycle: create/delete/recreate with active IO.
+
+    Layer 1 (nfs_protocol):
+        Export apply to modify access_type, delete with active IO,
+        recreate with same pseudo path, different-pseudo same-path.
+
+    Layer 2 (mds_backend):
+        mds_chaos profile: traceless replies + migration race during
+        export reorganization.
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    wf, cfg, rados_obj, injector = _common_setup(
+        config, ceph_cluster, "export_reorg_state_integrity"
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+        exports = wf.create_exports(
+            cfg["nfs_name"], cfg["fs_name"], max(3, cfg["num_exports"])
+        )
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(
+                injector, "export_reorg_state_integrity", config
+            )
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+
+        if cfg["enable_l1"] and len(exports) >= 2:
+            from cli.ceph.ceph import Ceph
+
+            _io_thread = _start_background_io(  # noqa: F841
+                wf,
+                assignments[:1],
+                cfg["fio_params"],
+                stop_event,
+            )
+
+            target_export = exports[1]
+            pseudo = target_export["pseudo"]
+
+            log.info("--- Delete export %s during IO ---", pseudo)
+            try:
+                Ceph(cfg["installer"]).nfs.export.delete(cfg["nfs_name"], pseudo)
+                log.info("Export %s deleted", pseudo)
+                time.sleep(10)
+
+                log.info("--- Recreate export %s ---", pseudo)
+                Ceph(cfg["installer"]).nfs.export.create(
+                    fs_name=cfg["fs_name"],
+                    nfs_name=cfg["nfs_name"],
+                    nfs_export=pseudo,
+                    fs=cfg["fs_name"],
+                )
+                log.info("Export %s recreated", pseudo)
+                time.sleep(10)
+            except Exception as e:
+                log.warning("Export reorg failed: %s", e)
+
+        if cfg["enable_l2"]:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+
+        stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        if cfg["enable_l1"] and len(exports) >= 2:
+            surviving = [a for a in assignments if a["export"] != exports[1]]
+        else:
+            surviving = assignments
+        test_failed = _common_validation(
+            wf, cfg, config, injector, surviving, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO export_reorg_state_integrity: PASSED ***")
+        else:
+            log.error("*** SCENARIO export_reorg_state_integrity: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Generative Client Behavior
+# ---------------------------------------------------------------------------
+
+
+def _scenario_generative_client_behavior(config, ceph_cluster):
+    """Role-based probabilistic client behavior generation.
+
+    Layer 1 (nfs_protocol):
+        Flaky client: iptables block/unblock cycles (3-10s blocks).
+        Slow-renew client: tc netem delay 5000ms +/- 3000ms jitter.
+        All roles: probabilistic file ops.
+
+    Layer 2 (mds_backend):
+        client_debug_inject_tick_delay=5 for FSAL-level slow renewal.
+        network_latency profile for delayed daemon messages.
+
+    Config keys:
+        duration (int): How long to run roles (default: 300)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    wf, cfg, rados_obj, injector = _common_setup(
+        config, ceph_cluster, "generative_client_behavior"
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "generative_client_behavior", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+        all_roles = [
+            "reader_heavy",
+            "lock_heavy",
+            "metadata_heavy",
+            "flaky",
+            "slow_renew",
+        ]
+        n_assign = len(assignments)
+        if n_assign < len(all_roles):
+            roles = all_roles[:n_assign]
+            if n_assign >= 2:
+                roles[-1] = "flaky"
+            if n_assign >= 3:
+                roles[-2] = "slow_renew"
+        else:
+            roles = [all_roles[i % len(all_roles)] for i in range(n_assign)]
+
+        if cfg["enable_l1"]:
+            with ThreadPoolExecutor(max_workers=min(n_assign, 5)) as executor:
+                futures = []
+                for i, a in enumerate(assignments):
+                    role = roles[i]
+                    client = a["client"]
+                    mp = a["mount_point"]
+
+                    if role == "flaky":
+
+                        def _flaky_loop(c, se):
+                            while not se.is_set():
+                                block_dur = random.randint(3, 10)
+                                wf.block_client_nfs_traffic(c, block_dur)
+                                _sleep_with_stop(se, random.randint(15, 30))
+
+                        futures.append(executor.submit(_flaky_loop, client, stop_event))
+                    else:
+                        if role == "slow_renew":
+                            wf.add_client_latency(client, 5000, 3000)
+                        futures.append(
+                            executor.submit(
+                                wf.run_churn_on_mount,
+                                client,
+                                mp,
+                                stop_event,
+                                3,
+                                role=role,
+                            )
+                        )
+                    log.info("Assigned role '%s' to %s", role, client.hostname)
+
+                _sleep_with_stop(stop_event, cfg["duration"], step=10)
+                stop_event.set()
+                for f in as_completed(futures, timeout=60):
+                    try:
+                        f.result()
+                    except Exception:
+                        pass
+        else:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+            stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO generative_client_behavior: PASSED ***")
+        else:
+            log.error("*** SCENARIO generative_client_behavior: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7: Admin Op Interleave
+# ---------------------------------------------------------------------------
+
+
+def _scenario_admin_op_interleave(config, ceph_cluster):
+    """Admin operations interleaved with active client IO.
+
+    Layer 1 (nfs_protocol):
+        Export CRUD, orch restart, orch redeploy, config set -- all
+        while fio runs on clients.
+
+    Layer 2 (mds_backend):
+        mds_chaos profile + ms_inject_delay during admin ops.
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    wf, cfg, rados_obj, injector = _common_setup(
+        config, ceph_cluster, "admin_op_interleave"
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "admin_op_interleave", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = []
+            futures.append(
+                executor.submit(
+                    wf.run_fio_on_assignments,
+                    assignments,
+                    {**cfg["fio_params"], "runtime": cfg["duration"]},
+                    stop_event,
+                )
+            )
+            if cfg["enable_l1"]:
+                futures.append(
+                    executor.submit(
+                        wf.run_admin_ops,
+                        cfg["nfs_name"],
+                        cfg["fs_name"],
+                        cfg["duration"],
+                        stop_event,
+                    )
+                )
+
+            _sleep_with_stop(stop_event, cfg["duration"], step=10)
+            stop_event.set()
+            for f in as_completed(futures, timeout=120):
+                try:
+                    f.result()
+                except Exception as e:
+                    log.warning("[admin_interleave] Thread error: %s", e)
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO admin_op_interleave: PASSED ***")
+        else:
+            log.error("*** SCENARIO admin_op_interleave: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 8: Observability Validation
+# ---------------------------------------------------------------------------
+
+
+def _scenario_observability_validation(config, ceph_cluster):
+    """Metrics-driven state tracking with convergence fail conditions.
+
+    Layer 1 (nfs_protocol):
+        Moderate churn with periodic state sampling every 10s.
+
+    Layer 2 (mds_backend):
+        client_session_stress with periodic state sampling.
+
+    Fail conditions (all layers):
+        - gRPC client count does not converge after churn stops
+        - Negative cid_refcount detected
+        - RSS monotonically growing after I/O stops (leak detection
+          via check_memory_stabilization: 5 samples at 60s intervals)
+        - IBMCEPH-13072 log flooding
+    Informational (logged, not a failure):
+        - State add vs deleted delta (active objects expected while
+          clients are mounted)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    wf, cfg, rados_obj, injector = _common_setup(
+        config, ceph_cluster, "observability_validation"
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+        log.info("Baseline snapshot: %s", baseline_snap)
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "observability_validation", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        churn_stop = Event()
+        sampler_stop = Event()
+        samples = [baseline_snap]
+
+        def _sampler():
+            while not sampler_stop.is_set():
+                _sleep_with_stop(sampler_stop, 10, step=2)
+                if sampler_stop.is_set():
+                    break
+                snap = wf.sample_state_snapshot(cfg["nfs_name"])
+                samples.append(snap)
+                log.info("[sampler] %s", snap)
+
+        wf.start_health_monitor(sampler_stop, interval=30)
+        _sample_thread = Thread(target=_sampler, daemon=True)  # noqa: F841
+        _sample_thread.start()
+
+        if cfg["enable_l1"]:
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                churn_futures = []
+                for a in assignments:
+                    churn_futures.append(
+                        executor.submit(
+                            wf.run_churn_on_mount,
+                            a["client"],
+                            a["mount_point"],
+                            churn_stop,
+                            2,
+                        )
+                    )
+                _sleep_with_stop(churn_stop, cfg["duration"], step=10)
+                churn_stop.set()
+        else:
+            _l2_soak_with_io(wf, cfg, assignments, churn_stop)
+            churn_stop.set()
+
+        log.info("Churn stopped, sampling continues for 120s convergence window...")
+        time.sleep(120)
+        sampler_stop.set()
+        _sample_thread.join(timeout=10)
+
+        _log_phase(3, "VALIDATION")
+        final_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+        samples.append(final_snap)
+        log.info("Final snapshot: %s", final_snap)
+        log.info("Total samples collected: %d", len(samples))
+
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO observability_validation: PASSED ***")
+        else:
+            log.error("*** SCENARIO observability_validation: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 9: Rapid Reconnect Storms
+# ---------------------------------------------------------------------------
+
+
+def _scenario_rapid_reconnect_storms(config, ceph_cluster):
+    """Simultaneous multi-client disconnect/reconnect thundering herd.
+
+    Layer 1 (nfs_protocol):
+        All clients iptables block simultaneously, staggered unblock
+        (3s/5s/8s per client).  Repeat 10 times.
+
+    Layer 2 (mds_backend):
+        ms_inject_socket_failures + objecter_inject_no_watch_ping
+        cause RADOS-level connection storms during reconnect.
+
+    Config keys:
+        reconnect_cycles (int): Number of storm repetitions (default: 10)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    wf, cfg, rados_obj, injector = _common_setup(
+        config, ceph_cluster, "rapid_reconnect_storms"
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "rapid_reconnect_storms", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+        storms = int(config.get("reconnect_cycles", 10))
+
+        if cfg["enable_l1"]:
+            _io_thread = _start_background_io(  # noqa: F841
+                wf,
+                assignments[:1],
+                cfg["fio_params"],
+                stop_event,
+            )
+
+            stagger_delays = [3, 5, 8]
+            for storm_idx in range(storms):
+                log.info("--- Storm %d/%d ---", storm_idx + 1, storms)
+                stagger_map = {}
+                for i in range(len(cfg["clients"])):
+                    stagger_map[i] = stagger_delays[i % len(stagger_delays)]
+
+                wf.block_all_clients_simultaneously(stagger_map)
+                time.sleep(30)
+
+        if cfg["enable_l2"]:
+            _l2_soak_with_io(wf, cfg, assignments, stop_event)
+
+        stop_event.set()
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO rapid_reconnect_storms: PASSED ***")
+        else:
+            log.error("*** SCENARIO rapid_reconnect_storms: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 10: Combined Churn + Failure
+# ---------------------------------------------------------------------------
+
+
+def _scenario_combined_churn_failure(config, ceph_cluster):
+    """Full integration: churn + admin ops + lease stress + backend chaos.
+
+    Layer 1 (nfs_protocol):
+        Client churn + admin ops + iptables delayed renewals with
+        chaos budget (max 2 active L1 generators).
+
+    Layer 2 (mds_backend):
+        multi_layer_chaos profile: network delays + storage errors +
+        OSD dispatch delays.
+
+    Combined:
+        All chaos axes with chaos budget (max 3 active generators).
+
+    Config keys:
+        churn_rate (int): Ops per 10s window (default: 3)
+        lease_lifetime (int): Shortened lease (default: 30)
+        duration (int): Thrash duration in seconds (default: 600)
+    """
+    wf = cfg = rados_obj = injector = None
+    assignments = []
+    exports = []
+    test_failed = False
+
+    lease_lt = config.get("lease_lifetime", 30)
+    wf, cfg, rados_obj, injector = _common_setup(
+        config,
+        ceph_cluster,
+        "combined_churn_failure",
+        lease_lifetime=int(lease_lt),
+    )
+
+    try:
+        _log_phase(0, "SETUP")
+        wf.archive_crash_state()
+
+        exports = wf.create_exports(cfg["nfs_name"], cfg["fs_name"], cfg["num_exports"])
+        assignments = wf.mount_exports_round_robin(
+            exports, cfg["nfs_name"], cfg["nfs_server"]
+        )
+        wf.log_cluster_health()
+
+        _log_phase(1, "PRE-THRASH BASELINE")
+        wf.write_integrity_baseline(assignments)
+        baseline_snap = wf.sample_state_snapshot(cfg["nfs_name"])
+
+        if cfg["enable_l2"] and injector:
+            wf.apply_scenario_injection(injector, "combined_churn_failure", config)
+        wf.log_cluster_health()
+
+        _log_phase(2, "THRASH")
+        stop_event = Event()
+        _health_thread = wf.start_health_monitor(stop_event)  # noqa: F841
+        churn_rate = int(config.get("churn_rate", 3))
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = []
+
+            futures.append(
+                executor.submit(
+                    wf.run_fio_on_assignments,
+                    assignments,
+                    {**cfg["fio_params"], "runtime": cfg["duration"]},
+                    stop_event,
+                )
+            )
+
+            if cfg["enable_l1"]:
+                for a in assignments[:2]:
+                    futures.append(
+                        executor.submit(
+                            wf.run_churn_on_mount,
+                            a["client"],
+                            a["mount_point"],
+                            stop_event,
+                            churn_rate,
+                        )
+                    )
+
+                futures.append(
+                    executor.submit(
+                        wf.run_admin_ops,
+                        cfg["nfs_name"],
+                        cfg["fs_name"],
+                        cfg["duration"],
+                        stop_event,
+                    )
+                )
+
+            _sleep_with_stop(stop_event, cfg["duration"], step=10)
+            stop_event.set()
+
+            for f in as_completed(futures, timeout=120):
+                try:
+                    result = f.result()
+                    log.info("[combined] Thread result: %s", result)
+                except Exception as e:
+                    log.warning("[combined] Thread error: %s", e)
+
+        _log_phase(3, "VALIDATION")
+        test_failed = _common_validation(
+            wf, cfg, config, injector, assignments, baseline_snap
+        )
+
+        if not test_failed:
+            log.info("*** SCENARIO combined_churn_failure: PASSED ***")
+        else:
+            log.error("*** SCENARIO combined_churn_failure: FAILED ***")
+
+    except Exception as e:
+        log.error("SCENARIO FAILED: %s", e)
+        log.exception(e)
+        test_failed = True
+
+    finally:
+        _log_phase(4, "CLEANUP")
+        _common_cleanup(wf, cfg, config, injector, assignments, exports)
+
+    return 1 if test_failed else 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario dispatch table
+# ---------------------------------------------------------------------------
+
+_SCENARIOS = {
+    "client_identity_lifecycle": _scenario_client_identity_lifecycle,
+    "lease_expiry_under_load": _scenario_lease_expiry_under_load,
+    "state_cardinality_stress": _scenario_state_cardinality_stress,
+    "client_state_churn": _scenario_client_state_churn,
+    "export_reorg_state_integrity": _scenario_export_reorg_state_integrity,
+    "generative_client_behavior": _scenario_generative_client_behavior,
+    "admin_op_interleave": _scenario_admin_op_interleave,
+    "observability_validation": _scenario_observability_validation,
+    "rapid_reconnect_storms": _scenario_rapid_reconnect_storms,
+    "combined_churn_failure": _scenario_combined_churn_failure,
+}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run(ceph_cluster, **kw):
+    """Dispatch to the appropriate NFS state lifecycle scenario.
+
+    The ``test_scenario`` config key selects which scenario to run.
+    The ``injection_layer`` config key selects the chaos layer:
+        - nfs_protocol  (Layer 1, default)
+        - mds_backend   (Layer 2)
+        - combined      (Layer 1 + Layer 2)
+
+    See module docstring for full configuration reference.
+    """
+    config = kw.get("config", {})
+    if not config:
+        raise ConfigError("No config provided")
+
+    scenario = config.get("test_scenario")
+    if not scenario:
+        raise ConfigError("test_scenario not specified in config")
+
+    handler = _SCENARIOS.get(scenario)
+    if not handler:
+        valid = ", ".join(sorted(_SCENARIOS.keys()))
+        log.error("Unknown test_scenario '%s'. Valid: %s", scenario, valid)
+        return 1
+
+    layer = config.get("injection_layer", "nfs_protocol")
+    log.info("=== NFS State Lifecycle: %s [%s] ===", scenario, layer)
+    return handler(config, ceph_cluster)


### PR DESCRIPTION
Implement 10 NFS-Ganesha state lifecycle scenarios validating client identity, lease expiry, state cardinality, churn resilience, export reorganization, generative behavior, admin interleaving, observability, reconnect storms, and combined failure modes.

Key design decisions:
- Per-scenario NFS cluster (lc-<hex8>) for isolation with shared CephFS
- Dual-layer injection: L1 (NFS protocol via iptables/tc/mount cycles) and L2 (MDS backend via CephErrorInjector), run independently or combined
- 5-phase lifecycle: setup, pre-thrash baseline, thrash, validation, cleanup
- gRPC-based state queries (GetClientIds/GetSessionIds) for convergence
- Memory leak detection via RSS stabilization (5 samples, 60s intervals)
- Consolidated apply_all_configs (gRPC + debug logging + grpcurl in single redeploy) and daemon ID caching for performance
- Background fio during L1 thrash for realistic workload pressure
- Stale mount healing via lazy-unmount + remount after network chaos
- Data integrity verification with fio crc32c checksums


pass logs : 
http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-U06HV9
http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-GBSGL2 


Note : I will have more runs and attach logs. In meanwhile, we can have the workflows reviewed.