### PR TITLE
9.2 - nfs_stats via prometheus - Complete Feature Automation

### DIFF
--- a/suites/tentacle/nfs/tier2-nfs-prometheus-stats.yaml
+++ b/suites/tentacle/nfs/tier2-nfs-prometheus-stats.yaml
@@ -1,0 +1,278 @@
+#===============================================================================================
+# NFS-Ganesha Scalable Statistics (Prometheus) — combined suite
+# S-*, F-*, A-*, R-*, X-*, SC-*, N-* (HA-* remains baremetal/tier1-nfs-prometheus-stats-ha.yaml)
+# Conf: conf/tentacle/nfs/1admin-7node-3client.yaml
+# Backend: Ceph FSAL only (GPFS cases excluded)
+# Requires 2 clients (S-07, F-09). Accuracy/scale use 4 clients (node4–node7).
+# Run with cluster reuse or uncomment bootstrap below.
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: false
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+      desc: Bootstrap and deploy Ceph services for NFS Prometheus stats testing.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client 1
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2
+        node: node5
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client 2
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client 2
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3
+        node: node6
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client 3
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client 3
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.4
+        node: node7
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client 4
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client 4
+
+  - test:
+      name: NFS Prometheus scalable statistics sanity
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics sanity
+      polarion-id: CEPH-83632504
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632504
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 2
+        nfs_version: 4.1
+        port: 2049
+        idle_wait_seconds: 120
+        idle_in_flight_max: 5
+        idle_max_counter_drift: 100
+        prometheus_query_wait_seconds: 30
+        prometheus_increase_window: 2m
+        s07_min_clients: 2
+        s07_max_client_series_when_disabled: 0
+        s08_fio_runtime: 60
+        s08_fio_size: 64M
+
+  - test:
+      name: NFS Prometheus scalable statistics functional
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics functional
+      polarion-id: CEPH-83632505
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632505
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 2
+        nfs_version: 4.1
+        port: 2049
+        f01_invalid_monitoring_port: 99999
+        f01_typo_line: "Enable_metrics xxxx = true;"
+        f01_redeploy_settle_seconds: 30
+        f02_alt_monitoring_port: 9588
+        f02_reload_wait_seconds: 5
+        f03_scrape_wait_seconds: 45
+        f04_parallel_scrapes: 10
+        f05_file_count: 100
+        f06_fio_runtime: 120
+        f06_fio_size: 256M
+        f10_file_count: 500
+        prometheus_query_wait_seconds: 30
+        prometheus_targets_timeout: 120
+        prometheus_targets_poll_interval: 10
+
+  - test:
+      name: NFS Prometheus scalable statistics accuracy
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics accuracy
+      polarion-id: CEPH-83632506
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632506
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 4
+        nfs_version: 4.1
+        port: 2049
+        fio_runtime: 120
+        read_size_mb: 128
+        write_size_mb: 128
+        num_exports: 5
+        idle_wait_seconds: 20
+        a09_idle_wait_seconds: 15
+        bytes_tolerance_pct: 15
+        prometheus_query_wait_seconds: 30
+        prometheus_targets_timeout: 120
+        prometheus_targets_poll_interval: 10
+
+  - test:
+      name: NFS Prometheus scalable statistics regression
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics regression
+      polarion-id: CEPH-83632509
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632509
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 1
+        nfs_version: 4.1
+        port: 2049
+        prometheus_query_wait_seconds: 30
+
+  - test:
+      name: NFS Prometheus scalable statistics failure and recovery
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics failure and recovery
+      polarion-id: CEPH-83632510
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632510
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 1
+        nfs_version: 4.1
+        port: 2049
+        f03_scrape_wait_seconds: 45
+        prometheus_query_wait_seconds: 30
+        prometheus_targets_timeout: 120
+        prometheus_targets_poll_interval: 10
+
+  - test:
+      name: NFS Prometheus scalable statistics scale
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics scale
+      polarion-id: CEPH-83632507
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632507
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 4
+        nfs_version: 4.1
+        port: 2049
+        num_exports: 5
+        fio_runtime: 60
+        sc04_fio_runtime: 30
+        prometheus_query_wait_seconds: 30
+
+  - test:
+      name: NFS Prometheus scalable statistics negative and edge
+      module: test_nfs_prometheus_stats.py
+      desc: NFS Prometheus scalable statistics negative and edge
+      polarion-id: CEPH-83632511
+      abort-on-fail: false
+      config:
+        polarion-id: CEPH-83632511
+        nfs_name: cephfs-nfs
+        nfs_export: /export
+        nfs_mount: /mnt/nfs
+        fs_name: cephfs
+        clients: 1
+        nfs_version: 4.1
+        port: 2049
+        prometheus_query_wait_seconds: 30

--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -1,0 +1,2796 @@
+"""Shared helpers for NFS-Ganesha Prometheus / scalable statistics CephCI tests."""
+
+import json
+import re
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import quote
+
+from cli.ceph.ceph import Ceph
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError
+from cli.utilities.filesys import Mount, Unmount
+from tests.nfs.nfs_delegation_operations import (
+    backup_ganesha_template,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    redeploy_nfs_clusters,
+    restore_ganesha_template,
+    run_cephadm_shell,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+DEFAULT_MONITORING_PORT = 9587
+DEFAULT_PROMETHEUS_PORT = 9095
+CONF_KEY = "mgr/cephadm/services/nfs/ganesha.conf"
+DEFAULT_TEMPLATE_PATH = (
+    "/usr/share/ceph/mgr/cephadm/templates/services/nfs/ganesha.conf.j2"
+)
+MOUNTED_TEMPLATE_PATH = "/var/lib/ceph/ganesha.conf"
+_PROM_RUN_ID = uuid.uuid4().hex
+WORK_TEMPLATE_PATH = "/tmp/ganesha_prometheus_%s_work.conf.j2" % _PROM_RUN_ID
+BACKUP_TEMPLATE_PATH = "/tmp/ganesha_prometheus_%s_backup.conf.j2" % _PROM_RUN_ID
+
+PROMETHEUS_GANESHA_PARAM_NAMES = {
+    "enable_metrics": "Enable_Metrics",
+    "enable_dynamic_metrics": "Enable_Dynamic_Metrics",
+    "monitoring_port": "Monitoring_Port",
+    "enable_FULLV4STATS": "Enable_FULLV4_Stats",
+}
+
+
+def _prometheus_param_aliases(key, canonical):
+    aliases = [key, canonical]
+    if key == "enable_FULLV4STATS":
+        aliases.extend(
+            [
+                "Enable_FULLV4STATS",
+                "enable_FULLV4STATS",
+                "Enable_FULLV4_Stats",
+            ]
+        )
+    return tuple(dict.fromkeys(aliases))
+
+
+PROMETHEUS_CORE_PARAM_ALIASES = {
+    key: _prometheus_param_aliases(key, canonical)
+    for key, canonical in PROMETHEUS_GANESHA_PARAM_NAMES.items()
+}
+
+# Ganesha 9.7 golden exposition (reference cluster 10.0.66.98:9587).
+# Core counters: rpcs_*, nfs_requests_total, client_requests_total, mdcache_cache_*.
+# Gauges: rpcs_in_flight, clients__confirmed_count, ganesha_build_info.
+# Histograms: nfs_latency_ms, nfsv4__op_latency.
+# Optional / dynamic: nfs_errors_total, nfs_requests_by_export_total, client_bytes_*,
+# nfsv4__op_count, last_client_update, compound__latency, connection_manager__clients.
+MANIFEST_V1_COUNTERS = (
+    "rpcs_received_total",
+    "rpcs_completed_total",
+    "nfs_requests_total",
+    "client_requests_total",
+    "mdcache_cache_hits_total",
+    "mdcache_cache_misses_total",
+)
+
+MANIFEST_V1_GAUGES = (
+    "rpcs_in_flight",
+    "clients__confirmed_count",
+    "ganesha_build_info",
+)
+
+MANIFEST_V1_HISTOGRAMS = (
+    "nfs_latency_ms",
+    "nfsv4__op_latency",
+)
+
+# Present on some builds or after specific workload; warn only.
+MANIFEST_V1_OPTIONAL = (
+    "nfs_errors_total",
+    "errors_total",
+    "nfs_requests_by_export_total",
+    "nfsv4__op_count",
+    "last_client_update",
+    "client_bytes_received_total",
+    "client_bytes_sent_total",
+    "nfs_bytes_received_by_export_total",
+    "nfs_bytes_sent_by_export_total",
+    "nfs_latency_ms_by_export",
+    "compound__latency",
+    "connection_manager__clients",
+    "clients_confirmed_count",
+    "requests_total",
+    "latency_ms",
+    "v4_op_latency",
+    "request_size_bytes",
+    "response_size_bytes",
+    "bytes_received_total",
+    "bytes_sent_total",
+)
+
+MANIFEST_METRIC_ALIASES = {
+    "nfs_latency_ms": (
+        "nfs_latency_ms",
+        "latency_ms",
+    ),
+    "latency_ms": (
+        "nfs_latency_ms",
+        "latency_ms",
+    ),
+    "v4_op_latency": (
+        "nfsv4__op_latency",
+        "nfs_v4_op_latency",
+        "v4_op_latency",
+    ),
+    "nfsv4__op_latency": (
+        "nfsv4__op_latency",
+        "nfs_v4_op_latency",
+        "v4_op_latency",
+    ),
+    "nfs_requests_total": (
+        "nfs_requests_total",
+        "requests_total",
+    ),
+    "requests_total": (
+        "nfs_requests_total",
+        "requests_total",
+    ),
+    "client_requests_total": (
+        "client_requests_total",
+        "nfs_client_requests_total",
+    ),
+    "nfs_errors_total": (
+        "nfs_errors_total",
+        "errors_total",
+    ),
+    "errors_total": (
+        "nfs_errors_total",
+        "errors_total",
+    ),
+    "clients__confirmed_count": (
+        "clients__confirmed_count",
+        "clients_confirmed_count",
+    ),
+    "clients_confirmed_count": (
+        "clients__confirmed_count",
+        "clients_confirmed_count",
+    ),
+    "bytes_received_total": (
+        "client_bytes_received_total",
+        "nfs_client_bytes_received_total",
+        "nfs_bytes_received_by_export_total",
+        "bytes_received_by_export_total",
+        "nfs_bytes_received_total",
+        "bytes_received_total",
+    ),
+    "bytes_sent_total": (
+        "client_bytes_sent_total",
+        "nfs_client_bytes_sent_total",
+        "nfs_bytes_sent_by_export_total",
+        "bytes_sent_by_export_total",
+        "nfs_bytes_sent_total",
+        "bytes_sent_total",
+    ),
+    "nfs_bytes_sent_total": (
+        "client_bytes_sent_total",
+        "nfs_client_bytes_sent_total",
+        "nfs_bytes_sent_by_export_total",
+        "bytes_sent_by_export_total",
+        "nfs_bytes_sent_total",
+        "bytes_sent_total",
+    ),
+    "nfs_bytes_received_total": (
+        "client_bytes_received_total",
+        "nfs_client_bytes_received_total",
+        "nfs_bytes_received_by_export_total",
+        "bytes_received_by_export_total",
+        "nfs_bytes_received_total",
+        "bytes_received_total",
+    ),
+    "mdcache_cache_hits_total": (
+        "mdcache_cache_hits_total",
+        "mdcache_cache_hits_by_export_total",
+        "nfs_mdcache_hits_total",
+    ),
+    "mdcache_cache_misses_total": (
+        "mdcache_cache_misses_total",
+        "mdcache_cache_misses_by_export_total",
+        "nfs_mdcache_misses_total",
+    ),
+    "nfs_requests_by_export_total": (
+        "nfs_requests_by_export_total",
+        "requests_by_export_total",
+    ),
+    "nfsv4__op_count": (
+        "nfsv4__op_count",
+        "nfs_v4_op_count",
+        "v4_op_count",
+        "nfs4_op_count",
+    ),
+    "nfs_v4_op_count": (
+        "nfsv4__op_count",
+        "nfs_v4_op_count",
+        "v4_op_count",
+        "nfs4_op_count",
+    ),
+    "rpcs_received_total": (
+        "rpcs_received_total",
+        "nfs_rpcs_received_total",
+    ),
+    "nfs_rpcs_received_total": (
+        "rpcs_received_total",
+        "nfs_rpcs_received_total",
+    ),
+    "rpcs_completed_total": (
+        "rpcs_completed_total",
+        "nfs_rpcs_completed_total",
+    ),
+    "nfs_rpcs_completed_total": (
+        "rpcs_completed_total",
+        "nfs_rpcs_completed_total",
+    ),
+    "rpcs_in_flight": (
+        "rpcs_in_flight",
+        "nfs_rpcs_in_flight",
+    ),
+    "nfs_rpcs_in_flight": (
+        "rpcs_in_flight",
+        "nfs_rpcs_in_flight",
+    ),
+    "clients__lease_expire_count": (
+        "clients__lease_expire_count",
+        "nfs_clients_lease_expire_count",
+        "clients_lease_expire_count",
+    ),
+    "nfs_clients_lease_expire_count": (
+        "clients__lease_expire_count",
+        "nfs_clients_lease_expire_count",
+        "clients_lease_expire_count",
+    ),
+}
+
+# Match any exported series in the family (e.g. *_by_export_total).
+MANIFEST_METRIC_PREFIX_FAMILIES = {
+    "mdcache_cache_hits_total": "mdcache_cache_hits",
+    "mdcache_cache_misses_total": "mdcache_cache_misses",
+}
+
+LATENCY_HISTOGRAM_PREFIXES = (
+    "nfs_latency_ms",
+    "latency_ms",
+    "nfsv4__op_latency",
+    "v4_op_latency",
+    "nfs_v4_op_latency",
+    "nfs_latency_ms_by_export",
+    "compound__latency",
+)
+
+V4_OP_COUNT_METRICS = (
+    "nfsv4__op_count",
+    "v4_op_count",
+    "nfs_v4_op_count",
+    "nfs4_op_count",
+)
+
+CLIENT_REQUEST_METRICS = (
+    "client_requests_total",
+    "nfs_client_requests_total",
+)
+
+CLIENT_BYTES_METRICS = (
+    "client_bytes_received_total",
+    "client_bytes_sent_total",
+    "nfs_client_bytes_received_total",
+    "nfs_client_bytes_sent_total",
+)
+
+BYTES_SENT_COUNTER_CANDIDATES = (
+    "client_bytes_sent_total",
+    "nfs_client_bytes_sent_total",
+    "nfs_bytes_sent_by_export_total",
+    "bytes_sent_by_export_total",
+    "nfs_bytes_sent_total",
+    "bytes_sent_total",
+)
+
+BYTES_RECEIVED_COUNTER_CANDIDATES = (
+    "client_bytes_received_total",
+    "nfs_client_bytes_received_total",
+    "nfs_bytes_received_by_export_total",
+    "bytes_received_by_export_total",
+    "nfs_bytes_received_total",
+    "bytes_received_total",
+)
+
+# Ganesha 9.7 byte counters are labeled by NFS operation (read, write, ...).
+# Read payload is on *_received_*; write payload is on *_sent_* (server-side naming).
+NFS_BYTE_READ_OPERATIONS = ("read",)
+NFS_BYTE_WRITE_OPERATIONS = ("write",)
+NFS_BYTE_READ_COUNTER = "bytes_received_total"
+NFS_BYTE_WRITE_COUNTER = "bytes_sent_total"
+
+MDCACHE_HIT_METRICS = (
+    "mdcache_cache_hits_total",
+    "nfs_mdcache_hits_total",
+)
+
+MDCACHE_MISS_METRICS = (
+    "mdcache_cache_misses_total",
+    "nfs_mdcache_misses_total",
+)
+
+PROMETHEUS_LABEL_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def get_installer(ceph_cluster):
+    return ceph_cluster.get_nodes(role="installer")[0]
+
+
+def _install_ceph_common_if_needed(node):
+    out, _ = node.exec_command(
+        sudo=True,
+        cmd="command -v ceph && echo present || echo absent",
+        check_ec=False,
+    )
+    if "present" in (out or ""):
+        return
+    for install_cmd in (
+        "dnf install -y ceph-common --nogpgcheck",
+        "yum install -y ceph-common --nogpgcheck",
+    ):
+        _, rc = node.exec_command(
+            sudo=True, cmd=install_cmd, check_ec=False, timeout=600
+        )
+        if rc == 0:
+            log.info("Installed ceph-common on %s", node.hostname)
+            return
+    raise OperationFailedError("Failed to install ceph-common on %s" % node.hostname)
+
+
+def prepare_cluster_ceph_access(ceph_cluster, installer, clients=None, nfs_nodes=None):
+    """Install ceph-common and deploy ceph.conf + admin keyring on NFS and client nodes."""
+    nfs_nodes = nfs_nodes or ceph_cluster.get_nodes(role="nfs")
+    clients = clients or ceph_cluster.get_nodes(role="client")
+    nodes = []
+    seen = set()
+    for node in list(nfs_nodes) + list(clients):
+        if node.hostname in seen:
+            continue
+        seen.add(node.hostname)
+        nodes.append(node)
+    for node in nodes:
+        _install_ceph_common_if_needed(node)
+    ensure_ceph_conf_and_admin_keyring_on_hosts(installer, nodes)
+    log.info(
+        "ceph-common with admin keyring configured on: %s",
+        ", ".join(sorted(seen)),
+    )
+
+
+def _format_ganesha_param(key, value):
+    if isinstance(value, bool):
+        value = "true" if value else "false"
+    name = PROMETHEUS_GANESHA_PARAM_NAMES.get(key, key)
+    return "%s = %s;" % (name, value)
+
+
+def _prometheus_core_params_from_config(config):
+    monitoring_port = int(config.get("monitoring_port", DEFAULT_MONITORING_PORT))
+    return {
+        "enable_metrics": bool(config.get("enable_metrics", True)),
+        "enable_dynamic_metrics": bool(config.get("enable_dynamic_metrics", True)),
+        "monitoring_port": monitoring_port,
+        "enable_FULLV4STATS": bool(config.get("enable_FULLV4STATS", True)),
+    }
+
+
+def _patch_ganesha_work_template(cmd_host, config):
+    """Insert Ganesha NFS_CORE_PARAM prometheus settings into the cephadm J2 template."""
+    params = _prometheus_core_params_from_config(config)
+    port = params["monitoring_port"]
+    cmd_host.exec_command(
+        sudo=True,
+        cmd=(
+            "sed -i -E "
+            "'s/^[[:space:]]*Monitoring_Port[[:space:]]*=.*/"
+            "        Monitoring_Port = %s;/' %s" % (port, WORK_TEMPLATE_PATH)
+        ),
+        check_ec=False,
+    )
+    for key in ("enable_metrics", "enable_dynamic_metrics", "enable_FULLV4STATS"):
+        line = _format_ganesha_param(key, params[key])
+        alias_pattern = "|".join(
+            re.escape(a) for a in PROMETHEUS_CORE_PARAM_ALIASES[key]
+        )
+        escaped_line = line.replace("/", "\\/")
+        cmd_host.exec_command(
+            sudo=True,
+            cmd=(
+                "sed -i -E "
+                "'s/^[[:space:]]*(%s)[[:space:]]*=[[:space:]]*[^;]+;/%s/' %s"
+                % (alias_pattern, escaped_line, WORK_TEMPLATE_PATH)
+            ),
+            check_ec=False,
+        )
+        out, _ = cmd_host.exec_command(
+            sudo=True,
+            cmd="grep -Ei '(%s)[[:space:]]*=' %s" % (alias_pattern, WORK_TEMPLATE_PATH),
+            check_ec=False,
+        )
+        if not (out or "").strip():
+            cmd_host.exec_command(
+                sudo=True,
+                cmd=(
+                    "sed -i '/allow_set_io_flusher_fail[[:space:]]*=/a\\"
+                    "        %s' %s" % (escaped_line, WORK_TEMPLATE_PATH)
+                ),
+            )
+        out, _ = cmd_host.exec_command(
+            sudo=True,
+            cmd="grep -F %r %s" % (line, WORK_TEMPLATE_PATH),
+            check_ec=False,
+        )
+        if line not in (out or ""):
+            raise OperationFailedError("Failed to set %s in ganesha template" % line)
+    snippet, _ = cmd_host.exec_command(
+        sudo=True,
+        cmd="sed -n '/NFS_CORE_PARAM/,/^}/p' %s | head -20" % WORK_TEMPLATE_PATH,
+        check_ec=False,
+    )
+    log.info(
+        "Patched ganesha template NFS_CORE_PARAM block:\n%s",
+        (snippet or "").strip(),
+    )
+
+
+def set_prometheus_ganesha_core_params(cmd_host, config):
+    """Patch NFS_CORE_PARAM prometheus settings in the cephadm ganesha template."""
+    run_cephadm_shell(
+        cmd_host,
+        "ceph config-key get %s > %s" % (CONF_KEY, WORK_TEMPLATE_PATH),
+        check_ec=False,
+    )
+    cmd_host.exec_command(
+        sudo=True,
+        cmd=(
+            "test -s %s || cephadm shell -- cat %s > %s"
+            % (WORK_TEMPLATE_PATH, DEFAULT_TEMPLATE_PATH, WORK_TEMPLATE_PATH)
+        ),
+    )
+    _patch_ganesha_work_template(cmd_host, config)
+    cmd_host.exec_command(
+        sudo=True,
+        cmd=(
+            "cephadm shell --mount %s:%s -- ceph config-key set %s -i %s"
+            % (
+                WORK_TEMPLATE_PATH,
+                MOUNTED_TEMPLATE_PATH,
+                CONF_KEY,
+                MOUNTED_TEMPLATE_PATH,
+            )
+        ),
+    )
+
+
+def _expect_prometheus_param(conf, label, key, value):
+    name = PROMETHEUS_GANESHA_PARAM_NAMES[key]
+    if key == "monitoring_port":
+        expected = "%s = %s" % (name, value)
+    else:
+        expected = _format_ganesha_param(key, value).rstrip(";")
+    if expected not in (conf or "") and not re.search(
+        r"(?i)%s\s*=\s*%s"
+        % (
+            re.escape(name),
+            value if key == "monitoring_port" else ("true" if value else "false"),
+        ),
+        conf or "",
+    ):
+        raise OperationFailedError("%s missing %s in %s" % (label, expected, name))
+
+
+def verify_prometheus_params_on_nfs_nodes(
+    cephadm, nfs_nodes, nfs_name, config, timeout_seconds=120, poll_interval=5
+):
+    """Poll orch ps and verify prometheus NFS_CORE_PARAM in container ganesha.conf."""
+    params = _prometheus_core_params_from_config(config)
+    deadline = time.time() + int(timeout_seconds)
+    last_error = None
+    while time.time() < deadline:
+        try:
+            raw = cephadm.orch.ps(service_name="nfs.%s" % nfs_name, format="json")
+            daemons = json.loads(raw) if raw else []
+            if not daemons:
+                raise OperationFailedError(
+                    "No nfs daemons found in orch ps for nfs.%s" % nfs_name
+                )
+            for daemon in daemons:
+                hostname = (daemon.get("hostname") or "").split(".")[0]
+                nfs_node = next(
+                    (
+                        node
+                        for node in nfs_nodes
+                        if node.hostname.split(".")[0] == hostname
+                        or hostname in node.hostname
+                    ),
+                    None,
+                )
+                if not nfs_node:
+                    raise OperationFailedError(
+                        "No nfs node matched orch daemon %s" % daemon.get("hostname")
+                    )
+                container_id = daemon.get("container_id")
+                if not container_id:
+                    raise OperationFailedError(
+                        "NFS daemon on %s has no container_id (status=%s)"
+                        % (nfs_node.hostname, daemon.get("status_desc"))
+                    )
+                conf, _ = nfs_node.exec_command(
+                    sudo=True,
+                    cmd="podman exec %s cat /etc/ganesha/ganesha.conf" % container_id,
+                )
+                label = "%s container %s" % (nfs_node.hostname, container_id)
+                for key, value in params.items():
+                    _expect_prometheus_param(conf, label, key, value)
+                log.info(
+                    "Verified prometheus NFS_CORE_PARAM on %s (container %s)",
+                    nfs_node.hostname,
+                    container_id,
+                )
+            return
+        except OperationFailedError as err:
+            last_error = err
+            log.info(
+                "Prometheus ganesha.conf verify not ready, retrying in %ss: %s",
+                poll_interval,
+                err,
+            )
+            time.sleep(int(poll_interval))
+    raise last_error or OperationFailedError(
+        "Timed out after %ss verifying prometheus params on nfs nodes" % timeout_seconds
+    )
+
+
+def apply_prometheus_ganesha_template(installer, nfs_node, nfs_name, config):
+    """Backup, patch ganesha template on NFS node, redeploy via installer."""
+    redeploy_wait = int(config.get("redeploy_wait", 10))
+    service_wait_timeout = int(config.get("service_wait_timeout", 300))
+    verify_timeout = int(config.get("prometheus_verify_timeout", service_wait_timeout))
+    verify_poll = int(config.get("prometheus_verify_poll_seconds", 5))
+    log.info(
+        "Running cephadm shell / config-key / template steps on NFS node %s",
+        nfs_node.hostname,
+    )
+    cephadm = CephAdm(installer).ceph
+    backup_exists = backup_ganesha_template(nfs_node, BACKUP_TEMPLATE_PATH)
+    set_prometheus_ganesha_core_params(nfs_node, config)
+    log.info(
+        "Updated ganesha NFS_CORE_PARAM prometheus settings: %s",
+        _prometheus_core_params_from_config(config),
+    )
+    redeploy_nfs_clusters(
+        cephadm, [nfs_name], installer, redeploy_wait, service_wait_timeout
+    )
+    verify_prometheus_params_on_nfs_nodes(
+        cephadm,
+        nfs_nodes=[nfs_node],
+        nfs_name=nfs_name,
+        config=config,
+        timeout_seconds=verify_timeout,
+        poll_interval=verify_poll,
+    )
+    return backup_exists
+
+
+def update_prometheus_ganesha_params(installer, nfs_node, nfs_name, config):
+    """Patch ganesha template and redeploy without taking a new backup."""
+    redeploy_wait = int(config.get("redeploy_wait", 10))
+    service_wait_timeout = int(config.get("service_wait_timeout", 300))
+    verify_timeout = int(config.get("prometheus_verify_timeout", service_wait_timeout))
+    verify_poll = int(config.get("prometheus_verify_poll_seconds", 5))
+    cephadm = CephAdm(installer).ceph
+    set_prometheus_ganesha_core_params(nfs_node, config)
+    log.info(
+        "Updated ganesha NFS_CORE_PARAM prometheus settings: %s",
+        _prometheus_core_params_from_config(config),
+    )
+    redeploy_nfs_clusters(
+        cephadm, [nfs_name], installer, redeploy_wait, service_wait_timeout
+    )
+    verify_prometheus_params_on_nfs_nodes(
+        cephadm,
+        nfs_nodes=[nfs_node],
+        nfs_name=nfs_name,
+        config=config,
+        timeout_seconds=verify_timeout,
+        poll_interval=verify_poll,
+    )
+
+
+def restore_prometheus_ganesha_template(
+    installer, nfs_node, nfs_name, backup_exists, config
+):
+    """Restore ganesha template and redeploy NFS (delegation-style cleanup)."""
+    if not config.get("restore_ganesha_template_on_exit", True):
+        return
+
+    redeploy_wait = int(config.get("redeploy_wait", 10))
+    service_wait_timeout = int(config.get("service_wait_timeout", 300))
+    if config.get("reset_ganesha_template_on_exit", False):
+        run_cephadm_shell(nfs_node, "ceph config-key rm %s" % CONF_KEY, check_ec=False)
+    else:
+        restore_ganesha_template(nfs_node, backup_exists, BACKUP_TEMPLATE_PATH)
+    cephadm = CephAdm(installer).ceph
+    redeploy_nfs_clusters(
+        cephadm, [nfs_name], installer, redeploy_wait, service_wait_timeout
+    )
+
+
+def _load_ganesha_work_template(cmd_host):
+    run_cephadm_shell(
+        cmd_host,
+        "ceph config-key get %s > %s" % (CONF_KEY, WORK_TEMPLATE_PATH),
+        check_ec=False,
+    )
+    cmd_host.exec_command(
+        sudo=True,
+        cmd=(
+            "test -s %s || cephadm shell -- cat %s > %s"
+            % (WORK_TEMPLATE_PATH, DEFAULT_TEMPLATE_PATH, WORK_TEMPLATE_PATH)
+        ),
+    )
+
+
+def _commit_ganesha_work_template(cmd_host):
+    cmd_host.exec_command(
+        sudo=True,
+        cmd=(
+            "cephadm shell --mount %s:%s -- ceph config-key set %s -i %s"
+            % (
+                WORK_TEMPLATE_PATH,
+                MOUNTED_TEMPLATE_PATH,
+                CONF_KEY,
+                MOUNTED_TEMPLATE_PATH,
+            )
+        ),
+    )
+
+
+def inject_ganesha_template_line(cmd_host, line, after_pattern="Enable_Metrics"):
+    escaped = line.replace("/", "\\/")
+    cmd_host.exec_command(
+        sudo=True,
+        cmd="sed -i '/%s/a\\        %s' %s"
+        % (after_pattern, escaped, WORK_TEMPLATE_PATH),
+    )
+
+
+def remove_ganesha_template_line(cmd_host, line):
+    escaped = line.replace("/", "\\/").replace("&", "\\&")
+    cmd_host.exec_command(
+        sudo=True,
+        cmd="sed -i '/%s/d' %s" % (escaped, WORK_TEMPLATE_PATH),
+        check_ec=False,
+    )
+
+
+def restore_f01_good_ganesha_config(
+    installer, nfs_node, nfs_name, config, typo_line=None
+):
+    """Remove injected typo (if any), re-apply valid prometheus params, redeploy."""
+    _load_ganesha_work_template(nfs_node)
+    if typo_line:
+        remove_ganesha_template_line(nfs_node, typo_line)
+    _patch_ganesha_work_template(nfs_node, config)
+    _commit_ganesha_work_template(nfs_node)
+    trigger_nfs_redeploy(installer, nfs_name, config, wait_for_running=True)
+    log.info("F-01: restored valid ganesha template after typo injection")
+
+
+def trigger_nfs_redeploy(installer, nfs_name, config, wait_for_running=True):
+    from tests.nfs.nfs_delegation_operations import (
+        verify_nfs_ganesha_service,
+        wait_for_nfs_cluster_daemons_running,
+    )
+
+    cephadm = CephAdm(installer).ceph
+    redeploy_wait = int(config.get("redeploy_wait", 10))
+    service_wait_timeout = int(config.get("service_wait_timeout", 300))
+    cephadm.orch.redeploy("nfs.%s" % nfs_name)
+    time.sleep(redeploy_wait)
+    if wait_for_running:
+        verify_nfs_ganesha_service(node=installer, timeout=service_wait_timeout)
+        wait_for_nfs_cluster_daemons_running(
+            cephadm, [nfs_name], timeout_seconds=service_wait_timeout
+        )
+
+
+def get_nfs_daemon_info(cephadm, nfs_name):
+    raw = cephadm.orch.ps(service_name="nfs.%s" % nfs_name, format="json")
+    return json.loads(raw) if raw else []
+
+
+def read_nfs_container_logs(nfs_node, container_id=None, tail_lines=300):
+    if container_id:
+        cmd = "podman logs --tail %s %s 2>&1" % (tail_lines, container_id)
+    else:
+        cmd = (
+            "cid=$(podman ps -a --format '{{.ID}} {{.Names}}' "
+            "| awk '/nfs|ganesha/ {print $1; exit}'); "
+            '[ -n "$cid" ] && podman logs --tail %s "$cid" 2>&1'
+        ) % tail_lines
+    out, _ = nfs_node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    return out or ""
+
+
+def apply_f01_invalid_monitoring_port(
+    installer, nfs_node, nfs_name, base_config, invalid_port
+):
+    bad_config = dict(base_config)
+    bad_config["monitoring_port"] = int(invalid_port)
+    set_prometheus_ganesha_core_params(nfs_node, bad_config)
+    trigger_nfs_redeploy(installer, nfs_name, base_config, wait_for_running=False)
+    settle = int(base_config.get("f01_redeploy_settle_seconds", 30))
+    time.sleep(settle)
+    cephadm = CephAdm(installer).ceph
+    daemons = get_nfs_daemon_info(cephadm, nfs_name)
+    logs = read_nfs_container_logs(nfs_node, tail_lines=400)
+    log.info(
+        "F-01A redeploy settle=%ss daemon statuses: %s",
+        settle,
+        [d.get("status_desc") for d in daemons],
+    )
+    return logs, daemons
+
+
+def apply_f01_config_typo_line(installer, nfs_node, nfs_name, base_config, typo_line):
+    _load_ganesha_work_template(nfs_node)
+    _patch_ganesha_work_template(nfs_node, base_config)
+    inject_ganesha_template_line(nfs_node, typo_line)
+    _commit_ganesha_work_template(nfs_node)
+    trigger_nfs_redeploy(installer, nfs_name, base_config, wait_for_running=False)
+    settle = int(base_config.get("f01_redeploy_settle_seconds", 30))
+    time.sleep(settle)
+    cephadm = CephAdm(installer).ceph
+    daemons = get_nfs_daemon_info(cephadm, nfs_name)
+    logs = read_nfs_container_logs(nfs_node, tail_lines=400)
+    log.info(
+        "F-01B redeploy settle=%ss daemon statuses: %s",
+        settle,
+        [d.get("status_desc") for d in daemons],
+    )
+    return logs, daemons
+
+
+def verify_f01_invalid_port_outcome(ctx, logs, daemons, invalid_port):
+    """Accept fatal config rejection, or running NFS without metrics on bad port."""
+    log_text = (logs or "").lower()
+    refuses = any(
+        marker in log_text
+        for marker in (
+            "out of range",
+            "fatal errors",
+            "fatal:",
+            "server exiting",
+            "error setting parameters",
+            "errors processing block",
+        )
+    )
+    running = any((d.get("status_desc") or "").lower() == "running" for d in daemons)
+
+    if refuses:
+        log.info(
+            "F-01A: Ganesha rejected invalid monitoring_port=%s (log error present)",
+            invalid_port,
+        )
+        return
+
+    if running:
+        code = scrape_prometheus_metrics_http_code(
+            ctx.client, ctx.nfs_ip, invalid_port, path="/metrics"
+        )
+        if code == "200":
+            raise OperationFailedError(
+                "F-01A: invalid monitoring_port=%s unexpectedly returned HTTP 200"
+                % invalid_port
+            )
+        perform_s06_minimal_workload(ctx.client, ctx.nfs_mount)
+        log.info(
+            "F-01A: Ganesha running with invalid port=%s; NFS OK, metrics not on bad port",
+            invalid_port,
+        )
+        return
+
+    log.info(
+        "F-01A: NFS daemon not running after invalid monitoring_port=%s (acceptable)",
+        invalid_port,
+    )
+
+
+def verify_f01_typo_outcome(ctx, logs, daemons=None):
+    """Typo line prevents clean start: expect parse error in log and/or NFS down."""
+    log_text = (logs or "").lower()
+    error_markers = (
+        "syntax error",
+        "fatal errors",
+        "fatal:",
+        "server exiting",
+        "error setting parameters",
+        "errors processing block",
+    )
+    has_error = any(marker in log_text for marker in error_markers)
+    running = any(
+        (d.get("status_desc") or "").lower() == "running" for d in (daemons or [])
+    )
+
+    if has_error:
+        log.info("F-01B: ganesha log reports config error after typo line")
+        if running:
+            log.warning("F-01B: NFS daemon running despite config error in log")
+            perform_s06_minimal_workload(ctx.client, ctx.nfs_mount)
+        else:
+            log.info("F-01B: NFS not running after typo (expected)")
+        return
+
+    if running:
+        perform_s06_minimal_workload(ctx.client, ctx.nfs_mount)
+        log.info("F-01B: typo line tolerated on this build; NFS operational")
+        return
+
+    log.info(
+        "F-01B: NFS not running after typo line (acceptable; no error text in log tail)"
+    )
+
+
+def get_monitoring_port(nfs_node, nfs_name, config):
+    configured = config.get("monitoring_port")
+    if configured is not None:
+        return int(configured)
+
+    out, _ = nfs_node.exec_command(
+        sudo=True,
+        cmd="ceph orch ls nfs --export -f json",
+        check_ec=False,
+    )
+    try:
+        services = json.loads(str(out).strip()) if out else []
+    except json.JSONDecodeError:
+        services = []
+
+    for svc in services:
+        if svc.get("service_id") == nfs_name:
+            port = svc.get("spec", {}).get("monitoring_port")
+            if port is not None:
+                return int(port)
+
+    return DEFAULT_MONITORING_PORT
+
+
+def scrape_prometheus_metrics(node, host, port, path="/metrics"):
+    cmd = f"curl -sf http://{host}:{port}{path}"
+    out, err = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    body = (out or "").strip()
+    if not body:
+        raise OperationFailedError(
+            f"Empty response from http://{host}:{port}{path}: {err}"
+        )
+    return body
+
+
+def scrape_prometheus_metrics_http_code(node, host, port, path="/metrics"):
+    cmd = f"curl -s -o /dev/null -w '%{{http_code}}' " f"http://{host}:{port}{path}"
+    out, _ = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    return (out or "").strip()
+
+
+def _node_ip_for_hostname(ceph_cluster, hostname):
+    short = (hostname or "").split(".")[0]
+    for node in ceph_cluster.get_nodes():
+        node_short = node.hostname.split(".")[0]
+        if node_short == short or short in node.hostname:
+            return node.ip_address
+    if hostname and re.match(r"^\d+\.\d+\.\d+\.\d+$", hostname):
+        return hostname
+    raise OperationFailedError("No cluster node IP for hostname %s" % hostname)
+
+
+def _pick_prometheus_daemon_port(daemon, default=DEFAULT_PROMETHEUS_PORT):
+    ports = daemon.get("ports") or []
+    for port in ports:
+        if int(port) == default:
+            return int(port)
+    if ports:
+        return int(ports[0])
+    return default
+
+
+def _prometheus_daemon_running(daemon):
+    status_desc = (daemon.get("status_desc") or "").lower()
+    if status_desc == "running":
+        return True
+    return daemon.get("status") == 1
+
+
+def get_prometheus_api_url(ceph_cluster, installer, config=None):
+    """Resolve cluster Prometheus base URL from ``ceph orch ps`` (e.g. http://10.0.66.24:9095)."""
+    config = config or {}
+    override = config.get("prometheus_api_url")
+    if override:
+        return str(override).rstrip("/")
+
+    default_port = int(config.get("prometheus_port", DEFAULT_PROMETHEUS_PORT))
+    cephadm = CephAdm(installer).ceph
+    raw = cephadm.orch.ps(format="json")
+    daemons = json.loads(raw) if raw else []
+    prom_daemons = [
+        daemon
+        for daemon in daemons
+        if "prometheus" in (daemon.get("service_name") or "").lower()
+        or (daemon.get("daemon_type") or "").lower() == "prometheus"
+    ]
+    if not prom_daemons:
+        raise OperationFailedError("No prometheus daemon found in ceph orch ps output")
+
+    for daemon in prom_daemons:
+        if not _prometheus_daemon_running(daemon):
+            continue
+        hostname = daemon.get("hostname")
+        port = _pick_prometheus_daemon_port(daemon, default_port)
+        host_ip = _node_ip_for_hostname(ceph_cluster, hostname)
+        api_url = "http://%s:%s" % (host_ip, port)
+        log.info(
+            "Discovered Prometheus API at %s (orch ps daemon on %s, port %s)",
+            api_url,
+            hostname,
+            port,
+        )
+        return api_url
+
+    raise OperationFailedError(
+        "Prometheus daemon found in orch ps but none are running"
+    )
+
+
+def fetch_prometheus_targets(scrape_node, api_base_url):
+    url = "%s/api/v1/targets" % api_base_url.rstrip("/")
+    out, err = scrape_node.exec_command(
+        sudo=True, cmd="curl -sf '%s'" % url, check_ec=False
+    )
+    body = (out or "").strip()
+    if not body:
+        raise OperationFailedError(
+            "Empty response from Prometheus targets API %s: %s" % (url, err)
+        )
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise OperationFailedError(
+            "Invalid JSON from Prometheus targets API %s: %s" % (url, exc)
+        )
+    if payload.get("status") != "success":
+        raise OperationFailedError(
+            "Prometheus targets API status=%s url=%s" % (payload.get("status"), url)
+        )
+    return payload.get("data", {}).get("activeTargets", [])
+
+
+def _nfs_ganesha_target_hosts(nfs_node, nfs_ip):
+    hosts = []
+    for value in (nfs_ip, nfs_node.hostname, nfs_node.hostname.split(".")[0]):
+        if value and value not in hosts:
+            hosts.append(value)
+    return hosts
+
+
+def _nfs_ganesha_target_matches(target, nfs_hosts, monitoring_port, nfs_name=None):
+    scrape_url = str(target.get("scrapeUrl") or "").lower()
+    port_token = ":%s" % monitoring_port
+    if port_token not in scrape_url:
+        return False
+
+    labels_blob = json.dumps(target.get("labels") or {})
+    discovered_blob = json.dumps(target.get("discoveredLabels") or {})
+    combined = ("%s%s%s" % (scrape_url, labels_blob, discovered_blob)).lower()
+
+    host_match = any(str(host).lower() in combined for host in nfs_hosts)
+    if not host_match:
+        return False
+
+    if nfs_name and nfs_name.lower() not in combined:
+        if "nfs" not in combined and "ganesha" not in combined:
+            log.info(
+                "NFS target matched on host/port but without nfs/ganesha labels: %s",
+                target.get("scrapeUrl"),
+            )
+    return True
+
+
+def verify_prometheus_nfs_scrape_target(
+    scrape_node,
+    ceph_cluster,
+    installer,
+    nfs_node,
+    nfs_ip,
+    monitoring_port,
+    nfs_name=None,
+    config=None,
+):
+    """Verify cluster Prometheus scrapes the NFS-Ganesha metrics endpoint."""
+    config = config or {}
+    api_url = get_prometheus_api_url(ceph_cluster, installer, config)
+    targets_url = "%s/api/v1/targets" % api_url
+    nfs_hosts = _nfs_ganesha_target_hosts(nfs_node, nfs_ip)
+    timeout = int(config.get("prometheus_targets_timeout", 120))
+    poll_interval = int(config.get("prometheus_targets_poll_interval", 10))
+    deadline = time.time() + timeout
+    last_targets = []
+
+    log.info(
+        "S-03: checking Prometheus targets at %s for NFS metrics on %s:%s",
+        targets_url,
+        nfs_ip,
+        monitoring_port,
+    )
+
+    while time.time() < deadline:
+        try:
+            last_targets = fetch_prometheus_targets(scrape_node, api_url)
+            for target in last_targets:
+                if not _nfs_ganesha_target_matches(
+                    target, nfs_hosts, monitoring_port, nfs_name=nfs_name
+                ):
+                    continue
+                health = (target.get("health") or "").lower()
+                scrape_url = target.get("scrapeUrl")
+                if health == "up":
+                    log.info(
+                        "Prometheus NFS-Ganesha scrape target is UP: %s",
+                        scrape_url,
+                    )
+                    return target
+                log.info(
+                    "Prometheus NFS target found but health=%s: %s",
+                    health,
+                    scrape_url,
+                )
+        except OperationFailedError as err:
+            log.info(
+                "Prometheus targets API not ready, retrying in %ss: %s",
+                poll_interval,
+                err,
+            )
+        time.sleep(poll_interval)
+
+    sample = [
+        "%s health=%s" % (t.get("scrapeUrl"), t.get("health"))
+        for t in last_targets[:10]
+    ]
+    raise OperationFailedError(
+        "No healthy Prometheus scrape target for NFS-Ganesha at %s:%s "
+        "(api=%s, active_targets_sample=%s)"
+        % (nfs_ip, monitoring_port, targets_url, sample)
+    )
+
+
+def get_prometheus_scrape_source_ip(ceph_cluster, installer, config, fallback_node):
+    api_url = get_prometheus_api_url(ceph_cluster, installer, config)
+    match = re.match(r"http://([^:/]+)", api_url)
+    if match:
+        return match.group(1)
+    return fallback_node.ip_address
+
+
+def get_prometheus_nfs_target_health(
+    scrape_node,
+    ceph_cluster,
+    installer,
+    nfs_node,
+    nfs_ip,
+    monitoring_port,
+    nfs_name=None,
+    config=None,
+):
+    config = config or {}
+    api_url = get_prometheus_api_url(ceph_cluster, installer, config)
+    nfs_hosts = _nfs_ganesha_target_hosts(nfs_node, nfs_ip)
+    for target in fetch_prometheus_targets(scrape_node, api_url):
+        if _nfs_ganesha_target_matches(
+            target, nfs_hosts, monitoring_port, nfs_name=nfs_name
+        ):
+            return (target.get("health") or "").lower(), target.get("scrapeUrl")
+    return None, None
+
+
+def wait_prometheus_nfs_target_health(
+    scrape_node,
+    ceph_cluster,
+    installer,
+    nfs_node,
+    nfs_ip,
+    monitoring_port,
+    expected_health,
+    nfs_name=None,
+    config=None,
+):
+    config = config or {}
+    timeout = int(config.get("prometheus_targets_timeout", 120))
+    poll_interval = int(config.get("prometheus_targets_poll_interval", 10))
+    deadline = time.time() + timeout
+    expected_health = expected_health.lower()
+
+    while time.time() < deadline:
+        health, scrape_url = get_prometheus_nfs_target_health(
+            scrape_node,
+            ceph_cluster,
+            installer,
+            nfs_node,
+            nfs_ip,
+            monitoring_port,
+            nfs_name=nfs_name,
+            config=config,
+        )
+        if health == expected_health:
+            log.info(
+                "Prometheus NFS target health=%s as expected: %s",
+                health,
+                scrape_url,
+            )
+            return
+        if expected_health == "down" and health == "down":
+            return
+        log.info(
+            "Waiting for Prometheus NFS target health=%s (current=%s url=%s)",
+            expected_health,
+            health,
+            scrape_url,
+        )
+        time.sleep(poll_interval)
+
+    raise OperationFailedError(
+        "Prometheus NFS target did not reach health=%s within %ss"
+        % (expected_health, timeout)
+    )
+
+
+def _metric_name_variants(metric_name):
+    variants = [metric_name]
+    if metric_name.startswith("nfs_"):
+        variants.append(metric_name[4:])
+    else:
+        variants.append("nfs_%s" % metric_name)
+
+    if "mdcache" in metric_name:
+        for prefix in ("nfs_mdcache_", "mdcache_", "mdcache_cache_"):
+            if metric_name.startswith(prefix):
+                suffix = metric_name[len(prefix) :]
+                variants.extend(
+                    [
+                        "mdcache_cache_%s" % suffix,
+                        "nfs_mdcache_%s" % suffix,
+                        "mdcache_%s" % suffix,
+                    ]
+                )
+                break
+    return list(dict.fromkeys(variants))
+
+
+def _metric_exact_name_present(metrics_text, metric_name):
+    pattern = re.compile(r"^%s(?:\{|\s)" % re.escape(metric_name))
+    for line in metrics_text.splitlines():
+        if line and not line.startswith("#") and pattern.match(line.strip()):
+            return True
+    return False
+
+
+def _sum_counter_for_exact_name(metrics_text, metric_name):
+    total = 0
+    pattern = re.compile(rf"^{re.escape(metric_name)}(?:{{.*?}})?\s+([0-9.eE+-]+)")
+    for line in metrics_text.splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            total += int(float(match.group(1)))
+    return total
+
+
+def metric_available(names, metric_name):
+    candidates = list(_metric_name_variants(metric_name))
+    candidates.extend(MANIFEST_METRIC_ALIASES.get(metric_name, ()))
+    for variant in dict.fromkeys(candidates):
+        if variant in names:
+            return True
+        if any(n.startswith("%s_" % variant) for n in names):
+            return True
+    prefix = MANIFEST_METRIC_PREFIX_FAMILIES.get(metric_name)
+    if prefix and any(n.startswith(prefix) for n in names):
+        return True
+    return False
+
+
+def verify_manifest_v1(metrics_text):
+    names = parse_prometheus_metrics(metrics_text)
+    missing = []
+    optional_missing = []
+    for metric in MANIFEST_V1_COUNTERS + MANIFEST_V1_GAUGES + MANIFEST_V1_HISTOGRAMS:
+        if metric_available(names, metric):
+            continue
+        if metric in MANIFEST_V1_OPTIONAL:
+            optional_missing.append(metric)
+        else:
+            missing.append(metric)
+    if optional_missing:
+        log.warning("Manifest v1 optional metrics not present: %s", optional_missing)
+    if "mdcache_cache_hits_total" in missing and metric_available(
+        names, "mdcache_cache_misses_total"
+    ):
+        log.warning("mdcache_cache_hits_total not exported yet; misses family present")
+        missing.remove("mdcache_cache_hits_total")
+    if missing:
+        mdcache_names = sorted(n for n in names if "mdcache" in n)
+        log.error(
+            "Manifest v1 scrape has mdcache families: %s",
+            mdcache_names[:30] or "(none)",
+        )
+        raise OperationFailedError("Manifest v1 metrics missing: %s" % missing)
+    log.info(
+        "Manifest v1 core metrics present (%s optional absent)",
+        len(optional_missing),
+    )
+
+
+def parse_prometheus_metrics(metrics_text):
+    names = set()
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        names.add(line.split("{", 1)[0].split(" ", 1)[0].strip())
+    return names
+
+
+def parse_metric_samples(metrics_text):
+    samples = []
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        if "{" in line:
+            name, rest = line.split("{", 1)
+            label_part, value = rest.rsplit("}", 1)
+            labels = {}
+            for item in label_part.split(","):
+                if "=" in item:
+                    key, val = item.split("=", 1)
+                    labels[key.strip()] = val.strip().strip('"')
+            samples.append((name.strip(), labels, float(value.strip())))
+        else:
+            parts = line.split()
+            if len(parts) >= 2:
+                samples.append((parts[0], {}, float(parts[1])))
+    return samples
+
+
+def get_counter_total(metrics_text, metric_name):
+    candidates = list(_metric_name_variants(metric_name))
+    candidates.extend(MANIFEST_METRIC_ALIASES.get(metric_name, ()))
+    totals = []
+    for variant in dict.fromkeys(candidates):
+        if _metric_exact_name_present(metrics_text, variant):
+            totals.append(_sum_counter_for_exact_name(metrics_text, variant))
+    return max(totals) if totals else 0
+
+
+def _bytes_counter_candidates(metric_name):
+    if "sent" in metric_name:
+        return BYTES_SENT_COUNTER_CANDIDATES
+    if "received" in metric_name:
+        return BYTES_RECEIVED_COUNTER_CANDIDATES
+    candidates = list(_metric_name_variants(metric_name))
+    candidates.extend(MANIFEST_METRIC_ALIASES.get(metric_name, ()))
+    return tuple(dict.fromkeys(candidates))
+
+
+def _metric_family_present(metrics_text, metric_name, operation_labels=None):
+    for candidate in _bytes_counter_candidates(metric_name):
+        if _labeled_counter_series_count(metrics_text, candidate, operation_labels) > 0:
+            return True
+    return False
+
+
+def _labeled_counter_series_count(metrics_text, metric_name, operation_labels=None):
+    operations = {op.lower() for op in operation_labels} if operation_labels else None
+    count = 0
+    for name, labels, _ in parse_metric_samples(metrics_text):
+        if name != metric_name:
+            continue
+        if operations and labels.get("operation", "").lower() not in operations:
+            continue
+        count += 1
+    return count
+
+
+def get_labeled_counter_total(metrics_text, metric_name, operation_labels=None):
+    """Sum a counter family, optionally filtering on the operation label."""
+    operations = {op.lower() for op in operation_labels} if operation_labels else None
+    for candidate in _bytes_counter_candidates(metric_name):
+        total = 0
+        series_count = 0
+        for name, labels, value in parse_metric_samples(metrics_text):
+            if name != candidate:
+                continue
+            if operations and labels.get("operation", "").lower() not in operations:
+                continue
+            total += value
+            series_count += 1
+        if series_count > 0:
+            return total, candidate
+    return 0, None
+
+
+def bytes_counter_delta(
+    metrics_before, metrics_after, metric_name, operation_labels=None
+):
+    """Return delta using operation-specific series first, then all labels."""
+    strategies = []
+    if operation_labels:
+        strategies.append(operation_labels)
+    strategies.append(None)
+
+    last_resolved = metric_name
+    for ops in strategies:
+        before, resolved = get_labeled_counter_total(metrics_before, metric_name, ops)
+        after, resolved_after = get_labeled_counter_total(
+            metrics_after, metric_name, ops
+        )
+        if not resolved and not resolved_after:
+            continue
+        resolved = resolved or resolved_after
+        last_resolved = resolved
+        delta = after - before
+        label_suffix = ""
+        if ops:
+            label_suffix = "{operation=%s}" % "|".join(ops)
+        full_name = "%s%s" % (resolved, label_suffix)
+        if delta > 0:
+            return delta, full_name
+        if ops is None:
+            return delta, full_name
+    return 0, last_resolved
+
+
+def get_histogram_prefix_variants(metric_prefix):
+    variants = [metric_prefix]
+    if metric_prefix.startswith("nfs_"):
+        variants.append(metric_prefix[4:])
+    else:
+        variants.append("nfs_%s" % metric_prefix)
+    return list(dict.fromkeys(variants))
+
+
+def get_histogram_count_sum(metrics_text, metric_prefix):
+    for prefix in get_histogram_prefix_variants(metric_prefix):
+        count = 0
+        total_sum = 0.0
+        for name, _, value in parse_metric_samples(metrics_text):
+            if name == "%s_count" % prefix:
+                count += int(value)
+            elif name == "%s_sum" % prefix:
+                total_sum += value
+        if count > 0 or any(
+            n.startswith("%s_" % prefix) for n in parse_prometheus_metrics(metrics_text)
+        ):
+            return count, total_sum
+    return 0, 0.0
+
+
+def assert_counter_increased(metrics_before, metrics_after, *metric_names):
+    for metric_name in metric_names:
+        before = get_counter_total(metrics_before, metric_name)
+        after = get_counter_total(metrics_after, metric_name)
+        if after > before:
+            log.info(
+                "Counter %s increased: %s -> %s",
+                metric_name,
+                before,
+                after,
+            )
+            return
+    raise OperationFailedError(
+        "Counters did not increase (tried: %s)" % ", ".join(metric_names)
+    )
+
+
+def prometheus_query_instant(scrape_node, api_base_url, promql):
+    url = "%s/api/v1/query?query=%s" % (api_base_url.rstrip("/"), quote(promql))
+    out, err = scrape_node.exec_command(
+        sudo=True, cmd="curl -sf '%s'" % url, check_ec=False
+    )
+    body = (out or "").strip()
+    if not body:
+        raise OperationFailedError(
+            "Empty response from Prometheus query API %s: %s" % (url, err)
+        )
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise OperationFailedError(
+            "Invalid JSON from Prometheus query API %s: %s" % (url, exc)
+        )
+    if payload.get("status") != "success":
+        raise OperationFailedError(
+            "Prometheus query API status=%s query=%r url=%s"
+            % (payload.get("status"), promql, url)
+        )
+    return payload
+
+
+def _sum_prometheus_instant_vector(payload):
+    total = 0
+    series = payload.get("data", {}).get("result", [])
+    for entry in series:
+        value = entry.get("value")
+        if value and len(value) >= 2:
+            total += int(float(value[1]))
+    return total, len(series)
+
+
+def get_prometheus_counter_value(scrape_node, api_base_url, metric_name):
+    last_error = None
+    for variant in _metric_name_variants(metric_name):
+        try:
+            payload = prometheus_query_instant(scrape_node, api_base_url, variant)
+            total, series_count = _sum_prometheus_instant_vector(payload)
+            if series_count > 0:
+                return total, variant
+        except OperationFailedError as err:
+            last_error = err
+    raise last_error or OperationFailedError(
+        "Prometheus query returned no series for %s" % metric_name
+    )
+
+
+def assert_prometheus_counter_increased_after_workload(
+    scrape_node,
+    ceph_cluster,
+    installer,
+    workload_fn,
+    *metric_names,
+    config=None,
+):
+    """Query cluster Prometheus before/after workload (same as UI graph check)."""
+    config = config or {}
+    wait_seconds = int(config.get("prometheus_query_wait_seconds", 30))
+    api_url = get_prometheus_api_url(ceph_cluster, installer, config)
+
+    before_value = None
+    used_metric = None
+    for metric_name in metric_names:
+        try:
+            before_value, used_metric = get_prometheus_counter_value(
+                scrape_node, api_url, metric_name
+            )
+            break
+        except OperationFailedError:
+            continue
+    if used_metric is None:
+        raise OperationFailedError(
+            "No Prometheus series found for metrics: %s (api=%s)"
+            % (", ".join(metric_names), api_url)
+        )
+
+    log.info(
+        "S-06: Prometheus query %s before workload: %s (api=%s)",
+        used_metric,
+        before_value,
+        api_url,
+    )
+    workload_fn()
+    time.sleep(wait_seconds)
+
+    after_value, _ = get_prometheus_counter_value(scrape_node, api_url, used_metric)
+    if after_value <= before_value:
+        raise OperationFailedError(
+            "Prometheus counter %s did not increase after workload: "
+            "%s -> %s (api=%s/api/v1/query)"
+            % (used_metric, before_value, after_value, api_url)
+        )
+    log.info(
+        "S-06: Prometheus counter %s increased %s -> %s via %s",
+        used_metric,
+        before_value,
+        after_value,
+        api_url,
+    )
+
+
+def _prometheus_vector_series(payload):
+    series = {}
+    for entry in payload.get("data", {}).get("result", []):
+        metric = entry.get("metric", {})
+        name = metric.get("__name__")
+        value = entry.get("value")
+        if not name or not value or len(value) < 2:
+            continue
+        labels = tuple(
+            sorted((key, val) for key, val in metric.items() if key != "__name__")
+        )
+        series[(name, labels)] = float(value[1])
+    return series
+
+
+def _operation_from_label_tuple(labels):
+    for key, val in labels:
+        if key == "operation":
+            return val
+    return None
+
+
+def get_prometheus_requests_by_operation(scrape_node, api_base_url, metric_name):
+    last_error = None
+    for variant in _metric_name_variants(metric_name):
+        try:
+            payload = prometheus_query_instant(scrape_node, api_base_url, variant)
+            series = _prometheus_vector_series(payload)
+            by_labels = {
+                labels: value
+                for (name, labels), value in series.items()
+                if name == variant
+            }
+            if by_labels:
+                return by_labels, variant
+        except OperationFailedError as err:
+            last_error = err
+    raise last_error or OperationFailedError(
+        "Prometheus query returned no %s series (api=%s)" % (metric_name, api_base_url)
+    )
+
+
+def _prometheus_increase_total(scrape_node, api_base_url, metric_name, window):
+    last_error = None
+    for variant in _metric_name_variants(metric_name):
+        for promql in (
+            "sum(increase(%s[%s]))" % (variant, window),
+            "increase(%s[%s])" % (variant, window),
+        ):
+            try:
+                payload = prometheus_query_instant(scrape_node, api_base_url, promql)
+                total, series_count = _sum_prometheus_instant_vector(payload)
+                if series_count > 0 and total > 0:
+                    return total, promql
+            except OperationFailedError as err:
+                last_error = err
+    if last_error:
+        log.info(
+            "Prometheus increase for %s returned no data: %s",
+            metric_name,
+            last_error,
+        )
+    return 0.0, None
+
+
+def perform_s06_minimal_workload(client, nfs_mount):
+    """Client mount check plus metadata ops (ls/stat) per S-06 manual."""
+    out, _ = client.exec_command(sudo=True, cmd="mount | grep nfs", check_ec=False)
+    mount_out = (out or "").strip()
+    if not mount_out or nfs_mount not in mount_out:
+        raise OperationFailedError(
+            "NFS mount %s not found in mount | grep nfs:\n%s" % (nfs_mount, mount_out)
+        )
+    client.exec_command(sudo=True, cmd="ls -la %s" % nfs_mount)
+    client.exec_command(sudo=True, cmd="stat %s" % nfs_mount)
+    log.info(
+        "S-06 workload on %s: mount verified, ls -la and stat completed",
+        nfs_mount,
+    )
+
+
+def verify_s06_minimal_workload_prometheus(
+    scrape_node,
+    ceph_cluster,
+    installer,
+    workload_fn,
+    config=None,
+    nfs_ip=None,
+    monitoring_port=None,
+):
+    """Verify requests_total per-operation increase via Prometheus (UI-equivalent)."""
+    config = config or {}
+    wait_seconds = int(config.get("prometheus_query_wait_seconds", 30))
+    increase_window = config.get("prometheus_increase_window", "2m")
+    api_url = get_prometheus_api_url(ceph_cluster, installer, config)
+
+    before_direct = None
+    if nfs_ip and monitoring_port:
+        before_direct = scrape_prometheus_metrics(scrape_node, nfs_ip, monitoring_port)
+
+    before_ops = {}
+    metric_name = None
+    try:
+        before_ops, metric_name = get_prometheus_requests_by_operation(
+            scrape_node, api_url, "requests_total"
+        )
+        log.info(
+            "S-06: Prometheus %s series before workload: %s operations",
+            metric_name,
+            len(before_ops),
+        )
+    except OperationFailedError:
+        log.info(
+            "S-06: requests_total not in Prometheus yet; "
+            "will check increase() after workload"
+        )
+
+    workload_fn()
+    time.sleep(wait_seconds)
+
+    if metric_name:
+        try:
+            after_ops, _ = get_prometheus_requests_by_operation(
+                scrape_node, api_url, metric_name
+            )
+            increased_operations = []
+            for labels, after_value in after_ops.items():
+                before_value = before_ops.get(labels, 0)
+                if after_value > before_value:
+                    op = _operation_from_label_tuple(labels) or str(labels)
+                    increased_operations.append(
+                        "%s (%s -> %s)" % (op, int(before_value), int(after_value))
+                    )
+            if increased_operations:
+                log.info(
+                    "S-06: Prometheus %s operations increased: %s",
+                    metric_name,
+                    ", ".join(increased_operations),
+                )
+                return
+        except OperationFailedError as err:
+            log.info("S-06: per-operation compare unavailable: %s", err)
+
+    for candidate in ("requests_total", "rpcs_received_total"):
+        increase_total, promql = _prometheus_increase_total(
+            scrape_node,
+            api_url,
+            candidate,
+            increase_window,
+        )
+        if increase_total > 0:
+            log.info(
+                "S-06: Prometheus increase query %r total=%s",
+                promql,
+                increase_total,
+            )
+            return
+
+    if before_direct is not None:
+        after_direct = scrape_prometheus_metrics(scrape_node, nfs_ip, monitoring_port)
+        assert_counter_increased(
+            before_direct,
+            after_direct,
+            "requests_total",
+            "rpcs_received_total",
+        )
+        log.info(
+            "S-06: direct scrape counters increased on %s:%s",
+            nfs_ip,
+            monitoring_port,
+        )
+        return
+
+    raise OperationFailedError(
+        "S-06: no counter increase in Prometheus or direct scrape after workload "
+        "(api=%s, tried increase(requests_total[%s]), increase(rpcs_received_total[%s]))"
+        % (api_url, increase_window, increase_window)
+    )
+
+
+def prometheus_count_metric_series(scrape_node, api_base_url, metric_name):
+    """Return series count via Prometheus ``count(<metric>)`` (UI-equivalent)."""
+    last_error = None
+    for variant in _metric_name_variants(metric_name):
+        for promql in ("count(%s)" % variant, variant):
+            try:
+                payload = prometheus_query_instant(scrape_node, api_base_url, promql)
+                series = payload.get("data", {}).get("result", [])
+                if not series:
+                    continue
+                if promql.startswith("count("):
+                    value = float(series[0].get("value", [0, 0])[1])
+                    return int(value), variant, promql
+                return len(series), variant, promql
+            except OperationFailedError as err:
+                last_error = err
+    if last_error:
+        log.info(
+            "Prometheus count for %s returned no series: %s",
+            metric_name,
+            last_error,
+        )
+    return 0, None, None
+
+
+def _find_v4_op_count_series(metrics_text):
+    series = {}
+    for name, labels, value in parse_metric_samples(metrics_text):
+        if name not in V4_OP_COUNT_METRICS:
+            continue
+        op = labels.get("op")
+        status = labels.get("status")
+        if not op or not status:
+            continue
+        key = (name, op, status)
+        series[key] = series.get(key, 0) + int(value)
+    return series
+
+
+def verify_nfsv4_op_count_after_workload(metrics_before, metrics_after):
+    """S-08: nfsv4__op_count present with op/status labels and increases after v4 IO."""
+    before = _find_v4_op_count_series(metrics_before)
+    after = _find_v4_op_count_series(metrics_after)
+    if not after:
+        raise OperationFailedError(
+            "nfsv4__op_count not found with op/status labels after workload"
+        )
+
+    increased = []
+    for key, after_value in after.items():
+        before_value = before.get(key, 0)
+        if after_value > before_value:
+            _, op, status = key
+            increased.append(
+                "%s/%s (%s -> %s)" % (op, status, before_value, after_value)
+            )
+
+    if not increased:
+        raise OperationFailedError(
+            "nfsv4__op_count series present but none increased after workload"
+        )
+
+    log.info(
+        "S-08: nfsv4__op_count increased for %s operations (total series after=%s)",
+        len(increased),
+        len(after),
+    )
+    log.info("S-08 sample increases: %s", ", ".join(increased[:8]))
+
+
+def verify_s07_dynamic_metrics_disabled(ctx, config=None):
+    """S-07: dynamic metrics off — no per-client series; global counters still move."""
+    config = config or {}
+    wait_seconds = int(config.get("prometheus_query_wait_seconds", 30))
+    max_client_series = int(config.get("s07_max_client_series_when_disabled", 0))
+    api_url = get_prometheus_api_url(ctx.ceph_cluster, ctx.installer, config)
+
+    before_global, global_metric = get_prometheus_counter_value(
+        ctx.client, api_url, "rpcs_received_total"
+    )
+    client_series_before, client_metric, client_promql = prometheus_count_metric_series(
+        ctx.client, api_url, "client_requests_total"
+    )
+    log.info(
+        "S-07 before traffic: %s=%s, count(%s)=%s via %r",
+        global_metric,
+        before_global,
+        client_metric or "client_requests_total",
+        client_series_before,
+        client_promql,
+    )
+
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1, file_name="s07_client0")
+    for idx, (client, mount) in enumerate(ctx.extra_mounts, start=1):
+        perform_nfs_io(client, mount, mb=1, file_name="s07_client%s" % idx)
+    time.sleep(wait_seconds)
+
+    client_series_after, _, after_promql = prometheus_count_metric_series(
+        ctx.client, api_url, client_metric or "client_requests_total"
+    )
+    after_global, _ = get_prometheus_counter_value(ctx.client, api_url, global_metric)
+
+    log.info(
+        "S-07 after traffic: %s=%s -> %s, count(%s)=%s via %r",
+        global_metric,
+        before_global,
+        after_global,
+        client_metric or "client_requests_total",
+        client_series_after,
+        after_promql,
+    )
+
+    if client_series_after > max_client_series:
+        raise OperationFailedError(
+            "Per-client series count %s exceeds max %s with enable_dynamic_metrics=false "
+            "(query=%r)" % (client_series_after, max_client_series, after_promql)
+        )
+
+    if after_global <= before_global:
+        raise OperationFailedError(
+            "Global counter %s did not increase with dynamic metrics disabled: "
+            "%s -> %s" % (global_metric, before_global, after_global)
+        )
+
+    log.info(
+        "S-07 PASS: per-client series=%s (max=%s), global %s increased",
+        client_series_after,
+        max_client_series,
+        global_metric,
+    )
+
+
+def verify_help_and_type(metrics_text):
+    if "# HELP" not in metrics_text or "# TYPE" not in metrics_text:
+        raise OperationFailedError("Missing # HELP or # TYPE in exposition")
+
+
+def verify_exposition_has_metric(metrics_text, metric_name):
+    names = parse_prometheus_metrics(metrics_text)
+    if not metric_available(names, metric_name):
+        raise OperationFailedError("%s not in metrics exposition" % metric_name)
+
+
+def verify_monitoring_port_listening(nfs_node, port):
+    out, _ = nfs_node.exec_command(
+        sudo=True, cmd=f"ss -H -tln sport = :{port}", check_ec=False
+    )
+    if str(port) not in (out or ""):
+        raise OperationFailedError(
+            f"Monitoring port {port} not listening on {nfs_node.hostname}"
+        )
+
+
+def verify_monitoring_port_not_listening(nfs_node, port):
+    out, _ = nfs_node.exec_command(
+        sudo=True, cmd=f"ss -H -tln sport = :{port}", check_ec=False
+    )
+    if str(port) in (out or ""):
+        raise OperationFailedError(
+            "Monitoring port %s still listening on %s with metrics disabled"
+            % (port, nfs_node.hostname)
+        )
+
+
+def verify_metrics_endpoint_not_accessible(client, nfs_node, nfs_ip, port):
+    """Expect connection refused / non-200 when Enable_Metrics=false."""
+    verify_monitoring_port_not_listening(nfs_node, port)
+    code = scrape_prometheus_metrics_http_code(client, nfs_ip, port)
+    if code == "200":
+        raise OperationFailedError(
+            "Metrics endpoint returned HTTP 200 with Enable_Metrics=false"
+        )
+    log.info(
+        "Metrics endpoint not accessible on %s:%s (http_code=%s)",
+        nfs_ip,
+        port,
+        code or "unreachable",
+    )
+
+
+def verify_latency_histogram_after_workload(metrics_text):
+    for prefix in LATENCY_HISTOGRAM_PREFIXES:
+        count, _ = get_histogram_count_sum(metrics_text, prefix)
+        if count > 0:
+            verify_histogram_cumulative(metrics_text, prefix)
+            log.info("Latency histogram %s count=%s after workload", prefix, count)
+            return
+    raise OperationFailedError(
+        "No latency histogram count > 0 after workload (tried: %s)"
+        % ", ".join(LATENCY_HISTOGRAM_PREFIXES)
+    )
+
+
+def verify_histogram_cumulative(metrics_text, metric_prefix):
+    prefixes = get_histogram_prefix_variants(metric_prefix)
+    if metric_prefix not in prefixes:
+        prefixes = [metric_prefix] + prefixes
+    buckets = {}
+    for name, labels, value in parse_metric_samples(metrics_text):
+        matched = None
+        for prefix in prefixes:
+            if name == "%s_bucket" % prefix:
+                matched = prefix
+                break
+        if not matched:
+            continue
+        label_key = tuple(sorted((k, v) for k, v in labels.items() if k != "le"))
+        le = labels.get("le", "")
+        buckets[(matched, label_key, le)] = int(value)
+
+    bucket_series = {}
+    for (prefix, label_key, le), count in buckets.items():
+        bucket_series.setdefault((prefix, label_key), []).append((le, count))
+
+    for (prefix, label_key), series in bucket_series.items():
+        ordered = []
+        inf_count = None
+        for le, count in series:
+            if le == "+Inf":
+                inf_count = count
+                continue
+            try:
+                ordered.append((float(le), count))
+            except ValueError:
+                continue
+        ordered.sort(key=lambda item: item[0])
+        for idx in range(1, len(ordered)):
+            prev_bound, prev_count = ordered[idx - 1]
+            cur_bound, cur_count = ordered[idx]
+            if cur_count < prev_count:
+                raise OperationFailedError(
+                    "Non-cumulative bucket for %s labels=%s between le=%s (%s) "
+                    "and le=%s (%s)"
+                    % (
+                        prefix,
+                        label_key,
+                        prev_bound,
+                        prev_count,
+                        cur_bound,
+                        cur_count,
+                    )
+                )
+        inf_count = buckets.get((prefix, label_key, "+Inf"))
+        count_name = "%s_count" % prefix
+        series_count = 0
+        for name, labels, val in parse_metric_samples(metrics_text):
+            if name != count_name:
+                continue
+            sample_key = tuple(sorted(labels.items()))
+            if sample_key == label_key:
+                series_count = int(val)
+                break
+        if inf_count is not None and series_count and inf_count != series_count:
+            log.warning(
+                "%s +Inf bucket=%s != _count=%s for labels=%s",
+                prefix,
+                inf_count,
+                series_count,
+                label_key,
+            )
+
+    for prefix in prefixes:
+        count, total_sum = get_histogram_count_sum(metrics_text, prefix)
+        if count > 0:
+            if total_sum < 0:
+                raise OperationFailedError("%s_sum is negative" % prefix)
+            log.info(
+                "%s histogram OK: count=%s avg=%s",
+                prefix,
+                count,
+                (total_sum / count) if count else 0,
+            )
+            return
+    raise OperationFailedError(
+        "%s_count is zero after workload (tried %s)" % (metric_prefix, prefixes)
+    )
+
+
+def verify_label_charset(metrics_text):
+    for line in metrics_text.splitlines():
+        if "{" not in line or line.startswith("#"):
+            continue
+        label_part = line.split("{", 1)[1].split("}", 1)[0]
+        for item in label_part.split(","):
+            if "=" not in item:
+                continue
+            key, val = item.split("=", 1)
+            key = key.strip()
+            val = val.strip().strip('"')
+            if not PROMETHEUS_LABEL_RE.match(key):
+                raise OperationFailedError(f"Invalid label name: {key}")
+            if not val or '"' in val or "\n" in val:
+                raise OperationFailedError(f"Invalid label value for {key}: {val}")
+
+
+def _parse_ganesha_release(version_text):
+    for line in version_text.splitlines():
+        if "NFS-Ganesha Release" in line and "=" in line:
+            return line.split("=", 1)[1].strip()
+    return None
+
+
+def _parse_ganesha_git_describe(version_text):
+    for line in version_text.splitlines():
+        if "Git Describe" in line and "=" in line:
+            return line.split("=", 1)[1].strip()
+    return None
+
+
+def _is_placeholder_ganesha_version(version):
+    return (version or "").strip().upper() in ("", "ARGS", "UNKNOWN", "N/A")
+
+
+def _ganesha_versions_compatible(metric_version, version_text):
+    if metric_version and metric_version in version_text:
+        return True
+
+    git_describe = _parse_ganesha_git_describe(version_text)
+    if git_describe and metric_version == git_describe:
+        return True
+
+    release = _parse_ganesha_release(version_text)
+    if not release:
+        return False
+
+    if _is_placeholder_ganesha_version(metric_version):
+        return True
+
+    if release in metric_version or metric_version in release:
+        return True
+
+    release_core = release.lstrip("Vv").split("-", 1)[0]
+    metric_core = metric_version.lstrip("Vv").split("-", 1)[0]
+    return (
+        release_core == metric_core
+        or release_core in metric_core
+        or metric_core in release_core
+    )
+
+
+def verify_ganesha_build_info(metrics_text, nfs_node, container_id=None):
+    metric_version = None
+    metric_built_time = None
+    server_scope = None
+    found = False
+    for name, labels, _ in parse_metric_samples(metrics_text):
+        if name in ("ganesha_build_info", "nfs_ganesha_build_info"):
+            found = True
+            metric_version = labels.get("GANESHA_VERSION")
+            metric_built_time = labels.get("BUILT_TIME")
+            server_scope = labels.get("SERVER_SCOPE")
+            if not metric_version:
+                raise OperationFailedError(
+                    "ganesha_build_info missing GANESHA_VERSION label"
+                )
+    if not found:
+        raise OperationFailedError("ganesha_build_info not found in metrics scrape")
+
+    version_cmd = "ganesha.nfsd -v"
+    if container_id:
+        version_cmd = "podman exec %s ganesha.nfsd -v" % container_id
+    out, _ = nfs_node.exec_command(sudo=True, cmd=version_cmd, check_ec=False)
+    version_text = (out or "").strip()
+    if not version_text and container_id:
+        out, _ = nfs_node.exec_command(
+            sudo=True,
+            cmd=(
+                "cid=$(podman ps --format '{{.ID}} {{.Names}}' "
+                "| awk '/nfs|ganesha/ {print $1; exit}'); "
+                '[ -n "$cid" ] && podman exec "$cid" ganesha.nfsd -v'
+            ),
+            check_ec=False,
+        )
+        version_text = (out or "").strip()
+    if not version_text:
+        raise OperationFailedError("ganesha.nfsd -v returned empty output")
+
+    release = _parse_ganesha_release(version_text)
+    git_describe = _parse_ganesha_git_describe(version_text)
+
+    if not _ganesha_versions_compatible(metric_version, version_text):
+        raise OperationFailedError(
+            "ganesha_build_info GANESHA_VERSION=%r not compatible with "
+            "ganesha.nfsd -v (release=%r, git_describe=%r)"
+            % (metric_version, release, git_describe)
+        )
+
+    if _is_placeholder_ganesha_version(metric_version):
+        log.info(
+            "ganesha_build_info GANESHA_VERSION=%r is a build placeholder; "
+            "matched ganesha.nfsd -v release=%r",
+            metric_version,
+            release,
+        )
+    elif git_describe and metric_version == git_describe:
+        log.info(
+            "ganesha_build_info GANESHA_VERSION matches Git Describe=%s",
+            git_describe,
+        )
+    else:
+        log.info(
+            "ganesha_build_info GANESHA_VERSION=%s compatible with release=%s",
+            metric_version,
+            release,
+        )
+
+    if metric_built_time:
+        built_token = metric_built_time.split()[0:3]
+        built_hint = " ".join(built_token)
+        if built_hint and built_hint not in version_text:
+            log.warning(
+                "ganesha_build_info BUILT_TIME=%r not matched literally in "
+                "ganesha.nfsd -v (non-fatal)",
+                metric_built_time,
+            )
+
+    if server_scope:
+        log.info("ganesha_build_info SERVER_SCOPE=%s", server_scope)
+    log.info("ganesha.nfsd -v: %s", version_text[:200])
+
+
+def verify_idle_baseline(metrics_first, metrics_second, config=None):
+    """Idle cluster: low in-flight RPCs; counters stable or slow background drift."""
+    config = config or {}
+    in_flight_max = int(config.get("idle_in_flight_max", 5))
+    max_drift = int(config.get("idle_max_counter_drift", 100))
+
+    for label, metrics in (("first", metrics_first), ("second", metrics_second)):
+        in_flight = get_counter_total(metrics, "rpcs_in_flight")
+        if in_flight > in_flight_max:
+            raise OperationFailedError(
+                "rpcs_in_flight=%s on %s scrape exceeds idle max %s"
+                % (in_flight, label, in_flight_max)
+            )
+
+    for metric in ("rpcs_received_total", "rpcs_completed_total"):
+        first = get_counter_total(metrics_first, metric)
+        second = get_counter_total(metrics_second, metric)
+        if second < first:
+            raise OperationFailedError(
+                "%s decreased while idle: %s -> %s" % (metric, first, second)
+            )
+        drift = second - first
+        if drift > max_drift:
+            raise OperationFailedError(
+                "%s idle drift %s exceeds max %s (%s -> %s)"
+                % (metric, drift, max_drift, first, second)
+            )
+        log.info(
+            "Idle %s stable: %s -> %s (drift=%s)",
+            metric,
+            first,
+            second,
+            drift,
+        )
+
+    log.info(
+        "Idle baseline OK: rpcs_in_flight first=%s second=%s",
+        get_counter_total(metrics_first, "rpcs_in_flight"),
+        get_counter_total(metrics_second, "rpcs_in_flight"),
+    )
+
+
+def concurrent_scrape(node, host, port, count=10):
+    results = []
+
+    def _scrape():
+        return scrape_prometheus_metrics_http_code(node, host, port)
+
+    with ThreadPoolExecutor(max_workers=count) as pool:
+        futures = [pool.submit(_scrape) for _ in range(count)]
+        for fut in as_completed(futures):
+            results.append(fut.result())
+    if any(code != "200" for code in results):
+        raise OperationFailedError(f"Concurrent scrape failures: {results}")
+    return results
+
+
+def concurrent_scrape_metrics(node, host, port, count=10):
+    """Run parallel full metric scrapes; return list of exposition bodies."""
+    bodies = []
+
+    def _scrape_body():
+        return scrape_prometheus_metrics(node, host, port)
+
+    with ThreadPoolExecutor(max_workers=count) as pool:
+        futures = [pool.submit(_scrape_body) for _ in range(count)]
+        for fut in as_completed(futures):
+            bodies.append(fut.result())
+    return bodies
+
+
+def verify_concurrent_scrape_metrics(bodies):
+    if not bodies:
+        raise OperationFailedError("No concurrent scrape responses")
+    rpc_totals = []
+    for idx, metrics in enumerate(bodies, start=1):
+        if not metrics or not metrics.strip():
+            raise OperationFailedError("Concurrent scrape %s returned empty body" % idx)
+        verify_help_and_type(metrics)
+        verify_exposition_has_metric(metrics, "rpcs_received_total")
+        rpc_totals.append(get_counter_total(metrics, "rpcs_received_total"))
+    if max(rpc_totals) - min(rpc_totals) > 1000:
+        log.warning(
+            "Concurrent scrape rpcs_received_total spread %s..%s (race window)",
+            min(rpc_totals),
+            max(rpc_totals),
+        )
+    log.info(
+        "Concurrent scrape OK: %s responses, rpcs_received_total range %s..%s",
+        len(bodies),
+        min(rpc_totals),
+        max(rpc_totals),
+    )
+
+
+def verify_promtool_metrics(client, host, port, remote_path="/tmp/ganesha_live.prom"):
+    client.exec_command(
+        sudo=True,
+        cmd="curl -sf http://%s:%s/metrics -o %s" % (host, port, remote_path),
+    )
+    out, _ = client.exec_command(
+        sudo=True,
+        cmd="command -v promtool >/dev/null && promtool check metrics %s || echo SKIP"
+        % remote_path,
+        check_ec=False,
+    )
+    result = (out or "").strip()
+    if result == "SKIP":
+        log.info("promtool not installed on client; skipping promtool check metrics")
+        verify_help_and_type(scrape_prometheus_metrics(client, host, port))
+        return
+    if "SUCCESS" not in result.upper() and result:
+        raise OperationFailedError("promtool check metrics failed: %s" % result[-500:])
+    log.info("promtool check metrics passed")
+
+
+def firewall_block_metrics_from_source(nfs_node, port, source_ip):
+    rule = (
+        'rule family="ipv4" source address=%s port port="%s" protocol="tcp" reject'
+        % (source_ip, port)
+    )
+    nfs_node.exec_command(
+        sudo=True,
+        cmd="firewall-cmd --permanent --add-rich-rule='%s'" % rule,
+        check_ec=False,
+    )
+    nfs_node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+    log.info(
+        "Blocked metrics port %s from source %s on %s",
+        port,
+        source_ip,
+        nfs_node.hostname,
+    )
+    return rule
+
+
+def firewall_unblock_metrics_from_source(nfs_node, rule):
+    nfs_node.exec_command(
+        sudo=True,
+        cmd="firewall-cmd --permanent --remove-rich-rule='%s'" % rule,
+        check_ec=False,
+    )
+    nfs_node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+    log.info("Removed firewall rich-rule on %s", nfs_node.hostname)
+
+
+def firewall_allow_port(node, port):
+    node.exec_command(
+        sudo=True,
+        cmd=f"firewall-cmd --permanent --add-port={port}/tcp",
+        check_ec=False,
+    )
+    node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+
+
+def run_ganesha_stats(nfs_node, container_id, *args):
+    cmd = "podman exec %s ganesha_stats %s" % (container_id, " ".join(args))
+    out, err = nfs_node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    return (out or "").strip(), (err or "").strip()
+
+
+def run_ganesha_stats_subcommands(nfs_node, container_id, subcommands):
+    for subcmd in subcommands:
+        out, err = run_ganesha_stats(nfs_node, container_id, *subcmd.split())
+        combined = f"{out}\n{err}".strip()
+        if not combined:
+            raise OperationFailedError(f"ganesha_stats {subcmd} returned empty output")
+        if "unknown command" in combined.lower():
+            raise OperationFailedError(f"ganesha_stats {subcmd} failed: {combined}")
+        log.info("ganesha_stats %s ok (len=%s)", subcmd, len(combined))
+
+
+def get_nfs_container_id(installer, nfs_name, nfs_node):
+    from tests.nfs.nfs_operations import get_ganesha_info_from_container
+
+    _, info = get_ganesha_info_from_container(installer, nfs_name, nfs_node)
+    return (info or {}).get("container_id")
+
+
+def _ganesha_conf_param_aliases(param_key):
+    canonical = PROMETHEUS_GANESHA_PARAM_NAMES.get(param_key, param_key)
+    aliases = PROMETHEUS_CORE_PARAM_ALIASES.get(param_key, (param_key, canonical))
+    return "|".join(re.escape(a) for a in aliases)
+
+
+def patch_ganesha_conf_param_in_container(nfs_node, container_id, param_key, value):
+    """Edit live container ganesha.conf (does not persist across redeploy)."""
+    if isinstance(value, bool):
+        value_str = "true" if value else "false"
+    else:
+        value_str = str(value)
+    alias_pattern = _ganesha_conf_param_aliases(param_key)
+    nfs_node.exec_command(
+        sudo=True,
+        cmd=(
+            "podman exec %s sed -i -E "
+            "'s/^([[:space:]]*(%s)[[:space:]]*=[[:space:]]*)[^;]+;/\\1%s;/' "
+            "/etc/ganesha/ganesha.conf" % (container_id, alias_pattern, value_str)
+        ),
+        check_ec=False,
+    )
+    log.info(
+        "Patched container ganesha.conf %s=%s (in-memory until redeploy)",
+        param_key,
+        value_str,
+    )
+
+
+def sighup_ganesha_in_container(nfs_node, container_id):
+    pid_out, _ = nfs_node.exec_command(
+        sudo=True,
+        cmd="podman exec %s pgrep -o ganesha.nfsd" % container_id,
+        check_ec=False,
+    )
+    pid = (pid_out or "").strip().split("\n")[0]
+    if not pid:
+        raise OperationFailedError(
+            "No ganesha.nfsd pid in container %s for SIGHUP" % container_id
+        )
+    nfs_node.exec_command(
+        sudo=True,
+        cmd="podman exec %s kill -HUP %s" % (container_id, pid),
+    )
+    log.info("Sent SIGHUP to ganesha.nfsd pid %s in container %s", pid, container_id)
+
+
+def metrics_scrape_ok(client, nfs_ip, port):
+    if scrape_prometheus_metrics_http_code(client, nfs_ip, port) != "200":
+        return False
+    metrics = scrape_prometheus_metrics(client, nfs_ip, port)
+    return metric_available(parse_prometheus_metrics(metrics), "rpcs_received_total")
+
+
+def verify_f02_port_reload_vs_restart(ctx, alt_port):
+    """Port change in live conf + SIGHUP does not bind new port; redeploy does."""
+    base_port = ctx.monitoring_port
+    log.info(
+        "F-02A: change monitoring_port %s -> %s in container conf + SIGHUP",
+        base_port,
+        alt_port,
+    )
+    patch_ganesha_conf_param_in_container(
+        ctx.nfs_node, ctx.container_id, "monitoring_port", alt_port
+    )
+    sighup_ganesha_in_container(ctx.nfs_node, ctx.container_id)
+    time.sleep(int(ctx.config.get("f02_reload_wait_seconds", 5)))
+    verify_monitoring_port_not_listening(ctx.nfs_node, alt_port)
+    if metrics_scrape_ok(ctx.client, ctx.nfs_ip, alt_port):
+        raise OperationFailedError(
+            "F-02A: monitoring_port=%s responded before restart" % alt_port
+        )
+    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, base_port):
+        log.warning(
+            "F-02A: baseline port %s not scraping after SIGHUP (metrics may need restart)",
+            base_port,
+        )
+    log.info("F-02A: monitoring_port change requires Ganesha restart (not SIGHUP)")
+
+
+def verify_f02_enable_metrics_reload_vs_restart(ctx):
+    """enable_metrics=false in live conf + SIGHUP leaves exporter up; redeploy disables it."""
+    port = ctx.monitoring_port
+    log.info("F-02B: enable_metrics=false in container conf + SIGHUP")
+    patch_ganesha_conf_param_in_container(
+        ctx.nfs_node, ctx.container_id, "enable_metrics", False
+    )
+    sighup_ganesha_in_container(ctx.nfs_node, ctx.container_id)
+    time.sleep(int(ctx.config.get("f02_reload_wait_seconds", 5)))
+    if metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+        log.info(
+            "F-02B: metrics still UP after enable_metrics=false + SIGHUP (restart required)"
+        )
+    else:
+        log.info("F-02B: metrics down after SIGHUP without redeploy")
+
+    metrics_off = dict(ctx.config)
+    metrics_off["enable_metrics"] = False
+    metrics_off["monitoring_port"] = port
+    update_prometheus_ganesha_params(
+        ctx.installer, ctx.nfs_node, ctx.nfs_name, metrics_off
+    )
+    ctx.refresh_container_id()
+    verify_metrics_endpoint_not_accessible(ctx.client, ctx.nfs_node, ctx.nfs_ip, port)
+    log.info("F-02B: enable_metrics=false takes effect after redeploy")
+
+    metrics_on = dict(ctx.config)
+    metrics_on["enable_metrics"] = True
+    metrics_on["monitoring_port"] = port
+    update_prometheus_ganesha_params(
+        ctx.installer, ctx.nfs_node, ctx.nfs_name, metrics_on
+    )
+    ctx.refresh_container_id()
+    verify_monitoring_port_listening(ctx.nfs_node, port)
+    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+        raise OperationFailedError(
+            "F-02B: metrics not restored after redeploy with enable_metrics=true"
+        )
+    log.info("F-02B: enable_metrics=true restored after redeploy")
+
+
+def verify_f02_dynamic_metrics_reload_vs_restart(ctx):
+    """enable_dynamic_metrics toggle requires redeploy; SIGHUP alone is insufficient."""
+    port = ctx.monitoring_port
+    log.info("F-02C: enable_dynamic_metrics=false in container conf + SIGHUP")
+    patch_ganesha_conf_param_in_container(
+        ctx.nfs_node, ctx.container_id, "enable_dynamic_metrics", False
+    )
+    sighup_ganesha_in_container(ctx.nfs_node, ctx.container_id)
+    time.sleep(int(ctx.config.get("f02_reload_wait_seconds", 5)))
+    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+        raise OperationFailedError(
+            "F-02C: global metrics unavailable after dynamic_metrics SIGHUP test"
+        )
+    log.info(
+        "F-02C: SIGHUP did not disable exporter; per-client series need redeploy to change"
+    )
+
+    dyn_off = dict(ctx.config)
+    dyn_off["enable_dynamic_metrics"] = False
+    dyn_off["monitoring_port"] = port
+    update_prometheus_ganesha_params(ctx.installer, ctx.nfs_node, ctx.nfs_name, dyn_off)
+    ctx.refresh_container_id()
+    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+        raise OperationFailedError(
+            "F-02C: metrics unavailable after enable_dynamic_metrics=false redeploy"
+        )
+
+    dyn_on = dict(ctx.config)
+    dyn_on["enable_dynamic_metrics"] = True
+    dyn_on["monitoring_port"] = port
+    update_prometheus_ganesha_params(ctx.installer, ctx.nfs_node, ctx.nfs_name, dyn_on)
+    ctx.refresh_container_id()
+    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+        raise OperationFailedError(
+            "F-02C: metrics not restored after enable_dynamic_metrics=true redeploy"
+        )
+    log.info("F-02C: enable_dynamic_metrics toggle requires redeploy (documented)")
+
+
+def perform_nfs_io(client, mount_path, file_name="prometheus_stats_testfile", mb=2):
+    test_file = f"{mount_path}/{file_name}"
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            f"dd if=/dev/urandom of={test_file} bs=1M count={mb} conv=fsync "
+            f"status=none && sync && cat {test_file} > /dev/null"
+        ),
+    )
+    client.exec_command(sudo=True, cmd=f"ls -la {mount_path} && stat {test_file}")
+
+
+def perform_metadata_workload(client, mount_path):
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            f"mkdir -p {mount_path}/mdtest && "
+            f"for i in $(seq 1 50); do touch {mount_path}/mdtest/f$i; done && "
+            f"ls -la {mount_path}/mdtest | head"
+        ),
+    )
+
+
+def perform_f05_manifest_warmup(client, mount_path, file_count=100):
+    """Cold then warm metadata so mdcache hit counters are exported."""
+    testdir = "%s/f05_manifest_%s" % (mount_path, int(time.time()))
+    client.exec_command(sudo=True, cmd="mkdir -p %s" % testdir)
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "for i in $(seq 1 %s); do "
+            "touch %s/file_$i; stat %s/file_$i >/dev/null; "
+            "done" % (file_count, testdir, testdir)
+        ),
+        timeout=180,
+    )
+    for pass_num in range(1, 4):
+        client.exec_command(
+            sudo=True,
+            cmd=(
+                "for i in $(seq 1 %s); do "
+                "stat %s/file_$i >/dev/null; ls %s/file_$i >/dev/null; "
+                "done; ls -la %s >/dev/null; "
+                "find %s -maxdepth 1 -type f -exec stat {} \\; >/dev/null"
+                % (file_count, testdir, testdir, testdir, testdir)
+            ),
+            timeout=180,
+        )
+    log.info("F-05 manifest warmup completed under %s", testdir)
+
+
+def perform_f10_mdcache_workload(client, mount_path, file_count=500):
+    """Cold then warm metadata paths for mdcache hit/miss counters."""
+    testdir = "%s/f10_mdcache_%s" % (mount_path, int(time.time()))
+    client.exec_command(sudo=True, cmd="mkdir -p %s" % testdir)
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "for i in $(seq 1 %s); do "
+            "touch %s/file_$i; stat %s/file_$i >/dev/null; "
+            "done" % (file_count, testdir, testdir)
+        ),
+        timeout=max(600, file_count // 2),
+    )
+    client.exec_command(
+        sudo=True,
+        cmd=(
+            "find %s -type f | wc -l; ls -laR %s >/dev/null; "
+            "for i in $(seq 1 %s); do "
+            "stat %s/file_$i >/dev/null; ls %s/file_$i >/dev/null; "
+            "done" % (testdir, testdir, min(file_count, 500), testdir, testdir)
+        ),
+        timeout=max(600, file_count // 2),
+    )
+    for _ in range(5):
+        client.exec_command(
+            sudo=True,
+            cmd="ls -la %s >/dev/null" % testdir,
+            check_ec=False,
+        )
+    log.info("F-10 metadata workload completed under %s", testdir)
+
+
+def verify_mdcache_counters_increased(metrics_before, metrics_after):
+    before_hits = max(get_counter_total(metrics_before, m) for m in MDCACHE_HIT_METRICS)
+    before_misses = max(
+        get_counter_total(metrics_before, m) for m in MDCACHE_MISS_METRICS
+    )
+    after_hits = max(get_counter_total(metrics_after, m) for m in MDCACHE_HIT_METRICS)
+    after_misses = max(
+        get_counter_total(metrics_after, m) for m in MDCACHE_MISS_METRICS
+    )
+    if after_hits <= before_hits and after_misses <= before_misses:
+        raise OperationFailedError(
+            "mdcache hits/misses did not increase (hits %s->%s misses %s->%s)"
+            % (before_hits, after_hits, before_misses, after_misses)
+        )
+    log.info(
+        "mdcache counters increased: hits %s->%s misses %s->%s",
+        before_hits,
+        after_hits,
+        before_misses,
+        after_misses,
+    )
+
+
+def get_export_bytes_by_export(metrics_text):
+    totals = {}
+    for name, labels, value in parse_metric_samples(metrics_text):
+        if "bytes_received_by_export_total" not in name and (
+            "bytes_sent_by_export_total" not in name
+        ):
+            continue
+        export = labels.get("export") or labels.get("export_id") or ""
+        path = labels.get("path", "")
+        key = export or path
+        if key:
+            totals[key] = totals.get(key, 0) + value
+    return totals
+
+
+def verify_export_traffic_attribution(metrics_before, metrics_after, min_delta=1024):
+    before = get_export_bytes_by_export(metrics_before)
+    after = get_export_bytes_by_export(metrics_after)
+    deltas = {
+        key: after.get(key, 0) - before.get(key, 0) for key in set(before) | set(after)
+    }
+    if not deltas:
+        raise OperationFailedError("No per-export byte counters in exposition")
+    positive = {k: v for k, v in deltas.items() if v > 0}
+    if not positive:
+        raise OperationFailedError(
+            "No per-export byte counter movement (deltas=%s)" % deltas
+        )
+    active = max(positive, key=lambda k: positive[k])
+    if positive[active] < min_delta:
+        raise OperationFailedError(
+            "Export %s byte delta %s below min_delta %s (deltas=%s)"
+            % (active, positive[active], min_delta, deltas)
+        )
+    log.info("Per-export bytes increased for %s: %s", active, deltas)
+    return active, deltas
+
+
+def count_client_request_samples(metrics_text):
+    names = set(CLIENT_REQUEST_METRICS)
+    return sum(1 for name, _, _ in parse_metric_samples(metrics_text) if name in names)
+
+
+def count_client_label_series(metrics_text):
+    clients = set()
+    client_metrics = set(CLIENT_REQUEST_METRICS)
+    for name, labels, _ in parse_metric_samples(metrics_text):
+        if name in CLIENT_BYTES_METRICS or name in client_metrics:
+            client = labels.get("client") or labels.get("client_id")
+            if client:
+                clients.add(client)
+    return clients
+
+
+def verify_client_label_present(metrics_text, min_clients=1):
+    clients = count_client_label_series(metrics_text)
+    if len(clients) < min_clients:
+        raise OperationFailedError(
+            "Expected at least %s client label series, found %s"
+            % (min_clients, sorted(clients))
+        )
+    verify_label_charset(metrics_text)
+    log.info("Client label series present: %s", sorted(clients))
+    return clients
+
+
+def drop_client_page_cache(client):
+    """Drop local page cache so a subsequent read must hit the NFS server."""
+    client.exec_command(
+        sudo=True,
+        cmd="sync; echo 3 > /proc/sys/vm/drop_caches",
+        check_ec=False,
+        timeout=60,
+    )
+    log.info("Requested page cache drop on %s", client.hostname)
+
+
+def run_fio_rw(client, mount_path, size="256M", runtime=120, rw="randrw"):
+    job = f"""
+[global]
+directory={mount_path}
+ioengine=psync
+direct=1
+runtime={runtime}
+time_based=1
+group_reporting=1
+
+[meta]
+rw=randread
+bs=4k
+size=64M
+numjobs=1
+
+[data]
+rw={rw}
+bs=1M
+size={size}
+numjobs=1
+"""
+    remote = "/tmp/nfs_prom_fio.job"
+    with client.remote_file(sudo=True, file_name=remote, file_mode="w") as fp:
+        fp.write(job)
+        fp.flush()
+    client.exec_command(
+        sudo=True,
+        cmd=f"fio {remote} --output-format=json",
+        timeout=max(runtime * 3, 120) + 180,
+    )
+
+
+def create_exports(nfs_node, nfs_name, fs_name, count, prefix="/export_prom"):
+    exports = []
+    for i in range(1, count + 1):
+        export = f"{prefix}_{i}"
+        Ceph(nfs_node).nfs.export.create(
+            fs_name=fs_name,
+            nfs_name=nfs_name,
+            nfs_export=export,
+            fs=fs_name,
+        )
+        exports.append(export)
+    return exports
+
+
+def mount_export(client, server, export, mount_path, version, port):
+    client.create_dirs(dir_path=mount_path, sudo=True)
+    if Mount(client).nfs(
+        mount=mount_path,
+        version=version,
+        port=port,
+        server=server,
+        export=export,
+    ):
+        raise OperationFailedError(
+            f"Failed to mount {server}:{export} on {client.hostname}"
+        )
+
+
+def unmount_export(client, mount_path):
+    if Unmount(client).unmount(mount_path):
+        raise OperationFailedError(f"Failed to unmount {mount_path}")
+
+
+def delete_exports(nfs_node, nfs_name, exports):
+    for export in exports:
+        try:
+            Ceph(nfs_node).nfs.export.delete(nfs_name, export)
+        except Exception as exc:
+            log.warning("Export delete %s: %s", export, exc)
+
+
+def inject_permission_error(client, mount_path):
+    client.exec_command(
+        sudo=True,
+        cmd=f"stat {mount_path}/no_such_file_for_getattr_test",
+        check_ec=False,
+    )
+
+
+def restart_nfs_container(nfs_node, container_id):
+    nfs_node.exec_command(sudo=True, cmd=f"podman restart {container_id}")
+    time.sleep(30)
+
+
+def kill_nfs_container(nfs_node, container_id):
+    nfs_node.exec_command(sudo=True, cmd=f"podman kill -s KILL {container_id}")
+    time.sleep(45)
+
+
+def wait_metrics_recovery(scrape_node, host, port, timeout=120):
+    for _ in range(timeout // 10):
+        try:
+            if scrape_prometheus_metrics_http_code(scrape_node, host, port) == "200":
+                return
+        except OperationFailedError:
+            pass
+        time.sleep(10)
+    raise OperationFailedError(f"Metrics endpoint did not recover on {host}:{port}")
+
+
+def rpc_gap_within_tolerance(metrics_before, metrics_after, tolerance_pct=5):
+    received_delta = get_counter_total(
+        metrics_after, "rpcs_received_total"
+    ) - get_counter_total(metrics_before, "rpcs_received_total")
+    completed_delta = get_counter_total(
+        metrics_after, "rpcs_completed_total"
+    ) - get_counter_total(metrics_before, "rpcs_completed_total")
+    if received_delta <= 0 or completed_delta <= 0:
+        raise OperationFailedError(
+            f"RPC counters did not increase: received={received_delta}, "
+            f"completed={completed_delta}"
+        )
+    gap_pct = abs(received_delta - completed_delta) * 100.0 / max(received_delta, 1)
+    if gap_pct > tolerance_pct:
+        raise OperationFailedError(
+            f"RPC gap {gap_pct:.1f}% exceeds tolerance {tolerance_pct}%"
+        )
+    log.info(
+        "rpcs_received_total/completed delta gap %.1f%% within tolerance %s%% "
+        "(received +%s, completed +%s)",
+        gap_pct,
+        tolerance_pct,
+        received_delta,
+        completed_delta,
+    )
+
+
+def bytes_delta_within_tolerance(
+    metrics_before,
+    metrics_after,
+    metric_name,
+    expected_bytes,
+    tolerance_pct=10,
+    operation_labels=None,
+):
+    delta, resolved = bytes_counter_delta(
+        metrics_before,
+        metrics_after,
+        metric_name,
+        operation_labels=operation_labels,
+    )
+    if (
+        not _metric_family_present(metrics_after, metric_name, operation_labels)
+        and not _metric_family_present(metrics_before, metric_name, operation_labels)
+        and not _metric_family_present(metrics_after, metric_name)
+        and not _metric_family_present(metrics_before, metric_name)
+    ):
+        raise OperationFailedError(
+            "no byte counter family found for %s (tried: %s)"
+            % (metric_name, ", ".join(_bytes_counter_candidates(metric_name)))
+        )
+    if expected_bytes <= 0:
+        raise OperationFailedError("expected_bytes must be positive")
+    diff_pct = abs(delta - expected_bytes) * 100.0 / expected_bytes
+    if diff_pct > tolerance_pct:
+        raise OperationFailedError(
+            "%s delta %s vs expected %s "
+            "(%.1f%% > %s%%)"
+            % (resolved, delta, expected_bytes, diff_pct, tolerance_pct)
+        )
+    log.info(
+        "%s delta %s within %.1f%% of expected %s",
+        resolved,
+        delta,
+        diff_pct,
+        expected_bytes,
+    )

--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -2,15 +2,17 @@
 
 import json
 import re
+import shlex
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import quote
 
+from ceph.ceph import CommandFailed
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
 from cli.exceptions import OperationFailedError
-from cli.utilities.filesys import Mount, Unmount
+from cli.utilities.filesys import Mount, MountFailedError, Unmount
 from tests.nfs.nfs_delegation_operations import (
     backup_ganesha_template,
     ensure_ceph_conf_and_admin_keyring_on_hosts,
@@ -24,6 +26,13 @@ log = Log(__name__)
 
 DEFAULT_MONITORING_PORT = 9587
 DEFAULT_PROMETHEUS_PORT = 9095
+# Keep curl scrapes from hanging CI when the endpoint/network stalls.
+CURL_CONNECT_TIMEOUT = 5
+CURL_MAX_TIME = 30
+CURL_TIMEOUT_OPTS = "--connect-timeout %s --max-time %s" % (
+    CURL_CONNECT_TIMEOUT,
+    CURL_MAX_TIME,
+)
 CONF_KEY = "mgr/cephadm/services/nfs/ganesha.conf"
 DEFAULT_TEMPLATE_PATH = (
     "/usr/share/ceph/mgr/cephadm/templates/services/nfs/ganesha.conf.j2"
@@ -428,7 +437,8 @@ def _patch_ganesha_work_template(cmd_host, config):
             )
         out, _ = cmd_host.exec_command(
             sudo=True,
-            cmd="grep -F %r %s" % (line, WORK_TEMPLATE_PATH),
+            cmd="grep -F -- %s %s"
+            % (shlex.quote(line), shlex.quote(WORK_TEMPLATE_PATH)),
             check_ec=False,
         )
         if line not in (out or ""):
@@ -868,7 +878,7 @@ def get_monitoring_port(nfs_node, nfs_name, config):
 
 
 def scrape_prometheus_metrics(node, host, port, path="/metrics"):
-    cmd = f"curl -sf http://{host}:{port}{path}"
+    cmd = "curl -sf %s http://%s:%s%s" % (CURL_TIMEOUT_OPTS, host, port, path)
     out, err = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
     body = (out or "").strip()
     if not body:
@@ -879,7 +889,12 @@ def scrape_prometheus_metrics(node, host, port, path="/metrics"):
 
 
 def scrape_prometheus_metrics_http_code(node, host, port, path="/metrics"):
-    cmd = f"curl -s -o /dev/null -w '%{{http_code}}' " f"http://{host}:{port}{path}"
+    cmd = "curl -s %s -o /dev/null -w '%%{http_code}' http://%s:%s%s" % (
+        CURL_TIMEOUT_OPTS,
+        host,
+        port,
+        path,
+    )
     out, _ = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
     return (out or "").strip()
 
@@ -955,7 +970,9 @@ def get_prometheus_api_url(ceph_cluster, installer, config=None):
 def fetch_prometheus_targets(scrape_node, api_base_url):
     url = "%s/api/v1/targets" % api_base_url.rstrip("/")
     out, err = scrape_node.exec_command(
-        sudo=True, cmd="curl -sf '%s'" % url, check_ec=False
+        sudo=True,
+        cmd="curl -sf %s '%s'" % (CURL_TIMEOUT_OPTS, url),
+        check_ec=False,
     )
     body = (out or "").strip()
     if not body:
@@ -1246,24 +1263,138 @@ def parse_prometheus_metrics(metrics_text):
     return names
 
 
+def _parse_prometheus_labels(label_part):
+    """Parse Prometheus label set; commas inside quoted values are preserved."""
+    labels = {}
+    key = []
+    value = []
+    state = "key"  # key | value | quoted
+    escaped = False
+    i = 0
+    length = len(label_part)
+    while i < length:
+        ch = label_part[i]
+        if state == "key":
+            if ch.isspace():
+                i += 1
+                continue
+            if ch == "=":
+                state = "value"
+                i += 1
+                continue
+            if ch == ",":
+                i += 1
+                continue
+            key.append(ch)
+            i += 1
+            continue
+        if state == "value":
+            if ch.isspace():
+                i += 1
+                continue
+            if ch == '"':
+                state = "quoted"
+                i += 1
+                continue
+            # Unquoted value until comma (rare in exposition, but tolerate).
+            while i < length and label_part[i] != ",":
+                value.append(label_part[i])
+                i += 1
+            labels["".join(key).strip()] = "".join(value).strip()
+            key = []
+            value = []
+            state = "key"
+            if i < length and label_part[i] == ",":
+                i += 1
+            continue
+        # quoted
+        if escaped:
+            if ch == "n":
+                value.append("\n")
+            elif ch == "\\":
+                value.append("\\")
+            elif ch == '"':
+                value.append('"')
+            else:
+                value.append(ch)
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\":
+            escaped = True
+            i += 1
+            continue
+        if ch == '"':
+            labels["".join(key).strip()] = "".join(value)
+            key = []
+            value = []
+            state = "key"
+            i += 1
+            while i < length and label_part[i].isspace():
+                i += 1
+            if i < length and label_part[i] == ",":
+                i += 1
+            continue
+        value.append(ch)
+        i += 1
+    if key and value:
+        labels["".join(key).strip()] = "".join(value).strip()
+    return labels
+
+
+def _split_prometheus_sample_value(tail):
+    """Return sample value, ignoring optional trailing timestamp."""
+    parts = tail.strip().split()
+    if not parts:
+        raise ValueError("missing sample value")
+    return float(parts[0])
+
+
+def _split_labeled_prometheus_line(line):
+    """Split ``name{labels} value [timestamp]`` respecting quoted braces/commas."""
+    open_idx = line.find("{")
+    if open_idx < 0:
+        raise ValueError("no label set")
+    name = line[:open_idx].strip()
+    i = open_idx + 1
+    in_quotes = False
+    escaped = False
+    while i < len(line):
+        ch = line[i]
+        if in_quotes:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_quotes = False
+        else:
+            if ch == '"':
+                in_quotes = True
+            elif ch == "}":
+                label_part = line[open_idx + 1 : i]
+                value = _split_prometheus_sample_value(line[i + 1 :])
+                return name, label_part, value
+        i += 1
+    raise ValueError("unterminated label set")
+
+
 def parse_metric_samples(metrics_text):
     samples = []
     for line in metrics_text.splitlines():
         if not line or line.startswith("#"):
             continue
-        if "{" in line:
-            name, rest = line.split("{", 1)
-            label_part, value = rest.rsplit("}", 1)
-            labels = {}
-            for item in label_part.split(","):
-                if "=" in item:
-                    key, val = item.split("=", 1)
-                    labels[key.strip()] = val.strip().strip('"')
-            samples.append((name.strip(), labels, float(value.strip())))
-        else:
-            parts = line.split()
-            if len(parts) >= 2:
-                samples.append((parts[0], {}, float(parts[1])))
+        try:
+            if "{" in line:
+                name, label_part, value = _split_labeled_prometheus_line(line)
+                labels = _parse_prometheus_labels(label_part)
+                samples.append((name, labels, value))
+            else:
+                parts = line.split()
+                if len(parts) >= 2:
+                    samples.append((parts[0], {}, float(parts[1])))
+        except (ValueError, IndexError) as exc:
+            log.debug("Skipping unparsable metrics line %r: %s", line, exc)
     return samples
 
 
@@ -1400,7 +1531,9 @@ def assert_counter_increased(metrics_before, metrics_after, *metric_names):
 def prometheus_query_instant(scrape_node, api_base_url, promql):
     url = "%s/api/v1/query?query=%s" % (api_base_url.rstrip("/"), quote(promql))
     out, err = scrape_node.exec_command(
-        sudo=True, cmd="curl -sf '%s'" % url, check_ec=False
+        sudo=True,
+        cmd="curl -sf %s '%s'" % (CURL_TIMEOUT_OPTS, url),
+        check_ec=False,
     )
     body = (out or "").strip()
     if not body:
@@ -1959,19 +2092,11 @@ def verify_histogram_cumulative(metrics_text, metric_prefix):
 
 
 def verify_label_charset(metrics_text):
-    for line in metrics_text.splitlines():
-        if "{" not in line or line.startswith("#"):
-            continue
-        label_part = line.split("{", 1)[1].split("}", 1)[0]
-        for item in label_part.split(","):
-            if "=" not in item:
-                continue
-            key, val = item.split("=", 1)
-            key = key.strip()
-            val = val.strip().strip('"')
+    for name, labels, _ in parse_metric_samples(metrics_text):
+        for key, val in labels.items():
             if not PROMETHEUS_LABEL_RE.match(key):
                 raise OperationFailedError(f"Invalid label name: {key}")
-            if not val or '"' in val or "\n" in val:
+            if not val or "\n" in val:
                 raise OperationFailedError(f"Invalid label value for {key}: {val}")
 
 
@@ -2199,37 +2324,64 @@ def verify_concurrent_scrape_metrics(bodies):
 def verify_promtool_metrics(client, host, port, remote_path="/tmp/ganesha_live.prom"):
     client.exec_command(
         sudo=True,
-        cmd="curl -sf http://%s:%s/metrics -o %s" % (host, port, remote_path),
+        cmd="curl -sf %s http://%s:%s/metrics -o %s"
+        % (CURL_TIMEOUT_OPTS, host, port, remote_path),
     )
-    out, _ = client.exec_command(
-        sudo=True,
-        cmd="command -v promtool >/dev/null && promtool check metrics %s || echo SKIP"
-        % remote_path,
-        check_ec=False,
+    which_out, _ = client.exec_command(
+        sudo=True, cmd="command -v promtool", check_ec=False
     )
-    result = (out or "").strip()
-    if result == "SKIP":
+    if not (which_out or "").strip():
         log.info("promtool not installed on client; skipping promtool check metrics")
         verify_help_and_type(scrape_prometheus_metrics(client, host, port))
         return
-    if "SUCCESS" not in result.upper() and result:
-        raise OperationFailedError("promtool check metrics failed: %s" % result[-500:])
-    log.info("promtool check metrics passed")
+    try:
+        out, err = client.exec_command(
+            sudo=True, cmd="promtool check metrics %s" % remote_path
+        )
+    except CommandFailed as exc:
+        detail = str(exc)
+        raise OperationFailedError(
+            "promtool check metrics failed: %s" % detail[-500:]
+        ) from exc
+    result = "%s\n%s" % ((out or "").strip(), (err or "").strip())
+    log.info(
+        "promtool check metrics passed%s",
+        (": %s" % result.strip()[-200:]) if result.strip() else "",
+    )
+
+
+def _firewalld_is_running(node):
+    """Return True if firewalld is active on node; False if absent/inactive."""
+    try:
+        out, _ = node.exec_command(sudo=True, cmd="firewall-cmd --state")
+    except CommandFailed:
+        return False
+    return (out or "").strip().lower() == "running"
 
 
 def firewall_block_metrics_from_source(nfs_node, port, source_ip):
+    if not _firewalld_is_running(nfs_node):
+        raise OperationFailedError(
+            "firewalld is not running on %s; cannot block metrics port %s from %s"
+            % (nfs_node.hostname, port, source_ip)
+        )
     rule = (
         'rule family="ipv4" source address=%s port port="%s" protocol="tcp" reject'
         % (source_ip, port)
     )
-    nfs_node.exec_command(
-        sudo=True,
-        cmd="firewall-cmd --permanent --add-rich-rule='%s'" % rule,
-        check_ec=False,
-    )
-    nfs_node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+    try:
+        # Runtime-only so the block does not persist past the suite / firewalld restart.
+        nfs_node.exec_command(
+            sudo=True,
+            cmd="firewall-cmd --add-rich-rule='%s'" % rule,
+        )
+    except CommandFailed as err:
+        raise OperationFailedError(
+            "Failed to block metrics port %s from %s on %s: %s"
+            % (port, source_ip, nfs_node.hostname, err)
+        ) from err
     log.info(
-        "Blocked metrics port %s from source %s on %s",
+        "Blocked metrics port %s from source %s on %s (runtime)",
         port,
         source_ip,
         nfs_node.hostname,
@@ -2238,22 +2390,63 @@ def firewall_block_metrics_from_source(nfs_node, port, source_ip):
 
 
 def firewall_unblock_metrics_from_source(nfs_node, rule):
-    nfs_node.exec_command(
-        sudo=True,
-        cmd="firewall-cmd --permanent --remove-rich-rule='%s'" % rule,
-        check_ec=False,
-    )
-    nfs_node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+    if not _firewalld_is_running(nfs_node):
+        log.info(
+            "firewalld not running on %s; skip removing rich-rule",
+            nfs_node.hostname,
+        )
+        return
+    try:
+        nfs_node.exec_command(
+            sudo=True,
+            cmd="firewall-cmd --remove-rich-rule='%s'" % rule,
+        )
+    except CommandFailed as err:
+        raise OperationFailedError(
+            "Failed to remove firewall rich-rule on %s: %s" % (nfs_node.hostname, err)
+        ) from err
     log.info("Removed firewall rich-rule on %s", nfs_node.hostname)
 
 
 def firewall_allow_port(node, port):
-    node.exec_command(
-        sudo=True,
-        cmd=f"firewall-cmd --permanent --add-port={port}/tcp",
-        check_ec=False,
-    )
-    node.exec_command(sudo=True, cmd="firewall-cmd --reload", check_ec=False)
+    """Open a TCP port in firewalld for the current runtime only (not permanent)."""
+    if not _firewalld_is_running(node):
+        log.info(
+            "firewalld not running on %s; port %s assumed reachable",
+            node.hostname,
+            port,
+        )
+        return
+    try:
+        node.exec_command(
+            sudo=True,
+            cmd=f"firewall-cmd --add-port={port}/tcp",
+        )
+    except CommandFailed as err:
+        raise OperationFailedError(
+            "Failed to open firewall port %s/tcp on %s: %s" % (port, node.hostname, err)
+        ) from err
+    log.info("Opened runtime firewall port %s/tcp on %s", port, node.hostname)
+
+
+def firewall_remove_port(node, port):
+    """Remove a runtime firewalld TCP port opened by firewall_allow_port()."""
+    if not _firewalld_is_running(node):
+        return
+    try:
+        node.exec_command(
+            sudo=True,
+            cmd=f"firewall-cmd --remove-port={port}/tcp",
+        )
+    except CommandFailed as err:
+        log.warning(
+            "Failed to remove firewall port %s/tcp on %s: %s",
+            port,
+            node.hostname,
+            err,
+        )
+        return
+    log.info("Removed runtime firewall port %s/tcp on %s", port, node.hostname)
 
 
 def run_ganesha_stats(nfs_node, container_id, *args):
@@ -2672,21 +2865,22 @@ def create_exports(nfs_node, nfs_name, fs_name, count, prefix="/export_prom"):
 
 def mount_export(client, server, export, mount_path, version, port):
     client.create_dirs(dir_path=mount_path, sudo=True)
-    if Mount(client).nfs(
-        mount=mount_path,
-        version=version,
-        port=port,
-        server=server,
-        export=export,
-    ):
-        raise OperationFailedError(
-            f"Failed to mount {server}:{export} on {client.hostname}"
+    try:
+        Mount(client).nfs(
+            mount=mount_path,
+            version=version,
+            port=port,
+            server=server,
+            export=export,
         )
+    except MountFailedError as err:
+        raise OperationFailedError(
+            f"Failed to mount {server}:{export} on {client.hostname}: {err}"
+        ) from err
 
 
 def unmount_export(client, mount_path):
-    if Unmount(client).unmount(mount_path):
-        raise OperationFailedError(f"Failed to unmount {mount_path}")
+    Unmount(client).unmount(mount_path)
 
 
 def delete_exports(nfs_node, nfs_name, exports):
@@ -2698,10 +2892,40 @@ def delete_exports(nfs_node, nfs_name, exports):
 
 
 def inject_permission_error(client, mount_path):
+    """Exercise an NFS operation that should return EACCES/EPERM.
+
+    Creates a mode-000 file and reads it as an unprivileged user so the
+    client receives permission denied (not ENOENT from a missing path).
+    """
+    denied_path = f"{mount_path}/a06_perm_denied_{uuid.uuid4().hex[:8]}"
     client.exec_command(
+        sudo=True, cmd=f"touch {denied_path} && chmod 000 {denied_path}"
+    )
+    # Prefer nobody/cephuser so root_squash / local root bypass does not hide EACCES.
+    out, err = client.exec_command(
         sudo=True,
-        cmd=f"stat {mount_path}/no_such_file_for_getattr_test",
+        cmd=(
+            "runuser -u nobody -- cat {0} 2>&1 || "
+            "su -s /bin/bash nobody -c 'cat {0}' 2>&1 || "
+            "su -s /bin/bash cephuser -c 'cat {0}' 2>&1 || "
+            "true"
+        ).format(denied_path),
         check_ec=False,
+    )
+    combined = "%s\n%s" % ((out or "").strip(), (err or "").strip())
+    if not any(
+        token in combined.lower()
+        for token in ("permission denied", "operation not permitted")
+    ):
+        log.warning(
+            "inject_permission_error: expected EACCES/EPERM for %s; got: %s",
+            denied_path,
+            combined[-300:],
+        )
+    else:
+        log.info("inject_permission_error: permission-denied I/O on %s", denied_path)
+    client.exec_command(
+        sudo=True, cmd=f"chmod 644 {denied_path} && rm -f {denied_path}", check_ec=False
     )
 
 

--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -10,7 +10,7 @@ from urllib.parse import quote
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
 from cli.exceptions import OperationFailedError
-from cli.utilities.filesys import Mount, MountFailedError, Unmount
+from cli.utilities.filesys import Mount, Unmount
 from tests.nfs.nfs_delegation_operations import (
     backup_ganesha_template,
     ensure_ceph_conf_and_admin_keyring_on_hosts,

--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -1210,14 +1210,13 @@ def metric_available(names, metric_name):
 def verify_manifest_v1(metrics_text):
     names = parse_prometheus_metrics(metrics_text)
     missing = []
-    optional_missing = []
     for metric in MANIFEST_V1_COUNTERS + MANIFEST_V1_GAUGES + MANIFEST_V1_HISTOGRAMS:
-        if metric_available(names, metric):
-            continue
-        if metric in MANIFEST_V1_OPTIONAL:
-            optional_missing.append(metric)
-        else:
+        if not metric_available(names, metric):
             missing.append(metric)
+
+    optional_missing = [
+        metric for metric in MANIFEST_V1_OPTIONAL if not metric_available(names, metric)
+    ]
     if optional_missing:
         log.warning("Manifest v1 optional metrics not present: %s", optional_missing)
     if "mdcache_cache_hits_total" in missing and metric_available(

--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -10,7 +10,7 @@ from urllib.parse import quote
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
 from cli.exceptions import OperationFailedError
-from cli.utilities.filesys import Mount, Unmount
+from cli.utilities.filesys import Mount, MountFailedError, Unmount
 from tests.nfs.nfs_delegation_operations import (
     backup_ganesha_template,
     ensure_ceph_conf_and_admin_keyring_on_hosts,

--- a/tests/nfs/test_nfs_prometheus_stats.py
+++ b/tests/nfs/test_nfs_prometheus_stats.py
@@ -28,6 +28,7 @@ from tests.nfs.nfs_prometheus_stats_utils import (
     drop_client_page_cache,
     firewall_allow_port,
     firewall_block_metrics_from_source,
+    firewall_remove_port,
     firewall_unblock_metrics_from_source,
     get_counter_total,
     get_histogram_count_sum,
@@ -143,6 +144,7 @@ class TestContext:
         self.extra_exports = []
         self.extra_mounts = []
         self.template_backup_exists = None
+        self.runtime_firewall_ports = set()
 
     def setup_cluster(self):
         setup_nfs_cluster(
@@ -178,6 +180,7 @@ class TestContext:
             self.installer, self.nfs_name, self.nfs_node
         )
         firewall_allow_port(self.nfs_node, self.monitoring_port)
+        self.runtime_firewall_ports.add(int(self.monitoring_port))
 
     def refresh_container_id(self):
         self.container_id = get_nfs_container_id(
@@ -193,6 +196,12 @@ class TestContext:
         return scrape_prometheus_metrics(self.client, self.nfs_ip, self.monitoring_port)
 
     def cleanup(self):
+        for port in list(self.runtime_firewall_ports):
+            try:
+                firewall_remove_port(self.nfs_node, port)
+            except Exception as exc:
+                log.warning("Firewall port cleanup %s: %s", port, exc)
+        self.runtime_firewall_ports.clear()
         for client, mount in self.extra_mounts:
             try:
                 unmount_export(client, mount)
@@ -469,6 +478,7 @@ def test_f_02(ctx):
         ctx.monitoring_port = alt_port
         ctx.refresh_container_id()
         firewall_allow_port(ctx.nfs_node, alt_port)
+        ctx.runtime_firewall_ports.add(alt_port)
         verify_monitoring_port_listening(ctx.nfs_node, alt_port)
         verify_exposition_has_metric(ctx.scrape(), "rpcs_received_total")
         log.info("F-02A: monitoring_port=%s active after redeploy", alt_port)
@@ -483,6 +493,10 @@ def test_f_02(ctx):
             ctx.monitoring_port = base_port
             ctx.refresh_container_id()
             firewall_allow_port(ctx.nfs_node, base_port)
+            ctx.runtime_firewall_ports.add(int(base_port))
+            if alt_port != base_port:
+                firewall_remove_port(ctx.nfs_node, alt_port)
+                ctx.runtime_firewall_ports.discard(alt_port)
         except Exception as exc:
             log.warning("F-02: failed to restore baseline ganesha config: %s", exc)
     log_test_passed(
@@ -1177,8 +1191,13 @@ def test_x_01(ctx):
     restart_nfs_container(ctx.nfs_node, ctx.container_id)
     wait_metrics_recovery(ctx.client, ctx.nfs_ip, ctx.monitoring_port, timeout=120)
     after = get_counter_total(ctx.scrape(), "rpcs_received_total")
-    if after > before:
-        log.warning("Counter did not reset after restart (may be expected)")
+    if after >= before:
+        log.warning(
+            "rpcs_received_total did not reset after restart "
+            "(before=%s, after=%s; may be expected)",
+            before,
+            after,
+        )
     perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1)
     log_test_passed(
         "X-01",
@@ -1258,8 +1277,10 @@ def test_n_02(ctx):
     code = scrape_prometheus_metrics_http_code(
         ctx.client, ctx.nfs_ip, ctx.monitoring_port, path="/not-metrics"
     )
+    if code == "200":
+        raise OperationFailedError("N-02: /not-metrics unexpectedly returned HTTP 200")
     if code not in ("404", "000", "403"):
-        log.info("Non-metrics path returned HTTP %s", code)
+        log.info("Non-metrics path returned HTTP %s (acceptable non-200)", code)
     log_test_passed(
         "N-02",
         "non-metrics path /not-metrics returned HTTP %s (not 200)" % code,

--- a/tests/nfs/test_nfs_prometheus_stats.py
+++ b/tests/nfs/test_nfs_prometheus_stats.py
@@ -1,0 +1,1579 @@
+"""
+NFS-Ganesha Scalable Statistics (Prometheus) — CephCI automation.
+
+Each suite entry sets ``polarion-id`` on the test block (for reporting) and in
+``config`` (for test dispatch). Internal plan IDs (S-01, F-02, etc.) are mapped
+in ``POLARION_TEST_IDS``.
+"""
+
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.nfs_operations import cleanup_cluster, setup_nfs_cluster
+from tests.nfs.nfs_prometheus_stats_utils import (
+    NFS_BYTE_READ_COUNTER,
+    NFS_BYTE_READ_OPERATIONS,
+    NFS_BYTE_WRITE_COUNTER,
+    NFS_BYTE_WRITE_OPERATIONS,
+    apply_f01_config_typo_line,
+    apply_f01_invalid_monitoring_port,
+    apply_prometheus_ganesha_template,
+    bytes_delta_within_tolerance,
+    concurrent_scrape,
+    concurrent_scrape_metrics,
+    count_client_request_samples,
+    create_exports,
+    delete_exports,
+    drop_client_page_cache,
+    firewall_allow_port,
+    firewall_block_metrics_from_source,
+    firewall_unblock_metrics_from_source,
+    get_counter_total,
+    get_histogram_count_sum,
+    get_installer,
+    get_monitoring_port,
+    get_nfs_container_id,
+    get_prometheus_scrape_source_ip,
+    inject_permission_error,
+    kill_nfs_container,
+    metric_available,
+    mount_export,
+    parse_metric_samples,
+    parse_prometheus_metrics,
+    perform_f05_manifest_warmup,
+    perform_f10_mdcache_workload,
+    perform_metadata_workload,
+    perform_nfs_io,
+    perform_s06_minimal_workload,
+    prepare_cluster_ceph_access,
+    restart_nfs_container,
+    restore_f01_good_ganesha_config,
+    restore_prometheus_ganesha_template,
+    rpc_gap_within_tolerance,
+    run_fio_rw,
+    run_ganesha_stats,
+    run_ganesha_stats_subcommands,
+    scrape_prometheus_metrics,
+    scrape_prometheus_metrics_http_code,
+    unmount_export,
+    update_prometheus_ganesha_params,
+    verify_client_label_present,
+    verify_concurrent_scrape_metrics,
+    verify_export_traffic_attribution,
+    verify_exposition_has_metric,
+    verify_f01_invalid_port_outcome,
+    verify_f01_typo_outcome,
+    verify_f02_dynamic_metrics_reload_vs_restart,
+    verify_f02_enable_metrics_reload_vs_restart,
+    verify_f02_port_reload_vs_restart,
+    verify_ganesha_build_info,
+    verify_help_and_type,
+    verify_idle_baseline,
+    verify_latency_histogram_after_workload,
+    verify_manifest_v1,
+    verify_mdcache_counters_increased,
+    verify_metrics_endpoint_not_accessible,
+    verify_monitoring_port_listening,
+    verify_nfsv4_op_count_after_workload,
+    verify_prometheus_nfs_scrape_target,
+    verify_promtool_metrics,
+    verify_s06_minimal_workload_prometheus,
+    verify_s07_dynamic_metrics_disabled,
+    wait_metrics_recovery,
+    wait_prometheus_nfs_target_health,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class TestNotSupported(Exception):
+    """Subtest requires manual validation or a lab environment not available in CI."""
+
+
+def log_test_passed(test_id, summary):
+    """Log explicit pass criteria for a subtest (visible in Jenkins logs)."""
+    log.info("%s validation PASSED: %s", test_id, summary)
+
+
+def log_test_skipped(test_id, reason=""):
+    """Mark subtest as skipped — not automated or needs lab setup."""
+    detail = reason or "manual validation or lab environment required"
+    log.info("%s SKIPPED: NOT SUPPORTED — %s", test_id, detail)
+    raise TestNotSupported(detail)
+
+
+def _sleep_for_metrics(ctx, default=5, config_key="prometheus_query_wait_seconds"):
+    sleep(int(ctx.config.get(config_key, default)))
+
+
+LEGACY_GANESHA_STATS_COMMANDS = (
+    "display",
+    "v4_full",
+    "mem_stats",
+    "export",
+    "client",
+)
+
+
+class TestContext:
+    def __init__(self, ceph_cluster, config):
+        self.ceph_cluster = ceph_cluster
+        self.config = config
+        self.installer = get_installer(ceph_cluster)
+        self.clients = ceph_cluster.get_nodes(role="client")
+        self.nfs_nodes = ceph_cluster.get_nodes(role="nfs")
+        self.num_clients = int(config.get("clients", 1))
+        if self.num_clients > len(self.clients):
+            raise ConfigError("Not enough client nodes for test")
+        self.clients = self.clients[: self.num_clients]
+        self.client = self.clients[0]
+        self.nfs_node = self.nfs_nodes[0]
+        self.nfs_name = config.get("nfs_name", "cephfs-nfs")
+        self.nfs_export = config.get("nfs_export", "/export")
+        self.nfs_mount = config.get("nfs_mount", "/mnt/nfs")
+        self.fs_name = config.get("fs_name", "cephfs")
+        self.nfs_version = config.get("nfs_version", 4.1)
+        self.nfs_port = config.get("port", 2049)
+        self.nfs_ip = self.nfs_node.ip_address
+        self.nfs_server = self.nfs_node.hostname
+        self.monitoring_port = None
+        self.container_id = None
+        self.extra_exports = []
+        self.extra_mounts = []
+        self.template_backup_exists = None
+
+    def setup_cluster(self):
+        setup_nfs_cluster(
+            clients=[self.client],
+            nfs_server=self.nfs_server,
+            port=self.nfs_port,
+            version=self.nfs_version,
+            nfs_name=self.nfs_name,
+            nfs_mount=self.nfs_mount,
+            fs_name=self.fs_name,
+            export=self.nfs_export,
+            fs=self.fs_name,
+            ceph_cluster=self.ceph_cluster,
+            ha=self.config.get("ha", False),
+            vip=self.config.get("vip"),
+            enable_rdma=self.config.get("enable_rdma", False),
+            rdma_port=self.config.get("rdma_port"),
+        )
+        prepare_cluster_ceph_access(
+            self.ceph_cluster,
+            self.installer,
+            clients=self.clients,
+            nfs_nodes=self.nfs_nodes,
+        )
+        if self.config.get("configure_ganesha_metrics", True):
+            self.template_backup_exists = apply_prometheus_ganesha_template(
+                self.installer, self.nfs_node, self.nfs_name, self.config
+            )
+        self.monitoring_port = get_monitoring_port(
+            self.nfs_node, self.nfs_name, self.config
+        )
+        self.container_id = get_nfs_container_id(
+            self.installer, self.nfs_name, self.nfs_node
+        )
+        firewall_allow_port(self.nfs_node, self.monitoring_port)
+
+    def refresh_container_id(self):
+        self.container_id = get_nfs_container_id(
+            self.installer, self.nfs_name, self.nfs_node
+        )
+        if not self.container_id:
+            log.warning(
+                "No NFS container_id on %s after refresh",
+                self.nfs_node.hostname,
+            )
+
+    def scrape(self):
+        return scrape_prometheus_metrics(self.client, self.nfs_ip, self.monitoring_port)
+
+    def cleanup(self):
+        for client, mount in self.extra_mounts:
+            try:
+                unmount_export(client, mount)
+            except Exception as exc:
+                log.warning("Unmount %s: %s", mount, exc)
+        if self.extra_exports:
+            delete_exports(self.nfs_node, self.nfs_name, self.extra_exports)
+        if self.template_backup_exists is not None:
+            try:
+                restore_prometheus_ganesha_template(
+                    self.installer,
+                    self.nfs_node,
+                    self.nfs_name,
+                    self.template_backup_exists,
+                    self.config,
+                )
+            except Exception as exc:
+                log.warning("Failed to restore ganesha template: %s", exc)
+        cleanup_cluster(
+            self.client,
+            self.nfs_mount,
+            self.nfs_name,
+            self.nfs_export,
+            nfs_nodes=self.nfs_node,
+        )
+
+
+def _mount_extra_clients(ctx):
+    for idx, client in enumerate(ctx.clients[1:], start=1):
+        mount = f"{ctx.nfs_mount}_{idx}"
+        mount_export(
+            client,
+            ctx.nfs_server,
+            f"{ctx.nfs_export}_{0}",
+            mount,
+            ctx.nfs_version,
+            ctx.nfs_port,
+        )
+        ctx.extra_mounts.append((client, mount))
+
+
+def test_s_01(ctx):
+    log.info("S-01a: cephadm NFS enables metrics by default; verifying active exporter")
+    verify_monitoring_port_listening(ctx.nfs_node, ctx.monitoring_port)
+    if (
+        scrape_prometheus_metrics_http_code(ctx.client, ctx.nfs_ip, ctx.monitoring_port)
+        != "200"
+    ):
+        raise OperationFailedError("Metrics endpoint not HTTP 200")
+
+    log.info("S-01b: Enable_Metrics=false; metrics unreachable, NFS still operational")
+    metrics_off = dict(ctx.config)
+    metrics_off["enable_metrics"] = False
+    metrics_on = dict(ctx.config)
+    metrics_on["enable_metrics"] = True
+    try:
+        update_prometheus_ganesha_params(
+            ctx.installer, ctx.nfs_node, ctx.nfs_name, metrics_off
+        )
+        verify_metrics_endpoint_not_accessible(
+            ctx.client,
+            ctx.nfs_node,
+            ctx.nfs_ip,
+            ctx.monitoring_port,
+        )
+        perform_s06_minimal_workload(ctx.client, ctx.nfs_mount)
+    finally:
+        try:
+            update_prometheus_ganesha_params(
+                ctx.installer, ctx.nfs_node, ctx.nfs_name, metrics_on
+            )
+            ctx.refresh_container_id()
+        except Exception as exc:
+            log.warning("Failed to re-enable enable_metrics: %s", exc)
+    log_test_passed(
+        "S-01",
+        "metrics endpoint HTTP 200 on port %s by default; "
+        "enable_metrics=false hides /metrics while NFS I/O succeeds; "
+        "enable_metrics restored" % ctx.monitoring_port,
+    )
+
+
+def test_s_02(ctx):
+    metrics = ctx.scrape()
+    verify_help_and_type(metrics)
+    verify_exposition_has_metric(metrics, "rpcs_received_total")
+    verify_monitoring_port_listening(ctx.nfs_node, ctx.monitoring_port)
+    log_test_passed(
+        "S-02",
+        "HELP/TYPE exposition valid; rpcs_received_total present; "
+        "monitoring port %s listening" % ctx.monitoring_port,
+    )
+
+
+def test_s_03(ctx):
+    metrics = ctx.scrape()
+    verify_help_and_type(metrics)
+    verify_exposition_has_metric(metrics, "rpcs_received_total")
+    verify_prometheus_nfs_scrape_target(
+        ctx.client,
+        ctx.ceph_cluster,
+        ctx.installer,
+        ctx.nfs_node,
+        ctx.nfs_ip,
+        ctx.monitoring_port,
+        nfs_name=ctx.nfs_name,
+        config=ctx.config,
+    )
+    log_test_passed(
+        "S-03",
+        "HELP/TYPE valid; rpcs_received_total present; "
+        "Prometheus NFS scrape target UP for %s:%s" % (ctx.nfs_ip, ctx.monitoring_port),
+    )
+
+
+def test_s_04(ctx):
+    metrics = ctx.scrape()
+    verify_exposition_has_metric(metrics, "ganesha_build_info")
+    verify_ganesha_build_info(metrics, ctx.nfs_node, ctx.container_id)
+    log_test_passed(
+        "S-04",
+        "ganesha_build_info metric present and matches NFS container build",
+    )
+
+
+def test_s_05(ctx):
+    first = ctx.scrape()
+    sleep(int(ctx.config.get("idle_wait_seconds", 120)))
+    second = ctx.scrape()
+    verify_idle_baseline(first, second, ctx.config)
+    idle_wait = int(ctx.config.get("idle_wait_seconds", 120))
+    log_test_passed(
+        "S-05",
+        "counter baselines stable over %ss idle (no spurious increments)" % idle_wait,
+    )
+
+
+def test_s_06(ctx):
+    verify_s06_minimal_workload_prometheus(
+        ctx.client,
+        ctx.ceph_cluster,
+        ctx.installer,
+        lambda: perform_s06_minimal_workload(ctx.client, ctx.nfs_mount),
+        config=ctx.config,
+        nfs_ip=ctx.nfs_ip,
+        monitoring_port=ctx.monitoring_port,
+    )
+    log_test_passed(
+        "S-06",
+        "minimal NFS workload increments Prometheus counters; "
+        "scrape target remains healthy",
+    )
+
+
+def test_s_07(ctx):
+    min_clients = int(ctx.config.get("s07_min_clients", 2))
+    if len(ctx.clients) < min_clients:
+        raise ConfigError(
+            "S-07 requires at least %s client nodes (have %s)"
+            % (min_clients, len(ctx.clients))
+        )
+
+    dyn_off = dict(ctx.config)
+    dyn_off["enable_dynamic_metrics"] = False
+    dyn_on = dict(ctx.config)
+    dyn_on["enable_dynamic_metrics"] = True
+
+    try:
+        update_prometheus_ganesha_params(
+            ctx.installer, ctx.nfs_node, ctx.nfs_name, dyn_off
+        )
+        _mount_extra_clients(ctx)
+        verify_s07_dynamic_metrics_disabled(ctx, dyn_off)
+    finally:
+        try:
+            update_prometheus_ganesha_params(
+                ctx.installer, ctx.nfs_node, ctx.nfs_name, dyn_on
+            )
+            ctx.refresh_container_id()
+        except Exception as exc:
+            log.warning("Failed to re-enable enable_dynamic_metrics: %s", exc)
+    log_test_passed(
+        "S-07",
+        "enable_dynamic_metrics=false suppresses dynamic client series "
+        "with %s client(s) mounted" % len(ctx.clients),
+    )
+
+
+def test_s_08(ctx):
+    before = ctx.scrape()
+    run_fio_rw(
+        ctx.client,
+        ctx.nfs_mount,
+        size=ctx.config.get("s08_fio_size", "64M"),
+        runtime=int(ctx.config.get("s08_fio_runtime", 60)),
+    )
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 5)))
+    after = ctx.scrape()
+    verify_nfsv4_op_count_after_workload(before, after)
+    log_test_passed(
+        "S-08",
+        "nfsv4__op_count increased after fio read/write workload",
+    )
+
+
+def test_f_01(ctx):
+    good_config = dict(ctx.config)
+    invalid_port = int(ctx.config.get("f01_invalid_monitoring_port", 99999))
+    typo_line = ctx.config.get("f01_typo_line", "Enable_metrics xxxx = true;")
+    try:
+        log.info("F-01A: invalid monitoring_port=%s", invalid_port)
+        logs, daemons = apply_f01_invalid_monitoring_port(
+            ctx.installer,
+            ctx.nfs_node,
+            ctx.nfs_name,
+            good_config,
+            invalid_port,
+        )
+        verify_f01_invalid_port_outcome(ctx, logs, daemons, invalid_port)
+
+        log.info("F-01B: restore valid template then inject typo: %s", typo_line)
+        update_prometheus_ganesha_params(
+            ctx.installer, ctx.nfs_node, ctx.nfs_name, good_config
+        )
+        ctx.refresh_container_id()
+        logs, daemons = apply_f01_config_typo_line(
+            ctx.installer,
+            ctx.nfs_node,
+            ctx.nfs_name,
+            good_config,
+            typo_line,
+        )
+        verify_f01_typo_outcome(ctx, logs, daemons)
+    finally:
+        try:
+            restore_f01_good_ganesha_config(
+                ctx.installer,
+                ctx.nfs_node,
+                ctx.nfs_name,
+                good_config,
+                typo_line=typo_line,
+            )
+            ctx.refresh_container_id()
+        except Exception as exc:
+            log.warning("F-01: failed to restore valid ganesha template: %s", exc)
+    log_test_passed(
+        "F-01",
+        "invalid monitoring_port rejected; config typo rejected; "
+        "valid ganesha template restored",
+    )
+
+
+def test_f_02(ctx):
+    ctx.refresh_container_id()
+    if not ctx.container_id:
+        raise OperationFailedError("F-02 requires NFS container_id")
+
+    good_config = dict(ctx.config)
+    base_port = ctx.monitoring_port
+    alt_port = int(ctx.config.get("f02_alt_monitoring_port", 9588))
+
+    verify_exposition_has_metric(ctx.scrape(), "rpcs_received_total")
+    verify_monitoring_port_listening(ctx.nfs_node, base_port)
+    log.info("F-02 baseline: metrics UP on port %s", base_port)
+
+    try:
+        verify_f02_port_reload_vs_restart(ctx, alt_port)
+
+        alt_config = dict(good_config)
+        alt_config["monitoring_port"] = alt_port
+        update_prometheus_ganesha_params(
+            ctx.installer, ctx.nfs_node, ctx.nfs_name, alt_config
+        )
+        ctx.monitoring_port = alt_port
+        ctx.refresh_container_id()
+        firewall_allow_port(ctx.nfs_node, alt_port)
+        verify_monitoring_port_listening(ctx.nfs_node, alt_port)
+        verify_exposition_has_metric(ctx.scrape(), "rpcs_received_total")
+        log.info("F-02A: monitoring_port=%s active after redeploy", alt_port)
+
+        verify_f02_enable_metrics_reload_vs_restart(ctx)
+        verify_f02_dynamic_metrics_reload_vs_restart(ctx)
+    finally:
+        try:
+            update_prometheus_ganesha_params(
+                ctx.installer, ctx.nfs_node, ctx.nfs_name, good_config
+            )
+            ctx.monitoring_port = base_port
+            ctx.refresh_container_id()
+            firewall_allow_port(ctx.nfs_node, base_port)
+        except Exception as exc:
+            log.warning("F-02: failed to restore baseline ganesha config: %s", exc)
+    log_test_passed(
+        "F-02",
+        "monitoring_port change and enable_metrics / enable_dynamic_metrics "
+        "reload vs restart behaviour validated",
+    )
+
+
+def test_f_03(ctx):
+    verify_prometheus_nfs_scrape_target(
+        ctx.client,
+        ctx.ceph_cluster,
+        ctx.installer,
+        ctx.nfs_node,
+        ctx.nfs_ip,
+        ctx.monitoring_port,
+        nfs_name=ctx.nfs_name,
+        config=ctx.config,
+    )
+    block_source = ctx.config.get(
+        "f03_block_source_ip"
+    ) or get_prometheus_scrape_source_ip(
+        ctx.ceph_cluster, ctx.installer, ctx.config, ctx.client
+    )
+    wait_seconds = int(ctx.config.get("f03_scrape_wait_seconds", 45))
+    rule = firewall_block_metrics_from_source(
+        ctx.nfs_node, ctx.monitoring_port, block_source
+    )
+    try:
+        sleep(wait_seconds)
+        wait_prometheus_nfs_target_health(
+            ctx.client,
+            ctx.ceph_cluster,
+            ctx.installer,
+            ctx.nfs_node,
+            ctx.nfs_ip,
+            ctx.monitoring_port,
+            expected_health="down",
+            nfs_name=ctx.nfs_name,
+            config=ctx.config,
+        )
+        if (
+            scrape_prometheus_metrics_http_code(
+                ctx.nfs_node, ctx.nfs_ip, ctx.monitoring_port
+            )
+            != "200"
+        ):
+            raise OperationFailedError(
+                "F-03: local scrape on NFS node failed while Prometheus blocked"
+            )
+        perform_nfs_io(ctx.client, ctx.nfs_mount, mb=2, file_name="f03_fw_block")
+    finally:
+        firewall_unblock_metrics_from_source(ctx.nfs_node, rule)
+    wait_prometheus_nfs_target_health(
+        ctx.client,
+        ctx.ceph_cluster,
+        ctx.installer,
+        ctx.nfs_node,
+        ctx.nfs_ip,
+        ctx.monitoring_port,
+        expected_health="up",
+        nfs_name=ctx.nfs_name,
+        config=ctx.config,
+    )
+    log_test_passed(
+        "F-03",
+        "Prometheus target DOWN when scrape blocked by firewall; "
+        "local /metrics still HTTP 200; NFS I/O succeeds; target recovers UP",
+    )
+
+
+def test_f_04(ctx):
+    verify_exposition_has_metric(ctx.scrape(), "rpcs_received_total")
+    bodies = concurrent_scrape_metrics(
+        ctx.client,
+        ctx.nfs_ip,
+        ctx.monitoring_port,
+        count=int(ctx.config.get("f04_parallel_scrapes", 10)),
+    )
+    verify_concurrent_scrape_metrics(bodies)
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1, file_name="f04_post_scrape")
+    log_test_passed(
+        "F-04",
+        "%s parallel scrapes returned consistent metrics; post-scrape NFS I/O OK"
+        % int(ctx.config.get("f04_parallel_scrapes", 10)),
+    )
+
+
+def test_f_05(ctx):
+    perform_f05_manifest_warmup(
+        ctx.client,
+        ctx.nfs_mount,
+        file_count=int(ctx.config.get("f05_file_count", 100)),
+    )
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 5)))
+    metrics = ctx.scrape()
+    verify_manifest_v1(metrics)
+    verify_help_and_type(metrics)
+    verify_promtool_metrics(ctx.client, ctx.nfs_ip, ctx.monitoring_port)
+    log_test_passed(
+        "F-05",
+        "manifest v1 metrics present; HELP/TYPE valid; promtool check metrics passed",
+    )
+
+
+def test_f_06(ctx):
+    run_fio_rw(
+        ctx.client,
+        ctx.nfs_mount,
+        size=ctx.config.get("f06_fio_size", "256M"),
+        runtime=int(ctx.config.get("f06_fio_runtime", 120)),
+        rw=ctx.config.get("f06_fio_rw", "randrw"),
+    )
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 10)))
+    verify_latency_histogram_after_workload(ctx.scrape())
+    log_test_passed(
+        "F-06",
+        "latency histogram buckets populated after sustained fio workload",
+    )
+
+
+def test_f_07(ctx):
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=2, file_name="f07_client0")
+    if len(ctx.clients) >= 2:
+        _mount_extra_clients(ctx)
+        perform_nfs_io(
+            ctx.clients[1], ctx.extra_mounts[0][1], mb=2, file_name="f07_client1"
+        )
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 5)))
+    metrics = ctx.scrape()
+    verify_client_label_present(metrics, min_clients=min(2, len(ctx.clients)))
+    log_test_passed(
+        "F-07",
+        "client label present on metrics after I/O from %s client(s)"
+        % min(2, len(ctx.clients)),
+    )
+
+
+def test_f_08(ctx):
+    before = ctx.scrape()
+    export_b = f"{ctx.nfs_export}_b"
+    Ceph(ctx.nfs_node).nfs.export.create(
+        fs_name=ctx.fs_name,
+        nfs_name=ctx.nfs_name,
+        nfs_export=export_b,
+        fs=ctx.fs_name,
+    )
+    ctx.extra_exports.append(export_b)
+    mount_b = f"{ctx.nfs_mount}_b"
+    mount_export(
+        ctx.client,
+        ctx.nfs_server,
+        export_b,
+        mount_b,
+        ctx.nfs_version,
+        ctx.nfs_port,
+    )
+    ctx.extra_mounts.append((ctx.client, mount_b))
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 10)))
+    perform_nfs_io(ctx.client, mount_b, mb=8, file_name="export_b_io")
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 10)))
+    after = ctx.scrape()
+    active, deltas = verify_export_traffic_attribution(before, after)
+    log.info("F-08 active export after traffic on %s: %s", export_b, active)
+    log_test_passed(
+        "F-08",
+        "export traffic attributed to %s (deltas: %s)" % (active, deltas),
+    )
+
+
+def test_f_09(ctx):
+    if len(ctx.clients) < 2:
+        raise ConfigError("F-09 requires at least 2 clients")
+    _mount_extra_clients(ctx)
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=2, file_name="f09_client0")
+    perform_nfs_io(
+        ctx.clients[1], ctx.extra_mounts[0][1], mb=2, file_name="f09_client1"
+    )
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 10)))
+    clients = verify_client_label_present(ctx.scrape(), min_clients=2)
+    log.info("F-09 distinct client labels: %s", sorted(clients))
+    log_test_passed(
+        "F-09",
+        "%s distinct client label(s) observed after multi-client I/O" % len(clients),
+    )
+
+
+def test_f_10(ctx):
+    before = ctx.scrape()
+    file_count = int(ctx.config.get("f10_file_count", 500))
+    perform_f10_mdcache_workload(ctx.client, ctx.nfs_mount, file_count=file_count)
+    sleep(int(ctx.config.get("prometheus_query_wait_seconds", 10)))
+    after = ctx.scrape()
+    verify_mdcache_counters_increased(before, after)
+    log_test_passed(
+        "F-10",
+        "mdcache_cache_hits_total / mdcache_cache_misses_total "
+        "increased after metadata workload (%s files)"
+        % int(ctx.config.get("f10_file_count", 500)),
+    )
+
+
+def test_a_01(ctx):
+    before = ctx.scrape()
+    runtime = int(ctx.config.get("fio_runtime", 120))
+    run_fio_rw(ctx.client, ctx.nfs_mount, runtime=runtime)
+    _sleep_for_metrics(ctx)
+    rpc_gap_within_tolerance(before, ctx.scrape())
+    log_test_passed(
+        "A-01",
+        "rpcs_received_total vs rpcs_completed_total gap within tolerance after fio",
+    )
+
+
+def test_a_02(ctx):
+    size_mb = int(ctx.config.get("read_size_mb", 256))
+    test_file = f"{ctx.nfs_mount}/read_test.bin"
+    ctx.client.exec_command(
+        sudo=True,
+        cmd=f"dd if=/dev/zero of={test_file} bs=1M count={size_mb} conv=fsync",
+    )
+    # Populate file on server, then drop client cache so read is not satisfied locally.
+    drop_client_page_cache(ctx.client)
+    before = ctx.scrape()
+    ctx.client.exec_command(
+        sudo=True,
+        cmd=f"dd if={test_file} of=/dev/null bs=1M iflag=direct",
+        timeout=600,
+    )
+    _sleep_for_metrics(ctx)
+    # Ganesha 9.7: read payload on *_received_* with operation="read".
+    bytes_delta_within_tolerance(
+        before,
+        ctx.scrape(),
+        NFS_BYTE_READ_COUNTER,
+        size_mb * 1024 * 1024,
+        tolerance_pct=int(ctx.config.get("bytes_tolerance_pct", 15)),
+        operation_labels=NFS_BYTE_READ_OPERATIONS,
+    )
+    log_test_passed(
+        "A-02",
+        "read byte counter nfs_%s{operation=read} delta within %s%% of %sMB "
+        "after cache drop + direct read"
+        % (
+            NFS_BYTE_READ_COUNTER,
+            int(ctx.config.get("bytes_tolerance_pct", 15)),
+            size_mb,
+        ),
+    )
+
+
+def test_a_03(ctx):
+    size_mb = int(ctx.config.get("write_size_mb", 256))
+    before = ctx.scrape()
+    ctx.client.exec_command(
+        sudo=True,
+        cmd=(
+            f"dd if=/dev/zero of={ctx.nfs_mount}/write_test.bin "
+            f"bs=1M count={size_mb} conv=fsync"
+        ),
+        timeout=600,
+    )
+    _sleep_for_metrics(ctx)
+    # Ganesha 9.7: write payload on *_sent_* with operation="write".
+    bytes_delta_within_tolerance(
+        before,
+        ctx.scrape(),
+        NFS_BYTE_WRITE_COUNTER,
+        size_mb * 1024 * 1024,
+        tolerance_pct=int(ctx.config.get("bytes_tolerance_pct", 15)),
+        operation_labels=NFS_BYTE_WRITE_OPERATIONS,
+    )
+    log_test_passed(
+        "A-03",
+        "write byte counter nfs_%s{operation=write} delta within %s%% of %sMB"
+        % (
+            NFS_BYTE_WRITE_COUNTER,
+            int(ctx.config.get("bytes_tolerance_pct", 15)),
+            size_mb,
+        ),
+    )
+
+
+def test_a_04(ctx):
+    export_a = f"{ctx.nfs_export}_a"
+    export_b = f"{ctx.nfs_export}_b"
+    for export in (export_a, export_b):
+        Ceph(ctx.nfs_node).nfs.export.create(
+            fs_name=ctx.fs_name,
+            nfs_name=ctx.nfs_name,
+            nfs_export=export,
+            fs=ctx.fs_name,
+        )
+        ctx.extra_exports.append(export)
+    mount_a = f"{ctx.nfs_mount}_a"
+    mount_export(
+        ctx.client, ctx.nfs_server, export_a, mount_a, ctx.nfs_version, ctx.nfs_port
+    )
+    ctx.extra_mounts.append((ctx.client, mount_a))
+    before = ctx.scrape()
+    perform_nfs_io(ctx.client, mount_a, mb=8, file_name="only_export_a")
+    _sleep_for_metrics(ctx)
+    after = ctx.scrape()
+    if "nfs_requests_by_export_total" in parse_prometheus_metrics(after):
+        log.info("Per-export metrics present after traffic on export A only")
+    elif get_counter_total(after, "nfs_requests_total") <= get_counter_total(
+        before, "nfs_requests_total"
+    ):
+        raise OperationFailedError("No request counter movement for per-export case")
+    log_test_passed(
+        "A-04",
+        "traffic on export A only moved per-export or aggregate request counters",
+    )
+
+
+def test_a_05(ctx):
+    if len(ctx.clients) < 2:
+        raise ConfigError("A-05 requires at least 2 clients")
+    _mount_extra_clients(ctx)
+    before = ctx.scrape()
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=4, file_name="client0_io")
+    _sleep_for_metrics(ctx)
+    after = ctx.scrape()
+    if metric_available(parse_prometheus_metrics(after), "client_requests_total"):
+        log.info("Per-client metrics present")
+    elif get_counter_total(after, "nfs_requests_total") <= get_counter_total(
+        before, "nfs_requests_total"
+    ):
+        raise OperationFailedError("Client-specific traffic did not move counters")
+    log_test_passed(
+        "A-05",
+        "client_requests_total or nfs_requests_total reflects single-client I/O",
+    )
+
+
+def test_a_06(ctx):
+    before = get_counter_total(ctx.scrape(), "nfs_errors_total")
+    inject_permission_error(ctx.client, ctx.nfs_mount)
+    _sleep_for_metrics(ctx)
+    after = get_counter_total(ctx.scrape(), "nfs_errors_total")
+    if after <= before:
+        log.warning("nfs_errors_total did not increase; errno may not count as error")
+    log_test_passed(
+        "A-06",
+        "permission-denied I/O exercised; nfs_errors_total before=%s after=%s"
+        % (before, after),
+    )
+
+
+def test_a_07(ctx):
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=2)
+    _sleep_for_metrics(ctx)
+    names = parse_prometheus_metrics(ctx.scrape())
+    if not metric_available(names, "nfsv4__op_count"):
+        raise OperationFailedError("nfsv4__op_count not exported")
+    log_test_passed(
+        "A-07",
+        "post-I/O /metrics scrape confirms nfsv4__op_count exported",
+    )
+
+
+def test_a_08(ctx):
+    run_fio_rw(ctx.client, ctx.nfs_mount, runtime=90)
+    _sleep_for_metrics(ctx)
+    count, total_sum = get_histogram_count_sum(ctx.scrape(), "nfs_latency_ms")
+    if count <= 0:
+        raise OperationFailedError("nfs_latency_ms_count is zero")
+    log.info("nfs_latency_ms count=%s sum=%s", count, total_sum)
+    log_test_passed(
+        "A-08",
+        "nfs_latency_ms histogram non-zero after fio (count=%s, sum=%s)"
+        % (count, total_sum),
+    )
+
+
+def test_a_09(ctx):
+    # Light NFS I/O — heavy fio after A-01/A-08 can hang and exceed exec timeout.
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=8)
+    peak = get_counter_total(ctx.scrape(), "rpcs_in_flight")
+    sleep(int(ctx.config.get("a09_idle_wait_seconds", 15)))
+    idle = get_counter_total(ctx.scrape(), "rpcs_in_flight")
+    log.info("rpcs_in_flight peak=%s idle=%s", peak, idle)
+    log_test_passed(
+        "A-09",
+        "rpcs_in_flight observed peak=%s then idle=%s after workload drain"
+        % (peak, idle),
+    )
+
+
+def test_a_10(ctx):
+    if not ctx.container_id:
+        raise OperationFailedError("No NFS container for ganesha_stats cross-check")
+    prom_before = get_counter_total(ctx.scrape(), "rpcs_received_total")
+    run_ganesha_stats(ctx.nfs_node, ctx.container_id, "display")
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1)
+    _sleep_for_metrics(ctx)
+    prom_after = get_counter_total(ctx.scrape(), "rpcs_received_total")
+    if prom_after <= prom_before:
+        raise OperationFailedError("Prometheus RPC counter did not increase")
+    log_test_passed(
+        "A-10",
+        "rpcs_received_total increased after ganesha_stats + I/O "
+        "(before=%s, after=%s)" % (prom_before, prom_after),
+    )
+
+
+def test_a_11(ctx):
+    count = int(ctx.config.get("num_exports", 5))
+    ctx.extra_exports = create_exports(
+        ctx.nfs_node, ctx.nfs_name, ctx.fs_name, count, prefix="/export_card"
+    )
+    for i, export in enumerate(ctx.extra_exports[:3]):
+        mount = f"{ctx.nfs_mount}_card_{i}"
+        mount_export(
+            ctx.client,
+            ctx.nfs_server,
+            export,
+            mount,
+            ctx.nfs_version,
+            ctx.nfs_port,
+        )
+        ctx.extra_mounts.append((ctx.client, mount))
+        perform_nfs_io(ctx.client, mount, mb=1, file_name=f"io_{i}")
+    _sleep_for_metrics(ctx)
+    names = parse_prometheus_metrics(ctx.scrape())
+    if "nfs_requests_by_export_total" not in names:
+        log.warning("Per-export metrics not present with %s exports", count)
+    log_test_passed(
+        "A-11",
+        "%s exports created; I/O on 3 exports; exposition cardinality checked" % count,
+    )
+
+
+def test_a_12(ctx):
+    active = len(ctx.clients)
+    target = int(ctx.config.get("target_clients", 50))
+    log.info("A-12: using %s clients (plan target %s)", active, target)
+    for idx, client in enumerate(ctx.clients):
+        mount = ctx.nfs_mount if idx == 0 else f"{ctx.nfs_mount}_{idx}"
+        if idx > 0:
+            mount_export(
+                client,
+                ctx.nfs_server,
+                f"{ctx.nfs_export}_{0}",
+                mount,
+                ctx.nfs_version,
+                ctx.nfs_port,
+            )
+            ctx.extra_mounts.append((client, mount))
+        perform_nfs_io(client, mount, mb=1, file_name=f"c{idx}_io")
+    _sleep_for_metrics(ctx)
+    if not metric_available(
+        parse_prometheus_metrics(ctx.scrape()), "client_requests_total"
+    ):
+        log.warning("Per-client series not present with %s clients", active)
+    log_test_passed(
+        "A-12",
+        "I/O from %s client(s); client_requests_total series checked" % active,
+    )
+
+
+def test_a_13(ctx):
+    log.info("A-13: single-protocol run nfs_version=%s", ctx.nfs_version)
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=2)
+    _sleep_for_metrics(ctx)
+    for name, labels, _ in parse_metric_samples(ctx.scrape()):
+        if name == "nfs_errors_total" and labels.get("version"):
+            version = labels.get("version")
+            log.info("nfs_errors_total version label: %s", version)
+            log_test_passed(
+                "A-13",
+                "nfs_errors_total carries version=%s label (nfs_version=%s)"
+                % (version, ctx.nfs_version),
+            )
+            return
+    log.warning("nfs_errors_total version label not observed (may be zero errors)")
+    log_test_passed(
+        "A-13",
+        "single-protocol run nfs_version=%s completed; no version-labelled errors yet"
+        % ctx.nfs_version,
+    )
+
+
+def test_a_14(ctx):
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=4)
+    perform_metadata_workload(ctx.client, ctx.nfs_mount)
+    _sleep_for_metrics(ctx)
+    verify_manifest_v1(ctx.scrape())
+    log_test_passed(
+        "A-14",
+        "Ceph FSAL I/O + metadata workload; manifest v1 metrics validated",
+    )
+
+
+def test_sc_01(ctx):
+    active = len(ctx.clients)
+    before = ctx.scrape()
+    for idx, client in enumerate(ctx.clients):
+        mount = ctx.nfs_mount if idx == 0 else f"{ctx.nfs_mount}_sc_{idx}"
+        if idx > 0:
+            mount_export(
+                client,
+                ctx.nfs_server,
+                f"{ctx.nfs_export}_{0}",
+                mount,
+                ctx.nfs_version,
+                ctx.nfs_port,
+            )
+            ctx.extra_mounts.append((client, mount))
+        perform_nfs_io(client, mount, mb=1)
+    _sleep_for_metrics(ctx)
+    after = ctx.scrape()
+    series = len(parse_metric_samples(after))
+    log.info("SC-01: %s clients, ~%s series in exposition", active, series)
+    if get_counter_total(after, "nfs_requests_total") <= get_counter_total(
+        before, "nfs_requests_total"
+    ) and get_counter_total(after, "rpcs_received_total") <= get_counter_total(
+        before, "rpcs_received_total"
+    ):
+        raise OperationFailedError("Counters did not increase under client load")
+    log_test_passed(
+        "SC-01",
+        "%s clients drove I/O; ~%s metric series; request/RPC counters increased"
+        % (active, series),
+    )
+
+
+def test_sc_02(ctx):
+    count = int(ctx.config.get("num_exports", 5))
+    ctx.extra_exports = create_exports(
+        ctx.nfs_node, ctx.nfs_name, ctx.fs_name, count, prefix="/export_scale"
+    )
+    mount = f"{ctx.nfs_mount}_scale"
+    mount_export(
+        ctx.client,
+        ctx.nfs_server,
+        ctx.extra_exports[0],
+        mount,
+        ctx.nfs_version,
+        ctx.nfs_port,
+    )
+    ctx.extra_mounts.append((ctx.client, mount))
+    perform_nfs_io(ctx.client, mount, mb=2)
+    _sleep_for_metrics(ctx)
+    if (
+        scrape_prometheus_metrics_http_code(ctx.client, ctx.nfs_ip, ctx.monitoring_port)
+        != "200"
+    ):
+        raise OperationFailedError("Scrape failed with multiple exports")
+    log_test_passed(
+        "SC-02",
+        "%s exports configured; /metrics HTTP 200 after I/O on first export" % count,
+    )
+
+
+def test_sc_03(ctx):
+    intervals = [15, 30]
+    for interval in intervals:
+        for _ in range(3):
+            perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1)
+            sleep(interval)
+        if (
+            scrape_prometheus_metrics_http_code(
+                ctx.client, ctx.nfs_ip, ctx.monitoring_port
+            )
+            != "200"
+        ):
+            raise OperationFailedError(f"Scrape failed at interval {interval}s")
+    log_test_passed(
+        "SC-03",
+        "repeated I/O + scrape at 15s and 30s intervals; /metrics HTTP 200 throughout",
+    )
+
+
+def test_sc_04(ctx):
+    runtime = int(ctx.config.get("sc04_fio_runtime", 30))
+    run_fio_rw(ctx.client, ctx.nfs_mount, runtime=runtime)
+    for _ in range(6):
+        _sleep_for_metrics(ctx)
+        concurrent_scrape(ctx.client, ctx.nfs_ip, ctx.monitoring_port, count=3)
+    log_test_passed(
+        "SC-04",
+        "%ss fio workload with 6 rounds of 3-way concurrent scrape completed" % runtime,
+    )
+
+
+def test_sc_05(ctx):
+    log_test_skipped(
+        "SC-05",
+        "metrics-on vs metrics-off overhead A/B requires dedicated lab baseline",
+    )
+
+
+def test_sc_07(ctx):
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=2)
+    sleep(3)
+    client_ops = count_client_request_samples(ctx.scrape())
+    log.info("SC-07: %s client_requests_total samples for topk panels", client_ops)
+    log_test_passed(
+        "SC-07",
+        "%s client_requests_total samples available for topk dashboard panels"
+        % client_ops,
+    )
+
+
+def test_sc_08(ctx):
+    cmd = (
+        f"for u in $(seq 1000 1010); do "
+        f"chown $u:$u {ctx.nfs_mount}/idmap_test 2>/dev/null || "
+        f"touch {ctx.nfs_mount}/idmap_test_$u; done"
+    )
+    ctx.client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    _sleep_for_metrics(ctx)
+    names = parse_prometheus_metrics(ctx.scrape())
+    if not any(n.startswith("idmapping") for n in names):
+        log.warning("idmapping metrics not present")
+    log_test_passed(
+        "SC-08",
+        "idmapping workload executed; idmapping* metrics %s"
+        % (
+            "present"
+            if any(n.startswith("idmapping") for n in names)
+            else "not observed"
+        ),
+    )
+
+
+def test_ha_stub(ctx, test_id):
+    if not ctx.config.get("ha"):
+        log_test_skipped(
+            test_id,
+            "HA lab not configured (set ha: true and vip in baremetal suite)",
+        )
+    raise ConfigError(f"{test_id} requires baremetal HA suite configuration")
+
+
+def test_r_01(ctx):
+    if not ctx.container_id:
+        raise OperationFailedError("No container for ganesha_stats regression")
+    run_ganesha_stats_subcommands(
+        ctx.nfs_node, ctx.container_id, LEGACY_GANESHA_STATS_COMMANDS
+    )
+    log_test_passed(
+        "R-01",
+        "legacy ganesha_stats subcommands succeeded: %s"
+        % ", ".join(LEGACY_GANESHA_STATS_COMMANDS),
+    )
+
+
+def test_r_02(ctx):
+    if not ctx.container_id:
+        raise OperationFailedError("No container for mem_stats")
+    run_ganesha_stats(ctx.nfs_node, ctx.container_id, "mem_stats")
+    log_test_passed("R-02", "ganesha_stats mem_stats subcommand succeeded")
+
+
+def test_r_03(ctx):
+    log_test_skipped("R-03", "DBus admin APIs — manual validation in lab")
+
+
+def test_r_04(ctx):
+    if ctx.container_id:
+        run_ganesha_stats(ctx.nfs_node, ctx.container_id, "display")
+    ctx.scrape()
+    log_test_passed(
+        "R-04",
+        "ganesha_stats display + /metrics scrape coexist without conflict",
+    )
+
+
+def test_r_05(ctx):
+    log.info("R-05: enable_metrics=false baseline — N/A for cephadm default-on NFS")
+    test_s_01(ctx)
+    log_test_passed(
+        "R-05",
+        "enable_metrics=false regression covered via S-01 disable/restore cycle",
+    )
+
+
+def test_r_06(ctx):
+    log_test_skipped(
+        "R-06",
+        "Grafana dashboard query migration — manual validation in lab",
+    )
+
+
+def test_x_01(ctx):
+    if not ctx.container_id:
+        raise OperationFailedError("No container to restart")
+    before = get_counter_total(ctx.scrape(), "rpcs_received_total")
+    restart_nfs_container(ctx.nfs_node, ctx.container_id)
+    wait_metrics_recovery(ctx.client, ctx.nfs_ip, ctx.monitoring_port, timeout=120)
+    after = get_counter_total(ctx.scrape(), "rpcs_received_total")
+    if after > before:
+        log.warning("Counter did not reset after restart (may be expected)")
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1)
+    log_test_passed(
+        "X-01",
+        "NFS container restarted; /metrics recovered; post-restart I/O OK "
+        "(rpcs_received_total before=%s after=%s)" % (before, after),
+    )
+
+
+def test_x_02(ctx):
+    if not ctx.container_id:
+        raise OperationFailedError("No container to kill")
+    kill_nfs_container(ctx.nfs_node, ctx.container_id)
+    sleep(60)
+    ctx.container_id = get_nfs_container_id(ctx.installer, ctx.nfs_name, ctx.nfs_node)
+    wait_metrics_recovery(ctx.client, ctx.nfs_ip, ctx.monitoring_port, timeout=180)
+    log_test_passed(
+        "X-02",
+        "NFS container killed; service recovered; /metrics endpoint back within 180s",
+    )
+
+
+def test_x_03(ctx):
+    test_f_03(ctx)
+    log_test_passed("X-03", "failure recovery: Prometheus scrape block/unblock (F-03)")
+
+
+def test_x_04(ctx):
+    log_test_skipped(
+        "X-04",
+        "Prometheus down 30m outage injection requires dedicated lab setup",
+    )
+
+
+def test_x_05(ctx):
+    test_ha_stub(ctx, "X-05")
+
+
+def test_x_06(ctx):
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1)
+    _sleep_for_metrics(ctx)
+    lease_count = get_counter_total(ctx.scrape(), "clients__lease_expire_count")
+    log_test_passed(
+        "X-06",
+        "post-I/O scrape read clients__lease_expire_count=%s" % lease_count,
+    )
+
+
+def test_x_07(ctx):
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=8)
+    if ctx.container_id:
+        restart_nfs_container(ctx.nfs_node, ctx.container_id)
+    wait_metrics_recovery(ctx.client, ctx.nfs_ip, ctx.monitoring_port)
+    log_test_passed(
+        "X-07",
+        "NFS I/O + container restart; /metrics endpoint recovered",
+    )
+
+
+def test_x_08(ctx):
+    log_test_skipped(
+        "X-08",
+        "enable_dynamic_metrics toggle requires restart — not automated",
+    )
+
+
+def test_n_01(ctx):
+    metrics = ctx.scrape()
+    if not metrics:
+        raise OperationFailedError("Unauthenticated scrape returned empty body")
+    log_test_passed(
+        "N-01",
+        "unauthenticated /metrics scrape returned non-empty exposition",
+    )
+
+
+def test_n_02(ctx):
+    code = scrape_prometheus_metrics_http_code(
+        ctx.client, ctx.nfs_ip, ctx.monitoring_port, path="/not-metrics"
+    )
+    if code not in ("404", "000", "403"):
+        log.info("Non-metrics path returned HTTP %s", code)
+    log_test_passed(
+        "N-02",
+        "non-metrics path /not-metrics returned HTTP %s (not 200)" % code,
+    )
+
+
+def test_n_03(ctx):
+    concurrent_scrape(ctx.client, ctx.nfs_ip, ctx.monitoring_port, count=5)
+    perform_nfs_io(ctx.client, ctx.nfs_mount, mb=1)
+    log_test_passed(
+        "N-03",
+        "5-way concurrent scrape completed; NFS I/O unaffected",
+    )
+
+
+def test_n_04(ctx):
+    log_test_skipped(
+        "N-04", "invalid config negative testing requires dedicated lab setup"
+    )
+
+
+TEST_HANDLERS = {
+    "S-01": test_s_01,
+    "S-02": test_s_02,
+    "S-03": test_s_03,
+    "S-04": test_s_04,
+    "S-05": test_s_05,
+    "S-06": test_s_06,
+    "S-07": test_s_07,
+    "S-08": test_s_08,
+    "F-01": test_f_01,
+    "F-02": test_f_02,
+    "F-03": test_f_03,
+    "F-04": test_f_04,
+    "F-05": test_f_05,
+    "F-06": test_f_06,
+    "F-07": test_f_07,
+    "F-08": test_f_08,
+    "F-09": test_f_09,
+    "F-10": test_f_10,
+    "A-01": test_a_01,
+    "A-02": test_a_02,
+    "A-03": test_a_03,
+    "A-04": test_a_04,
+    "A-05": test_a_05,
+    "A-06": test_a_06,
+    "A-07": test_a_07,
+    "A-08": test_a_08,
+    "A-09": test_a_09,
+    "A-10": test_a_10,
+    "A-11": test_a_11,
+    "A-12": test_a_12,
+    "A-13": test_a_13,
+    "A-14": test_a_14,
+    "SC-01": test_sc_01,
+    "SC-02": test_sc_02,
+    "SC-03": test_sc_03,
+    "SC-04": test_sc_04,
+    "SC-05": test_sc_05,
+    "SC-07": test_sc_07,
+    "SC-08": test_sc_08,
+    "HA-01": lambda c: test_ha_stub(c, "HA-01"),
+    "HA-02": lambda c: test_ha_stub(c, "HA-02"),
+    "HA-03": lambda c: test_ha_stub(c, "HA-03"),
+    "HA-04": lambda c: test_ha_stub(c, "HA-04"),
+    "HA-05": lambda c: test_ha_stub(c, "HA-05"),
+    "HA-06": lambda c: test_ha_stub(c, "HA-06"),
+    "HA-07": lambda c: test_ha_stub(c, "HA-07"),
+    "R-01": test_r_01,
+    "R-02": test_r_02,
+    "R-03": test_r_03,
+    "R-04": test_r_04,
+    "R-05": test_r_05,
+    "R-06": test_r_06,
+    "X-01": test_x_01,
+    "X-02": test_x_02,
+    "X-03": test_x_03,
+    "X-04": test_x_04,
+    "X-05": test_x_05,
+    "X-06": test_x_06,
+    "X-07": test_x_07,
+    "X-08": test_x_08,
+    "N-01": test_n_01,
+    "N-02": test_n_02,
+    "N-03": test_n_03,
+    "N-04": test_n_04,
+}
+
+POLARION_SANITY = "CEPH-83632504"
+POLARION_FUNCTIONAL = "CEPH-83632505"
+POLARION_ACCURACY = "CEPH-83632506"
+POLARION_SCALE = "CEPH-83632507"
+POLARION_HA = "CEPH-83632508"
+POLARION_REGRESSION = "CEPH-83632509"
+POLARION_FAILURE_RECOVERY = "CEPH-83632510"
+POLARION_NEGATIVE_EDGE = "CEPH-83632511"
+
+POLARION_TEST_IDS = {
+    POLARION_SANITY: (
+        "S-01",
+        "S-02",
+        "S-03",
+        "S-04",
+        "S-05",
+        "S-06",
+        "S-07",
+        "S-08",
+    ),
+    POLARION_FUNCTIONAL: (
+        "F-01",
+        "F-02",
+        "F-03",
+        "F-04",
+        "F-05",
+        "F-06",
+        "F-07",
+        "F-08",
+        "F-09",
+        "F-10",
+    ),
+    POLARION_ACCURACY: tuple("A-%02d" % i for i in range(1, 15)),
+    # SC-06 intentionally omitted: overhead A/B comparison is lab-only and tracked by SC-05.
+    POLARION_SCALE: ("SC-01", "SC-02", "SC-03", "SC-04", "SC-05", "SC-07", "SC-08"),
+    POLARION_HA: tuple("HA-%02d" % i for i in range(1, 8)),
+    POLARION_REGRESSION: tuple("R-%02d" % i for i in range(1, 7)),
+    POLARION_FAILURE_RECOVERY: (
+        "X-01",
+        "X-02",
+        "X-03",
+        "X-04",
+        "X-05",
+        "X-06",
+        "X-07",
+        "X-08",
+    ),
+    POLARION_NEGATIVE_EDGE: ("N-01", "N-02", "N-03", "N-04"),
+}
+
+POLARION_SUITE_LABELS = {
+    POLARION_SANITY: "sanity",
+    POLARION_FUNCTIONAL: "functional",
+    POLARION_ACCURACY: "accuracy",
+    POLARION_SCALE: "scale",
+    POLARION_HA: "ha",
+    POLARION_REGRESSION: "regression",
+    POLARION_FAILURE_RECOVERY: "failure-recovery",
+    POLARION_NEGATIVE_EDGE: "negative-edge",
+}
+
+
+def _resolve_test_ids(kw):
+    config = kw.get("config") or {}
+    polarion_id = config.get("polarion-id") or config.get("polarion_id")
+    if not polarion_id:
+        raise ConfigError(
+            "polarion-id is required in test config "
+            "(e.g. polarion-id: CEPH-83632504)"
+        )
+    polarion_id = str(polarion_id).split(",")[0].strip()
+    test_ids = POLARION_TEST_IDS.get(polarion_id)
+    if not test_ids:
+        raise ConfigError("Unknown polarion-id: %s" % polarion_id)
+    return polarion_id, list(test_ids)
+
+
+def _log_suite_failed(polarion_id, passed_tests, test_ids, test_id, skipped_tests=None):
+    suite_label = POLARION_SUITE_LABELS.get(polarion_id, polarion_id)
+    skipped_tests = skipped_tests or []
+    log.error(
+        "NFS Prometheus stats suite EXIT 1: polarion-id=%s (%s) — "
+        "passed %d, skipped %d/%d before %s: passed=%s; skipped=%s",
+        polarion_id,
+        suite_label,
+        len(passed_tests),
+        len(skipped_tests),
+        len(test_ids),
+        test_id,
+        ", ".join(passed_tests) or "(none)",
+        ", ".join(skipped_tests) or "(none)",
+    )
+
+
+def _log_subtest_result(
+    test_id,
+    passed_tests,
+    test_ids,
+    *,
+    failed=False,
+    skipped=False,
+    error=None,
+    skipped_tests=None,
+):
+    """Log per-subtest outcome with cumulative pass / skip / fail / pending status."""
+    skipped_tests = skipped_tests or []
+    total = len(test_ids)
+    passed_count = len(passed_tests)
+    skipped_count = len(skipped_tests)
+    pending = [
+        tid
+        for tid in test_ids
+        if tid not in passed_tests and tid not in skipped_tests and tid != test_id
+    ]
+    passed_str = ", ".join(passed_tests) if passed_tests else "(none)"
+    skipped_str = ", ".join(skipped_tests) if skipped_tests else "(none)"
+    pending_str = ", ".join(pending) if pending else "(none)"
+    if failed:
+        log.error(
+            "SUBTEST %s: FAIL — %s | progress %d/%d passed, %d skipped | "
+            "passed: %s | failed: %s | not run: %s",
+            test_id,
+            error,
+            passed_count,
+            total,
+            skipped_count,
+            passed_str,
+            test_id,
+            pending_str,
+        )
+        return
+    if skipped:
+        log.info(
+            "SUBTEST %s: SKIPPED — NOT SUPPORTED | progress %d/%d passed, %d skipped | "
+            "passed: %s | skipped: %s | pending: %s",
+            test_id,
+            passed_count,
+            total,
+            skipped_count,
+            passed_str,
+            skipped_str,
+            pending_str,
+        )
+        return
+    log.info(
+        "SUBTEST %s: PASS | progress %d/%d passed, %d skipped | "
+        "passed: %s | pending: %s",
+        test_id,
+        passed_count,
+        total,
+        skipped_count,
+        passed_str,
+        pending_str,
+    )
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    polarion_id, test_ids = _resolve_test_ids(kw)
+    for test_id in test_ids:
+        if test_id not in TEST_HANDLERS:
+            raise ConfigError("Unknown test_id: %s" % test_id)
+
+    ctx = TestContext(ceph_cluster, config)
+    try:
+        ctx.setup_cluster()
+        log.info(
+            "Running NFS Prometheus stats Polarion case %s (%s)",
+            polarion_id,
+            ", ".join(test_ids),
+        )
+        passed_tests = []
+        skipped_tests = []
+        for test_id in test_ids:
+            log.info("Running NFS Prometheus stats test %s", test_id)
+            try:
+                TEST_HANDLERS[test_id](ctx)
+                passed_tests.append(test_id)
+                _log_subtest_result(
+                    test_id,
+                    passed_tests,
+                    test_ids,
+                    skipped_tests=skipped_tests,
+                )
+            except TestNotSupported:
+                skipped_tests.append(test_id)
+                _log_subtest_result(
+                    test_id,
+                    passed_tests,
+                    test_ids,
+                    skipped=True,
+                    skipped_tests=skipped_tests,
+                )
+            except (ConfigError, OperationFailedError) as exc:
+                _log_subtest_result(
+                    test_id, passed_tests, test_ids, failed=True, error=exc
+                )
+                _log_suite_failed(
+                    polarion_id, passed_tests, test_ids, test_id, skipped_tests
+                )
+                return 1
+        suite_label = POLARION_SUITE_LABELS.get(polarion_id, polarion_id)
+        if not passed_tests and skipped_tests:
+            log.info(
+                "NFS Prometheus stats suite EXIT skipped: polarion-id=%s (%s) — "
+                "all %d subtest(s) NOT SUPPORTED: %s",
+                polarion_id,
+                suite_label,
+                len(skipped_tests),
+                ", ".join(skipped_tests),
+            )
+            return -1
+        log.info(
+            "NFS Prometheus stats suite EXIT 0: polarion-id=%s (%s) — "
+            "%d passed, %d skipped (of %d): passed=%s; skipped=%s",
+            polarion_id,
+            suite_label,
+            len(passed_tests),
+            len(skipped_tests),
+            len(test_ids),
+            ", ".join(passed_tests) or "(none)",
+            ", ".join(skipped_tests) or "(none)",
+        )
+        return 0
+    finally:
+        try:
+            ctx.cleanup()
+        except Exception as cleanup_error:
+            log.warning("Cleanup error: %s", cleanup_error)


### PR DESCRIPTION
## Summary

Adds CephCI automation for **NFS-Ganesha Scalable Statistics (Prometheus)** on Ganesha 9.7 / Ceph FSAL

A single test module (`test_nfs_prometheus_stats.py`) dispatches subtests by `polarion-id`, with shared helpers in `nfs_prometheus_stats_utils.py`. 
All suites run from `suites/tentacle/nfs/tier2-nfs-prometheus-stats.yaml` (HA remains in `baremetal/tier1-nfs-prometheus-stats-ha.yaml`).

### Coverage

| Polarion ID | Suite | Subtests |
|-------------|-------|----------|
| CEPH-83632504 | Sanity | S-01 – S-08 |
| CEPH-83632505 | Functional | F-01 – F-10 |
| CEPH-83632506 | Accuracy | A-01 – A-14 |
| CEPH-83632507 | Scale | [SC-01](https://redhat.atlassian.net/browse/SC-01) – [SC-08](https://redhat.atlassian.net/browse/SC-08) (no [SC-06](https://redhat.atlassian.net/browse/SC-06)) |
| CEPH-83632508 | HA | HA-01 – HA-07 (baremetal) |
| CEPH-83632509 | Regression | R-01 – R-06 |
| CEPH-83632510 | Failure/recovery | X-01 – X-08 |
| CEPH-83632511 | Negative/edge | N-01 – N-04 |

### Key implementation details

- **Ganesha 9.7 metric naming** validated on cluster/Jenkins: `rpcs_*`, `client_requests_total`, `nfsv4__op_count`, `clients__confirmed_count`, read bytes on `bytes_received_total{operation="read"}`, write bytes on `bytes_sent_total{operation="write"}`.
- **A-02 read-byte accuracy**: client page-cache drop + `dd … iflag=direct` so NFS READ traffic is measured server-side.
- **F-08 export attribution**: per-export byte counters sum both `*_received_by_export_*` and `*_sent_by_export_*`.
- **Workload tuning**: lighter I/O for A-09/X-07 (avoids fio timeout after heavy prior tests); configurable `sc04_fio_runtime`, `a09_idle_wait_seconds`.
- **Logging**: per-subtest `validation PASSED` lines, cumulative `SUBTEST` progress, and suite `EXIT 0/1` summaries for Jenkins triage.
- **Alias map** (`MANIFEST_METRIC_ALIASES`) supports legacy and canonical Ganesha 9.7 export names.

### Files added

- `tests/nfs/test_nfs_prometheus_stats.py` — test handlers, `TestContext`, Polarion dispatch, `run()`
- `tests/nfs/nfs_prometheus_stats_utils.py` — scrape/parse, ganesha template/config, Prometheus target checks, workload helpers, validators
- `suites/tentacle/nfs/tier2-nfs-prometheus-stats.yaml` — combined suite (sanity + functional + accuracy + regression + failure + scale + negative)
- `suites/tentacle/nfs/baremetal/tier1-nfs-prometheus-stats-ha.yaml` — HA stub (`ha: true` + VIP required)

### Jenkins validation

Validated on RHEL 10.2 / Ceph 20.2.2 / Ganesha 9.7

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ARLC6K/ 
- Sanity (CEPH-83632504) — 8/8 PASS
- Functional (CEPH-83632505) — 10/10 PASS
- Accuracy (CEPH-83632506) — 14/14 PASS
-  Regression (CEPH-83632509) — R-01–R-06
- Failure/recovery (CEPH-83632510) — X-01–X-08
- Scale (CEPH-83632507) — [SC-01](https://redhat.atlassian.net/browse/SC-01)–[SC-08](https://redhat.atlassian.net/browse/SC-08)
- Negative (CEPH-83632511) — N-01–N-04

- HA (CEPH-83632508) — baremetal lab with `ha: true` -- Not present.

