### PR TITLE
[rgw] using ceph-qe-ng/configs for gklm files instead of --custom-config and extending gklm tests support to single site

### DIFF
--- a/suites/reef/rgw/sanity_rgw_multisite.yaml
+++ b/suites/reef/rgw/sanity_rgw_multisite.yaml
@@ -466,6 +466,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            git_clone_configs_repo: true
             setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -399,6 +399,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            git_clone_configs_repo: true
             setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml

--- a/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -453,6 +453,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            git_clone_configs_repo: true
             setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml

--- a/suites/squid/upstream/sanity_rgw_multisite.yaml
+++ b/suites/squid/upstream/sanity_rgw_multisite.yaml
@@ -399,6 +399,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            git_clone_configs_repo: true
             setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml

--- a/suites/tentacle/rgw/sanity_rgw_multisite.yaml
+++ b/suites/tentacle/rgw/sanity_rgw_multisite.yaml
@@ -399,6 +399,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            git_clone_configs_repo: true
             setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml

--- a/suites/tentacle/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -443,6 +443,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            git_clone_configs_repo: true
             setup_gklm_prerequisites: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml

--- a/suites/tentacle/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_regression_test.yaml
@@ -460,3 +460,15 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_rename.yaml
+
+  # GKLM tests
+  - test:
+      config:
+        git_clone_configs_repo: true
+        setup_gklm_prerequisites: true
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
+      desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload
+      module: sanity_rgw.py
+      name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload
+      polarion-id: CEPH-83592485

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -56,6 +56,7 @@ import os
 
 import yaml
 
+from ceph.ceph_admin.helper import check_service_exists
 from utility import utils
 from utility.log import Log
 from utility.utils import (
@@ -64,6 +65,7 @@ from utility.utils import (
     get_cephci_config,
     install_start_kafka,
     setup_cluster_access,
+    setup_gklm_prereq,
 )
 
 log = Log(__name__)
@@ -95,6 +97,7 @@ def run(ceph_cluster, **kw):
     log.info("Running RGW test version: %s", config.get("test-version", "v2"))
 
     rgw_ceph_object = ceph_cluster.get_ceph_object("rgw")
+    rgw_nodes = ceph_cluster.get_ceph_objects("rgw")
     client_ceph_object = ceph_cluster.get_ceph_object("client")
     run_io_verify = config.get("run_io_verify", False)
     extra_pkgs = config.get("extra-pkgs")
@@ -156,7 +159,8 @@ def run(ceph_cluster, **kw):
         exec_from.exec_command(cmd=f"sudo mkdir {test_folder}")
         utils.clone_the_repo(config, exec_from, test_folder_path)
     if git_clone_configs_repo:
-        utils.clone_configs_repo(rgw_node, repo_name="rgw_configs")
+        for rgw_ceph_object in rgw_nodes:
+            utils.clone_configs_repo(rgw_ceph_object.node, repo_name="rgw_configs")
         utils.clone_configs_repo(client_node, repo_name="rgw_configs")
 
     install_common = config.get("install_common", True)
@@ -178,6 +182,18 @@ def run(ceph_cluster, **kw):
         install_start_kafka(rgw_node, cloud_type)
     if configure_kafka_broker_security:
         configure_kafka_security(rgw_node, cloud_type)
+
+    setup_gklm_prerequisites = config.get("setup_gklm_prerequisites")
+    if setup_gklm_prerequisites:
+        setup_gklm_prereq(ceph_cluster, cloud_type)
+        rgw_status = check_service_exists(
+            ceph_cluster.get_nodes(role="installer")[0],
+            service_type="rgw",
+            interval=10,
+            timeout=180,
+        )
+        if not rgw_status:
+            raise Exception("rgw service restart failed")
 
     if install_keystone_ldap:
         config_keystone_ldap(rgw_node, cloud_type)

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -96,9 +96,6 @@ def run(**kw):
     config["git-url"] = config.get(
         "git-url", "https://github.com/red-hat-storage/ceph-qe-scripts.git"
     )
-    test_data = kw.get("test_data")
-    custom_config = test_data.get("custom-config", {})
-
     set_env = config.get("set-env", False)
     extra_pkgs = config.get("extra-pkgs")
     git_clone_configs_repo = config.get("git_clone_configs_repo", False)
@@ -206,10 +203,12 @@ def run(**kw):
     if git_clone_configs_repo:
         for i in range(0, len(primary_rgw_nodes)):
             utils.clone_configs_repo(primary_rgw_nodes[i].node, repo_name="rgw_configs")
+        utils.clone_configs_repo(primary_client_node, repo_name="rgw_configs")
         for i in range(0, len(secondary_rgw_nodes)):
             utils.clone_configs_repo(
                 secondary_rgw_nodes[i].node, repo_name="rgw_configs"
             )
+        utils.clone_configs_repo(secondary_client_node, repo_name="rgw_configs")
         if archive_cluster_exists:
             utils.clone_configs_repo(archive_rgw_node, repo_name="rgw_configs")
             utils.clone_configs_repo(archive_client_node, repo_name="rgw_configs")
@@ -260,7 +259,7 @@ def run(**kw):
 
     setup_gklm_prerequisites = config.get("setup_gklm_prerequisites")
     if setup_gklm_prerequisites:
-        setup_gklm_prereq(primary_cluster, cloud_type, custom_config)
+        setup_gklm_prereq(primary_cluster, cloud_type)
         rgw_status = check_service_exists(
             primary_cluster.get_nodes(role="installer")[0],
             service_type="rgw",
@@ -269,7 +268,7 @@ def run(**kw):
         )
         if not rgw_status:
             raise Exception("rgw service restart failed")
-        setup_gklm_prereq(secondary_cluster, cloud_type, custom_config)
+        setup_gklm_prereq(secondary_cluster, cloud_type)
         rgw_status = check_service_exists(
             secondary_cluster.get_nodes(role="installer")[0],
             service_type="rgw",

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -54,6 +54,8 @@ magna_server = "http://magna002.ceph.redhat.com"
 magna_url = f"{magna_server}/cephci-jenkins/"
 magna_rhcs_artifacts = f"{magna_server}/cephci-jenkins/latest-rhceph-container-info/"
 KAFKA_HOME = "/usr/local/kafka"
+GKLM_HOME = "/usr/local/gklm"
+GKLM_CONFIGS_DIR = "/home/cephuser/configs/rgw/gklm"
 MANIFEST_URL = (
     "https://raw.githubusercontent.com/ibmstorage/qe-ceph-manifest/refs/heads/main/"
 )
@@ -2850,61 +2852,44 @@ def restart_rgw_and_wait(rgw_node, rgw_service_name):
         log.info("RGW daemons are up and running")
 
 
-def setup_gklm_prereq(ceph_cluster, cloud_type, custom_config):
+def setup_gklm_prereq(ceph_cluster, cloud_type):
     """setup GKLM authentication certs on the rgw nodes, redeploy rgw to mounted gklm certs path
     and set ceph configs for sse-kms-kmip"""
     log.info("setting up GKLM prerequisites")
     rgw_nodes = ceph_cluster.get_ceph_objects("rgw")
-    gklm_auth_cert_path_remote = "/usr/local/gklm/rgwselfsigned.cert"
-    gklm_auth_key_path_remote = "/usr/local/gklm/rgwselfsigned.key"
-    gklm_auth_cert_path_local = None
-    gklm_auth_key_path_local = None
-    gklm_endpoint_openstack = None
-    gklm_endpoint_ibmc = None
-
-    for config_item in custom_config:
-        key, value = config_item.split("=")
-        if key == "gklm-auth-cert-path":
-            gklm_auth_cert_path_local = value.strip()
-        if key == "gklm-auth-key-path":
-            gklm_auth_key_path_local = value.strip()
-        if key == "gklm-endpoint-openstack":
-            gklm_endpoint_openstack = value.strip()
-        if key == "gklm-endpoint-ibmc":
-            gklm_endpoint_ibmc = value.strip()
-
-    if gklm_auth_cert_path_local is None:
+    gklm_auth_cert_path_remote = f"{GKLM_HOME}/rgwselfsigned.cert"
+    gklm_auth_key_path_remote = f"{GKLM_HOME}/rgwselfsigned.key"
+    cp_cert_cmd = (
+        f"cp {GKLM_CONFIGS_DIR}/rgwselfsigned.cert {gklm_auth_cert_path_remote}"
+    )
+    cp_key_cmd = f"cp {GKLM_CONFIGS_DIR}/rgwselfsigned.key {gklm_auth_key_path_remote}"
+    endpoint_files = {
+        "openstack": f"{GKLM_CONFIGS_DIR}/gklm_endpoint_openstack",
+        "ibmc": f"{GKLM_CONFIGS_DIR}/gklm_endpoint_ibmc",
+    }
+    if cloud_type not in endpoint_files:
         raise GKLMSetupError(
-            "gklm-auth-cert-path not passed as custom-config which is required for gklm tests prerequisites"
+            f"unsupported cloud_type {cloud_type!r} for GKLM tests; "
+            "expected openstack or ibmc"
         )
-    if gklm_auth_key_path_local is None:
-        raise GKLMSetupError(
-            "gklm-auth-cert-path not passed as custom-config which is required for gklm tests prerequisites"
-        )
-    if gklm_endpoint_openstack is None or gklm_endpoint_ibmc is None:
-        raise GKLMSetupError(
-            "gklm-endpoint not passed as custom-config which is required for gklm tests prerequisites"
-        )
+    endpoint_file = endpoint_files[cloud_type]
 
     for rgw_node_obj in rgw_nodes:
         rgw_node = rgw_node_obj.node
         log.info(f"setting up auth certs on node {rgw_node.ip_address}")
-        rgw_node.exec_command(sudo=True, cmd="mkdir -p /usr/local/gklm")
-        # copy gklm_auth_cert
+        rgw_node.exec_command(sudo=True, cmd=f"mkdir -p {GKLM_HOME}")
         log.info(
-            f"copying local file '{gklm_auth_cert_path_local}' to remote file '{gklm_auth_cert_path_remote}'. "
-            + f"remote node ip: {rgw_node.ip_address}"
+            f"copying GKLM cert/key from configs repo to {GKLM_HOME} on node "
+            f"{rgw_node.ip_address}"
         )
-        rgw_node.upload_file(
-            sudo=True, src=gklm_auth_cert_path_local, dst=gklm_auth_cert_path_remote
-        )
-        # copy gklm_auth_key
-        log.info(
-            f"copying local file '{gklm_auth_key_path_local}' to remote file '{gklm_auth_key_path_remote}'. "
-            + f"remote node ip: {rgw_node.ip_address}"
-        )
-        rgw_node.upload_file(
-            sudo=True, src=gklm_auth_key_path_local, dst=gklm_auth_key_path_remote
+        rgw_node.exec_command(sudo=True, cmd=f"{cp_cert_cmd} && {cp_key_cmd}")
+
+    gklm_endpoint, _ = rgw_nodes[0].node.exec_command(cmd=f"cat {endpoint_file}")
+    gklm_endpoint = gklm_endpoint.strip()
+    if not gklm_endpoint:
+        raise GKLMSetupError(
+            f"GKLM endpoint not found in {endpoint_file} on node "
+            f"{rgw_nodes[0].node.ip_address}"
         )
 
     # set ceph configs for kmip
@@ -2917,30 +2902,16 @@ def setup_gklm_prereq(ceph_cluster, cloud_type, custom_config):
     )
     client_node.exec_command(
         sudo=True,
-        cmd="ceph config set client.rgw rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert",
+        cmd=f"ceph config set client.rgw rgw_crypt_kmip_client_cert {gklm_auth_cert_path_remote}",
     )
     client_node.exec_command(
         sudo=True,
-        cmd="ceph config set client.rgw rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key",
+        cmd=f"ceph config set client.rgw rgw_crypt_kmip_client_key {gklm_auth_key_path_remote}",
     )
-    if cloud_type == "openstack":
-        if gklm_endpoint_openstack is None:
-            raise GKLMSetupError(
-                "gklm-endpoint-openstack not passed as custom-config which is required for gklm tests prerequisites"
-            )
-        client_node.exec_command(
-            sudo=True,
-            cmd=f"ceph config set client.rgw rgw_crypt_kmip_addr {gklm_endpoint_openstack}:5696",
-        )
-    elif cloud_type == "ibmc":
-        if gklm_endpoint_ibmc is None:
-            raise GKLMSetupError(
-                "gklm-endpoint-ibmc not passed as custom-config which is required for gklm tests prerequisites"
-            )
-        client_node.exec_command(
-            sudo=True,
-            cmd=f"ceph config set client.rgw rgw_crypt_kmip_addr {gklm_endpoint_ibmc}:5696",
-        )
+    client_node.exec_command(
+        sudo=True,
+        cmd=f"ceph config set client.rgw rgw_crypt_kmip_addr {gklm_endpoint}:5696",
+    )
 
     # redeploy rgw to mount gklm certs path to rgw container
     client_node.exec_command(


### PR DESCRIPTION
this PR is for two enhancements of GKLM tests:
1. for GKLM files, we will be now using ceph-qe-ng/configs repo instead of --custom-config arguments. as jenkins for ibmc is ignoring GKLM custom-config arguments, as a result tests are failing there.
2. extend the support for GKLM tests to run on single site as well.

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/gklm_ceph_qe_ng_and_single_site_support/cephci-run-CERYC3/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
