### PR TITLE
adding rgw-ssl SAN entries testing support with virtual_host_bucket_access

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -66,6 +66,9 @@ tests:
                       spec:
                         generate_cert: true
                         ssl: true
+                        zonegroup_hostnames:
+                          - s3.example.com
+                        wildcard_enabled: true
                       placement:
                         nodes:
                           - node5
@@ -114,6 +117,9 @@ tests:
                       spec:
                         generate_cert: true
                         ssl: true
+                        zonegroup_hostnames:
+                          - s3.example.com
+                        wildcard_enabled: true
                       placement:
                         nodes:
                           - node5
@@ -239,7 +245,7 @@ tests:
       module: exec.py
       name: get shared realm info on secondary
 
-  # Test work flow
+   # Test work flow
 
   - test:
       clusters:
@@ -299,3 +305,27 @@ tests:
           config:
             script-name: ../aws/test_aws.py
             config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
+
+  # test rgw-ssl SAN virtual_host_bucket_access
+
+  - test:
+      name: Test rgw-ssl SAN virtual_host_bucket_access
+      desc: Test rgw-ssl SAN virtual_host_bucket_access
+      polarion-id: CEPH-83604472
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../curl/test_rgw_using_curl.py
+            config-file-name: ../../curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access.yaml
+
+  - test:
+      name: Test rgw-ssl SAN virtual_host_bucket_access multipart_upload
+      desc: Test rgw-ssl SAN virtual_host_bucket_access multipart_upload
+      polarion-id: CEPH-83604472
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../curl/test_rgw_using_curl.py
+            config-file-name: ../../curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access_multipart_upload.yaml

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -65,6 +65,9 @@ tests:
                   spec:
                     ssl: true
                     generate_cert: true
+                    zonegroup_hostnames:
+                      - s3.example.com
+                    wildcard_enabled: true
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py
@@ -317,3 +320,26 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_enable_object_exp.yaml
+
+
+  # test rgw-ssl SAN virtual_host_bucket_access
+
+  - test:
+      name: Test rgw-ssl SAN virtual_host_bucket_access
+      desc: Test rgw-ssl SAN virtual_host_bucket_access
+      polarion-id: CEPH-83604472
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access.yaml
+
+  - test:
+      name: Test rgw-ssl SAN virtual_host_bucket_access multipart_upload
+      desc: Test rgw-ssl SAN virtual_host_bucket_access multipart_upload
+      polarion-id: CEPH-83604472
+      module: sanity_rgw.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../curl/test_rgw_using_curl.py
+            config-file-name: ../../curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access_multipart_upload.yaml


### PR DESCRIPTION
Automation of virtual host bucket access testing with curl. rgw-ssl deployed with generate_cert and zonegroup-hostnames to allow virtual_host_bucket_access
Tests cephadm feature support SAN entries for wildcard dns.

ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/881

Feature bzs:
https://bugzilla.redhat.com/show_bug.cgi?id=2249984
https://bugzilla.redhat.com/show_bug.cgi?id=2330954

polarion testcase: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83604472

pass logs on 8.1z2:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/SAN_virtual_host_bucket_access/cephci-run-IPULFD/

Note:
this feature is broken on latest 8.1, 9.1 and 9.2 builds. hence provided the pass logs on an older 8.1 build where the feature is working properly.
bz's filed for the issues:
https://ibm-ceph.atlassian.net/browse/IBMCEPH-16390
https://ibm-ceph.atlassian.net/browse/IBMCEPH-16394
https://ibm-ceph.atlassian.net/browse/IBMCEPH-17328

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
