### PR TITLE
Include coverage of RGW service deployment via spec file

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_conditional_put_delete.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_conditional_put_delete.yaml
@@ -35,23 +35,40 @@ tests:
               service: osd
               args:
                 all-available-devices: true
-          - config:
-              command: apply
-              service: rgw
-              pos_args:
-                - rgw.1
-              args:
-                placement:
-                  label: rgw
-                  nodes:
-                    - node4
-                    - node3
-                    - node5
       desc: bootstrap with registry-url option and deployment services.
       destroy-cluster: false
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: RGW Service deployment with spec
+      desc: Add RGW services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574640
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgw.1
+                  placement:
+                    count_per_host: 1
+                    nodes:
+                      - node3
+                      - node4
+                      - node5
+                  spec:
+                    rgw_frontend_port: 80
+                    rgw_frontend_extra_args:
+                      - "max_header_size=65536"
+          - config:
+              command: shell
+              args:              # sleep to get all services deployed
+                - sleep
+                - "120"
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
# Description
Include coverage of RGW service deployment via spec file for non-ssl suite
Pass log: http://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-298/rgw/2176/logs/tier_2_rgw_conditional_put_delete/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
