### PR TITLE
[NFS][Feature Automation]: Add NFS Multi-Active HA baremetal test suite

### DIFF
--- a/cli/ceph/nfs/export/qos.py
+++ b/cli/ceph/nfs/export/qos.py
@@ -37,6 +37,26 @@ class Qos(Cli):
             )
         return self._execute_qos_cmd("enable", operation, nfs_name, export, params)
 
+    def enable_per_client(
+        self,
+        nfs_name: str,
+        export: str,
+        operation: str,
+        max_client_combined_bw: str = None,
+        max_client_write_bw: str = None,
+        max_client_read_bw: str = None,
+        max_client_iops: int = None,
+    ) -> str:
+        if operation == "ops_control":
+            if max_client_iops is None:
+                raise ValueError("max_client_iops is required for export ops_control")
+            params = [str(max_client_iops)]
+        else:
+            params = self._build_client_params(
+                max_client_combined_bw, max_client_write_bw, max_client_read_bw
+            )
+        return self._execute_qos_cmd("enable", operation, nfs_name, export, params)
+
     def enable_per_share_per_client(
         self,
         nfs_name: str,

--- a/suites/tentacle/nfs/baremetal/tier1-nfs-multi-active-ha.yaml
+++ b/suites/tentacle/nfs/baremetal/tier1-nfs-multi-active-ha.yaml
@@ -1,0 +1,282 @@
+#===============================================================================================
+#-------------------------------------
+#--- Test Suite for NFS Multi-Active (Baremetal) ---
+#-------------------------------------
+# Note: NFS Multi-Active is supported on baremetal clusters only
+# **** IMP: To update the VIP accordingly in this suite file *****
+# Conf: conf/baremetal/nfs_grim_multi_active.yaml
+# globals:
+#   - ceph-cluster:
+#       name: ceph
+#       networks:
+#         public: ['10.64.66.192/26']
+#       nodes:
+#         - hostname: grim061
+#           ip: 10.64.66.198
+#           id: node1
+#           root_password: pass123
+#           role:
+#             - _admin
+#             - installer
+#             - mon
+#             - mgr
+#             - osd
+#             - crash
+#             - mds
+#             - nfs
+#           volumes:
+#             - /dev/nvme2n1
+#             - /dev/nvme3n1
+#             - /dev/nvme4n1
+#             - /dev/nvme5n1
+#             - /dev/nvme6n1
+#             - /dev/nvme7n1
+#             - /dev/nvme8n1
+#             - /dev/nvme9n1
+#         - hostname: grim062
+#           ip: 10.64.66.199
+#           id: node2
+#           root_password: pass123
+#           role:
+#             - osd
+#             - mon
+#             - mgr
+#             - mds
+#             - crash
+#             - rgw
+#             - nfs
+#           volumes:
+#             - /dev/nvme2n1
+#             - /dev/nvme3n1
+#             - /dev/nvme4n1
+#             - /dev/nvme5n1
+#             - /dev/nvme6n1
+#             - /dev/nvme7n1
+#             - /dev/nvme8n1
+#             - /dev/nvme9n1
+#         - hostname: grim063
+#           ip: 10.64.66.200
+#           id: node3
+#           root_password: pass123
+#           role:
+#             - mon
+#             - osd
+#             - crash
+#             - rgw
+#             - mds
+#             - nfs
+#           volumes:
+#             - /dev/nvme2n1
+#             - /dev/nvme3n1
+#             - /dev/nvme4n1
+#             - /dev/nvme5n1
+#             - /dev/nvme6n1
+#             - /dev/nvme7n1
+#             - /dev/nvme8n1
+#             - /dev/nvme9n1
+#         - hostname: grim064
+#           ip: 10.64.66.201
+#           id: node4
+#           root_password: pass123
+#           role:
+#             - osd
+#             - mds
+#             - crash
+#             - nfs
+#           volumes:
+#             - /dev/nvme2n1
+#             - /dev/nvme3n1
+#             - /dev/nvme4n1
+#             - /dev/nvme5n1
+#             - /dev/nvme6n1
+#             - /dev/nvme7n1
+#             - /dev/nvme8n1
+#             - /dev/nvme9n1
+#         - hostname: grim065
+#           ip: 10.64.66.202
+#           id: node5
+#           root_password: pass123
+#           role:
+#             - client
+#         - hostname: grim066
+#           ip: 10.64.66.203
+#           id: node6
+#           root_password: pass123
+#           role:
+#             - client
+#         - hostname: grim067
+#           ip: 10.64.66.204
+#           id: node7
+#           root_password: pass123
+#           role:
+#             - client
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+      desc: Bootstrap cluster and deploy CephFS with MDS.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node5
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      desc: Configure NFS client on node5
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2
+        node: node6
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      desc: Configure NFS client on node6
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3
+        node: node7
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      desc: Configure NFS client on node7
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      name: Deploy NFS Multi-Active via spec
+      module: multi_active.test_nfs_multi_active_functional.py
+      desc: Functional tests for NFS Multi-Active deployment
+      polarion-id: CEPH-83632226
+      abort-on-fail: false
+      config:
+        skip_health_check: false
+        vips:
+          - 10.64.66.241/26
+          - 10.64.66.242/26
+
+  - test:
+      name: NFS Multi-Active colocation ports via spec
+      module: multi_active.test_nfs_multi_active_colocation_ports.py
+      desc: Colocation port deploy and label failover (TC-A1, TC-C1..C4) with custom ports, VIP mount, backend/ingress drain, and dual-client IO
+      polarion-id: CEPH-83632227
+      abort-on-fail: false
+      config:
+        skip_health_check: false
+        io_tool: fio
+        vips:
+          - 10.64.66.241/26
+          - 10.64.66.242/26
+
+  - test:
+      name: NFS Multi-Active ingress negative via spec
+      module: multi_active.test_nfs_multi_active_negative.py
+      desc: NEG-1..NEG-5 — invalid ingress apply, IP export restrictions with HAProxy failover, and Ganesha SIGKILL recovery with IO continuity
+      polarion-id: CEPH-83632228
+      abort-on-fail: false
+      config:
+        skip_health_check: false
+        io_tool: fio
+        vips:
+          - 10.64.66.241/26
+          - 10.64.66.242/26
+
+  - test:
+      name: NFS Multi-Active daemon disruption via spec
+      module: multi_active.test_nfs_multi_active_daemon_disruption.py
+      desc: Single deploy DR-1..DR-7 — nfs/haproxy/keepalived restart and stop/start with background IO and per-phase validation
+      polarion-id: CEPH-83632229
+      abort-on-fail: false
+      config:
+        skip_health_check: true
+        io_tool: fio
+        vips:
+          - 10.64.66.241/26
+          - 10.64.66.242/26
+
+  - test:
+      name: NFS Multi-Active failover via spec
+      module: multi_active.test_nfs_multi_active_failover.py
+      desc: Label-based failover during background IO — 4 sessions TC-1..TC-6 covering single/dual-client drain, roundtrip, reboot, and dual-cluster VIP failover
+      polarion-id: CEPH-83632862
+      abort-on-fail: false
+      config:
+        skip_health_check: false
+        io_tool: fio
+        vips:
+          - 10.64.66.241/26
+          - 10.64.66.242/26
+
+  - test:
+      name: NFS Multi-Active integration via spec
+      module: multi_active.test_nfs_multi_active_integration.py
+      desc: TC-1..TC-4 shared session — MDS failover, per-share CQoS, RW delegation, per-client colocation CQoS
+      polarion-id: CEPH-83632861
+      abort-on-fail: false
+      comments: Known issue IBMCEPH-16488
+      config:
+        skip_health_check: false
+        io_tool: fio
+        vips:
+          - 10.64.66.241/26
+          - 10.64.66.242/26
+

--- a/tests/nfs/lib/multi_active/__init__.py
+++ b/tests/nfs/lib/multi_active/__init__.py
@@ -1,0 +1,41 @@
+"""NFS Multi-Active helpers: deploy, validate, mount, cleanup."""
+
+from tests.nfs.lib.multi_active.cleanup import NfsMultiActiveCleanup
+from tests.nfs.lib.multi_active.client import NfsMultiActiveClient
+from tests.nfs.lib.multi_active.common import (
+    init_crash_monitoring,
+    wait_for_ceph_health,
+)
+from tests.nfs.lib.multi_active.config import NfsMultiActiveConfig
+from tests.nfs.lib.multi_active.delegation import NfsMultiActiveDelegation
+from tests.nfs.lib.multi_active.deploy import NfsMultiActiveDeploy
+from tests.nfs.lib.multi_active.failover import NfsMultiActiveFailover
+from tests.nfs.lib.multi_active.haproxy import NfsMultiActiveHaproxy
+from tests.nfs.lib.multi_active.qos import NfsMultiActiveQos
+from tests.nfs.lib.multi_active.session import (
+    client_backend_mappings,
+    io_runtime,
+    io_tool_label,
+    session_setup,
+    session_teardown,
+    stop_phase_io,
+)
+
+__all__ = [
+    "NfsMultiActiveCleanup",
+    "NfsMultiActiveClient",
+    "NfsMultiActiveConfig",
+    "NfsMultiActiveDelegation",
+    "NfsMultiActiveDeploy",
+    "NfsMultiActiveFailover",
+    "NfsMultiActiveHaproxy",
+    "NfsMultiActiveQos",
+    "client_backend_mappings",
+    "io_runtime",
+    "io_tool_label",
+    "session_setup",
+    "session_teardown",
+    "stop_phase_io",
+    "init_crash_monitoring",
+    "wait_for_ceph_health",
+]

--- a/tests/nfs/lib/multi_active/cleanup.py
+++ b/tests/nfs/lib/multi_active/cleanup.py
@@ -1,0 +1,66 @@
+"""Remove NFS Multi-Active clusters."""
+
+from ceph.waiter import WaitUntil
+from tests.nfs.lib.multi_active.constants import log_section
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveCleanup:
+    """Remove the NFS cluster."""
+
+    def __init__(self, ceph_cluster):
+        self.ceph_cluster = ceph_cluster
+
+    @staticmethod
+    def _wait_cluster_teardown(client, nfs_name, timeout=300):
+        """Wait until nfs cluster ls, orch ps, and orch ls are clear for ``nfs_name``."""
+        services = (f"nfs.{nfs_name}", f"ingress.nfs.{nfs_name}")
+        for _ in WaitUntil(timeout=timeout, interval=5):
+            ls, _ = client.exec_command(
+                sudo=True, cmd="ceph nfs cluster ls", check_ec=False
+            )
+            if nfs_name in (ls or ""):
+                continue
+            drained = True
+            for svc in services:
+                out, _ = client.exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch ps --service_name {svc}",
+                    check_ec=False,
+                )
+                if "No daemons reported" not in (out or ""):
+                    drained = False
+                    break
+                out, _ = client.exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch ls --service_name {svc}",
+                    check_ec=False,
+                )
+                if "No services reported" not in (out or ""):
+                    drained = False
+                    break
+            if drained:
+                log.info("NFS cluster %r teardown complete", nfs_name)
+                return
+        log.warning(
+            "Timed out after %ss waiting for NFS cluster %r to drain", timeout, nfs_name
+        )
+
+    def remove_cluster(self, nfs_name):
+        clients = self.ceph_cluster.get_nodes("client")
+        client = clients[0] if clients else self.ceph_cluster.get_nodes("installer")[0]
+
+        log_section(log, "NFS MULTI-ACTIVE CLUSTER CLEANUP")
+        log.info("Removing NFS cluster %s", nfs_name)
+        try:
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph nfs cluster rm {nfs_name}",
+                check_ec=False,
+            )
+        except Exception as ex:
+            log.warning("Failed to remove NFS cluster %s: %s", nfs_name, ex)
+        else:
+            self._wait_cluster_teardown(client, nfs_name)

--- a/tests/nfs/lib/multi_active/client.py
+++ b/tests/nfs/lib/multi_active/client.py
@@ -1,0 +1,154 @@
+"""VIP mount, basic IO validation, and export cleanup on clients."""
+
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import OperationFailedError
+from cli.utilities.utils import perform_lookups
+from tests.nfs.lib.multi_active.constants import log_section
+from utility.log import Log
+
+log = Log(__name__)
+from tests.nfs.lib.multi_active.client_io import NfsMultiActiveClientIO
+from tests.nfs.nfs_operations import mount_cleanup_retry, mount_retry
+
+
+class NfsMultiActiveClient(NfsMultiActiveClientIO):
+    """VIP mount, minimal IO validation, unmount, and background IO (via mixin)."""
+
+    @staticmethod
+    def client_mount_ip(client):
+        ip = getattr(client, "ip_address", None)
+        if not ip:
+            raise OperationFailedError(
+                f"Could not determine mount IP for client {client.hostname}"
+            )
+        return ip
+
+    @staticmethod
+    def mount_via_vip(client, vip, nfs_mount, export_name, port, version="4.2"):
+        mount_server = vip.split("/")[0]
+        log.info(
+            "Mounting %s on %s via VIP %s (client IP %s)",
+            export_name,
+            client.hostname,
+            vip,
+            NfsMultiActiveClient.client_mount_ip(client),
+        )
+        client.create_dirs(dir_path=nfs_mount, sudo=True)
+        mount_retry(client, nfs_mount, version, port, mount_server, export_name)
+        client.exec_command(sudo=True, cmd=f"chown cephuser:cephuser {nfs_mount}")
+        sleep(2)
+
+    @staticmethod
+    def _umount_lazy_then_force(client, nfs_mount):
+        """Try lazy unmount first; fall back to force unmount on failure."""
+        log.info("Lazy-unmounting NFS on %s: %s", client.hostname, nfs_mount)
+        _, err = client.exec_command(
+            sudo=True,
+            cmd=f"umount -l {nfs_mount}",
+            check_ec=False,
+        )
+        if err:
+            log.warning(
+                "Lazy umount %s on %s failed (%s); trying force unmount",
+                nfs_mount,
+                client.hostname,
+                err.strip(),
+            )
+            log.info("Force-unmounting NFS on %s: %s", client.hostname, nfs_mount)
+            _, err = client.exec_command(
+                sudo=True,
+                cmd=f"umount -f {nfs_mount}",
+                check_ec=False,
+            )
+        return err
+
+    @staticmethod
+    def remount_clients_via_vip(
+        clients, vip, nfs_mount, export_name, port, version="4"
+    ):
+        """Force-remount clients on the VIP to refresh stick-table pins."""
+        for client in clients:
+            log.info("Remounting %s on %s via VIP %s", nfs_mount, client.hostname, vip)
+            err = NfsMultiActiveClient._umount_lazy_then_force(client, nfs_mount)
+            if err:
+                log.warning(
+                    "umount %s on %s before remount: %s",
+                    nfs_mount,
+                    client.hostname,
+                    err.strip(),
+                )
+            NfsMultiActiveClient.mount_via_vip(
+                client, vip, nfs_mount, export_name, str(port), version
+            )
+
+    @staticmethod
+    def run_basic_io(
+        writer_client,
+        reader_client,
+        nfs_mount,
+        file_count=2,
+        io_subdir="io_check",
+    ):
+        """Exercise minimal create/write, cross-client read/list, append, and cleanup."""
+        io_dir = f"{nfs_mount.rstrip('/')}/{io_subdir}"
+        test_file = f"{io_dir}/file1"
+        log_section(log, "NFS MULTI-ACTIVE BASIC IO")
+        log.info(
+            "IO dir %s — writer %s, reader %s, file_count=%s",
+            io_dir,
+            writer_client.hostname,
+            reader_client.hostname,
+            file_count,
+        )
+
+        writer_client.exec_command(sudo=True, cmd=f"mkdir -p {io_dir}")
+        writer_client.exec_command(sudo=True, cmd=f"chown cephuser:cephuser {io_dir}")
+        NfsMultiActiveClient._assert_io_dir_on_nfs(writer_client, io_dir)
+        NfsMultiActiveClient._assert_io_dir_on_nfs(reader_client, io_dir)
+
+        for i in range(1, file_count + 1):
+            writer_client.exec_command(
+                sudo=True,
+                cmd=f"touch {io_dir}/file{i} && echo write-test-{i} > {io_dir}/file{i}",
+            )
+
+        perform_lookups(reader_client, io_dir, file_count)
+
+        out, _ = reader_client.exec_command(sudo=True, cmd=f"cat {test_file}")
+        if "write-test-1" not in (out or ""):
+            raise OperationFailedError(
+                f"Cross-client read failed on {reader_client.hostname}"
+            )
+
+        reader_client.exec_command(sudo=True, cmd=f"mkdir -p {io_dir}/subdir")
+        writer_client.exec_command(
+            sudo=True,
+            cmd=f"echo nfs-multi-active-io >> {test_file}",
+        )
+        out, _ = reader_client.exec_command(sudo=True, cmd=f"cat {test_file}")
+        if "nfs-multi-active-io" not in (out or ""):
+            raise OperationFailedError(
+                f"Cross-client append/read failed on {reader_client.hostname}"
+            )
+
+        writer_client.exec_command(sudo=True, cmd=f"rm -rf {io_dir}")
+        log.info("Basic IO validation completed on %s", io_dir)
+
+    @staticmethod
+    def unmount_and_delete_export(clients, nfs_mount, nfs_name, export_name):
+        for client in clients:
+            if not mount_cleanup_retry(client, nfs_mount):
+                raise OperationFailedError(
+                    f"Failed to cleanup mount directory on {client.hostname}"
+                )
+            err = NfsMultiActiveClient._umount_lazy_then_force(client, nfs_mount)
+            if err:
+                raise OperationFailedError(
+                    f"Failed to unmount NFS on {client.hostname}: {err.strip()}"
+                )
+            client.exec_command(sudo=True, cmd=f"rm -rf {nfs_mount}", check_ec=False)
+
+        Ceph(clients[0]).nfs.export.delete(nfs_name, export_name)
+        log.info("Removed export %s and unmounted clients", export_name)

--- a/tests/nfs/lib/multi_active/client_io.py
+++ b/tests/nfs/lib/multi_active/client_io.py
@@ -1,0 +1,957 @@
+"""Background IO (dd/fio) helpers for NFS Multi-Active failover tests."""
+
+from datetime import datetime
+from threading import Thread
+from time import monotonic, sleep
+
+from cli.exceptions import OperationFailedError
+from tests.nfs.lib.multi_active.config import NfsMultiActiveConfig
+from tests.nfs.lib.multi_active.constants import (
+    BG_IO_RUNTIME,
+    DD_BS,
+    DD_COUNT,
+    FIO_BS,
+    FIO_IODEPTH,
+    FIO_JOB_PREFIX,
+    FIO_SIZE,
+    log_section,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveClientIO:
+    """Background dd/fio IO, resume probes, and io_tool dispatch."""
+
+    @staticmethod
+    def _assert_io_dir_on_nfs(client, io_dir):
+        """Fail fast if ``io_dir`` is not on an NFS mount (avoid local-disk IO)."""
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=f"findmnt -n -T {io_dir} -o FSTYPE,SOURCE",
+            check_ec=False,
+        )
+        fs_line = (out or "").strip().splitlines()[0] if (out or "").strip() else ""
+        if "nfs" not in fs_line.lower():
+            raise OperationFailedError(
+                f"IO dir {io_dir} is not on an NFS mount on {client.hostname}: "
+                f"{fs_line or 'findmnt returned no output'!r}"
+            )
+        log.info("IO dir %s is on NFS (%s)", io_dir, fs_line)
+
+    @staticmethod
+    def _dd_data_file(io_dir, client):
+        return f"{io_dir}/dd_{client.hostname}.dat"
+
+    @staticmethod
+    def _dd_stop_file(io_dir):
+        return f"{io_dir}/.dd_stop"
+
+    @staticmethod
+    def _probe_nfs_path_responsive(client, path, probe_timeout=20):
+        """Return True when ``stat`` on ``path`` completes successfully within the timeout."""
+        cmd_timeout = probe_timeout + 15
+        _, err, exit_code, _ = client.exec_command(
+            sudo=True,
+            cmd=f"timeout {probe_timeout} stat {path}",
+            check_ec=False,
+            verbose=True,
+            timeout=cmd_timeout,
+        )
+        if exit_code != 0:
+            log.info(
+                "%s: NFS path probe failed for %s (exit=%s err=%s)",
+                client.hostname,
+                path,
+                exit_code,
+                (err or "").strip(),
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _sessions_active(sessions):
+        return [
+            (client, thread, io_dir)
+            for client, thread, _, io_dir in sessions
+            if thread.is_alive()
+        ]
+
+    @staticmethod
+    def _probe_io_dir_stall(client, nfs_mount, io_dir, probe_timeout=20):
+        """Return True while ``io_dir`` is still reachable over NFS."""
+        return NfsMultiActiveClientIO._probe_nfs_path_responsive(
+            client, io_dir, probe_timeout=probe_timeout
+        )
+
+    @staticmethod
+    def _probe_client_dd_io_resume(client, nfs_mount, io_dir, probe_timeout=20):
+        """Return True when dd is still running and the mount responds to stat.
+
+        Uses pgrep first (no NFS) then a lightweight stat on the mount point.
+        Avoids write/cat probes that contend with the background dd loop on the
+        same mount and falsely fail while dd is still active.
+        """
+        dd_file = NfsMultiActiveClientIO._dd_data_file(io_dir, client)
+        hostname = client.hostname
+        cmd_timeout = probe_timeout + 10
+
+        out, err, exit_code, _ = client.exec_command(
+            sudo=True,
+            cmd=f"pgrep -af 'dd if=/dev/zero of={dd_file}'",
+            check_ec=False,
+            verbose=True,
+            timeout=cmd_timeout,
+        )
+        if exit_code != 0 or not (out or "").strip():
+            log.info(
+                "%s: IO resume probe failed: dd not running for %s",
+                hostname,
+                dd_file,
+            )
+            return False
+
+        return NfsMultiActiveClientIO._probe_nfs_path_responsive(
+            client, nfs_mount, probe_timeout=probe_timeout
+        )
+
+    @staticmethod
+    def _recovery_seconds_since_trigger(triggered_at):
+        if not triggered_at:
+            return None
+        try:
+            started = datetime.strptime(triggered_at, "%Y-%m-%d %H:%M:%S")
+        except (TypeError, ValueError):
+            return None
+        return (datetime.now() - started).total_seconds()
+
+    @staticmethod
+    def _wait_for_background_io_resume(
+        active,
+        nfs_mount,
+        probe_fn,
+        io_label,
+        timeout=300,
+        interval=10,
+        probe_timeout=20,
+        timings=None,
+        skip_log_message=None,
+        skip_timings_value="skipped (IO already finished)",
+        require_live_io=False,
+        triggered_at=None,
+    ):
+        if not active:
+            log.info(
+                skip_log_message
+                or "No background IO threads running; skip IO resume wait"
+            )
+            if timings is not None:
+                timings["io_resume"] = skip_timings_value
+            return
+
+        log_section(
+            log,
+            f"WAIT {io_label} IO RESUME — {len(active)} client(s): "
+            f"{', '.join(c.hostname for c, _, _ in active)}",
+        )
+
+        wait_start = monotonic()
+        last_pending = []
+        while True:
+            if monotonic() - wait_start >= timeout:
+                break
+
+            pending = []
+            for client, thread, io_dir in active:
+                if require_live_io and not thread.is_alive():
+                    pending.append(client.hostname)
+                    continue
+                remaining = timeout - (monotonic() - wait_start)
+                if remaining <= 0:
+                    break
+                effective_probe_timeout = min(probe_timeout, max(1, int(remaining)))
+                if not probe_fn(
+                    client,
+                    nfs_mount,
+                    io_dir,
+                    probe_timeout=effective_probe_timeout,
+                ):
+                    pending.append(client.hostname)
+
+            if not pending:
+                elapsed = monotonic() - wait_start
+                recovery_since_trigger = (
+                    NfsMultiActiveClientIO._recovery_seconds_since_trigger(triggered_at)
+                )
+                if recovery_since_trigger is not None:
+                    log.info(
+                        "%s IO resumed on all active client(s) after %.1fs since "
+                        "failover trigger (%.1fs since polling started)",
+                        io_label,
+                        recovery_since_trigger,
+                        elapsed,
+                    )
+                    if timings is not None:
+                        timings["io_resume"] = f"{recovery_since_trigger:.1f}s"
+                else:
+                    log.info(
+                        "%s IO resumed on all active client(s) after %.1fs",
+                        io_label,
+                        elapsed,
+                    )
+                    if timings is not None:
+                        timings["io_resume"] = f"{elapsed:.1f}s"
+                return
+
+            last_pending = pending
+            remaining = max(0.0, timeout - (monotonic() - wait_start))
+            if remaining <= 0:
+                log.error(
+                    "NFS mount/%s not responsive on %s; giving up (0s remaining)",
+                    io_label,
+                    pending,
+                )
+                break
+            log.info(
+                "NFS mount/%s not yet responsive on %s; retrying (%.0fs remaining)",
+                io_label,
+                pending,
+                remaining,
+            )
+            sleep(min(interval, remaining))
+
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {io_label} IO to resume on "
+            f"{last_pending} after failover"
+            + (
+                " (background IO stopped on one or more clients)"
+                if require_live_io and last_pending
+                else ""
+            )
+        )
+
+    @staticmethod
+    def _wait_for_background_io_stall(
+        active,
+        nfs_mount,
+        probe_fn,
+        io_label,
+        timeout=300,
+        interval=5,
+        probe_timeout=20,
+        timings=None,
+    ):
+        if not active:
+            raise OperationFailedError(
+                f"No background {io_label} IO sessions to confirm stall"
+            )
+
+        log_section(
+            log,
+            f"WAIT {io_label} IO STALL — {len(active)} client(s): "
+            f"{', '.join(c.hostname for c, _, _ in active)}",
+        )
+
+        wait_start = monotonic()
+        last_responsive = []
+        while monotonic() - wait_start < timeout:
+            responsive = []
+            for client, thread, io_dir in active:
+                if not thread.is_alive():
+                    continue
+                remaining = timeout - (monotonic() - wait_start)
+                if remaining <= 0:
+                    break
+                effective_probe_timeout = min(probe_timeout, max(1, int(remaining)))
+                if probe_fn(
+                    client,
+                    nfs_mount,
+                    io_dir,
+                    probe_timeout=effective_probe_timeout,
+                ):
+                    responsive.append(client.hostname)
+
+            if not responsive:
+                elapsed = monotonic() - wait_start
+                log.info(
+                    "%s IO stall confirmed on all active client(s) after %.1fs",
+                    io_label,
+                    elapsed,
+                )
+                if timings is not None:
+                    timings["io_stall"] = f"{elapsed:.1f}s"
+                return
+
+            last_responsive = responsive
+            remaining = max(0.0, timeout - (monotonic() - wait_start))
+            if remaining <= 0:
+                break
+            log.info(
+                "%s IO still responsive on %s; waiting for stall (%.0fs remaining)",
+                io_label,
+                responsive,
+                remaining,
+            )
+            sleep(min(interval, remaining))
+
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {io_label} IO to stall; "
+            f"still responsive on {last_responsive}"
+        )
+
+    @staticmethod
+    def _wait_for_io_stall(
+        sessions,
+        nfs_mount,
+        probe_fn,
+        io_label,
+        timeout=300,
+        interval=5,
+        probe_timeout=20,
+        timings=None,
+    ):
+        """Wait until background IO is no longer responsive on the NFS mount."""
+        active = NfsMultiActiveClientIO._sessions_active(sessions)
+        NfsMultiActiveClientIO._wait_for_background_io_stall(
+            active,
+            nfs_mount,
+            probe_fn,
+            io_label,
+            timeout=timeout,
+            interval=interval,
+            probe_timeout=probe_timeout,
+            timings=timings,
+        )
+
+    @staticmethod
+    def _wait_for_io_resume(
+        sessions,
+        nfs_mount,
+        probe_fn,
+        io_label,
+        skip_log_message,
+        skip_timings_value,
+        timeout=300,
+        interval=10,
+        probe_timeout=20,
+        timings=None,
+        triggered_at=None,
+    ):
+        """Wait until NFS IO is responsive and the background tool is still running."""
+        active = NfsMultiActiveClientIO._sessions_active(sessions)
+        NfsMultiActiveClientIO._wait_for_background_io_resume(
+            active,
+            nfs_mount,
+            probe_fn,
+            io_label,
+            timeout=timeout,
+            interval=interval,
+            probe_timeout=probe_timeout,
+            timings=timings,
+            skip_log_message=skip_log_message,
+            skip_timings_value=skip_timings_value,
+            require_live_io=True,
+            triggered_at=triggered_at,
+        )
+
+    @staticmethod
+    def _run_dd(client, nfs_mount, io_subdir="failover_io", runtime=BG_IO_RUNTIME):
+        """Start continuous dd writes in a background thread; return (thread, error_box, io_dir)."""
+        io_dir = f"{nfs_mount.rstrip('/')}/{io_subdir}"
+        error_box = {"exc": None, "stopped": False}
+        dd_file = NfsMultiActiveClientIO._dd_data_file(io_dir, client)
+        stop_file = NfsMultiActiveClientIO._dd_stop_file(io_dir)
+
+        def _dd_worker():
+            try:
+                client.exec_command(
+                    sudo=True,
+                    cmd=f"mkdir -p {io_dir} && chown cephuser:cephuser {io_dir}",
+                )
+                NfsMultiActiveClientIO._assert_io_dir_on_nfs(client, io_dir)
+                dd_cmd = (
+                    f"timeout {runtime} sh -c "
+                    f"'rm -f {stop_file}; "
+                    f"while [ ! -f {stop_file} ]; do "
+                    f"dd if=/dev/zero of={dd_file} bs={DD_BS} count={DD_COUNT} "
+                    f"conv=fsync status=none; sleep 1; done'"
+                )
+                log_section(
+                    log, f"START DD — continuous write on {client.hostname} at {io_dir}"
+                )
+                log.info("DD command on %s: %s", client.hostname, dd_cmd)
+                client.exec_command(sudo=True, long_running=True, cmd=dd_cmd)
+                if not error_box.get("stopped"):
+                    log_section(log, f"END DD — completed on {client.hostname}")
+            except Exception as exc:
+                if not error_box.get("stopped"):
+                    error_box["exc"] = exc
+                    log_section(log, f"END DD — failed on {client.hostname}: {exc}")
+                    log.error("Background dd failed on %s: %s", client.hostname, exc)
+
+        thread = Thread(target=_dd_worker, daemon=True)
+        thread.start()
+        return thread, error_box, io_dir
+
+    @staticmethod
+    def _stop_dd(client, io_dir, error_box=None):
+        """Stop the background dd loop on the client."""
+        if error_box is not None:
+            error_box["stopped"] = True
+        stop_file = NfsMultiActiveClientIO._dd_stop_file(io_dir)
+        dd_file = NfsMultiActiveClientIO._dd_data_file(io_dir, client)
+        client.exec_command(
+            sudo=True,
+            cmd=f"timeout 10 pkill -9 -f 'dd if=/dev/zero of={dd_file}'",
+            check_ec=False,
+            timeout=15,
+        )
+        client.exec_command(
+            sudo=True,
+            cmd=f"timeout 10 touch {stop_file}",
+            check_ec=False,
+            timeout=15,
+        )
+        log.info("Stopped background dd on %s", client.hostname)
+
+    @staticmethod
+    def _assert_dd_completed(
+        thread,
+        error_box,
+        stop_client=None,
+        io_dir=None,
+        nfs_mount=None,
+        join_timeout=120,
+        wait_io_resume_timeout=300,
+        timings=None,
+    ):
+        """Join dd thread; optionally wait for IO resume, then stop dd."""
+        if (
+            stop_client is not None
+            and nfs_mount
+            and io_dir
+            and thread.is_alive()
+            and wait_io_resume_timeout > 0
+        ):
+            NfsMultiActiveClientIO._wait_for_io_resume(
+                [(stop_client, thread, error_box, io_dir)],
+                nfs_mount,
+                NfsMultiActiveClientIO._probe_client_dd_io_resume,
+                "DD",
+                "No background dd threads still running; skip IO resume wait",
+                "skipped (dd already finished)",
+                timeout=wait_io_resume_timeout,
+                timings=timings,
+            )
+        if stop_client is not None and io_dir is not None:
+            NfsMultiActiveClientIO._stop_dd(stop_client, io_dir, error_box)
+        thread.join(timeout=join_timeout)
+        if thread.is_alive():
+            raise OperationFailedError(
+                f"Background dd did not exit within {join_timeout}s after stop request"
+            )
+        if error_box.get("exc") and not error_box.get("stopped"):
+            raise OperationFailedError(f"Background dd failed: {error_box['exc']}")
+        if error_box.get("stopped"):
+            log_section(
+                log,
+                f"END DD — stopped after failover validation on "
+                f"{stop_client.hostname if stop_client else 'client'}",
+            )
+
+    @staticmethod
+    def _assert_dd_completed_on_clients(
+        sessions,
+        nfs_mount,
+        join_timeout=120,
+        wait_io_resume_timeout=300,
+        timings=None,
+    ):
+        """Wait for IO resume, stop and join dd on every client."""
+        if wait_io_resume_timeout > 0:
+            NfsMultiActiveClientIO._wait_for_io_resume(
+                sessions,
+                nfs_mount,
+                NfsMultiActiveClientIO._probe_client_dd_io_resume,
+                "DD",
+                "No background dd threads still running; skip IO resume wait",
+                "skipped (dd already finished)",
+                timeout=wait_io_resume_timeout,
+                timings=timings,
+            )
+        for client, thread, error_box, io_dir in sessions:
+            if not thread.is_alive():
+                if error_box.get("exc") and not error_box.get("stopped"):
+                    raise OperationFailedError(
+                        f"Background dd failed on {client.hostname}: "
+                        f"{error_box['exc']}"
+                    )
+                raise OperationFailedError(
+                    f"Background dd on {client.hostname} stopped before IO resume "
+                    f"validation completed"
+                )
+            NfsMultiActiveClientIO._assert_dd_completed(
+                thread,
+                error_box,
+                stop_client=client,
+                io_dir=io_dir,
+                join_timeout=join_timeout,
+                wait_io_resume_timeout=0,
+            )
+
+    @staticmethod
+    def _run_dd_on_clients(
+        clients, nfs_mount, io_subdir="failover_io", runtime=BG_IO_RUNTIME
+    ):
+        """Start dd on each client; return [(client, thread, error_box, io_dir), ...]."""
+        sessions = []
+        for client in clients:
+            client_subdir = f"{io_subdir}/{client.hostname}"
+            thread, error_box, io_dir = NfsMultiActiveClientIO._run_dd(
+                client, nfs_mount, io_subdir=client_subdir, runtime=runtime
+            )
+            sessions.append((client, thread, error_box, io_dir))
+        log.info(
+            "Started background dd on %d client(s): %s",
+            len(sessions),
+            ", ".join(client.hostname for client, _, _, _ in sessions),
+        )
+        return sessions
+
+    @staticmethod
+    def _stop_dd_on_clients(sessions):
+        """Stop dd on all clients in ``sessions``."""
+        for client, _, error_box, io_dir in sessions:
+            NfsMultiActiveClientIO._stop_dd(client, io_dir, error_box)
+
+    @staticmethod
+    def _fio_job_name(client):
+        safe_host = client.hostname.replace(".", "_").replace("-", "_")
+        return f"{FIO_JOB_PREFIX}_{safe_host}"
+
+    @staticmethod
+    def _fio_data_file(io_dir, client):
+        return f"{io_dir}/fio_{client.hostname}.dat"
+
+    @staticmethod
+    def _fio_stop_file(io_dir):
+        return f"{io_dir}/.fio_stop"
+
+    @staticmethod
+    def ensure_fio(client):
+        """Install fio on the client node when missing."""
+        log.info("Ensuring fio is installed on %s", client.hostname)
+        client.exec_command(
+            sudo=True,
+            cmd="rpm -q fio || yum install -y fio",
+            check_ec=False,
+        )
+
+    @staticmethod
+    def _probe_client_fio_io_resume(client, nfs_mount, io_dir, probe_timeout=20):
+        """Return True when fio is still running and the mount responds to stat."""
+        job_name = NfsMultiActiveClientIO._fio_job_name(client)
+        fio_file = NfsMultiActiveClientIO._fio_data_file(io_dir, client)
+        hostname = client.hostname
+        cmd_timeout = probe_timeout + 10
+
+        out, err, exit_code, _ = client.exec_command(
+            sudo=True,
+            cmd=f"pgrep -af 'fio.*{job_name}'",
+            check_ec=False,
+            verbose=True,
+            timeout=cmd_timeout,
+        )
+        if exit_code != 0 or not (out or "").strip():
+            log.info(
+                "%s: IO resume probe failed: fio job %s not running (%s)",
+                hostname,
+                job_name,
+                fio_file,
+            )
+            return False
+
+        return NfsMultiActiveClientIO._probe_nfs_path_responsive(
+            client, io_dir, probe_timeout=probe_timeout
+        )
+
+    @staticmethod
+    def _run_fio(
+        client,
+        nfs_mount,
+        io_subdir="failover_io",
+        runtime=BG_IO_RUNTIME,
+        fio_bs=FIO_BS,
+        fio_size=FIO_SIZE,
+        fio_iodepth=FIO_IODEPTH,
+    ):
+        """Start continuous fio writes in a background thread."""
+        io_dir = f"{nfs_mount.rstrip('/')}/{io_subdir}"
+        error_box = {"exc": None, "stopped": False}
+        job_name = NfsMultiActiveClientIO._fio_job_name(client)
+        fio_file = NfsMultiActiveClientIO._fio_data_file(io_dir, client)
+        stop_file = NfsMultiActiveClientIO._fio_stop_file(io_dir)
+
+        def _fio_worker():
+            try:
+                NfsMultiActiveClientIO.ensure_fio(client)
+                client.exec_command(
+                    sudo=True,
+                    cmd=f"mkdir -p {io_dir} && chown cephuser:cephuser {io_dir}",
+                )
+                NfsMultiActiveClientIO._assert_io_dir_on_nfs(client, io_dir)
+                fio_cmd = (
+                    f"timeout {runtime + 120} sh -c "
+                    f"'rm -f {stop_file}; "
+                    f"while [ ! -f {stop_file} ]; do "
+                    f"fio --name={job_name} --rw=randwrite --bs={fio_bs} "
+                    f"--size={fio_size} --numjobs=1 --iodepth={fio_iodepth} "
+                    f"--runtime=60 --time_based --direct=0 "
+                    f"--filename={fio_file} --output=/dev/null --group_reporting; "
+                    f"sleep 1; done'"
+                )
+                log_section(
+                    log,
+                    f"START FIO — continuous write on {client.hostname} at {io_dir}",
+                )
+                log.info("FIO command on %s: %s", client.hostname, fio_cmd)
+                client.exec_command(sudo=True, long_running=True, cmd=fio_cmd)
+                if not error_box.get("stopped"):
+                    log_section(log, f"END FIO — completed on {client.hostname}")
+            except Exception as exc:
+                if not error_box.get("stopped"):
+                    error_box["exc"] = exc
+                    log_section(log, f"END FIO — failed on {client.hostname}: {exc}")
+                    log.error("Background fio failed on %s: %s", client.hostname, exc)
+
+        thread = Thread(target=_fio_worker, daemon=True)
+        thread.start()
+        return thread, error_box, io_dir
+
+    @staticmethod
+    def _stop_fio(client, io_dir, error_box=None):
+        """Stop the background fio loop on the client."""
+        if error_box is not None:
+            error_box["stopped"] = True
+        stop_file = NfsMultiActiveClientIO._fio_stop_file(io_dir)
+        job_name = NfsMultiActiveClientIO._fio_job_name(client)
+        client.exec_command(
+            sudo=True,
+            cmd=f"timeout 10 pkill -9 -f 'fio.*{job_name}'",
+            check_ec=False,
+            timeout=15,
+        )
+        client.exec_command(
+            sudo=True,
+            cmd=f"timeout 10 touch {stop_file}",
+            check_ec=False,
+            timeout=15,
+        )
+        log.info("Stopped background fio on %s", client.hostname)
+
+    @staticmethod
+    def _assert_fio_completed(
+        thread,
+        error_box,
+        stop_client=None,
+        io_dir=None,
+        nfs_mount=None,
+        join_timeout=120,
+        wait_io_resume_timeout=300,
+        timings=None,
+    ):
+        """Join fio thread; optionally wait for IO resume, then stop fio."""
+        if (
+            stop_client is not None
+            and nfs_mount
+            and io_dir
+            and thread.is_alive()
+            and wait_io_resume_timeout > 0
+        ):
+            NfsMultiActiveClientIO._wait_for_io_resume(
+                [(stop_client, thread, error_box, io_dir)],
+                nfs_mount,
+                NfsMultiActiveClientIO._probe_client_fio_io_resume,
+                "FIO",
+                "No background fio threads still running; skip IO resume wait",
+                "skipped (fio already finished)",
+                timeout=wait_io_resume_timeout,
+                timings=timings,
+            )
+        if stop_client is not None and io_dir is not None:
+            NfsMultiActiveClientIO._stop_fio(stop_client, io_dir, error_box)
+        thread.join(timeout=join_timeout)
+        if thread.is_alive():
+            raise OperationFailedError(
+                f"Background fio did not exit within {join_timeout}s after stop request"
+            )
+        if error_box.get("exc") and not error_box.get("stopped"):
+            raise OperationFailedError(f"Background fio failed: {error_box['exc']}")
+        if error_box.get("stopped"):
+            log_section(
+                log,
+                f"END FIO — stopped after failover validation on "
+                f"{stop_client.hostname if stop_client else 'client'}",
+            )
+
+    @staticmethod
+    def _assert_fio_completed_on_clients(
+        sessions,
+        nfs_mount,
+        join_timeout=120,
+        wait_io_resume_timeout=300,
+        timings=None,
+    ):
+        """Wait for IO resume, stop and join fio on every client."""
+        if wait_io_resume_timeout > 0:
+            NfsMultiActiveClientIO._wait_for_io_resume(
+                sessions,
+                nfs_mount,
+                NfsMultiActiveClientIO._probe_client_fio_io_resume,
+                "FIO",
+                "No background fio threads still running; skip IO resume wait",
+                "skipped (fio already finished)",
+                timeout=wait_io_resume_timeout,
+                timings=timings,
+            )
+        for client, thread, error_box, io_dir in sessions:
+            if not thread.is_alive():
+                if error_box.get("exc") and not error_box.get("stopped"):
+                    raise OperationFailedError(
+                        f"Background fio failed on {client.hostname}: "
+                        f"{error_box['exc']}"
+                    )
+                raise OperationFailedError(
+                    f"Background fio on {client.hostname} stopped before IO resume "
+                    f"validation completed"
+                )
+            NfsMultiActiveClientIO._assert_fio_completed(
+                thread,
+                error_box,
+                stop_client=client,
+                io_dir=io_dir,
+                join_timeout=join_timeout,
+                wait_io_resume_timeout=0,
+            )
+
+    @staticmethod
+    def _run_fio_on_clients(
+        clients,
+        nfs_mount,
+        io_subdir="failover_io",
+        runtime=BG_IO_RUNTIME,
+        fio_bs=FIO_BS,
+        fio_size=FIO_SIZE,
+        fio_iodepth=FIO_IODEPTH,
+    ):
+        """Start fio on each client; return [(client, thread, error_box, io_dir), ...]."""
+        sessions = []
+        for client in clients:
+            client_subdir = f"{io_subdir}/{client.hostname}"
+            thread, error_box, io_dir = NfsMultiActiveClientIO._run_fio(
+                client,
+                nfs_mount,
+                io_subdir=client_subdir,
+                runtime=runtime,
+                fio_bs=fio_bs,
+                fio_size=fio_size,
+                fio_iodepth=fio_iodepth,
+            )
+            sessions.append((client, thread, error_box, io_dir))
+        log.info(
+            "Started background fio on %d client(s): %s",
+            len(sessions),
+            ", ".join(client.hostname for client, _, _, _ in sessions),
+        )
+        return sessions
+
+    @staticmethod
+    def _stop_fio_on_clients(sessions):
+        """Stop fio on all clients in ``sessions``."""
+        for client, _, error_box, io_dir in sessions:
+            NfsMultiActiveClientIO._stop_fio(client, io_dir, error_box)
+
+    @staticmethod
+    def run_background_io(
+        client, nfs_mount, config, io_subdir="failover_io", runtime=None
+    ):
+        """Start background IO using ``io_tool`` from suite config (``dd`` or ``fio``)."""
+        runtime = runtime or NfsMultiActiveConfig.io_runtime(config)
+        if NfsMultiActiveConfig.resolve_io_tool(config) == "fio":
+            params = NfsMultiActiveConfig.fio_params(config)
+            return NfsMultiActiveClientIO._run_fio(
+                client,
+                nfs_mount,
+                io_subdir=io_subdir,
+                runtime=runtime,
+                fio_bs=params["bs"],
+                fio_size=params["size"],
+                fio_iodepth=params["iodepth"],
+            )
+        return NfsMultiActiveClientIO._run_dd(
+            client, nfs_mount, io_subdir=io_subdir, runtime=runtime
+        )
+
+    @staticmethod
+    def run_background_io_on_clients(
+        clients, nfs_mount, config, io_subdir="failover_io", runtime=None
+    ):
+        """Start background IO on each client per ``io_tool`` in config."""
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        runtime = runtime or NfsMultiActiveConfig.io_runtime(config)
+        if tool == "fio":
+            params = NfsMultiActiveConfig.fio_params(config)
+            return NfsMultiActiveClientIO._run_fio_on_clients(
+                clients,
+                nfs_mount,
+                io_subdir=io_subdir,
+                runtime=runtime,
+                fio_bs=params["bs"],
+                fio_size=params["size"],
+                fio_iodepth=params["iodepth"],
+            )
+        return NfsMultiActiveClientIO._run_dd_on_clients(
+            clients, nfs_mount, io_subdir=io_subdir, runtime=runtime
+        )
+
+    @staticmethod
+    def stop_background_io(client, io_dir, config, error_box=None):
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        if tool == "fio":
+            NfsMultiActiveClientIO._stop_fio(client, io_dir, error_box)
+        else:
+            NfsMultiActiveClientIO._stop_dd(client, io_dir, error_box)
+
+    @staticmethod
+    def stop_background_io_on_clients(sessions, config):
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        if tool == "fio":
+            NfsMultiActiveClientIO._stop_fio_on_clients(sessions)
+        else:
+            NfsMultiActiveClientIO._stop_dd_on_clients(sessions)
+
+    @staticmethod
+    def wait_for_background_io_stall(
+        sessions,
+        nfs_mount,
+        config,
+        timeout=300,
+        interval=5,
+        probe_timeout=20,
+        timings=None,
+    ):
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        io_label = "FIO" if tool == "fio" else "DD"
+        NfsMultiActiveClientIO._wait_for_io_stall(
+            sessions,
+            nfs_mount,
+            NfsMultiActiveClientIO._probe_io_dir_stall,
+            io_label,
+            timeout=timeout,
+            interval=interval,
+            probe_timeout=probe_timeout,
+            timings=timings,
+        )
+
+    @staticmethod
+    def wait_for_background_io_resume(
+        sessions,
+        nfs_mount,
+        config,
+        timeout=300,
+        interval=10,
+        probe_timeout=20,
+        timings=None,
+        triggered_at=None,
+    ):
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        if tool == "fio":
+            NfsMultiActiveClientIO._wait_for_io_resume(
+                sessions,
+                nfs_mount,
+                NfsMultiActiveClientIO._probe_client_fio_io_resume,
+                "FIO",
+                "No background fio threads still running; skip IO resume wait",
+                "skipped (fio already finished)",
+                timeout=timeout,
+                interval=interval,
+                probe_timeout=probe_timeout,
+                timings=timings,
+                triggered_at=triggered_at,
+            )
+            return
+        NfsMultiActiveClientIO._wait_for_io_resume(
+            sessions,
+            nfs_mount,
+            NfsMultiActiveClientIO._probe_client_dd_io_resume,
+            "DD",
+            "No background dd threads still running; skip IO resume wait",
+            "skipped (dd already finished)",
+            timeout=timeout,
+            interval=interval,
+            probe_timeout=probe_timeout,
+            timings=timings,
+            triggered_at=triggered_at,
+        )
+
+    @staticmethod
+    def assert_io_completed(
+        thread,
+        error_box,
+        config,
+        stop_client=None,
+        io_dir=None,
+        nfs_mount=None,
+        join_timeout=120,
+        wait_io_resume_timeout=300,
+        timings=None,
+    ):
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        if tool == "fio":
+            return NfsMultiActiveClientIO._assert_fio_completed(
+                thread,
+                error_box,
+                stop_client=stop_client,
+                io_dir=io_dir,
+                nfs_mount=nfs_mount,
+                join_timeout=join_timeout,
+                wait_io_resume_timeout=wait_io_resume_timeout,
+                timings=timings,
+            )
+        return NfsMultiActiveClientIO._assert_dd_completed(
+            thread,
+            error_box,
+            stop_client=stop_client,
+            io_dir=io_dir,
+            nfs_mount=nfs_mount,
+            join_timeout=join_timeout,
+            wait_io_resume_timeout=wait_io_resume_timeout,
+            timings=timings,
+        )
+
+    @staticmethod
+    def assert_io_completed_on_clients(
+        sessions,
+        nfs_mount,
+        config,
+        join_timeout=120,
+        wait_io_resume_timeout=300,
+        timings=None,
+    ):
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        if tool == "fio":
+            return NfsMultiActiveClientIO._assert_fio_completed_on_clients(
+                sessions,
+                nfs_mount,
+                join_timeout=join_timeout,
+                wait_io_resume_timeout=wait_io_resume_timeout,
+                timings=timings,
+            )
+        return NfsMultiActiveClientIO._assert_dd_completed_on_clients(
+            sessions,
+            nfs_mount,
+            join_timeout=join_timeout,
+            wait_io_resume_timeout=wait_io_resume_timeout,
+            timings=timings,
+        )

--- a/tests/nfs/lib/multi_active/common.py
+++ b/tests/nfs/lib/multi_active/common.py
@@ -1,0 +1,103 @@
+"""Shared helpers for NFS Multi-Active suite tests."""
+
+from datetime import datetime
+
+from cli.exceptions import ConfigError
+from cli.utilities.utils import check_coredump_generated
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from tests.nfs.lib.multi_active.constants import DEFAULT_HEALTH_WAIT
+from utility.log import Log
+
+log = Log(__name__)
+
+NFS_COREDUMP_PATH = "/var/lib/systemd/coredump"
+_SKIP_COREDUMP_CONTEXTS = frozenset({"post-NEG-5"})
+
+
+def init_crash_monitoring(config):
+    """Record suite start time for per-TC NFS coredump windows."""
+    config.setdefault("coredump_since", datetime.now())
+
+
+def check_for_crashes(ceph_cluster, config=None, *, context="inter-session"):
+    """Fail when ceph crash archive or NFS coredumps are present.
+
+    Set ``skip_health_check: true`` in the test config to skip (same as health).
+    """
+    config = config or {}
+    if config.get("skip_health_check"):
+        log.info(
+            "Skipping %s crash check (skip_health_check=true)",
+            context,
+        )
+        return
+
+    clients = ceph_cluster.get_ceph_objects("client")
+    if not clients:
+        raise ConfigError(f"{context} crash check requires at least one client node")
+
+    client = clients[0]
+    out, _ = client.exec_command(sudo=True, cmd="ceph crash ls-new", check_ec=False)
+    if out and out.strip():
+        log.error(
+            "Ceph crash archive has entries (%s):\n%s",
+            context,
+            out.strip(),
+        )
+        client.exec_command(sudo=True, cmd="ceph crash archive-all", check_ec=False)
+        raise ConfigError(f"Ceph crash detected before health check ({context})")
+
+    if context in _SKIP_COREDUMP_CONTEXTS:
+        log.info(
+            "Skipping NFS coredump check for %s (expected daemon crash TC)",
+            context,
+        )
+        return
+
+    since = config.get("_last_crash_check_at") or config.get("coredump_since")
+    if since is None:
+        log.warning(
+            "coredump_since not set; call init_crash_monitoring() at suite run start "
+            "(%s)",
+            context,
+        )
+        return
+
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    for nfs_node in nfs_nodes:
+        if check_coredump_generated(nfs_node, NFS_COREDUMP_PATH, since):
+            raise ConfigError(
+                f"NFS coredump on {nfs_node.hostname} since {since} ({context})"
+            )
+
+    log.info("No ceph crashes or NFS coredumps detected (%s)", context)
+
+
+def wait_for_ceph_health(ceph_cluster, config=None, *, context="inter-session"):
+    """Check for crashes, then wait for Ceph HEALTH_OK.
+
+    Set ``skip_health_check: true`` in the test config to skip.
+    """
+    config = config or {}
+    if config.get("skip_health_check"):
+        log.info(
+            "Skipping %s Ceph health check (skip_health_check=true)",
+            context,
+        )
+        return
+
+    check_for_crashes(ceph_cluster, config, context=context)
+
+    clients = ceph_cluster.get_ceph_objects("client")
+    if not clients:
+        raise ConfigError(f"{context} health check requires at least one client node")
+
+    wait_time = int(config.get("health_wait", DEFAULT_HEALTH_WAIT))
+    cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
+    log.info("Proceed only if Ceph health is OK (%s)", context)
+    if cephfs_common_utils.wait_for_healthy_ceph(clients[0], wait_time):
+        raise ConfigError(
+            f"Cluster health is not OK even after waiting for {wait_time}s ({context})"
+        )
+    log.info("Cluster is HEALTH_OK (%s)", context)
+    config["_last_crash_check_at"] = datetime.now()

--- a/tests/nfs/lib/multi_active/config.py
+++ b/tests/nfs/lib/multi_active/config.py
@@ -1,0 +1,252 @@
+"""Suite config and orchestrator spec builders."""
+
+import json
+
+from ceph.waiter import WaitUntil
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active.constants import (
+    BG_IO_RUNTIME,
+    FIO_BS,
+    FIO_IODEPTH,
+    FIO_SIZE,
+)
+from tests.nfs.lib.multi_active.placement import node_slice
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveConfig:
+    """Suite config and orchestrator spec builders."""
+
+    @staticmethod
+    def get_vips(config):
+        if not config:
+            raise ConfigError("Test config is required to resolve NFS ingress VIPs")
+
+        vips = config.get("vips") or []
+        if not vips and config.get("vip"):
+            vips = [config["vip"]]
+        if not vips:
+            raise ConfigError(
+                "No VIPs configured. Add 'vips' (or 'vip') under the test config "
+                "in the suite YAML."
+            )
+        return vips
+
+    @staticmethod
+    def resolve_io_tool(config):
+        """Return background IO tool: ``dd`` (default) or ``fio``."""
+        tool = str((config or {}).get("io_tool", "dd")).lower()
+        if tool not in ("dd", "fio"):
+            raise ConfigError(f"io_tool must be 'dd' or 'fio', got {tool!r}")
+        return tool
+
+    @staticmethod
+    def io_runtime(config, default=BG_IO_RUNTIME):
+        """Return background IO runtime in seconds for the configured tool."""
+        tool = NfsMultiActiveConfig.resolve_io_tool(config)
+        if tool == "fio":
+            return int(
+                (config or {}).get(
+                    "fio_runtime",
+                    (config or {}).get("bg_io_runtime", default),
+                )
+            )
+        return int((config or {}).get("bg_io_runtime", default))
+
+    @staticmethod
+    def fio_params(config):
+        """Return fio CLI parameters from suite config."""
+        cfg = config or {}
+        return {
+            "bs": str(cfg.get("fio_bs", FIO_BS)),
+            "size": str(cfg.get("fio_size", FIO_SIZE)),
+            "iodepth": int(cfg.get("fio_iodepth", FIO_IODEPTH)),
+        }
+
+    @staticmethod
+    def _nfs_placement(nfs_hosts, nfs_count, label=None):
+        placement = {"count": nfs_count}
+        if label:
+            placement["label"] = label
+        else:
+            placement["hosts"] = nfs_hosts
+        return placement
+
+    @staticmethod
+    def build_nfs_spec(nfs_hosts, nfs_count, nfs_name, nfs_backend_port, label=None):
+        return {
+            "service_type": "nfs",
+            "service_id": nfs_name,
+            "placement": NfsMultiActiveConfig._nfs_placement(
+                nfs_hosts, nfs_count, label
+            ),
+            "spec": {
+                "port": nfs_backend_port,
+                "enable_haproxy_protocol": True,
+            },
+        }
+
+    @staticmethod
+    def build_nfs_colocation_spec(
+        nfs_hosts,
+        nfs_count,
+        nfs_name,
+        port,
+        monitoring_port,
+        colocation_ports,
+        label=None,
+    ):
+        """NFS spec with monitoring_port and colocation_ports for multi-daemon hosts."""
+        if len(colocation_ports) != nfs_count - 1:
+            raise ConfigError(
+                f"colocation_ports must have count-1 ({nfs_count - 1}) entries, "
+                f"got {len(colocation_ports)}"
+            )
+        return {
+            "service_type": "nfs",
+            "service_id": nfs_name,
+            "placement": NfsMultiActiveConfig._nfs_placement(
+                nfs_hosts, nfs_count, label
+            ),
+            "spec": {
+                "port": port,
+                "monitoring_port": monitoring_port,
+                "colocation_ports": colocation_ports,
+                "enable_haproxy_protocol": True,
+            },
+        }
+
+    @staticmethod
+    def expected_colocation_data_ports(nfs_spec):
+        """Return the set of NFS data ports defined by a colocation spec."""
+        spec = nfs_spec["spec"]
+        ports = {int(spec["port"])}
+        for entry in spec.get("colocation_ports") or []:
+            ports.add(int(entry["data_port"]))
+        return ports
+
+    @staticmethod
+    def build_ingress_spec(
+        vip,
+        nfs_name,
+        ingress_frontend_port,
+        ingress_monitor_port,
+        health_check_interval,
+        *,
+        ingress_hostnames=None,
+        label=None,
+    ):
+        """Ingress placement: hosts or label only — never count."""
+        if label:
+            placement = {"label": label}
+        else:
+            if not ingress_hostnames:
+                raise ConfigError(
+                    "ingress_hostnames is required when ingress placement "
+                    "does not use a label"
+                )
+            placement = {"hosts": ingress_hostnames}
+        return {
+            "service_type": "ingress",
+            "service_id": f"nfs.{nfs_name}",
+            "placement": placement,
+            "spec": {
+                "backend_service": f"nfs.{nfs_name}",
+                "frontend_port": ingress_frontend_port,
+                "monitor_port": ingress_monitor_port,
+                "virtual_ip": vip,
+                "health_check_interval": health_check_interval,
+                "enable_haproxy_protocol": True,
+            },
+        }
+
+    @staticmethod
+    def sorted_nfs_nodes(ceph_cluster):
+        """Return NFS-capable nodes in stable hostname order for placement slices."""
+        return sorted(
+            ceph_cluster.get_nodes("nfs"),
+            key=lambda node: node.hostname,
+        )
+
+    @staticmethod
+    def apply_placement_labels(client, nfs_nodes, nfs_slice, ingress_slice, labels):
+        nfs_label, ingress_label = labels["nfs"], labels["ingress"]
+        nfs_hosts = []
+        for node in node_slice(nfs_nodes, nfs_slice[0], nfs_slice[1]):
+            nfs_hosts.append(node.hostname)
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch host label add {node.hostname} {nfs_label}",
+            )
+        ingress_hosts = []
+        for node in node_slice(nfs_nodes, ingress_slice[0], ingress_slice[1]):
+            ingress_hosts.append(node.hostname)
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch host label add {node.hostname} {ingress_label}",
+            )
+        log.info(
+            "Applied placement labels nfs=%r on %s ingress=%r on %s",
+            nfs_label,
+            nfs_hosts,
+            ingress_label,
+            ingress_hosts,
+        )
+
+    @staticmethod
+    def remove_placement_labels(client, nfs_nodes, nfs_slice, ingress_slice, labels):
+        nfs_label, ingress_label = labels["nfs"], labels["ingress"]
+        for node in node_slice(nfs_nodes, nfs_slice[0], nfs_slice[1]):
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch host label rm {node.hostname} {nfs_label}",
+                check_ec=False,
+            )
+        for node in node_slice(nfs_nodes, ingress_slice[0], ingress_slice[1]):
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch host label rm {node.hostname} {ingress_label}",
+                check_ec=False,
+            )
+        log.info(
+            "Removed placement labels nfs=%r ingress=%r",
+            nfs_label,
+            ingress_label,
+        )
+
+    @staticmethod
+    def clear_placement_labels(client, nfs_nodes, labels):
+        """Remove placement labels from every NFS-capable host (incl. failover spares)."""
+        nfs_label, ingress_label = labels["nfs"], labels["ingress"]
+        for label in (nfs_label, ingress_label):
+            for node in nfs_nodes:
+                client.exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch host label rm {node.hostname} {label}",
+                    check_ec=False,
+                )
+        log.info(
+            "Cleared placement labels nfs=%r ingress=%r from all NFS hosts",
+            nfs_label,
+            ingress_label,
+        )
+
+    @staticmethod
+    def wait_until_export_visible(
+        client, nfs_name, export_name, timeout=60, interval=1
+    ):
+        for _ in WaitUntil(timeout=timeout, interval=interval):
+            raw = Ceph(client).nfs.export.ls(nfs_name)
+            if not raw:
+                continue
+            exports = json.loads(raw.strip()) if isinstance(raw, str) else raw
+            if export_name in exports:
+                log.info("Export %s listed for %s", export_name, nfs_name)
+                return
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for export {export_name!r} "
+            f"on {nfs_name!r}"
+        )

--- a/tests/nfs/lib/multi_active/constants.py
+++ b/tests/nfs/lib/multi_active/constants.py
@@ -1,0 +1,109 @@
+"""Shared constants for NFS Multi-Active suite tests."""
+
+# Timeouts (seconds)
+DEPLOY_TIMEOUT = 300
+IO_RESUME_TIMEOUT = 300
+IO_JOIN_TIMEOUT = 120
+MARKER_IO_TIMEOUT = 60
+DEFAULT_HEALTH_WAIT = 1200
+DEFAULT_TC3_SERVICE_WAIT_TIMEOUT = DEPLOY_TIMEOUT
+
+# Short delays / polling (seconds)
+POLL_INTERVAL_SEC = 5
+IO_WARMUP_SEC = POLL_INTERVAL_SEC
+BG_IO_START_DELAY = POLL_INTERVAL_SEC
+
+# Mount / export
+NFS_MOUNT = "/mnt/nfs"
+NFS_MOUNT_A = "/mnt/nfs_a"
+NFS_MOUNT_B = "/mnt/nfs_b"
+EXPORT_NAME = "/export_0"
+FS_NAME = "cephfs"
+NFS_VERSION = "4"
+
+# Cluster sizing
+NFS_DAEMON_COUNT = 2
+MIN_NFS_NODES = 4
+HEALTH_CHECK_INTERVAL = "5m"
+
+# Background IO — long enough to outlive failover + IO-resume wait
+BG_IO_RUNTIME = 900
+DD_RUNTIME = BG_IO_RUNTIME
+FIO_RUNTIME = BG_IO_RUNTIME
+IO_BLOCK_SIZE = "4M"
+DD_BS = IO_BLOCK_SIZE
+FIO_BS = IO_BLOCK_SIZE
+DD_COUNT = 16
+FIO_SIZE = "256M"
+FIO_IODEPTH = 4
+FIO_JOB_PREFIX = "nfs_ma"
+
+# IO wait aliases (failover / colocation / daemon_disruption tests)
+BG_IO_RESUME_TIMEOUT = IO_RESUME_TIMEOUT
+BG_IO_JOIN_TIMEOUT = IO_JOIN_TIMEOUT
+
+
+def log_section(logger, title):
+    logger.info("\n" + "*" * 70 + "  %s\n", title)
+
+
+# Service ID prefixes per suite module
+SERVICE_ID_PREFIX = {
+    "functional": "cephfs-nfs",
+    "failover": "cephfs-nfs",
+    "colocation": "cephfs-nfs-coloc",
+    "integration": "cephfs-nfs",
+    "negative": "cephfs-nfs-neg",
+    "daemon_disruption": "cephfs-nfs",
+}
+
+# QoS defaults (integration TC-2 / TC-4 colocation)
+DEFAULT_EXPORT_BW = {"max_export_combined_bw": "8MB"}
+DEFAULT_CLUSTER_BW = {"max_export_combined_bw": "100MB"}
+DEFAULT_CLIENT_BW = {"max_client_combined_bw": "8MB"}
+DEFAULT_TC4_CLUSTER_BW = {
+    "max_client_combined_bw": "100MB",
+    "max_export_combined_bw": "100MB",
+}
+DEFAULT_QOS_TYPE = "PerShare"
+DEFAULT_TC4_QOS_TYPE = "PerShare_PerClient"
+DEFAULT_QOS_OPERATION = "bandwidth_control"
+QOS_BLOCK_POLL_TIMEOUT = 30
+QOS_BLOCK_POLL_INTERVAL = 2
+QOS_SETTLE_SEC = 10
+QOS_BW_KEYS = (
+    "max_export_write_bw",
+    "max_export_read_bw",
+    "max_export_combined_bw",
+    "max_export_iops",
+    "max_client_write_bw",
+    "max_client_read_bw",
+    "max_client_combined_bw",
+    "max_client_iops",
+)
+DEFAULT_TC4_FIO_PARAMS = {
+    "bs": "1M",
+    "iodepth": 1,
+    "numjobs": 1,
+    "runtime": 15,
+    "size": FIO_SIZE,
+}
+
+# Integration workflow presets
+INTEGRATION_PORTS = (17792, 17892, 17992)
+TC4_NFS_COUNT = 4
+TC4_COLOCATION = {
+    "port": 18692,
+    "monitoring_port": 19692,
+    "colocation_ports": [
+        {"data_port": 18792, "monitoring_port": 19792, "cluster_qos_port": 32711},
+        {"data_port": 18892, "monitoring_port": 19892, "cluster_qos_port": 33711},
+        {"data_port": 18992, "monitoring_port": 19992, "cluster_qos_port": 34711},
+    ],
+}
+TC4_INGRESS_PORTS = (18801, 18901)
+TC4_LABELS = {"nfs": "nfs-ma-int-tc4-nfs", "ingress": "nfs-ma-int-tc4-ingress"}
+DEFAULT_TC3_REDEPLOY_WAIT = 10
+DEFAULT_TC3_DELEGATION_HOLD_SEC = 300
+DEFAULT_TC3_DELEGATION_HOLD_READY_SEC = 8
+DEFAULT_TC3_DELEGATION_RELEASE_WAIT_SEC = 8

--- a/tests/nfs/lib/multi_active/daemon_disruption.py
+++ b/tests/nfs/lib/multi_active/daemon_disruption.py
@@ -1,0 +1,239 @@
+"""Helpers for NFS multi-active per-daemon restart and stop/start."""
+
+from datetime import datetime
+
+from ceph.waiter import WaitUntil
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active.validation import NfsMultiActiveValidation
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveDaemonDisruption:
+    @staticmethod
+    def _service_name(nfs_service_id, component):
+        if component == "nfs":
+            return f"nfs.{nfs_service_id}"
+        return f"ingress.nfs.{nfs_service_id}"
+
+    @staticmethod
+    def _daemon_name(daemon):
+        name = daemon.get("daemon_name") or daemon.get("name")
+        if name:
+            return name
+        raise OperationFailedError(f"No daemon name in orch ps record: {daemon!r}")
+
+    @staticmethod
+    def _parse_orch_timestamp(value):
+        if not value:
+            return None
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+    @staticmethod
+    def _find_daemon_record(
+        validator, nfs_service_id, hostname, component, daemon_name=None
+    ):
+        service = NfsMultiActiveDaemonDisruption._service_name(
+            nfs_service_id, component
+        )
+        for daemon in validator.get_orch_ps_daemons(service):
+            if daemon.get("hostname") != hostname:
+                continue
+            if NfsMultiActiveValidation.daemon_component(daemon) != component:
+                continue
+            name = daemon.get("daemon_name") or daemon.get("name")
+            if daemon_name and name != daemon_name:
+                continue
+            if name:
+                return daemon
+        raise OperationFailedError(
+            f"No {component!r} daemon on {hostname!r} for {service}"
+        )
+
+    @staticmethod
+    def stop(client, validator, nfs_service_id, hostname, component):
+        daemon_name = NfsMultiActiveDaemonDisruption._daemon_name(
+            NfsMultiActiveDaemonDisruption._find_daemon_record(
+                validator, nfs_service_id, hostname, component
+            )
+        )
+        log.info(
+            "Daemon disruption: stop %s on %s (%s)",
+            component,
+            hostname,
+            daemon_name,
+        )
+        client.exec_command(
+            sudo=True, cmd=f"ceph orch daemon stop {daemon_name} --force"
+        )
+        return daemon_name
+
+    @staticmethod
+    def start(client, daemon_name, hostname, component):
+        log.info(
+            "Daemon disruption: start %s on %s (%s)",
+            component,
+            hostname,
+            daemon_name,
+        )
+        client.exec_command(
+            sudo=True, cmd=f"ceph orch daemon start {daemon_name} --force"
+        )
+
+    @staticmethod
+    def _is_daemon_stopped(daemon):
+        status_desc = str(daemon.get("status_desc", "")).strip().lower()
+        if status_desc == "stopped":
+            return True
+        if daemon.get("status") == 0 and status_desc != "running":
+            return True
+        return False
+
+    @staticmethod
+    def wait_stopped(
+        validator,
+        nfs_service_id,
+        hostname,
+        component,
+        daemon_name=None,
+        timeout=300,
+    ):
+        """Wait until orch ps reports the target daemon as stopped."""
+        last_status = None
+        last_user_stopped = None
+        for _ in WaitUntil(timeout=timeout, interval=10):
+            daemon = NfsMultiActiveDaemonDisruption._find_daemon_record(
+                validator,
+                nfs_service_id,
+                hostname,
+                component,
+                daemon_name=daemon_name,
+            )
+            name = NfsMultiActiveDaemonDisruption._daemon_name(daemon)
+            last_status = daemon.get("status_desc")
+            last_user_stopped = daemon.get("user_stopped")
+            if NfsMultiActiveDaemonDisruption._is_daemon_stopped(daemon):
+                log.info(
+                    "%s daemon stopped on %s (%s, status_desc=%s, user_stopped=%s)",
+                    component,
+                    hostname,
+                    name,
+                    last_status,
+                    last_user_stopped,
+                )
+                return daemon
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {component!r} on "
+            f"{hostname!r} to reach stopped (last status={last_status!r}, "
+            f"user_stopped={last_user_stopped!r})"
+        )
+
+    @staticmethod
+    def wait_running(
+        validator,
+        nfs_service_id,
+        hostname,
+        component,
+        daemon_name=None,
+        timeout=300,
+    ):
+        last_status = None
+        for _ in WaitUntil(timeout=timeout, interval=10):
+            daemon = NfsMultiActiveDaemonDisruption._find_daemon_record(
+                validator,
+                nfs_service_id,
+                hostname,
+                component,
+                daemon_name=daemon_name,
+            )
+            name = NfsMultiActiveDaemonDisruption._daemon_name(daemon)
+            last_status = daemon.get("status_desc")
+            if str(last_status or "").strip().lower() == "running":
+                log.info(
+                    "%s daemon running on %s (%s)",
+                    component,
+                    hostname,
+                    name,
+                )
+                return daemon
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {component!r} on "
+            f"{hostname!r} to reach running (last status={last_status!r})"
+        )
+
+    @staticmethod
+    def wait_restarted(
+        validator,
+        nfs_service_id,
+        hostname,
+        component,
+        daemon_name,
+        started_before,
+        timeout=300,
+    ):
+        """Wait until orch ps shows a newer ``started`` time than before restart."""
+        started_before_ts = NfsMultiActiveDaemonDisruption._parse_orch_timestamp(
+            started_before
+        )
+        if started_before_ts is None:
+            raise ConfigError(
+                f"No orch ps started timestamp before restart for {daemon_name!r}"
+            )
+
+        last_status = None
+        last_started = started_before
+        for _ in WaitUntil(timeout=timeout, interval=10):
+            daemon = NfsMultiActiveDaemonDisruption._find_daemon_record(
+                validator,
+                nfs_service_id,
+                hostname,
+                component,
+                daemon_name=daemon_name,
+            )
+            last_status = daemon.get("status_desc")
+            last_started = daemon.get("started")
+            started_ts = NfsMultiActiveDaemonDisruption._parse_orch_timestamp(
+                last_started
+            )
+            if str(last_status or "").strip().lower() != "running":
+                continue
+            if started_ts and started_ts > started_before_ts:
+                log.info(
+                    "%s daemon restarted on %s (%s); started %s -> %s",
+                    component,
+                    hostname,
+                    daemon_name,
+                    started_before,
+                    last_started,
+                )
+                return daemon
+
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {component!r} on "
+            f"{hostname!r} to restart (last status={last_status!r}, "
+            f"started={last_started!r}, started_before={started_before!r})"
+        )
+
+    @staticmethod
+    def apply(client, validator, nfs_service_id, hostname, component, action):
+        if action != "restart":
+            raise ConfigError(f"Unsupported daemon action {action!r}")
+
+        daemon = NfsMultiActiveDaemonDisruption._find_daemon_record(
+            validator, nfs_service_id, hostname, component
+        )
+        daemon_name = NfsMultiActiveDaemonDisruption._daemon_name(daemon)
+        started_before = daemon.get("started")
+        log.info(
+            "Daemon disruption: %s %s on %s (%s, started=%s)",
+            action,
+            component,
+            hostname,
+            daemon_name,
+            started_before,
+        )
+        client.exec_command(
+            sudo=True, cmd=f"ceph orch daemon restart {daemon_name} --force"
+        )
+        return daemon_name, started_before

--- a/tests/nfs/lib/multi_active/delegation.py
+++ b/tests/nfs/lib/multi_active/delegation.py
@@ -1,0 +1,298 @@
+"""NFS Multi-Active helpers for NFSv4 delegation tests."""
+
+import json
+import time
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError
+from tests.nfs.lib.multi_active.constants import (
+    DEFAULT_TC3_DELEGATION_HOLD_READY_SEC,
+    DEFAULT_TC3_DELEGATION_HOLD_SEC,
+    DEFAULT_TC3_REDEPLOY_WAIT,
+    DEFAULT_TC3_SERVICE_WAIT_TIMEOUT,
+    EXPORT_NAME,
+)
+from tests.nfs.nfs_delegation_operations import (
+    LOG_TEMPLATE_BACKUP_PATH,
+    _expect_export_delegation,
+    clamp_delegation_log_settle_seconds,
+    enable_ganesha_debug_logging,
+    ensure_ceph_conf_and_admin_keyring_on_hosts,
+    hold_delegation_open,
+    parse_nfs4_open_delegation_types,
+    read_ganesha_delegation_tailf_capture,
+    redeploy_nfs_clusters,
+    restore_ganesha_template,
+    start_ganesha_delegation_tailf_follow,
+    stop_ganesha_delegation_tailf_follow,
+    truncate_ganesha_container_log,
+    update_export_delegation,
+    validate_delegation_ganesha_window,
+    wait_for_delegation_path,
+    write_delegation_file,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveDelegation:
+    """Bridge multi-active sessions to nfs_delegation_operations helpers."""
+
+    @staticmethod
+    def _installer(ceph_cluster):
+        installers = ceph_cluster.get_nodes("installer")
+        if not installers:
+            raise OperationFailedError("Delegation tests require an installer node")
+        return installers[0]
+
+    @staticmethod
+    def _redeploy_clusters(
+        cephadm, cluster_ids, installer, redeploy_wait, service_wait_timeout
+    ):
+        redeploy_nfs_clusters(
+            cephadm,
+            cluster_ids,
+            installer,
+            redeploy_wait,
+            service_wait_timeout,
+        )
+
+    @staticmethod
+    def _export_delegation(
+        nfs_cmd_host, nfs_service_id, export_name, mode, *, update=False
+    ):
+        if update:
+            update_export_delegation(nfs_cmd_host, nfs_service_id, export_name, mode)
+        _expect_export_delegation(nfs_cmd_host, nfs_service_id, export_name, mode)
+
+    @staticmethod
+    def prepare_nfs_hosts(ceph_cluster, nfs_nodes):
+        ensure_ceph_conf_and_admin_keyring_on_hosts(
+            NfsMultiActiveDelegation._installer(ceph_cluster), nfs_nodes
+        )
+
+    @staticmethod
+    def enable_ganesha_debug_logging_for_clusters(
+        nfs_cmd_host,
+        ceph_cluster,
+        cluster_ids,
+        redeploy_wait=DEFAULT_TC3_REDEPLOY_WAIT,
+        service_wait_timeout=DEFAULT_TC3_SERVICE_WAIT_TIMEOUT,
+    ):
+        """Enable Ganesha FULL_DEBUG logging and redeploy the given NFS clusters."""
+        installer = NfsMultiActiveDelegation._installer(ceph_cluster)
+        cephadm = CephAdm(installer).ceph
+        logging_backup = enable_ganesha_debug_logging(nfs_cmd_host)
+        log.info(
+            "Enabled Ganesha FULL_DEBUG logging; redeploying %s",
+            ", ".join(cluster_ids),
+        )
+        NfsMultiActiveDelegation._redeploy_clusters(
+            cephadm, cluster_ids, installer, redeploy_wait, service_wait_timeout
+        )
+        return logging_backup, cephadm, installer
+
+    @staticmethod
+    def enable_rw_export(nfs_cmd_host, nfs_service_id, export_name=EXPORT_NAME):
+        NfsMultiActiveDelegation._export_delegation(
+            nfs_cmd_host, nfs_service_id, export_name, "rw", update=True
+        )
+        log.info(
+            "Export %s on %s has delegations=rw",
+            export_name,
+            nfs_service_id,
+        )
+
+    @staticmethod
+    def assert_export_delegation(nfs_cmd_host, nfs_service_id, export_name, mode="rw"):
+        NfsMultiActiveDelegation._export_delegation(
+            nfs_cmd_host, nfs_service_id, export_name, mode
+        )
+
+    @staticmethod
+    def restore_ganesha_debug_logging(
+        nfs_cmd_host,
+        cephadm,
+        installer,
+        cluster_ids,
+        logging_template_backup,
+        redeploy_wait=DEFAULT_TC3_REDEPLOY_WAIT,
+        service_wait_timeout=DEFAULT_TC3_SERVICE_WAIT_TIMEOUT,
+    ):
+        if not logging_template_backup:
+            return
+        restore_ganesha_template(
+            nfs_cmd_host, logging_template_backup, LOG_TEMPLATE_BACKUP_PATH
+        )
+        NfsMultiActiveDelegation._redeploy_clusters(
+            cephadm, cluster_ids, installer, redeploy_wait, service_wait_timeout
+        )
+
+    @staticmethod
+    def assert_cluster_services_running(client, nfs_service_id, label):
+        """Return when nfs and ingress daemons for *nfs_service_id* are running."""
+        for service in (f"nfs.{nfs_service_id}", f"ingress.nfs.{nfs_service_id}"):
+            raw, _ = client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch ps --service_name {service} --format json",
+                check_ec=False,
+            )
+            daemons = json.loads(raw) if raw else []
+            running = [d for d in daemons if d.get("status_desc") == "running"]
+            if not running:
+                raise OperationFailedError(
+                    f"{label}: no running daemons for {service} ({daemons!r})"
+                )
+            log.info(
+                "%s: %d running daemon(s) for %s",
+                label,
+                len(running),
+                service,
+            )
+
+    @staticmethod
+    def hold_rw_delegation_on_mount(
+        client,
+        mount_point,
+        rel_path,
+        hold_seconds=DEFAULT_TC3_DELEGATION_HOLD_SEC,
+        hold_ready_seconds=DEFAULT_TC3_DELEGATION_HOLD_READY_SEC,
+    ):
+        """Seed a file on *mount_point* and keep it OPEN to hold an RW delegation."""
+        parent = "/".join(rel_path.split("/")[:-1])
+        if parent:
+            client.exec_command(
+                sudo=True,
+                cmd=f"mkdir -p {mount_point}/{parent}",
+            )
+        path = f"{mount_point}/{rel_path}"
+        seed = f"hold-seed-{getattr(client, 'hostname', 'client')}\n"
+        write_delegation_file(client, path, seed)
+        wait_for_delegation_path(client, path, "delegation hold seed")
+        write_delegation_file(client, path, "hold-prime\n", append=True)
+        hold_delegation_open(client, path, "r+b", int(hold_seconds))
+        if hold_ready_seconds > 0:
+            time.sleep(int(hold_ready_seconds))
+        log.info("RW delegation hold active on %s for %ss", path, hold_seconds)
+        return path, seed
+
+    @staticmethod
+    def assert_delegation_access_after_failover(client_a, client_b, path, seed_marker):
+        """Verify both clients can read a held file via the existing VIP mount."""
+        for client, label in ((client_a, "A"), (client_b, "B")):
+            out, _ = client.exec_command(
+                sudo=True,
+                cmd=f"cat {path}",
+                check_ec=False,
+            )
+            if int(getattr(client, "exit_status", 1)) != 0:
+                raise OperationFailedError(
+                    f"Client {label} cannot read {path} after failover "
+                    f"(ec={getattr(client, 'exit_status', '?')})"
+                )
+            if seed_marker not in (out or ""):
+                raise OperationFailedError(
+                    f"Client {label} readback missing seed on {path} after failover: "
+                    f"{out!r}"
+                )
+            log.info(
+                "Client %s read delegated file after failover (%d bytes)",
+                label,
+                len(out or ""),
+            )
+
+    @staticmethod
+    def _resolve_nfs_node(nfs_nodes, hostname):
+        for node in nfs_nodes:
+            if node.hostname == hostname:
+                return node
+        raise OperationFailedError(
+            f"No NFS node matching backend hostname {hostname!r}"
+        )
+
+    @staticmethod
+    def _ganesha_container_on_backend(installer, nfs_service_id, nfs_host_node):
+        cephadm = CephAdm(installer).ceph
+        raw = cephadm.orch.ps(service_name=f"nfs.{nfs_service_id}", format="json")
+        daemons = json.loads(raw) if raw else []
+        hostname = nfs_host_node.hostname
+        for daemon in daemons:
+            if daemon.get("hostname") == hostname and daemon.get("container_id"):
+                return daemon["container_id"]
+        raise OperationFailedError(
+            f"No Ganesha container for nfs.{nfs_service_id} on {hostname}"
+        )
+
+    @staticmethod
+    def _run_rw_delegation_client_io(client, testfile):
+        """Trigger RW delegation OPEN paths (nfs_verify_delegation_rw_none_scenarios)."""
+        client.exec_command(
+            sudo=True,
+            cmd=f"bash -c 'echo rw-deleg > {testfile} && sync'",
+        )
+        client.exec_command(
+            sudo=True,
+            cmd=f"bash -c 'echo append >> {testfile} && sync'",
+        )
+        client.exec_command(sudo=True, cmd=f"cat {testfile}")
+
+    @staticmethod
+    def assert_rw_delegation_ganesha_logs(
+        client,
+        installer,
+        nfs_service_id,
+        nfs_nodes,
+        backend_hostname,
+        mount_point,
+        config,
+        tag,
+    ):
+        """Validate export-level RW delegation via filtered Ganesha log capture."""
+        settle_seconds = clamp_delegation_log_settle_seconds(config)
+        nfs_node = NfsMultiActiveDelegation._resolve_nfs_node(
+            nfs_nodes, backend_hostname
+        )
+        container_id = NfsMultiActiveDelegation._ganesha_container_on_backend(
+            installer, nfs_service_id, nfs_node
+        )
+        testfile = f"{mount_point}/deleg_ganesha_io_{tag}.txt"
+
+        truncate_ganesha_container_log(nfs_node, container_id)
+        start_ganesha_delegation_tailf_follow(nfs_node, container_id)
+        try:
+            NfsMultiActiveDelegation._run_rw_delegation_client_io(client, testfile)
+            log.info(
+                "Waiting %ss after IO on %s for delegation lines in ganesha.log",
+                settle_seconds,
+                tag,
+            )
+            time.sleep(settle_seconds)
+        finally:
+            stop_ganesha_delegation_tailf_follow(nfs_node, container_id)
+
+        hits = read_ganesha_delegation_tailf_capture(nfs_node, container_id)
+        if not hits:
+            raise OperationFailedError(
+                f"Empty ganesha.log tail capture for {tag} (export delegations=rw)"
+            )
+        log.info(
+            "Delegation log for %s: %d tail -f capture lines",
+            tag,
+            len(hits),
+        )
+        for line in hits[-25:]:
+            log.debug("%s", line)
+
+        window_text = "\n".join(hits)
+        ok, reason = validate_delegation_ganesha_window("rw", window_text)
+        if not ok:
+            raise OperationFailedError(
+                f"Ganesha log validation failed for {tag} (delegations=rw): {reason}; "
+                f"{len(hits)} capture lines"
+            )
+        log.info(
+            "Passed %s export-level RW delegation logs; nfs4_op_open types=%s",
+            tag,
+            parse_nfs4_open_delegation_types(window_text),
+        )

--- a/tests/nfs/lib/multi_active/deploy.py
+++ b/tests/nfs/lib/multi_active/deploy.py
@@ -1,0 +1,200 @@
+"""Deploy NFS Multi-Active services via orchestrator spec."""
+
+import json
+from time import sleep
+
+import yaml
+
+from ceph.waiter import WaitUntil
+from cli.ceph.ceph import Ceph
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active.constants import log_section
+from utility.log import Log
+
+log = Log(__name__)
+from tests.nfs.lib.multi_active.validation import NfsMultiActiveValidation
+from tests.nfs.nfs_operations import create_nfs_via_file_and_verify
+
+
+class NfsMultiActiveDeploy:
+    """Deploy NFS Multi-Active services via orchestrator spec."""
+
+    def __init__(self, ceph_cluster, nfs_name, vip, client=None):
+        self.ceph_cluster = ceph_cluster
+        self.nfs_name = nfs_name
+        self.vip = vip
+        self.installer = ceph_cluster.get_nodes("installer")[0]
+        if client is None:
+            clients = ceph_cluster.get_nodes("client")
+            if not clients:
+                raise ConfigError(
+                    "At least one client node is required to enable NFS mgr module"
+                )
+            client = clients[0]
+        self.client = client
+        self.validator = NfsMultiActiveValidation(ceph_cluster, self.client)
+
+    def deploy(
+        self,
+        specs,
+        nfs_nodes,
+        deploy_timeout=300,
+        expected_ingress_hosts=None,
+        ingress_wait_targets=None,
+        cluster_validations=None,
+        colocation_validation=False,
+        skip_mgr_enable=False,
+        ingress_poll_interval=5,
+    ):
+        log_section(log, "DEPLOY NFS MULTI-ACTIVE VIA SPEC")
+        wait_targets = ingress_wait_targets or [(self.nfs_name, self.vip)]
+        log.info(
+            "Ingress VIP(s): %s",
+            ", ".join(f"{name}={vip}" for name, vip in wait_targets),
+        )
+
+        if skip_mgr_enable:
+            log.info("Skipping NFS mgr module enable (already initialized this suite)")
+        else:
+            Ceph(self.client).mgr.module.enable(module="nfs", force=True)
+            sleep(3)
+
+        spec_yaml = yaml.dump_all(
+            specs, sort_keys=False, default_flow_style=False, indent=2
+        )
+        log_section(log, "ORCHESTRATOR SPEC TO APPLY")
+        log.info("%s", spec_yaml)
+
+        if not create_nfs_via_file_and_verify(
+            self.installer,
+            specs,
+            deploy_timeout,
+            nfs_nodes=nfs_nodes,
+            cluster_nodes=self.ceph_cluster.node_list,
+        ):
+            raise OperationFailedError(
+                "Failed to deploy NFS Multi-Active services via spec"
+            )
+
+        self._wait_all_ingress(
+            wait_targets, deploy_timeout, interval=ingress_poll_interval
+        )
+
+        if cluster_validations:
+            for nfs_spec, ingress_spec, exp_ingress_hosts in cluster_validations:
+                nfs_name = nfs_spec["service_id"]
+                cluster_info = self.validator.get_cluster_info(nfs_name)
+                if colocation_validation:
+                    self.validator.assert_colocation_cluster_info(
+                        cluster_info, nfs_spec, ingress_spec
+                    )
+                    self.validator.assert_colocation_ports_listening(
+                        cluster_info, nfs_spec
+                    )
+                else:
+                    self.validator.assert_cluster_info(
+                        cluster_info, nfs_spec, ingress_spec
+                    )
+                self.validator.assert_orch_ps(
+                    nfs_spec,
+                    ingress_spec,
+                    expected_ingress_hosts=exp_ingress_hosts,
+                    timeout=deploy_timeout,
+                )
+        else:
+            nfs_spec = self._find_spec(specs, "nfs")
+            ingress_spec = self._find_spec(specs, "ingress")
+            cluster_info = self.validator.get_cluster_info(self.nfs_name)
+            if colocation_validation:
+                self.validator.assert_colocation_cluster_info(
+                    cluster_info, nfs_spec, ingress_spec
+                )
+                self.validator.assert_colocation_ports_listening(cluster_info, nfs_spec)
+            else:
+                self.validator.assert_cluster_info(cluster_info, nfs_spec, ingress_spec)
+            self.validator.assert_orch_ps(
+                nfs_spec,
+                ingress_spec,
+                expected_ingress_hosts=expected_ingress_hosts,
+                timeout=deploy_timeout,
+            )
+
+        log.info("NFS Multi-Active services deployed successfully via spec")
+
+    def reapply_specs(
+        self,
+        specs,
+        nfs_nodes,
+        deploy_timeout=300,
+        ingress_poll_interval=5,
+        timings=None,
+        timings_trigger_key=None,
+    ):
+        """Re-apply orchestrator specs after label swap (no mgr module re-enable)."""
+        log_section(log, "RE-APPLY NFS MULTI-ACTIVE SPECS")
+        spec_yaml = yaml.dump_all(
+            specs, sort_keys=False, default_flow_style=False, indent=2
+        )
+        log.info("%s", spec_yaml)
+        if not create_nfs_via_file_and_verify(
+            self.installer,
+            specs,
+            deploy_timeout,
+            nfs_nodes=nfs_nodes,
+            cluster_nodes=self.ceph_cluster.node_list,
+            timings=timings,
+            timings_key=timings_trigger_key,
+        ):
+            raise OperationFailedError(
+                "Failed to re-apply NFS Multi-Active services via spec"
+            )
+        self._wait_ingress(deploy_timeout, interval=ingress_poll_interval)
+        log.info("NFS Multi-Active specs re-applied successfully")
+
+    def _wait_ingress(self, deploy_timeout, interval=5):
+        self._wait_ingress_for(
+            self.nfs_name, self.vip, deploy_timeout, interval=interval
+        )
+
+    def _wait_all_ingress(self, wait_targets, deploy_timeout, interval=5):
+        for nfs_name, vip in wait_targets:
+            self._wait_ingress_for(nfs_name, vip, deploy_timeout, interval=interval)
+
+    def _wait_ingress_for(self, nfs_name, vip, deploy_timeout, interval=5):
+        service_name = f"ingress.nfs.{nfs_name}"
+
+        for w in WaitUntil(timeout=deploy_timeout, interval=interval):
+            services = json.loads(
+                CephAdm(self.installer).ceph.orch.ls(
+                    format="json", service_type="ingress"
+                )
+            )
+            ingress = [
+                svc for svc in services if svc.get("service_name") == service_name
+            ]
+            if not ingress:
+                continue
+
+            status = ingress[0].get("status", {})
+            if status.get("running") != status.get("size"):
+                continue
+
+            if ingress[0].get("spec", {}).get("virtual_ip") != vip:
+                raise OperationFailedError(
+                    f"Ingress VIP mismatch for {service_name}: expected {vip!r}, "
+                    f"got {ingress[0].get('spec', {}).get('virtual_ip')!r}"
+                )
+            log.info("Ingress service %s is running with VIP %s", service_name, vip)
+            return
+
+        raise OperationFailedError(
+            f"Ingress service {service_name} not running within {deploy_timeout}s"
+        )
+
+    @staticmethod
+    def _find_spec(specs, service_type):
+        for spec in specs:
+            if spec.get("service_type") == service_type:
+                return spec
+        raise OperationFailedError(f"No {service_type!r} spec found in {specs!r}")

--- a/tests/nfs/lib/multi_active/export_restriction.py
+++ b/tests/nfs/lib/multi_active/export_restriction.py
@@ -1,0 +1,847 @@
+"""IP-based NFS export restrictions with HAProxy protocol in multi-active HA."""
+
+from datetime import datetime
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active.cleanup import NfsMultiActiveCleanup
+from tests.nfs.lib.multi_active.client import NfsMultiActiveClient
+from tests.nfs.lib.multi_active.config import NfsMultiActiveConfig
+from tests.nfs.lib.multi_active.constants import (
+    DEPLOY_TIMEOUT,
+    FS_NAME,
+    HEALTH_CHECK_INTERVAL,
+    IO_JOIN_TIMEOUT,
+    IO_RESUME_TIMEOUT,
+    IO_WARMUP_SEC,
+    NFS_VERSION,
+    log_section,
+)
+from tests.nfs.lib.multi_active.deploy import NfsMultiActiveDeploy
+from tests.nfs.lib.multi_active.failover import NfsMultiActiveFailover
+from tests.nfs.lib.multi_active.haproxy import NfsMultiActiveHaproxy
+from tests.nfs.lib.multi_active.placement import (
+    NEGATIVE_PLACEMENT,
+    resolve_placement_hosts,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+_MOUNT_DENIED_MARKERS = (
+    "no such file or directory",
+    "access denied",
+    "permission denied",
+    "operation not permitted",
+    "not permitted",
+    "mount.nfs:",
+)
+
+NEG4_EXPORT_NAME = "/export_ip_restrict"
+NEG4_AUTH_MOUNT = "/mnt/nfs_neg_auth"
+NEG4_UNAUTH_MOUNT = "/mnt/nfs_neg_unauth"
+NEG4_IO_SUBDIR = "neg4_ip_restrict_io"
+
+
+class NegExportClusterSession:
+    """Cluster state shared between NEG-4 (setup/failover) and NEG-5 (Ganesha crash)."""
+
+    def __init__(self):
+        self.ceph_cluster = None
+        self.config = None
+        self.nfs_name = None
+        self.vip = None
+        self.frontend_port = None
+        self.authorized_client = None
+        self.unauthorized_client = None
+        self.nfs_nodes = None
+        self.labels = None
+        self.deploy = None
+        self.haproxy = None
+        self.failover = None
+        self.deploy_timeout = DEPLOY_TIMEOUT
+        self.nfs_spec = None
+        self.ingress_spec = None
+        self.deploy_nodes = None
+        self.spare_host = None
+        self.ingress_hosts = None
+        self.nfs_count = None
+        self.cluster_deployed = False
+        self.export_created = False
+        self.labels_applied = False
+        self.auth_mounted = False
+        self.io_sessions = []
+        self.timings = {}
+
+    def cleanup(self):
+        if self.io_sessions:
+            try:
+                NfsMultiActiveExportRestriction.stop_background_io(
+                    self.io_sessions, NEG4_AUTH_MOUNT, self.config
+                )
+            except Exception as exc:
+                log.warning("IO session cleanup failed: %s", exc)
+            self.io_sessions = []
+        if self.auth_mounted and self.authorized_client:
+            try:
+                NfsMultiActiveExportRestriction.umount_authorized(
+                    self.authorized_client, NEG4_AUTH_MOUNT
+                )
+            except Exception as exc:
+                log.warning("Authorized client umount failed: %s", exc)
+        for client, mount_point in (
+            (self.authorized_client, NEG4_AUTH_MOUNT),
+            (self.unauthorized_client, NEG4_UNAUTH_MOUNT),
+        ):
+            if client is None:
+                continue
+            try:
+                client.exec_command(
+                    sudo=True,
+                    cmd=f"rm -rf {mount_point}",
+                    check_ec=False,
+                )
+            except Exception as exc:
+                log.warning(
+                    "Cleanup mount dir %s on %s failed: %s",
+                    mount_point,
+                    client.hostname,
+                    exc,
+                )
+        if self.export_created and self.authorized_client and self.nfs_name:
+            try:
+                Ceph(self.authorized_client).nfs.export.delete(
+                    self.nfs_name, NEG4_EXPORT_NAME
+                )
+            except Exception as exc:
+                log.warning("Export delete failed: %s", exc)
+        if self.cluster_deployed and self.ceph_cluster and self.nfs_name:
+            try:
+                NfsMultiActiveCleanup(self.ceph_cluster).remove_cluster(self.nfs_name)
+            except Exception as exc:
+                log.warning("Cluster cleanup failed: %s", exc)
+        if (
+            self.labels_applied
+            and self.authorized_client
+            and self.nfs_nodes
+            and self.labels
+        ):
+            try:
+                NfsMultiActiveConfig.clear_placement_labels(
+                    self.authorized_client,
+                    self.nfs_nodes,
+                    self.labels,
+                )
+            except Exception as exc:
+                log.warning("Placement label cleanup failed: %s", exc)
+
+
+def _now():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+class NfsMultiActiveExportRestriction:
+    """Validate IP-based export client restrictions over ingress VIP + HAProxy protocol."""
+
+    @staticmethod
+    def assert_haproxy_protocol_enabled(validator, nfs_spec, ingress_spec):
+        cluster_info = validator.get_cluster_info(nfs_spec["service_id"])
+        validator.assert_cluster_info(cluster_info, nfs_spec, ingress_spec)
+        mode = cluster_info.get("ingress_mode")
+        if mode != "haproxy-protocol":
+            raise OperationFailedError(
+                f"Expected ingress mode haproxy-protocol, got {mode!r}"
+            )
+        log.info("Ingress mode confirmed: haproxy-protocol")
+
+    @staticmethod
+    def assert_export_restricts_client_ip(client, nfs_name, export_name, client_ip):
+        raw = Ceph(client).nfs.export.get(nfs_name, export_name)
+        if client_ip not in (raw or ""):
+            raise OperationFailedError(
+                f"Export {export_name!r} does not list restricted client IP "
+                f"{client_ip!r}:\n{raw}"
+            )
+        log.info(
+            "Export %s restricts client IP %s as expected",
+            export_name,
+            client_ip,
+        )
+
+    @staticmethod
+    def mount_authorized_via_vip(
+        client, vip, mount_point, export_name, port, version=NFS_VERSION
+    ):
+        NfsMultiActiveClient.mount_via_vip(
+            client,
+            vip,
+            mount_point,
+            export_name,
+            str(port),
+            version,
+        )
+        log.info(
+            "Authorized client %s mounted %s via VIP %s",
+            client.hostname,
+            export_name,
+            vip,
+        )
+
+    @staticmethod
+    def assert_mount_via_vip_denied(
+        client, vip, mount_point, export_name, port, version=NFS_VERSION
+    ):
+        mount_server = vip.split("/")[0]
+        client.create_dirs(dir_path=mount_point, sudo=True)
+        cmd = (
+            f"mount -t nfs -o vers={version},port={port} "
+            f"{mount_server}:{export_name} {mount_point}"
+        )
+        out, err = client.exec_command(cmd=cmd, sudo=True, check_ec=False)
+        combined = f"{out or ''}\n{err or ''}"
+        mp_out, mp_err = client.exec_command(
+            sudo=True,
+            cmd=f"mountpoint {mount_point}",
+            check_ec=False,
+        )
+        if "is a mountpoint" in f"{mp_out or ''}{mp_err or ''}".lower():
+            raise OperationFailedError(
+                f"Unauthorized client {client.hostname} mounted "
+                f"{export_name} via VIP {vip}"
+            )
+        if not any(marker in combined.lower() for marker in _MOUNT_DENIED_MARKERS):
+            raise OperationFailedError(
+                f"Expected unauthorized mount denial on {client.hostname}, got:\n"
+                f"{combined}"
+            )
+        log.info(
+            "Unauthorized client %s denied mount to %s via VIP %s",
+            client.hostname,
+            export_name,
+            vip,
+        )
+
+    @staticmethod
+    def run_sync_io(authorized_client, mount_point, phase_label):
+        log_section(log, f"NEG-4 SYNC IO — {phase_label}")
+        NfsMultiActiveClient.run_basic_io(
+            authorized_client,
+            authorized_client,
+            mount_point,
+            file_count=2,
+            io_subdir=f"neg4_sync_{phase_label.replace(' ', '_')}",
+        )
+        log.info("Sync IO completed for %s", phase_label)
+
+    @staticmethod
+    def start_background_io(authorized_client, mount_point, config):
+        runtime = NfsMultiActiveConfig.io_runtime(config)
+        thread, error_box, io_dir = NfsMultiActiveClient.run_background_io(
+            authorized_client,
+            mount_point,
+            config,
+            io_subdir=NEG4_IO_SUBDIR,
+            runtime=runtime,
+        )
+        warmup = int(config.get("neg4_io_start_delay", IO_WARMUP_SEC))
+        if warmup > 0:
+            log.info("Background IO warmup %ss before failover", warmup)
+            sleep(warmup)
+        if error_box.get("exc"):
+            raise OperationFailedError(
+                f"Background IO failed during warmup on "
+                f"{authorized_client.hostname}: {error_box['exc']}"
+            )
+        if not thread.is_alive():
+            raise OperationFailedError(
+                f"Background IO stopped during warmup on {authorized_client.hostname}"
+            )
+        return [(authorized_client, thread, error_box, io_dir)]
+
+    @staticmethod
+    def wait_io_resume(io_sessions, mount_point, config, timings, trigger_key, stage):
+        if not io_sessions:
+            raise OperationFailedError(f"No IO sessions to resume-check for {stage}")
+        active = [session for session in io_sessions if session[1].is_alive()]
+        if not active:
+            raise OperationFailedError(
+                f"Background IO already stopped before {stage} resume check"
+            )
+        log_section(log, f"NEG-4 WAIT IO RESUME — {stage}")
+        NfsMultiActiveClient.wait_for_background_io_resume(
+            active,
+            mount_point,
+            config,
+            timeout=int(config.get("io_resume_timeout", IO_RESUME_TIMEOUT)),
+            timings=timings,
+            triggered_at=timings.get(trigger_key),
+        )
+        log.info("Background IO resumed after %s", stage)
+
+    @staticmethod
+    def stop_background_io(io_sessions, mount_point, config):
+        for client, thread, error_box, io_dir in io_sessions:
+            if thread.is_alive():
+                NfsMultiActiveClient.stop_background_io(
+                    client, io_dir, config, error_box=error_box
+                )
+            thread.join(timeout=IO_JOIN_TIMEOUT)
+            if thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO on {client.hostname} did not stop within "
+                    f"{IO_JOIN_TIMEOUT}s"
+                )
+            if error_box.get("exc") and not error_box.get("stopped"):
+                raise OperationFailedError(
+                    f"Background IO failed on {client.hostname}: {error_box['exc']}"
+                )
+        log.info("Background IO stopped on %s", mount_point)
+
+    @staticmethod
+    def umount_authorized(client, mount_point):
+        err = NfsMultiActiveClient._umount_lazy_then_force(client, mount_point)
+        if err:
+            raise OperationFailedError(
+                f"Failed to unmount {mount_point} on {client.hostname}: {err.strip()}"
+            )
+        log.info("Unmounted %s on %s", mount_point, client.hostname)
+
+    @classmethod
+    def verify_ip_restrictions(
+        cls,
+        nfs_name,
+        vip,
+        export_name,
+        frontend_port,
+        authorized_client,
+        unauthorized_client,
+        phase_label,
+        *,
+        mount_authorized=True,
+    ):
+        auth_ip = NfsMultiActiveClient.client_mount_ip(authorized_client)
+        log_section(log, f"NEG-4 IP RESTRICTION CHECK — {phase_label}")
+        log.info(
+            "%s: authorized=%s (%s) unauthorized=%s (%s)",
+            phase_label,
+            authorized_client.hostname,
+            auth_ip,
+            unauthorized_client.hostname,
+            NfsMultiActiveClient.client_mount_ip(unauthorized_client),
+        )
+        cls.assert_export_restricts_client_ip(
+            authorized_client, nfs_name, export_name, auth_ip
+        )
+        cls.assert_mount_via_vip_denied(
+            unauthorized_client,
+            vip,
+            NEG4_UNAUTH_MOUNT,
+            export_name,
+            frontend_port,
+        )
+        if mount_authorized:
+            cls.mount_authorized_via_vip(
+                authorized_client,
+                vip,
+                NEG4_AUTH_MOUNT,
+                export_name,
+                frontend_port,
+            )
+
+    @classmethod
+    def remount_run_io_and_verify_restrictions(
+        cls,
+        nfs_name,
+        vip,
+        export_name,
+        frontend_port,
+        authorized_client,
+        unauthorized_client,
+        config,
+        phase_label,
+    ):
+        cls.umount_authorized(authorized_client, NEG4_AUTH_MOUNT)
+        cls.verify_ip_restrictions(
+            nfs_name,
+            vip,
+            export_name,
+            frontend_port,
+            authorized_client,
+            unauthorized_client,
+            phase_label,
+            mount_authorized=True,
+        )
+        cls.run_sync_io(authorized_client, NEG4_AUTH_MOUNT, phase_label)
+        return cls.start_background_io(authorized_client, NEG4_AUTH_MOUNT, config)
+
+    @classmethod
+    def _failover_ingress_with_io(
+        cls,
+        failover,
+        authorized_client,
+        deploy,
+        ingress_spec,
+        nfs_name,
+        deploy_nodes,
+        vip_holder,
+        spare_host,
+        ingress_label,
+        ingress_hosts,
+        config,
+        io_sessions,
+        timings,
+        deploy_timeout,
+        case_id,
+    ):
+        log_section(log, f"{case_id} INGRESS FAILOVER WITH BACKGROUND IO")
+        timings["ingress_failover_triggered_at"] = _now()
+
+        def _wait_io_after_ingress():
+            cls.wait_io_resume(
+                io_sessions,
+                NEG4_AUTH_MOUNT,
+                config,
+                timings,
+                "ingress_failover_triggered_at",
+                "ingress failover",
+            )
+
+        failover.failover_ingress_by_label(
+            authorized_client,
+            deploy,
+            ingress_spec,
+            nfs_name,
+            deploy_nodes,
+            vip_holder,
+            spare_host,
+            ingress_label,
+            expected_ingress_count=len(ingress_hosts),
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            timings_trigger_key="ingress_failover_triggered_at",
+            post_apply_callback=_wait_io_after_ingress,
+        )
+        new_vip_holder = failover.get_active_ingress_host(
+            deploy.ceph_cluster, deploy.vip, ingress_hosts
+        )
+        if new_vip_holder == vip_holder:
+            raise OperationFailedError(
+                f"Ingress failover did not move VIP {deploy.vip!r} off {vip_holder!r}"
+            )
+        log.info(
+            "Ingress VIP %s moved from %s to %s",
+            deploy.vip,
+            vip_holder,
+            new_vip_holder,
+        )
+
+    @classmethod
+    def _failover_nfs_with_io(
+        cls,
+        failover,
+        haproxy,
+        authorized_client,
+        deploy,
+        nfs_spec,
+        deploy_nodes,
+        spare_host,
+        nfs_label,
+        nfs_count,
+        config,
+        io_sessions,
+        timings,
+        deploy_timeout,
+        case_id,
+    ):
+        pinned_nfs = haproxy.get_client_backend_hostname(authorized_client)
+        log_section(log, f"{case_id} NFS FAILOVER WITH BACKGROUND IO")
+        log.info(
+            "NFS failover target from stick table: drain %s -> %s",
+            pinned_nfs,
+            spare_host,
+        )
+        timings["nfs_failover_triggered_at"] = _now()
+
+        def _wait_io_after_nfs():
+            cls.wait_io_resume(
+                io_sessions,
+                NEG4_AUTH_MOUNT,
+                config,
+                timings,
+                "nfs_failover_triggered_at",
+                "NFS failover",
+            )
+
+        failover.failover_nfs_by_label(
+            authorized_client,
+            deploy,
+            nfs_spec,
+            deploy_nodes,
+            pinned_nfs,
+            spare_host,
+            nfs_label,
+            nfs_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            timings_trigger_key="nfs_failover_triggered_at",
+            post_apply_callback=_wait_io_after_nfs,
+        )
+
+    @classmethod
+    def _crash_ganesha_with_io(
+        cls,
+        failover,
+        haproxy,
+        authorized_client,
+        deploy,
+        nfs_name,
+        config,
+        io_sessions,
+        timings,
+        deploy_timeout,
+        case_id,
+    ):
+        pinned_nfs = haproxy.get_client_backend_hostname(authorized_client)
+        nfs_host_node = failover._node_by_hostname(deploy.ceph_cluster, pinned_nfs)
+        ganesha_pid = failover.get_ganesha_host_pid(
+            deploy.validator,
+            nfs_name,
+            pinned_nfs,
+            nfs_host_node,
+        )
+        log_section(log, f"{case_id} GANESHA CRASH (kill -9) WITH BACKGROUND IO")
+        log.info(
+            "Crashing ganesha on pinned NFS backend %s (PID %s)",
+            pinned_nfs,
+            ganesha_pid,
+        )
+        timings["ganesha_crash_triggered_at"] = _now()
+        failover.crash_ganesha_process(nfs_host_node, ganesha_pid, pinned_nfs)
+        cls.wait_io_resume(
+            io_sessions,
+            NEG4_AUTH_MOUNT,
+            config,
+            timings,
+            "ganesha_crash_triggered_at",
+            "Ganesha crash",
+        )
+        failover.wait_nfs_daemon_on_host(
+            deploy.validator,
+            nfs_name,
+            pinned_nfs,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+        new_pid = failover.get_ganesha_host_pid(
+            deploy.validator,
+            nfs_name,
+            pinned_nfs,
+            nfs_host_node,
+        )
+        if new_pid == ganesha_pid:
+            raise OperationFailedError(
+                f"Ganesha PID on {pinned_nfs!r} unchanged after SIGKILL ({ganesha_pid})"
+            )
+        log.info(
+            "Ganesha restarted on %s (old PID %s, new PID %s)",
+            pinned_nfs,
+            ganesha_pid,
+            new_pid,
+        )
+
+    @classmethod
+    def bootstrap_neg_export_session(
+        cls, ceph_cluster, config, case_id, workflow_key=None
+    ):
+        """Deploy HA cluster, IP-restricted export, mount, and start background IO."""
+        session = NegExportClusterSession()
+        session.ceph_cluster = ceph_cluster
+        session.config = config
+        clients = ceph_cluster.get_nodes("client")
+        nfs_nodes = NfsMultiActiveConfig.sorted_nfs_nodes(ceph_cluster)
+        if len(clients) < 2:
+            raise ConfigError(
+                f"{case_id} requires at least 2 client nodes for IP restriction validation"
+            )
+        placement = NEGATIVE_PLACEMENT
+        (
+            nfs_hosts,
+            ingress_hosts,
+            deploy_nodes,
+            nfs_count,
+            labels,
+            spare_host,
+        ) = resolve_placement_hosts(nfs_nodes, placement, config)
+
+        authorized_client, unauthorized_client = clients[0], clients[1]
+        session.authorized_client = authorized_client
+        session.unauthorized_client = unauthorized_client
+        session.nfs_nodes = nfs_nodes
+        session.spare_host = spare_host
+        session.ingress_hosts = ingress_hosts
+        session.deploy_nodes = deploy_nodes
+        session.labels = labels
+        session.nfs_count = nfs_count
+        nfs_slice = placement["nfs"]
+        ingress_slice = placement["ingress"]
+        log.info(
+            "%s placement: nfs=%s ingress=%s spare=%s",
+            case_id,
+            nfs_hosts,
+            ingress_hosts,
+            spare_host,
+        )
+        workflow_key = workflow_key or config.get(
+            "neg4_workflow_key", "neg4_ip_export_restriction"
+        )
+        frontend_port = int(config.get("neg4_frontend_port", 17801))
+        monitor_port = int(config.get("neg4_monitor_port", 17901))
+        backend_port = int(config.get("neg4_backend_port", 17781))
+        deploy_timeout = int(config.get("deploy_timeout", DEPLOY_TIMEOUT))
+        session.deploy_timeout = deploy_timeout
+        vip = NfsMultiActiveConfig.get_vips(config)[0]
+        session.vip = vip
+        session.frontend_port = frontend_port
+        nfs_name = (
+            f"cephfs-nfs-neg-{workflow_key}-"
+            f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+        )
+        session.nfs_name = nfs_name
+        auth_ip = NfsMultiActiveClient.client_mount_ip(authorized_client)
+
+        nfs_spec = NfsMultiActiveConfig.build_nfs_spec(
+            nfs_hosts, nfs_count, nfs_name, backend_port, label=labels["nfs"]
+        )
+        ingress_spec = NfsMultiActiveConfig.build_ingress_spec(
+            vip,
+            nfs_name,
+            frontend_port,
+            monitor_port,
+            config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+            label=labels["ingress"],
+        )
+        session.nfs_spec = nfs_spec
+        session.ingress_spec = ingress_spec
+        deploy = NfsMultiActiveDeploy(
+            ceph_cluster, nfs_name, vip, client=authorized_client
+        )
+        session.deploy = deploy
+        session.failover = NfsMultiActiveFailover()
+
+        log_section(log, f"{case_id} DEPLOY NFS MULTI-ACTIVE FOR IP RESTRICTIONS")
+        NfsMultiActiveConfig.clear_placement_labels(
+            authorized_client,
+            nfs_nodes,
+            labels,
+        )
+        NfsMultiActiveConfig.apply_placement_labels(
+            authorized_client,
+            nfs_nodes,
+            nfs_slice,
+            ingress_slice,
+            labels,
+        )
+        session.labels_applied = True
+        deploy.deploy(
+            [nfs_spec, ingress_spec],
+            deploy_nodes,
+            deploy_timeout=deploy_timeout,
+            expected_ingress_hosts=ingress_hosts,
+            skip_mgr_enable=False,
+        )
+        session.cluster_deployed = True
+        session.haproxy = NfsMultiActiveHaproxy(
+            ceph_cluster, nfs_name, info_client=authorized_client
+        )
+        cls.assert_haproxy_protocol_enabled(deploy.validator, nfs_spec, ingress_spec)
+
+        Ceph(authorized_client).nfs.export.create(
+            fs_name=FS_NAME,
+            nfs_name=nfs_name,
+            nfs_export=NEG4_EXPORT_NAME,
+            fs=FS_NAME,
+            client_addr=auth_ip,
+        )
+        NfsMultiActiveConfig.wait_until_export_visible(
+            authorized_client,
+            nfs_name,
+            NEG4_EXPORT_NAME,
+        )
+        session.export_created = True
+
+        cls.verify_ip_restrictions(
+            nfs_name,
+            vip,
+            NEG4_EXPORT_NAME,
+            frontend_port,
+            authorized_client,
+            unauthorized_client,
+            "initial mount",
+            mount_authorized=True,
+        )
+        session.auth_mounted = True
+        cls.run_sync_io(authorized_client, NEG4_AUTH_MOUNT, "initial mount")
+        session.io_sessions = cls.start_background_io(
+            authorized_client, NEG4_AUTH_MOUNT, config
+        )
+        return session
+
+    @classmethod
+    def run_neg4_ip_export_restriction_haproxy_failover(
+        cls, ceph_cluster, config, case_id
+    ):
+        """Deploy HA ingress, verify IP restrictions, ingress/NFS failover; leave session."""
+        session = cls.bootstrap_neg_export_session(ceph_cluster, config, case_id)
+        failover = session.failover
+        deploy = session.deploy
+        timings = session.timings
+        authorized_client = session.authorized_client
+        unauthorized_client = session.unauthorized_client
+        nfs_name = session.nfs_name
+        vip = session.vip
+        frontend_port = session.frontend_port
+        nfs_spec = session.nfs_spec
+        ingress_spec = session.ingress_spec
+        deploy_nodes = session.deploy_nodes
+        spare_host = session.spare_host
+        ingress_hosts = session.ingress_hosts
+        labels = session.labels
+        nfs_count = session.nfs_count
+        deploy_timeout = session.deploy_timeout
+        haproxy = session.haproxy
+        io_sessions = session.io_sessions
+
+        vip_holder = failover.get_active_ingress_host(ceph_cluster, vip, ingress_hosts)
+        cls._failover_ingress_with_io(
+            failover,
+            authorized_client,
+            deploy,
+            ingress_spec,
+            nfs_name,
+            deploy_nodes,
+            vip_holder,
+            spare_host,
+            labels["ingress"],
+            ingress_hosts,
+            config,
+            io_sessions,
+            timings,
+            deploy_timeout,
+            case_id,
+        )
+        cls.stop_background_io(io_sessions, NEG4_AUTH_MOUNT, config)
+        io_sessions = cls.remount_run_io_and_verify_restrictions(
+            nfs_name,
+            vip,
+            NEG4_EXPORT_NAME,
+            frontend_port,
+            authorized_client,
+            unauthorized_client,
+            config,
+            "after ingress failover remount",
+        )
+
+        cls._failover_nfs_with_io(
+            failover,
+            haproxy,
+            authorized_client,
+            deploy,
+            nfs_spec,
+            deploy_nodes,
+            spare_host,
+            labels["nfs"],
+            nfs_count,
+            config,
+            io_sessions,
+            timings,
+            deploy_timeout,
+            case_id,
+        )
+        cls.stop_background_io(io_sessions, NEG4_AUTH_MOUNT, config)
+        session.io_sessions = cls.remount_run_io_and_verify_restrictions(
+            nfs_name,
+            vip,
+            NEG4_EXPORT_NAME,
+            frontend_port,
+            authorized_client,
+            unauthorized_client,
+            config,
+            "after NFS failover remount",
+        )
+
+        log.info("%s passed; cluster left running for NEG-5", case_id)
+        return session
+
+    @classmethod
+    def run_neg5_ganesha_crash_with_io(
+        cls, ceph_cluster, config, case_id, session=None
+    ):
+        """SIGKILL ganesha on pinned backend; IO continues and service restarts."""
+        if session is None:
+            workflow_key = config.get("neg5_workflow_key", "neg5_ganesha_crash")
+            session = cls.bootstrap_neg_export_session(
+                ceph_cluster,
+                config,
+                case_id,
+                workflow_key=workflow_key,
+            )
+        cls._require_neg_export_session(session)
+        if not session.auth_mounted:
+            raise OperationFailedError(
+                "NEG-5 requires an authorized mount on the export cluster session"
+            )
+        io_sessions = session.io_sessions
+        if not io_sessions:
+            io_sessions = cls.start_background_io(
+                session.authorized_client, NEG4_AUTH_MOUNT, session.config
+            )
+            session.io_sessions = io_sessions
+
+        cls._crash_ganesha_with_io(
+            session.failover,
+            session.haproxy,
+            session.authorized_client,
+            session.deploy,
+            session.nfs_name,
+            session.config,
+            io_sessions,
+            session.timings,
+            session.deploy_timeout,
+            case_id,
+        )
+        cls.stop_background_io(io_sessions, NEG4_AUTH_MOUNT, session.config)
+        session.io_sessions = []
+        session.io_sessions = cls.remount_run_io_and_verify_restrictions(
+            session.nfs_name,
+            session.vip,
+            NEG4_EXPORT_NAME,
+            session.frontend_port,
+            session.authorized_client,
+            session.unauthorized_client,
+            session.config,
+            "after Ganesha crash remount",
+        )
+        cls.stop_background_io(session.io_sessions, NEG4_AUTH_MOUNT, session.config)
+        session.io_sessions = []
+        log.info("%s passed", case_id)
+        return session
+
+    @staticmethod
+    def _require_neg_export_session(session):
+        if session is None:
+            raise ConfigError("NEG export cluster session is required")
+        required = (
+            "ceph_cluster",
+            "nfs_name",
+            "deploy",
+            "haproxy",
+            "failover",
+            "authorized_client",
+        )
+        missing = [name for name in required if getattr(session, name, None) is None]
+        if missing:
+            raise ConfigError(
+                f"NEG-4 session incomplete for NEG-5 (missing: {', '.join(missing)})"
+            )

--- a/tests/nfs/lib/multi_active/failover.py
+++ b/tests/nfs/lib/multi_active/failover.py
@@ -1,0 +1,611 @@
+"""NFS Multi-Active failover via placement label swap."""
+
+import json
+from datetime import datetime
+
+from ceph.waiter import WaitUntil
+from cli.exceptions import OperationFailedError
+from cli.utilities.utils import reboot_node
+from tests.nfs.lib.multi_active.config import NfsMultiActiveConfig
+from tests.nfs.lib.multi_active.constants import log_section
+from tests.nfs.lib.multi_active.validation import NfsMultiActiveValidation
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveFailover:
+    """Simulate baremetal-safe failover by updating placement labels."""
+
+    @staticmethod
+    def _format_daemon_wait_snapshot(daemons, max_events=3):
+        return [
+            {
+                "name": daemon.get("daemon_name") or daemon.get("name"),
+                "hostname": daemon.get("hostname"),
+                "status_desc": daemon.get("status_desc"),
+                "daemon_type": daemon.get("daemon_type"),
+                "events": (daemon.get("events") or [])[-max_events:],
+            }
+            for daemon in daemons
+        ]
+
+    @classmethod
+    def _raise_daemon_wait_timeout(
+        cls,
+        service_name,
+        expected_count,
+        exclude_host,
+        timeout,
+        last_daemons,
+        running_daemons,
+        extra=None,
+    ):
+        running_hosts = [d.get("hostname") for d in running_daemons]
+        snapshot = cls._format_daemon_wait_snapshot(last_daemons)
+        log.error(
+            "Timed out after %ss waiting for %d daemon(s) on %s (exclude %r); "
+            "running=%d on %s\nLast orch ps snapshot:\n%s",
+            timeout,
+            expected_count,
+            service_name,
+            exclude_host,
+            len(running_daemons),
+            running_hosts,
+            json.dumps(snapshot, indent=2),
+        )
+        if extra:
+            log.error(extra)
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {expected_count} daemon(s) "
+            f"on {service_name} (exclude {exclude_host!r}); "
+            f"running={len(running_daemons)} on {running_hosts}"
+        )
+
+    @staticmethod
+    def swap_label(client, remove_host, add_host, label):
+        client.exec_command(
+            sudo=True,
+            cmd=f"ceph orch host label rm {remove_host} {label}",
+        )
+        client.exec_command(
+            sudo=True,
+            cmd=f"ceph orch host label add {add_host} {label}",
+        )
+        log.info(
+            "Swapped label %r from %s to %s",
+            label,
+            remove_host,
+            add_host,
+        )
+
+    @staticmethod
+    def wait_nfs_daemons(
+        validator,
+        nfs_name,
+        expected_count,
+        exclude_host=None,
+        timeout=300,
+        timings=None,
+    ):
+        """Wait until NFS daemons are running and excluded host is drained."""
+        nfs_service = f"nfs.{nfs_name}"
+        log_section(log, "WAIT NFS DAEMON FAILOVER")
+        last_daemons = []
+        for _ in WaitUntil(timeout=timeout, interval=10):
+            daemons = validator.get_orch_ps_daemons(nfs_service)
+            last_daemons = daemons
+            running = NfsMultiActiveValidation.running_daemons(daemons)
+            if exclude_host and any(
+                daemon.get("hostname") == exclude_host for daemon in running
+            ):
+                continue
+            if len(running) == expected_count:
+                hosts = [daemon.get("hostname") for daemon in running]
+                log.info(
+                    "%d NFS daemon(s) running on %s (excluded %r)",
+                    expected_count,
+                    hosts,
+                    exclude_host,
+                )
+                if timings is not None:
+                    timings["nfs_ready"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                return running
+        NfsMultiActiveFailover._raise_daemon_wait_timeout(
+            nfs_service,
+            expected_count,
+            exclude_host,
+            timeout,
+            last_daemons,
+            NfsMultiActiveValidation.running_daemons(last_daemons),
+        )
+
+    @staticmethod
+    def get_ganesha_host_pid(validator, nfs_name, hostname, nfs_host_node):
+        """Return the host PID of ganesha.nfsd for the NFS daemon on *hostname*."""
+        nfs_service = f"nfs.{nfs_name}"
+        daemons = validator.get_orch_ps_daemons(nfs_service)
+        running = NfsMultiActiveValidation.running_daemons(daemons)
+        target = next(
+            (daemon for daemon in running if daemon.get("hostname") == hostname),
+            None,
+        )
+        if target is None:
+            raise OperationFailedError(
+                f"No running NFS daemon for {nfs_service} on {hostname!r}"
+            )
+        cmd = "ps -ef | grep '[g]anesha.nfsd' | grep -v grep | awk '{print $2}'"
+        out, err = nfs_host_node.exec_command(cmd=cmd, sudo=True, check_ec=False)
+        combined = f"{out or ''}{err or ''}".strip()
+        pid = (out or "").strip().split("\n")[0].strip()
+        if not pid.isdigit():
+            raise OperationFailedError(
+                f"Could not resolve ganesha PID on {hostname!r}: {combined or 'no output'}"
+            )
+        log.info(
+            "Ganesha PID on %s (%s): %s",
+            hostname,
+            target.get("daemon_name"),
+            pid,
+        )
+        return int(pid)
+
+    @staticmethod
+    def crash_ganesha_process(nfs_host_node, pid, hostname):
+        """Send SIGKILL to the ganesha process on *hostname*."""
+        nfs_host_node.exec_command(
+            sudo=True,
+            cmd=f"kill -9 {pid}",
+        )
+        log.info("Sent SIGKILL to ganesha PID %s on %s", pid, hostname)
+
+    @staticmethod
+    def wait_nfs_daemon_on_host(
+        validator, nfs_name, hostname, timeout=300, timings=None
+    ):
+        """Wait until an NFS daemon is running again on *hostname*."""
+        nfs_service = f"nfs.{nfs_name}"
+        log_section(log, f"WAIT NFS DAEMON RECOVERY ON {hostname}")
+        last_daemons = []
+        for _ in WaitUntil(timeout=timeout, interval=10):
+            daemons = validator.get_orch_ps_daemons(nfs_service)
+            last_daemons = daemons
+            running = [
+                daemon
+                for daemon in NfsMultiActiveValidation.running_daemons(daemons)
+                if daemon.get("hostname") == hostname
+            ]
+            if running:
+                log.info(
+                    "NFS daemon running on %s: %s",
+                    hostname,
+                    running[0].get("daemon_name"),
+                )
+                if timings is not None:
+                    timings["nfs_daemon_recovered_at"] = datetime.now().strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                return running[0]
+        NfsMultiActiveFailover._raise_daemon_wait_timeout(
+            nfs_service,
+            1,
+            None,
+            timeout,
+            last_daemons,
+            [
+                daemon
+                for daemon in NfsMultiActiveValidation.running_daemons(last_daemons)
+                if daemon.get("hostname") == hostname
+            ],
+            extra=f"Expected NFS daemon to recover on {hostname!r}",
+        )
+
+    @staticmethod
+    def _node_by_hostname(ceph_cluster, hostname):
+        for node in ceph_cluster.node_list:
+            if getattr(node, "hostname", None) == hostname:
+                return node
+        raise OperationFailedError(f"Node {hostname!r} not found in cluster node list")
+
+    @classmethod
+    def get_active_ingress_host(
+        cls, ceph_cluster, vip, ingress_hosts, exclude_hosts=None
+    ):
+        """Return ingress node currently hosting the VIP (keepalived master).
+
+        The VIP is detected by checking ``ip addr`` output on each ingress host.
+        """
+        vip_addr = vip.split("/")[0].strip()
+        exclude_hosts = set(exclude_hosts or [])
+        log_section(log, "IDENTIFY ACTIVE INGRESS (VIP HOLDER)")
+        for hostname in ingress_hosts:
+            if hostname in exclude_hosts:
+                log.info("Skipping ingress host %s (excluded)", hostname)
+                continue
+            node = cls._node_by_hostname(ceph_cluster, hostname)
+            out, _ = node.exec_command(
+                sudo=True,
+                cmd=f"ip -o addr show | grep -F '{vip_addr}'",
+                check_ec=False,
+            )
+            if out and vip_addr in out:
+                log.info(
+                    "Active ingress host %s holds VIP %s (keepalived)",
+                    hostname,
+                    vip,
+                )
+                return hostname
+            log.info("VIP %s not present on ingress host %s", vip, hostname)
+        raise OperationFailedError(
+            f"VIP {vip!r} not found on any ingress host in {ingress_hosts} "
+            f"(exclude={exclude_hosts})"
+        )
+
+    @classmethod
+    def get_standby_ingress_host(
+        cls, ceph_cluster, vip, ingress_hosts, exclude_hosts=None
+    ):
+        """Return ingress pool member that is not the current VIP holder."""
+        vip_holder = cls.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts=exclude_hosts
+        )
+        excluded = set(exclude_hosts or [])
+        excluded.add(vip_holder)
+        for hostname in ingress_hosts:
+            if hostname not in excluded:
+                log.info(
+                    "Standby ingress host %s (VIP %s held by %s)",
+                    hostname,
+                    vip,
+                    vip_holder,
+                )
+                return hostname
+        raise OperationFailedError(
+            f"No standby ingress host in {ingress_hosts} "
+            f"(VIP holder={vip_holder!r}, exclude={excluded})"
+        )
+
+    @staticmethod
+    def wait_ingress_daemons(
+        validator,
+        nfs_name,
+        expected_count,
+        exclude_host=None,
+        timeout=300,
+        timings=None,
+    ):
+        """Wait until ingress haproxy/keepalived daemons are stable."""
+        ingress_service = f"ingress.nfs.{nfs_name}"
+        log_section(log, "WAIT INGRESS DAEMON FAILOVER")
+        last_daemons = []
+        for _ in WaitUntil(timeout=timeout, interval=10):
+            daemons = validator.get_orch_ps_daemons(ingress_service)
+            last_daemons = daemons
+            running = NfsMultiActiveValidation.running_daemons(daemons)
+            haproxy = [
+                d
+                for d in running
+                if NfsMultiActiveValidation.daemon_component(d) == "haproxy"
+            ]
+            keepalived = [
+                d
+                for d in running
+                if NfsMultiActiveValidation.daemon_component(d) == "keepalived"
+            ]
+            if exclude_host and any(
+                d.get("hostname") == exclude_host for d in haproxy + keepalived
+            ):
+                continue
+            if len(haproxy) == expected_count and len(keepalived) == expected_count:
+                hosts = [d.get("hostname") for d in haproxy]
+                log.info(
+                    "%d ingress daemon pair(s) running on %s (excluded %r)",
+                    expected_count,
+                    hosts,
+                    exclude_host,
+                )
+                if timings is not None:
+                    timings["ingress_ready"] = datetime.now().strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                return haproxy
+        running = NfsMultiActiveValidation.running_daemons(last_daemons)
+        haproxy = [
+            d
+            for d in running
+            if NfsMultiActiveValidation.daemon_component(d) == "haproxy"
+        ]
+        keepalived = [
+            d
+            for d in running
+            if NfsMultiActiveValidation.daemon_component(d) == "keepalived"
+        ]
+        NfsMultiActiveFailover._raise_daemon_wait_timeout(
+            ingress_service,
+            expected_count,
+            exclude_host,
+            timeout,
+            last_daemons,
+            running,
+            extra=(
+                f"Ingress component counts: haproxy={len(haproxy)}, "
+                f"keepalived={len(keepalived)} (expected {expected_count} each)"
+            ),
+        )
+
+    def failover_nfs_by_label(
+        self,
+        client,
+        deploy,
+        nfs_spec,
+        nfs_nodes,
+        remove_host,
+        add_host,
+        label,
+        nfs_count,
+        deploy_timeout=300,
+        timings=None,
+        timings_trigger_key="nfs_failover_triggered_at",
+        post_apply_callback=None,
+    ):
+        """Move NFS backend off remove_host onto add_host via label swap."""
+        log_section(log, "NFS MULTI-ACTIVE FAILOVER — nfs")
+        log.info(
+            "Failing over NFS label %r: %s -> %s",
+            label,
+            remove_host,
+            add_host,
+        )
+        self.swap_label(client, remove_host, add_host, label)
+        if timings is not None and timings_trigger_key:
+            timings[timings_trigger_key] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            timings["failover_triggered_at"] = timings[timings_trigger_key]
+        if post_apply_callback:
+            post_apply_callback()
+        return self.wait_nfs_daemons(
+            deploy.validator,
+            nfs_spec["service_id"],
+            nfs_count,
+            exclude_host=remove_host,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+
+    def failover_ingress_by_label(
+        self,
+        client,
+        deploy,
+        ingress_spec,
+        nfs_service_id,
+        nfs_nodes,
+        remove_host,
+        add_host,
+        label,
+        expected_ingress_count,
+        deploy_timeout=300,
+        timings=None,
+        timings_trigger_key="ingress_failover_triggered_at",
+        post_apply_callback=None,
+    ):
+        """Move ingress off remove_host onto add_host via label swap."""
+        log_section(log, "NFS MULTI-ACTIVE FAILOVER — ingress")
+        log.info(
+            "Failing over ingress label %r: %s -> %s",
+            label,
+            remove_host,
+            add_host,
+        )
+        self.swap_label(client, remove_host, add_host, label)
+        if timings is not None and timings_trigger_key:
+            timings[timings_trigger_key] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            timings["failover_triggered_at"] = timings[timings_trigger_key]
+        if post_apply_callback:
+            post_apply_callback()
+        return self.wait_ingress_daemons(
+            deploy.validator,
+            nfs_service_id,
+            expected_ingress_count,
+            exclude_host=remove_host,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+
+    def failover_nfs_roundtrip(
+        self,
+        client,
+        deploy,
+        nfs_spec,
+        nfs_nodes,
+        original_host,
+        spare_host,
+        label,
+        nfs_count,
+        deploy_timeout=300,
+        timings=None,
+        post_apply_callback=None,
+    ):
+        """Label-drain NFS from original_host to spare and back."""
+        log_section(log, "NFS MULTI-ACTIVE FAILOVER — nfs roundtrip")
+        self.failover_nfs_by_label(
+            client,
+            deploy,
+            nfs_spec,
+            nfs_nodes,
+            original_host,
+            spare_host,
+            label,
+            nfs_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            timings_trigger_key="nfs_failover_out_triggered_at",
+            post_apply_callback=post_apply_callback,
+        )
+        return self.failover_nfs_by_label(
+            client,
+            deploy,
+            nfs_spec,
+            nfs_nodes,
+            spare_host,
+            original_host,
+            label,
+            nfs_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            timings_trigger_key="nfs_failover_return_triggered_at",
+            post_apply_callback=post_apply_callback,
+        )
+
+    def failover_ingress_roundtrip(
+        self,
+        client,
+        deploy,
+        ingress_spec,
+        nfs_service_id,
+        nfs_nodes,
+        original_host,
+        spare_host,
+        label,
+        expected_ingress_count,
+        deploy_timeout=300,
+        timings=None,
+        post_apply_callback=None,
+    ):
+        """Label-drain ingress from original_host to spare and back."""
+        log_section(log, "NFS MULTI-ACTIVE FAILOVER — ingress roundtrip")
+        self.failover_ingress_by_label(
+            client,
+            deploy,
+            ingress_spec,
+            nfs_service_id,
+            nfs_nodes,
+            original_host,
+            spare_host,
+            label,
+            expected_ingress_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            timings_trigger_key="ingress_failover_out_triggered_at",
+            post_apply_callback=post_apply_callback,
+        )
+        return self.failover_ingress_by_label(
+            client,
+            deploy,
+            ingress_spec,
+            nfs_service_id,
+            nfs_nodes,
+            spare_host,
+            original_host,
+            label,
+            expected_ingress_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            timings_trigger_key="ingress_failover_return_triggered_at",
+            post_apply_callback=post_apply_callback,
+        )
+
+    def reboot_and_wait_nfs(
+        self,
+        ceph_cluster,
+        validator,
+        nfs_name,
+        hostname,
+        nfs_count,
+        deploy_timeout=300,
+        timings=None,
+    ):
+        """Reboot an NFS backend node and wait for daemons to recover."""
+        log_section(log, f"NFS MULTI-ACTIVE FAILOVER — reboot nfs backend {hostname}")
+        node = self._node_by_hostname(ceph_cluster, hostname)
+        if not reboot_node(node):
+            raise OperationFailedError(
+                f"Node {hostname!r} did not reconnect after reboot"
+            )
+        return self.wait_nfs_daemons(
+            validator,
+            nfs_name,
+            nfs_count,
+            exclude_host=None,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+
+    def reboot_and_wait_ingress(
+        self,
+        ceph_cluster,
+        validator,
+        nfs_name,
+        hostname,
+        vip,
+        ingress_hosts,
+        expected_ingress_count,
+        deploy_timeout=300,
+        timings=None,
+    ):
+        """Reboot an ingress node and wait for VIP + ingress daemons to recover."""
+        log_section(log, f"NFS MULTI-ACTIVE FAILOVER — reboot ingress {hostname}")
+        node = self._node_by_hostname(ceph_cluster, hostname)
+        if not reboot_node(node):
+            raise OperationFailedError(
+                f"Node {hostname!r} did not reconnect after reboot"
+            )
+        self.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts=set()
+        )
+        return self.wait_ingress_daemons(
+            validator,
+            nfs_name,
+            expected_ingress_count,
+            exclude_host=None,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+
+    def restore_baseline_placement(
+        self,
+        client,
+        deploy,
+        nfs_nodes,
+        nfs_spec,
+        ingress_spec,
+        nfs_service_id,
+        placement,
+        labels,
+        spare_host,
+        nfs_count,
+        ingress_hosts,
+        deploy_nodes,
+        deploy_timeout=300,
+        timings=None,
+    ):
+        """Reset placement labels after a label-drain phase."""
+        log_section(log, "RESTORE BASELINE PLACEMENT")
+        NfsMultiActiveConfig.apply_placement_labels(
+            client,
+            nfs_nodes,
+            placement["nfs"],
+            placement["ingress"],
+            labels,
+        )
+        for spare_label in labels.values():
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch host label rm {spare_host} {spare_label}",
+                check_ec=False,
+            )
+        self.wait_nfs_daemons(
+            deploy.validator,
+            nfs_service_id,
+            nfs_count,
+            exclude_host=None,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+        self.wait_ingress_daemons(
+            deploy.validator,
+            nfs_service_id,
+            len(ingress_hosts),
+            exclude_host=None,
+            timeout=deploy_timeout,
+            timings=timings,
+        )
+        log.info("Baseline placement restored for %s", nfs_service_id)

--- a/tests/nfs/lib/multi_active/haproxy.py
+++ b/tests/nfs/lib/multi_active/haproxy.py
@@ -1,0 +1,473 @@
+"""HAProxy stick table validation for NFS Multi-Active ingress."""
+
+import re
+from time import monotonic, sleep
+
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active.client import NfsMultiActiveClient
+from tests.nfs.lib.multi_active.constants import log_section
+from tests.nfs.lib.multi_active.validation import NfsMultiActiveValidation
+from utility.log import Log
+
+log = Log(__name__)
+
+STICK_TABLE_TIMEOUT = 120
+STICK_TABLE_INTERVAL = 5
+
+
+class NfsMultiActiveHaproxy:
+    """Validate HAProxy backend stick table state."""
+
+    def __init__(self, ceph_cluster, nfs_name, info_client=None):
+        self.ceph_cluster = ceph_cluster
+        self.nfs_name = nfs_name
+        self.info_client = info_client
+        if info_client is None:
+            clients = ceph_cluster.get_nodes("client")
+            info_client = (
+                clients[0] if clients else ceph_cluster.get_nodes("installer")[0]
+            )
+        self.validator = NfsMultiActiveValidation(ceph_cluster, info_client)
+
+    def validate_entries(
+        self,
+        mounted_clients=None,
+        info_client=None,
+        stick_table_timeout=STICK_TABLE_TIMEOUT,
+        stick_table_interval=STICK_TABLE_INTERVAL,
+        timings=None,
+    ):
+        """Validate stick table is empty or matches mounted clients (poll up to timeout)."""
+        mounted_clients = mounted_clients or []
+        info_client = info_client or self.info_client
+        haproxy_daemons = self._running_haproxy_daemons()
+
+        if not mounted_clients:
+            log_section(
+                log,
+                f"HAPROXY STICK TABLE — empty ({len(haproxy_daemons)} ingress nodes)",
+            )
+            self._wait_for_stick_table_state(
+                haproxy_daemons,
+                expected_used=0,
+                expected_client_ips=set(),
+                info_client=info_client,
+                timeout=stick_table_timeout,
+                interval=stick_table_interval,
+            )
+            return
+
+        if info_client is None:
+            raise ConfigError(
+                "info_client is required when validating stick table entries"
+            )
+
+        log_section(
+            log,
+            f"HAPROXY STICK TABLE — {len(mounted_clients)} client(s): "
+            f"{', '.join(c.hostname for c in mounted_clients)}",
+        )
+        expected_client_ips = {
+            NfsMultiActiveClient.client_mount_ip(client) for client in mounted_clients
+        }
+        self._wait_for_stick_table_state(
+            haproxy_daemons,
+            expected_used=len(expected_client_ips),
+            expected_client_ips=expected_client_ips,
+            info_client=info_client,
+            timeout=stick_table_timeout,
+            interval=stick_table_interval,
+            mounted_clients=mounted_clients,
+        )
+        if timings is not None:
+            timings["stick_table"] = f"ready within {stick_table_timeout}s poll"
+
+    def _wait_for_stick_table_state(
+        self,
+        haproxy_daemons,
+        expected_used,
+        expected_client_ips,
+        info_client,
+        timeout,
+        interval,
+        mounted_clients=None,
+    ):
+        wait_start = monotonic()
+        last_error = None
+        while monotonic() - wait_start < timeout:
+            try:
+                if expected_used == 0:
+                    self._validate_empty(haproxy_daemons, raise_on_fail=True)
+                else:
+                    self._validate_client_entries(
+                        haproxy_daemons[0],
+                        mounted_clients,
+                        info_client,
+                        raise_on_fail=True,
+                    )
+                elapsed = monotonic() - wait_start
+                log.info("Stick table reached expected state after %.1fs", elapsed)
+                return
+            except OperationFailedError as exc:
+                last_error = exc
+                remaining = timeout - (monotonic() - wait_start)
+                if remaining <= 0:
+                    break
+                log.info(
+                    "Stick table not ready (expected used:%s); retrying (%.0fs remaining)",
+                    expected_used,
+                    remaining,
+                )
+                sleep(min(interval, remaining))
+        if last_error is not None:
+            raise last_error
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for stick table used:{expected_used}"
+        )
+
+    def _validate_empty(self, haproxy_daemons, raise_on_fail=True):
+        for daemon in haproxy_daemons:
+            hostname = daemon.get("hostname")
+            daemon_name = daemon.get("daemon_name") or daemon.get("name")
+            node = self._node_by_hostname(hostname)
+            haproxy_dir = self._daemon_dir(node, daemon_name)
+
+            log.info(
+                "Checking empty stick table on %s (%s) in %s",
+                hostname,
+                daemon_name,
+                haproxy_dir,
+            )
+            output = self._stick_table_output(node, haproxy_dir)
+            log.info("Stick table output on %s:\n%s", hostname, output)
+
+            used_count = self._parse_used_count(output)
+            if used_count != 0:
+                msg = (
+                    f"Expected empty haproxy stick table on {hostname}, found "
+                    f"used:{used_count}:\n{output}"
+                )
+                if raise_on_fail:
+                    raise OperationFailedError(msg)
+                log.warning(msg)
+                return
+
+            data_lines = [
+                line
+                for line in output.splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ]
+            if data_lines:
+                msg = f"Unexpected stick table entries on {hostname}:\n" + "\n".join(
+                    data_lines
+                )
+                if raise_on_fail:
+                    raise OperationFailedError(msg)
+                log.warning(msg)
+                return
+            log.info("Stick table empty on %s (used:0)", hostname)
+
+        log.info(
+            "HAProxy stick table validation passed on %d node(s) (empty)",
+            len(haproxy_daemons),
+        )
+
+    def _validate_client_entries(
+        self, daemon, mounted_clients, info_client, raise_on_fail=True
+    ):
+        hostname = daemon.get("hostname")
+        daemon_name = daemon.get("daemon_name") or daemon.get("name")
+        node = self._node_by_hostname(hostname)
+        haproxy_dir = self._daemon_dir(node, daemon_name)
+
+        cluster_info = NfsMultiActiveValidation.fetch_cluster_info(
+            info_client, self.nfs_name
+        )
+        allowed_backend_ips = NfsMultiActiveValidation.backend_ips(cluster_info)
+        backend_map = self._backend_map(node, haproxy_dir)
+        expected_client_ips = {
+            NfsMultiActiveClient.client_mount_ip(client) for client in mounted_clients
+        }
+
+        log.info(
+            "Checking stick table on %s (%s), expecting %d client entries",
+            hostname,
+            daemon_name,
+            len(expected_client_ips),
+        )
+
+        output = self._stick_table_output(node, haproxy_dir)
+        log.info("Stick table output on %s:\n%s", hostname, output)
+
+        used_count = self._parse_used_count(output)
+        if used_count != len(expected_client_ips):
+            msg = (
+                f"Expected stick table used:{len(expected_client_ips)}, "
+                f"got used:{used_count}:\n{output}"
+            )
+            if raise_on_fail:
+                raise OperationFailedError(msg)
+            log.warning(msg)
+            return
+
+        entries = self._parse_entries(output)
+        if len(entries) != len(expected_client_ips):
+            msg = (
+                f"Expected {len(expected_client_ips)} stick table entries, parsed "
+                f"{len(entries)}:\n{output}"
+            )
+            if raise_on_fail:
+                raise OperationFailedError(msg)
+            log.warning(msg)
+            return
+
+        entry_keys = {entry["key"] for entry in entries}
+        if entry_keys != expected_client_ips:
+            msg = (
+                f"Stick table client keys mismatch: expected {expected_client_ips}, "
+                f"got {entry_keys}:\n{output}"
+            )
+            if raise_on_fail:
+                raise OperationFailedError(msg)
+            log.warning(msg)
+            return
+
+        for entry in entries:
+            backend_ip = backend_map.get(entry["server_id"])
+            if not backend_ip or backend_ip not in allowed_backend_ips:
+                msg = (
+                    f"Stick table entry {entry['raw']!r} maps to backend IP "
+                    f"{backend_ip!r}, expected one of {allowed_backend_ips}"
+                )
+                if raise_on_fail:
+                    raise OperationFailedError(msg)
+                log.warning(msg)
+                return
+            log.info(
+                "Client %s pinned to NFS backend %s (server_id=%s)",
+                entry["key"],
+                backend_ip,
+                entry["server_id"],
+            )
+
+        log.info(
+            "Stick table validation passed for %d client(s) on %s",
+            len(mounted_clients),
+            hostname,
+        )
+
+    def get_client_backend_ip(self, client, info_client=None):
+        """Return NFS backend IP pinned for a mounted client in the stick table."""
+        info_client = info_client or self.info_client
+        client_ip = NfsMultiActiveClient.client_mount_ip(client)
+        daemon = self._running_haproxy_daemons()[0]
+        hostname = daemon.get("hostname")
+        daemon_name = daemon.get("daemon_name") or daemon.get("name")
+        node = self._node_by_hostname(hostname)
+        haproxy_dir = self._daemon_dir(node, daemon_name)
+
+        output = self._stick_table_output(node, haproxy_dir)
+        entries = self._parse_entries(output)
+        backend_map = self._backend_map(node, haproxy_dir)
+        for entry in entries:
+            if entry["key"] != client_ip:
+                continue
+            backend_ip = backend_map.get(entry["server_id"])
+            if not backend_ip:
+                raise OperationFailedError(
+                    f"No backend IP for client {client.hostname} ({client_ip}) "
+                    f"server_id={entry['server_id']}"
+                )
+            return backend_ip
+
+        raise OperationFailedError(
+            f"Client {client.hostname} ({client_ip}) not found in stick table "
+            f"on {hostname}:\n{output}"
+        )
+
+    def get_client_backend_endpoint(self, client, info_client=None):
+        """Return (hostname, port) for the NFS backend pinned to a mounted client."""
+        info_client = info_client or self.info_client
+        client_ip = NfsMultiActiveClient.client_mount_ip(client)
+        daemon = self._running_haproxy_daemons()[0]
+        hostname = daemon.get("hostname")
+        daemon_name = daemon.get("daemon_name") or daemon.get("name")
+        node = self._node_by_hostname(hostname)
+        haproxy_dir = self._daemon_dir(node, daemon_name)
+
+        output = self._stick_table_output(node, haproxy_dir)
+        entries = self._parse_entries(output)
+        endpoint_map = self._backend_endpoint_map(node, haproxy_dir)
+        for entry in entries:
+            if entry["key"] != client_ip:
+                continue
+            endpoint = endpoint_map.get(entry["server_id"])
+            if not endpoint:
+                raise OperationFailedError(
+                    f"No backend endpoint for client {client.hostname} ({client_ip}) "
+                    f"server_id={entry['server_id']}"
+                )
+            backend_ip, backend_port = endpoint
+            cluster_info = NfsMultiActiveValidation.fetch_cluster_info(
+                info_client, self.nfs_name
+            )
+            matches = [
+                (backend.get("hostname"), int(backend["port"]))
+                for backend in cluster_info.get("backend") or []
+                if backend.get("ip") == backend_ip
+                and backend.get("port") is not None
+                and int(backend["port"]) == backend_port
+            ]
+            if len(matches) == 1:
+                return matches[0]
+            raise OperationFailedError(
+                f"Could not map backend endpoint ({backend_ip!r}, {backend_port}) "
+                f"for client {client.hostname}; backends="
+                f"{cluster_info.get('backend')!r}"
+            )
+
+        raise OperationFailedError(
+            f"Client {client.hostname} ({client_ip}) not found in stick table "
+            f"on {hostname}:\n{output}"
+        )
+
+    def get_client_backend_hostname(self, client, info_client=None):
+        """Return NFS backend hostname pinned for a mounted client."""
+        return self.get_client_backend_endpoint(client, info_client=info_client)[0]
+
+    def _running_haproxy_daemons(self):
+        ingress_service = f"ingress.nfs.{self.nfs_name}"
+        ingress_daemons = self.validator.get_orch_ps_daemons(ingress_service)
+        haproxy_daemons = [
+            daemon
+            for daemon in NfsMultiActiveValidation.running_daemons(ingress_daemons)
+            if NfsMultiActiveValidation.daemon_component(daemon) == "haproxy"
+        ]
+        if not haproxy_daemons:
+            raise OperationFailedError(
+                f"No running haproxy daemons found for {ingress_service}"
+            )
+        return haproxy_daemons
+
+    def _node_by_hostname(self, hostname):
+        for node in self.ceph_cluster.node_list:
+            if getattr(node, "hostname", None) == hostname:
+                return node
+        raise OperationFailedError(f"Node {hostname!r} not found in cluster node list")
+
+    @staticmethod
+    def _daemon_dir(node, daemon_name):
+        cmd = f"ls -d /var/lib/ceph/*/{daemon_name} 2>/dev/null | head -1"
+        out, _ = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        haproxy_dir = (out or "").strip()
+        if not haproxy_dir:
+            raise OperationFailedError(
+                f"Could not locate haproxy daemon directory for {daemon_name!r} on "
+                f"{node.hostname}"
+            )
+        return haproxy_dir
+
+    @staticmethod
+    def _stick_table_output(node, haproxy_dir):
+        cmd = (
+            f'cd {haproxy_dir} && echo "show table backend" | socat stdio haproxy/stats'
+        )
+        out, err = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        output = f"{out or ''}{err or ''}".strip()
+        if not output:
+            raise OperationFailedError(
+                f"Empty stick table output from haproxy on {node.hostname} "
+                f"({haproxy_dir})"
+            )
+        return output
+
+    @staticmethod
+    def _parse_used_count(output):
+        match = re.search(r"# table: backend.*used:(\d+)", output)
+        if not match:
+            raise OperationFailedError(
+                f"Could not parse backend stick table usage from output:\n{output}"
+            )
+        return int(match.group(1))
+
+    @staticmethod
+    def _parse_entries(output):
+        entries = []
+        for line in output.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key_match = re.search(r"key=([^\s]+)", line)
+            server_id_match = re.search(r"server_id=(\d+)", line)
+            if key_match and server_id_match:
+                entries.append(
+                    {
+                        "key": key_match.group(1),
+                        "server_id": int(server_id_match.group(1)),
+                        "raw": line,
+                    }
+                )
+        return entries
+
+    @staticmethod
+    def _cfg_path(node, haproxy_dir):
+        candidates = [
+            f"{haproxy_dir}/haproxy/haproxy.cfg",
+            f"{haproxy_dir}/haproxy.cfg",
+        ]
+        for path in candidates:
+            out, _ = node.exec_command(
+                sudo=True,
+                cmd=f"test -f {path} && echo {path}",
+                check_ec=False,
+            )
+            if (out or "").strip():
+                return path.strip()
+        raise OperationFailedError(
+            f"Could not locate haproxy.cfg under {haproxy_dir} "
+            f"(tried: {', '.join(candidates)})"
+        )
+
+    @classmethod
+    def _backend_map(cls, node, haproxy_dir):
+        haproxy_cfg = cls._cfg_path(node, haproxy_dir)
+        out, _ = node.exec_command(
+            sudo=True,
+            cmd=f"grep -E '^[[:space:]]*server ' {haproxy_cfg}",
+            check_ec=False,
+        )
+        backend_map = {}
+        for line in (out or "").splitlines():
+            match = re.search(r"server\s+\S+\s+([^\s:]+):\d+\s+id\s+(\d+)", line)
+            if match:
+                backend_map[int(match.group(2))] = match.group(1)
+        if not backend_map:
+            raise OperationFailedError(
+                f"Could not parse haproxy backend servers from {haproxy_cfg}"
+            )
+        return backend_map
+
+    @classmethod
+    def _backend_endpoint_map(cls, node, haproxy_dir):
+        haproxy_cfg = cls._cfg_path(node, haproxy_dir)
+        out, _ = node.exec_command(
+            sudo=True,
+            cmd=f"grep -E '^[[:space:]]*server ' {haproxy_cfg}",
+            check_ec=False,
+        )
+        endpoint_map = {}
+        for line in (out or "").splitlines():
+            match = re.search(
+                r"server\s+\S+\s+([^\s:]+):(\d+)\s+id\s+(\d+)",
+                line,
+            )
+            if match:
+                endpoint_map[int(match.group(3))] = (
+                    match.group(1),
+                    int(match.group(2)),
+                )
+        if not endpoint_map:
+            raise OperationFailedError(
+                f"Could not parse haproxy backend endpoints from {haproxy_cfg}"
+            )
+        return endpoint_map

--- a/tests/nfs/lib/multi_active/ingress_negative.py
+++ b/tests/nfs/lib/multi_active/ingress_negative.py
@@ -1,0 +1,239 @@
+"""Helpers for NFS multi-active ingress negative orchestrator apply tests."""
+
+import json
+import uuid
+from time import monotonic, sleep
+
+import yaml
+
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError
+from tests.nfs.lib.multi_active.constants import HEALTH_CHECK_INTERVAL, log_section
+from utility.log import Log
+
+log = Log(__name__)
+
+_INFRA_FAILURE_MARKERS = (
+    "can't open input file",
+    "no such file or directory",
+    "errno 2",
+)
+
+
+class IngressApplyResult:
+    def __init__(self, exit_code, stdout, stderr):
+        self.exit_code = exit_code
+        self.stdout = stdout or ""
+        self.stderr = stderr or ""
+
+    @property
+    def combined_output(self):
+        return f"{self.stdout}\n{self.stderr}".strip()
+
+
+class NfsMultiActiveIngressNegative:
+    @staticmethod
+    def build_base_ingress_spec(
+        nfs_name,
+        vip,
+        ingress_hosts,
+        frontend_port,
+        monitor_port,
+        backend_service=None,
+    ):
+        return {
+            "service_type": "ingress",
+            "service_id": f"nfs.{nfs_name}",
+            "placement": {"hosts": list(ingress_hosts)},
+            "spec": {
+                "backend_service": backend_service or f"nfs.{nfs_name}",
+                "frontend_port": frontend_port,
+                "monitor_port": monitor_port,
+                "virtual_ip": vip,
+                "health_check_interval": HEALTH_CHECK_INTERVAL,
+                "enable_haproxy_protocol": True,
+            },
+        }
+
+    @staticmethod
+    def _reject_infra_failure(result, case_id):
+        output = result.combined_output.lower()
+        for marker in _INFRA_FAILURE_MARKERS:
+            if marker in output:
+                raise OperationFailedError(
+                    f"{case_id}: orch apply failed for infrastructure/setup reason, "
+                    f"not ingress spec validation:\n{result.combined_output}"
+                )
+
+    @staticmethod
+    def _log_apply_rejection(result, case_id, expected_errors):
+        log.info(
+            "%s: orch apply rejected (exit=%s)\n%s",
+            case_id,
+            result.exit_code,
+            result.combined_output,
+        )
+        NfsMultiActiveIngressNegative._assert_expected_error_messages(
+            result.combined_output,
+            case_id,
+            expected_errors,
+        )
+
+    @staticmethod
+    def apply_specs(installer, specs, mount="/tmp"):
+        """Apply orchestrator specs and return exit code plus captured output."""
+        mount_dir = mount if mount.endswith("/") else f"{mount}/"
+        remote_spec = f"{mount_dir}cephci_neg_{uuid.uuid4().hex}.yaml"
+        spec_fp = None
+        try:
+            spec_fp = installer.remote_file(
+                sudo=True, file_name=remote_spec, file_mode="wb"
+            )
+            spec_fp.write(
+                yaml.dump_all(
+                    specs,
+                    sort_keys=False,
+                    indent=2,
+                    default_flow_style=False,
+                ).encode("utf-8")
+            )
+            spec_fp.flush()
+        finally:
+            if spec_fp is not None:
+                try:
+                    spec_fp.close()
+                except OSError:
+                    pass
+
+        log_section(log, "NEGATIVE ORCHESTRATOR SPEC TO APPLY")
+        log.info("%s", yaml.dump_all(specs, sort_keys=False, default_flow_style=False))
+
+        cephadm = CephAdm(installer, mount=mount_dir)
+        cmd = f"{cephadm.base_shell_cmd} ceph orch apply -i {remote_spec}"
+        try:
+            result = installer.exec_command(
+                sudo=True,
+                cmd=cmd,
+                check_ec=False,
+                verbose=True,
+            )
+            if isinstance(result, tuple) and len(result) >= 3:
+                stdout, stderr, exit_code = result[0], result[1], result[2]
+            else:
+                stdout, stderr, exit_code = result or "", "", 0
+            return IngressApplyResult(exit_code, stdout, stderr)
+        finally:
+            installer.exec_command(
+                sudo=True, cmd=f"rm -f {remote_spec}", check_ec=False
+            )
+
+    @staticmethod
+    def _assert_expected_error_messages(output, case_id, patterns, source="orch apply"):
+        """Require at least one expected error fragment in output."""
+        if not patterns:
+            return
+        text = output or ""
+        lowered = text.lower()
+        if any(pattern.lower() in lowered for pattern in patterns):
+            log.info(
+                "%s: matched expected error message from %s",
+                case_id,
+                source,
+            )
+            return
+        raise OperationFailedError(
+            f"{case_id}: expected error message from {source}. "
+            f"Expected one of {patterns!r}. Got:\n{text}"
+        )
+
+    @staticmethod
+    def assert_apply_validation_failure(result, case_id, expected_errors=()):
+        """Require orch apply to fail immediately with a validation-style error."""
+        NfsMultiActiveIngressNegative._reject_infra_failure(result, case_id)
+        if result.exit_code != 0:
+            NfsMultiActiveIngressNegative._log_apply_rejection(
+                result, case_id, expected_errors
+            )
+            return
+
+        raise OperationFailedError(
+            f"{case_id}: expected orch apply validation failure, got exit 0. "
+            f"Output:\n{result.combined_output}"
+        )
+
+    @staticmethod
+    def wait_ingress_unhealthy(installer, service_name, timeout=120, interval=10):
+        """Return once ingress is absent or not fully healthy."""
+        last_seen = None
+        for _ in WaitUntil(timeout=timeout, interval=interval):
+            raw = CephAdm(installer).ceph.orch.ls(format="json", service_type="ingress")
+            services = json.loads(raw.strip()) if raw else []
+            match = [svc for svc in services if svc.get("service_name") == service_name]
+            if not match:
+                log.info("%s not present in orch ls", service_name)
+                return "absent"
+
+            status = match[0].get("status") or {}
+            last_seen = status
+            running = status.get("running")
+            size = status.get("size")
+            if running != size or not running:
+                log.info(
+                    "%s unhealthy in orch ls (running=%s size=%s)",
+                    service_name,
+                    running,
+                    size,
+                )
+                return "unhealthy"
+
+        raise OperationFailedError(
+            f"Timed out after {timeout}s waiting for {service_name} to be "
+            f"absent or unhealthy (last status={last_seen!r})"
+        )
+
+    @staticmethod
+    def assert_apply_failed_or_ingress_unhealthy(
+        installer,
+        result,
+        service_name,
+        case_id,
+        timeout=120,
+        expected_errors=(),
+    ):
+        """NEG-2: apply may fail or ingress may remain unhealthy."""
+        NfsMultiActiveIngressNegative._reject_infra_failure(result, case_id)
+        if result.exit_code != 0:
+            NfsMultiActiveIngressNegative._log_apply_rejection(
+                result, case_id, expected_errors
+            )
+            return
+
+        state = NfsMultiActiveIngressNegative.wait_ingress_unhealthy(
+            installer, service_name, timeout=timeout
+        )
+        log.info("%s: orch apply accepted; ingress state=%s", case_id, state)
+
+    @staticmethod
+    def remove_ingress_service(installer, service_name):
+        log.info("Cleaning up ingress service %s", service_name)
+        installer.exec_command(
+            sudo=True,
+            cmd=f"ceph orch rm {service_name} --force",
+            check_ec=False,
+        )
+        wait_start = monotonic()
+        while monotonic() - wait_start < 120:
+            raw = CephAdm(installer).ceph.orch.ls(
+                format="json", service_name=service_name
+            )
+            if not raw or "No services reported" in raw:
+                return
+            try:
+                services = json.loads(raw.strip())
+            except json.JSONDecodeError:
+                sleep(5)
+                continue
+            if not services:
+                return
+            sleep(5)

--- a/tests/nfs/lib/multi_active/placement.py
+++ b/tests/nfs/lib/multi_active/placement.py
@@ -1,0 +1,116 @@
+"""Label placement geometry and host resolution for NFS Multi-Active tests."""
+
+from cli.exceptions import ConfigError
+from tests.nfs.lib.multi_active.constants import MIN_NFS_NODES, NFS_DAEMON_COUNT
+
+# Default spare slice when placement omits "spare".
+SPARE_SLICE = (3, 4)
+
+
+def _placement(min_nodes, nfs, ingress, spare, nfs_label, ingress_label):
+    return {
+        "min_nodes": min_nodes,
+        "nfs": nfs,
+        "ingress": ingress,
+        "spare": spare,
+        "labels": {"nfs": nfs_label, "ingress": ingress_label},
+    }
+
+
+# Rotate nfs/ingress/spare across the 4-node grim lab so each suite uses all nodes.
+FAILOVER_PLACEMENT = _placement(
+    4, (0, 2), (1, 3), (3, 4), "nfs-ma-nfs", "nfs-ma-ingress"
+)
+INTEGRATION_PLACEMENT = _placement(
+    4, (1, 3), (2, 4), (0, 1), "nfs-ma-int-nfs", "nfs-ma-int-ingress"
+)
+COLOCATION_PLACEMENT = _placement(
+    4, (2, 4), (3, 1), (1, 2), "nfs-ma-coloc-nfs", "nfs-ma-coloc-ingress"
+)
+NEGATIVE_PLACEMENT = _placement(
+    4, (3, 1), (0, 2), (2, 3), "nfs-ma-neg-nfs", "nfs-ma-neg-ingress"
+)
+
+
+def hostnames(nodes):
+    return [node.hostname for node in nodes]
+
+
+def unique_nodes(*node_groups):
+    seen = set()
+    ordered = []
+    for group in node_groups:
+        for node in group:
+            key = node.hostname
+            if key not in seen:
+                seen.add(key)
+                ordered.append(node)
+    return ordered
+
+
+def node_slice(nodes, start, end):
+    """Return nodes[start:end], wrapping when start >= end (e.g. (3, 1) -> [3, 0])."""
+    if start < end:
+        return nodes[start:end]
+    if start > end:
+        return nodes[start:] + nodes[:end]
+    return []
+
+
+def _node_slice(nodes, start, end):
+    return node_slice(nodes, start, end)
+
+
+def resolve_placement_hosts(
+    nfs_nodes,
+    placement,
+    config=None,
+    *,
+    nfs_count=None,
+    spare_slice=SPARE_SLICE,
+    min_nodes=None,
+    include_spare=True,
+):
+    """Return nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, spare_host."""
+    config = config or {}
+    min_nodes = min_nodes or placement.get("min_nodes", MIN_NFS_NODES)
+    nfs_count = int(
+        nfs_count
+        if nfs_count is not None
+        else config.get("nfs_count", NFS_DAEMON_COUNT)
+    )
+    nfs_start, nfs_end = placement["nfs"]
+    ingress_start, ingress_end = placement["ingress"]
+
+    if len(nfs_nodes) < min_nodes:
+        raise ConfigError(f"Need {min_nodes} NFS-capable nodes, found {len(nfs_nodes)}")
+
+    nfs_sel = _node_slice(nfs_nodes, nfs_start, nfs_end)
+    ingress_sel = _node_slice(nfs_nodes, ingress_start, ingress_end)
+    deploy_groups = [nfs_sel, ingress_sel]
+    spare_host = None
+    if include_spare:
+        spare_start, spare_end = placement.get("spare", spare_slice)
+        spare_sel = _node_slice(nfs_nodes, spare_start, spare_end)
+        if not spare_sel:
+            raise ConfigError(f"No spare node in slice {(spare_start, spare_end)!r}")
+        deploy_groups.append(spare_sel)
+        spare_host = spare_sel[0].hostname
+
+    labels = placement.get("labels") or {}
+    return (
+        hostnames(nfs_sel),
+        hostnames(ingress_sel),
+        unique_nodes(*deploy_groups),
+        nfs_count,
+        labels,
+        spare_host,
+    )
+
+
+def resolve_integration_hosts(nfs_nodes, placement=INTEGRATION_PLACEMENT):
+    """Return nfs_hosts, ingress_hosts, deploy_nodes, spare_host."""
+    nfs_hosts, ingress_hosts, deploy_nodes, _nfs_count, _labels, spare_host = (
+        resolve_placement_hosts(nfs_nodes, placement)
+    )
+    return nfs_hosts, ingress_hosts, deploy_nodes, spare_host

--- a/tests/nfs/lib/multi_active/qos.py
+++ b/tests/nfs/lib/multi_active/qos.py
@@ -1,0 +1,485 @@
+"""QoS helpers for NFS Multi-Active integration tests (TC-2 / TC-4)."""
+
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import OperationFailedError
+from tests.nfs.lib.multi_active.constants import (
+    DEFAULT_CLIENT_BW,
+    DEFAULT_CLUSTER_BW,
+    DEFAULT_EXPORT_BW,
+    DEFAULT_TC4_CLUSTER_BW,
+    DEFAULT_TC4_QOS_TYPE,
+    EXPORT_NAME,
+    QOS_BLOCK_POLL_INTERVAL,
+    QOS_BLOCK_POLL_TIMEOUT,
+    QOS_BW_KEYS,
+)
+from tests.nfs.qos.test_nfs_qos_on_cluster_level_enablement import (
+    _maybe_json_loads,
+    _within_qos_limit,
+    capture_copy_details,
+    enable_disable_qos_for_cluster,
+)
+from tests.nfs.qos.test_nfs_qos_on_export_level_enablement import (
+    enable_disable_qos_for_export,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveQos:
+    """Export/cluster QoS enablement, polling, and speed validation."""
+
+    @staticmethod
+    def export_bw_config(config):
+        export_bw = config.get("export_bw")
+        if isinstance(export_bw, list):
+            export_bw = export_bw[0]
+        if not export_bw:
+            export_bw = DEFAULT_EXPORT_BW
+        return dict(export_bw)
+
+    @staticmethod
+    def cluster_bw_config(config):
+        cluster_bw = config.get("cluster_bw")
+        if isinstance(cluster_bw, list):
+            cluster_bw = cluster_bw[0]
+        if not cluster_bw:
+            cluster_bw = DEFAULT_CLUSTER_BW
+        return dict(cluster_bw)
+
+    @staticmethod
+    def client_bw_config(config):
+        client_bw = config.get("tc4_client_bw") or config.get("client_bw")
+        if isinstance(client_bw, list):
+            client_bw = client_bw[0]
+        if not client_bw:
+            export_bw = config.get("tc4_export_bw") or config.get("export_bw")
+            if isinstance(export_bw, list):
+                export_bw = export_bw[0]
+            if export_bw:
+                client_bw = {
+                    k: export_bw[k]
+                    for k in (
+                        "max_client_write_bw",
+                        "max_client_read_bw",
+                        "max_client_combined_bw",
+                        "max_client_iops",
+                    )
+                    if k in export_bw
+                }
+        if not client_bw:
+            client_bw = DEFAULT_CLIENT_BW
+        return dict(client_bw)
+
+    @staticmethod
+    def tc4_cluster_bw_config(config):
+        cluster_bw = config.get("tc4_cluster_bw") or config.get("cluster_bw")
+        if isinstance(cluster_bw, list):
+            cluster_bw = cluster_bw[0]
+        if not cluster_bw:
+            cluster_bw = dict(DEFAULT_TC4_CLUSTER_BW)
+        else:
+            cluster_bw = dict(cluster_bw)
+        qos_type = config.get(
+            "tc4_qos_type", config.get("qos_type", DEFAULT_TC4_QOS_TYPE)
+        )
+        if qos_type == "PerShare_PerClient":
+            cluster_bw.setdefault("max_export_combined_bw", "100MB")
+            cluster_bw.setdefault("max_client_combined_bw", "100MB")
+        return cluster_bw
+
+    @staticmethod
+    def tc4_export_bw_config(config):
+        export_bw = dict(NfsMultiActiveQos.client_bw_config(config))
+        cluster_bw = NfsMultiActiveQos.tc4_cluster_bw_config(config)
+        export_bw.setdefault(
+            "max_export_combined_bw",
+            cluster_bw.get("max_export_combined_bw", "100MB"),
+        )
+        return export_bw
+
+    @staticmethod
+    def bw_params(bw_config):
+        return {k: bw_config[k] for k in QOS_BW_KEYS if k in bw_config}
+
+    @staticmethod
+    def limit_key(bw_config):
+        for key in (
+            "max_client_combined_bw",
+            "max_client_write_bw",
+            "max_client_read_bw",
+            "max_export_combined_bw",
+            "max_export_write_bw",
+            "max_export_read_bw",
+        ):
+            if bw_config.get(key):
+                return key, bw_config[key]
+        return None, None
+
+    @staticmethod
+    def enable(session, cluster_bw, export_bw, qos_type, qos_operation):
+        """Enable cluster QoS; export QoS for PerShare / PerShare_PerClient."""
+        client = session.client1
+        ceph_nfs = Ceph(client).nfs
+        params = NfsMultiActiveQos.bw_params
+        if qos_type == "PerClient":
+            enable_disable_qos_for_cluster(
+                enable_flag=True,
+                ceph_cluster_nfs_obj=ceph_nfs.cluster,
+                cluster_name=session.nfs_service_id,
+                qos_type=qos_type,
+                operation=qos_operation,
+                **params(export_bw),
+            )
+            session.cluster_qos_enabled = True
+            return
+
+        enable_disable_qos_for_cluster(
+            enable_flag=True,
+            ceph_cluster_nfs_obj=ceph_nfs.cluster,
+            cluster_name=session.nfs_service_id,
+            qos_type=qos_type,
+            operation=qos_operation,
+            **params(cluster_bw),
+        )
+        session.cluster_qos_enabled = True
+        enable_disable_qos_for_export(
+            enable_flag=True,
+            ceph_export_nfs_obj=ceph_nfs.export,
+            cluster_name=session.nfs_service_id,
+            qos_type=qos_type,
+            operation=qos_operation,
+            nfs_name=session.nfs_service_id,
+            export=EXPORT_NAME,
+            **params(export_bw),
+        )
+        session.qos_enabled = True
+
+    @staticmethod
+    def disable(session):
+        client = session.client1
+        if session.qos_enabled:
+            enable_disable_qos_for_export(
+                enable_flag=False,
+                ceph_export_nfs_obj=Ceph(client).nfs.export,
+                cluster_name=session.nfs_service_id,
+                nfs_name=session.nfs_service_id,
+                export=EXPORT_NAME,
+            )
+            session.qos_enabled = False
+        if session.cluster_qos_enabled:
+            enable_disable_qos_for_cluster(
+                enable_flag=False,
+                ceph_cluster_nfs_obj=Ceph(client).nfs.cluster,
+                cluster_name=session.nfs_service_id,
+            )
+            session.cluster_qos_enabled = False
+
+    @staticmethod
+    def wait_ready(client, nfs_service_id, bw_config, qos_type, stage, config=None):
+        if qos_type == "PerClient":
+            return NfsMultiActiveQos._wait_cluster_ready(
+                client, nfs_service_id, bw_config, qos_type, stage, config
+            )
+        return NfsMultiActiveQos._wait_export_ready(
+            client, nfs_service_id, bw_config, qos_type, stage, config
+        )
+
+    @staticmethod
+    def validate_persisted(
+        client, nfs_service_id, bw_config, qos_type, baseline_get, baseline_block, stage
+    ):
+        if qos_type == "PerClient":
+            return NfsMultiActiveQos._validate_cluster_persisted(
+                client, nfs_service_id, bw_config, qos_type, baseline_get, stage
+            )
+        return NfsMultiActiveQos._validate_export_persisted(
+            client,
+            nfs_service_id,
+            bw_config,
+            qos_type,
+            baseline_get,
+            baseline_block,
+            stage,
+        )
+
+    @staticmethod
+    def validate_speeds(client, nfs_mount, export_bw, qos_type, file_tag):
+        speed = capture_copy_details(client, nfs_mount, f"tc2_qos_{file_tag}")
+        log.info(
+            "TC-2 QoS speed (%s): write=%s read=%s type=%s limits=%s",
+            file_tag,
+            speed.get("write_speed"),
+            speed.get("read_speed"),
+            qos_type,
+            export_bw,
+        )
+        write_speed = speed.get("write_speed")
+        read_speed = speed.get("read_speed")
+        max_export_write_bw = export_bw.get("max_export_write_bw")
+        max_export_read_bw = export_bw.get("max_export_read_bw")
+        max_export_combined_bw = export_bw.get("max_export_combined_bw")
+        if max_export_combined_bw:
+            max_export_write_bw = max_export_combined_bw
+            max_export_read_bw = max_export_combined_bw
+
+        export_ok = False
+        if max_export_write_bw is not None or max_export_read_bw is not None:
+            export_ok = True
+            if max_export_write_bw is not None:
+                export_ok = export_ok and _within_qos_limit(
+                    max_export_write_bw, write_speed
+                )
+            if max_export_read_bw is not None:
+                export_ok = export_ok and _within_qos_limit(
+                    max_export_read_bw, read_speed
+                )
+
+        if not export_ok:
+            raise OperationFailedError(
+                f"QoS limits violated ({file_tag}): write={write_speed} "
+                f"read={read_speed} limits={export_bw}"
+            )
+        log.info("TC-2 QoS speed validation passed (%s)", file_tag)
+
+    @staticmethod
+    def validate_perclient_speeds(
+        clients, nfs_mount, client_bw, qos_type, file_tag, session=None
+    ):
+        """Validate per-client bandwidth limits on the VIP export mount."""
+        for client in clients:
+            if session:
+                backend_host, backend_port = (
+                    session.haproxy.get_client_backend_endpoint(client)
+                )
+                log.info(
+                    "TC-4 QoS via VIP %s on %s (pinned %s:%s, %s)",
+                    nfs_mount,
+                    client.hostname,
+                    backend_host,
+                    backend_port,
+                    file_tag,
+                )
+            speed = capture_copy_details(
+                client, nfs_mount, f"tc4_qos_{file_tag}_{client.hostname}"
+            )
+            log.info(
+                "TC-4 per-client QoS speed (%s_%s): write=%s read=%s type=%s limits=%s",
+                file_tag,
+                client.hostname,
+                speed.get("write_speed"),
+                speed.get("read_speed"),
+                qos_type,
+                client_bw,
+            )
+            write_speed = speed.get("write_speed")
+            read_speed = speed.get("read_speed")
+            max_client_combined_bw = client_bw.get("max_client_combined_bw")
+            max_client_write_bw = client_bw.get("max_client_write_bw")
+            max_client_read_bw = client_bw.get("max_client_read_bw")
+            if max_client_combined_bw:
+                max_client_write_bw = max_client_combined_bw
+                max_client_read_bw = max_client_combined_bw
+            client_ok = False
+            if max_client_write_bw is not None or max_client_read_bw is not None:
+                client_ok = True
+                if max_client_write_bw is not None:
+                    client_ok = client_ok and _within_qos_limit(
+                        max_client_write_bw, write_speed
+                    )
+                if max_client_read_bw is not None:
+                    client_ok = client_ok and _within_qos_limit(
+                        max_client_read_bw, read_speed
+                    )
+            if not client_ok:
+                raise OperationFailedError(
+                    f"Per-client QoS limits violated ({file_tag}_{client.hostname}): "
+                    f"write={write_speed} read={read_speed} limits={client_bw}"
+                )
+            log.info(
+                "TC-4 per-client QoS speed validation passed (%s_%s)",
+                file_tag,
+                client.hostname,
+            )
+
+    @staticmethod
+    def assert_colocated_client_isolation(session, case_id):
+        endpoint1 = session.haproxy.get_client_backend_endpoint(session.client1)
+        endpoint2 = session.haproxy.get_client_backend_endpoint(session.client2)
+        if endpoint1 == endpoint2:
+            raise OperationFailedError(
+                f"{case_id} clients are pinned to the same NFS backend instance "
+                f"{endpoint1}; expected distinct colocated backends"
+            )
+        log.info(
+            "%s colocated backend isolation: client1=%s client2=%s",
+            case_id,
+            endpoint1,
+            endpoint2,
+        )
+        return endpoint1, endpoint2
+
+    @staticmethod
+    def _read_cluster_get(client, nfs_service_id):
+        qos_data = Ceph(client).nfs.cluster.qos.get(
+            cluster_id=nfs_service_id,
+            format="json",
+        )
+        return _maybe_json_loads(qos_data)
+
+    @staticmethod
+    def _read_export_block(client, nfs_service_id):
+        export_data = Ceph(client).nfs.export.get(
+            nfs_name=nfs_service_id,
+            nfs_export=EXPORT_NAME,
+        )
+        export_data = _maybe_json_loads(export_data)
+        if isinstance(export_data, dict):
+            return export_data.get("qos_block") or {}
+        return {}
+
+    @staticmethod
+    def _read_export_get(client, nfs_service_id):
+        return Ceph(client).nfs.export.qos.get(
+            nfs_name=nfs_service_id,
+            export=EXPORT_NAME,
+        )
+
+    @staticmethod
+    def _cluster_is_ready(qos_get, bw_config):
+        if not isinstance(qos_get, dict):
+            return False
+        if qos_get.get("enable_bw_control") is not True:
+            return False
+        limit_key, _ = NfsMultiActiveQos.limit_key(bw_config)
+        return bool(limit_key and qos_get.get(limit_key))
+
+    @staticmethod
+    def _export_is_ready(qos_get, export_bw):
+        if not isinstance(qos_get, dict):
+            return False
+        if qos_get.get("enable_bw_control") is not True:
+            return False
+        limit_key, _ = NfsMultiActiveQos.limit_key(export_bw)
+        return bool(limit_key and qos_get.get(limit_key))
+
+    @staticmethod
+    def _wait_export_ready(
+        client, nfs_service_id, export_bw, qos_type, stage, config=None
+    ):
+        cfg = config or {}
+        timeout = int(cfg.get("qos_poll_timeout", QOS_BLOCK_POLL_TIMEOUT))
+        interval = int(cfg.get("qos_poll_interval", QOS_BLOCK_POLL_INTERVAL))
+        remaining = timeout
+        while remaining > 0:
+            qos_get = NfsMultiActiveQos._read_export_get(client, nfs_service_id)
+            qos_block = NfsMultiActiveQos._read_export_block(client, nfs_service_id)
+            if NfsMultiActiveQos._export_is_ready(qos_get, export_bw):
+                log.info(
+                    "TC-2 export QoS ready at %s: get=%s block=%s (%s)",
+                    stage,
+                    qos_get,
+                    qos_block,
+                    qos_type,
+                )
+                return qos_get, qos_block
+            sleep(interval)
+            remaining -= interval
+        raise OperationFailedError(
+            f"Timed out waiting for export QoS at {stage} on {EXPORT_NAME}"
+        )
+
+    @staticmethod
+    def _wait_cluster_ready(
+        client, nfs_service_id, bw_config, qos_type, stage, config=None
+    ):
+        cfg = config or {}
+        timeout = int(cfg.get("qos_poll_timeout", QOS_BLOCK_POLL_TIMEOUT))
+        interval = int(cfg.get("qos_poll_interval", QOS_BLOCK_POLL_INTERVAL))
+        remaining = timeout
+        while remaining > 0:
+            qos_get = NfsMultiActiveQos._read_cluster_get(client, nfs_service_id)
+            if NfsMultiActiveQos._cluster_is_ready(qos_get, bw_config):
+                log.info(
+                    "Cluster QoS ready at %s: get=%s (%s)",
+                    stage,
+                    qos_get,
+                    qos_type,
+                )
+                return qos_get, {}
+            sleep(interval)
+            remaining -= interval
+        raise OperationFailedError(
+            f"Timed out waiting for cluster QoS at {stage} on {nfs_service_id}"
+        )
+
+    @staticmethod
+    def _validate_cluster_persisted(
+        client, nfs_service_id, bw_config, qos_type, baseline_get, stage
+    ):
+        qos_get = NfsMultiActiveQos._read_cluster_get(client, nfs_service_id)
+        if not NfsMultiActiveQos._cluster_is_ready(qos_get, bw_config):
+            raise OperationFailedError(f"Cluster QoS not enabled at {stage}: {qos_get}")
+        limit_key, _ = NfsMultiActiveQos.limit_key(bw_config)
+        if baseline_get:
+            for key in (
+                "enable_bw_control",
+                "enable_qos",
+                "combined_rw_bw_control",
+                "qos_type",
+                limit_key,
+            ):
+                if key and baseline_get.get(key) != qos_get.get(key):
+                    raise OperationFailedError(
+                        f"Cluster QoS {key!r} changed at {stage}: "
+                        f"before={baseline_get.get(key)!r} after={qos_get.get(key)!r}"
+                    )
+        log.info(
+            "Cluster QoS persisted at %s: get=%s (%s)",
+            stage,
+            qos_get,
+            qos_type,
+        )
+
+    @staticmethod
+    def _validate_export_persisted(
+        client,
+        nfs_service_id,
+        export_bw,
+        qos_type,
+        baseline_get,
+        baseline_block,
+        stage,
+    ):
+        qos_get = NfsMultiActiveQos._read_export_get(client, nfs_service_id)
+        qos_block = NfsMultiActiveQos._read_export_block(client, nfs_service_id)
+        if not NfsMultiActiveQos._export_is_ready(qos_get, export_bw):
+            raise OperationFailedError(f"Export QoS not enabled at {stage}: {qos_get}")
+        limit_key, _ = NfsMultiActiveQos.limit_key(export_bw)
+        if baseline_get:
+            for key in (
+                "enable_bw_control",
+                "enable_qos",
+                "combined_rw_bw_control",
+                limit_key,
+            ):
+                if key and baseline_get.get(key) != qos_get.get(key):
+                    raise OperationFailedError(
+                        f"Export QoS {key!r} changed at {stage}: "
+                        f"before={baseline_get.get(key)!r} after={qos_get.get(key)!r}"
+                    )
+        if baseline_block and qos_block != baseline_block:
+            raise OperationFailedError(
+                f"Export qos_block changed at {stage} for {qos_type}:\n"
+                f"before={baseline_block}\nafter={qos_block}"
+            )
+        log.info(
+            "TC-2 QoS persisted at %s: get=%s block=%s (%s)",
+            stage,
+            qos_get,
+            qos_block,
+            qos_type,
+        )

--- a/tests/nfs/lib/multi_active/session.py
+++ b/tests/nfs/lib/multi_active/session.py
@@ -1,0 +1,260 @@
+"""Session bootstrap, teardown, and shared deploy helpers."""
+
+from datetime import datetime
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError
+from tests.nfs.lib.multi_active import (
+    NfsMultiActiveCleanup,
+    NfsMultiActiveClient,
+    NfsMultiActiveConfig,
+    NfsMultiActiveDeploy,
+    NfsMultiActiveFailover,
+    NfsMultiActiveHaproxy,
+)
+from tests.nfs.lib.multi_active.constants import (
+    BG_IO_RUNTIME,
+    DEPLOY_TIMEOUT,
+    EXPORT_NAME,
+    FS_NAME,
+    HEALTH_CHECK_INTERVAL,
+    NFS_MOUNT,
+    NFS_VERSION,
+    POLL_INTERVAL_SEC,
+)
+from tests.nfs.lib.multi_active.placement import (
+    FAILOVER_PLACEMENT,
+    resolve_placement_hosts,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def _poll_interval(config):
+    return int(config.get("poll_interval_sec", POLL_INTERVAL_SEC))
+
+
+def io_runtime(config):
+    return NfsMultiActiveConfig.io_runtime(config, default=BG_IO_RUNTIME)
+
+
+def io_tool_label(config):
+    return NfsMultiActiveConfig.resolve_io_tool(config)
+
+
+def _deploy_kwargs(config, is_first_session):
+    """Build deploy kwargs; skip one-time setup on subsequent sessions."""
+    kwargs = {
+        "deploy_timeout": DEPLOY_TIMEOUT,
+        "ingress_poll_interval": _poll_interval(config),
+    }
+    if not is_first_session:
+        kwargs.update(
+            {
+                "skip_mgr_enable": True,
+            }
+        )
+    return kwargs
+
+
+def client_backend_mappings(haproxy, mounted_clients, spare_host):
+    """Return [(client, pinned_backend), ...] for clients not pinned to spare."""
+    mappings = []
+    for client in mounted_clients:
+        backend = haproxy.get_client_backend_hostname(client)
+        if backend == spare_host:
+            continue
+        mappings.append((client, backend))
+    if not mappings:
+        raise ConfigError(
+            f"No mounted client pinned to a non-spare backend (spare={spare_host!r})"
+        )
+    return mappings
+
+
+def stop_phase_io(
+    config,
+    dual_client_io,
+    io_sessions,
+    io_thread,
+    io_error_box,
+    primary_io_client,
+    io_dir,
+):
+    """Stop background IO after a failover phase completes."""
+    if dual_client_io and io_sessions:
+        NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+        for _, thread, _, _ in io_sessions:
+            thread.join(timeout=30)
+    elif (
+        io_thread is not None and io_thread.is_alive() and primary_io_client and io_dir
+    ):
+        NfsMultiActiveClient.stop_background_io(
+            primary_io_client, io_dir, config, io_error_box
+        )
+        io_thread.join(timeout=30)
+
+
+def session_setup(
+    ceph_cluster,
+    config,
+    session_name,
+    vip_slot,
+    ports,
+    is_first_workflow,
+    *,
+    service_id_prefix,
+    placement=FAILOVER_PLACEMENT,
+    spare_slice=None,
+):
+    """Deploy NFS multi-active once for a failover-style session."""
+    client1, client2 = ceph_cluster.get_nodes("client")[:2]
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    spare_kw = {} if spare_slice is None else {"spare_slice": spare_slice}
+    (
+        nfs_hosts,
+        ingress_hosts,
+        deploy_nodes,
+        nfs_count,
+        labels,
+        spare_host,
+    ) = resolve_placement_hosts(nfs_nodes, placement, config, **spare_kw)
+    nfs_backend_port, ingress_frontend_port, ingress_monitor_port = ports
+    vip = NfsMultiActiveConfig.get_vips(config)[vip_slot - 1]
+    nfs_service_id = (
+        f"{service_id_prefix}-{session_name}-"
+        f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+
+    NfsMultiActiveConfig.apply_placement_labels(
+        client1,
+        nfs_nodes,
+        placement["nfs"],
+        placement["ingress"],
+        labels,
+    )
+
+    nfs_spec = NfsMultiActiveConfig.build_nfs_spec(
+        nfs_hosts,
+        nfs_count,
+        nfs_service_id,
+        nfs_backend_port,
+        label=labels["nfs"],
+    )
+    ingress_spec = NfsMultiActiveConfig.build_ingress_spec(
+        vip,
+        nfs_service_id,
+        ingress_frontend_port,
+        ingress_monitor_port,
+        config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+        label=labels["ingress"],
+    )
+    deploy = NfsMultiActiveDeploy(ceph_cluster, nfs_service_id, vip, client=client1)
+    haproxy = NfsMultiActiveHaproxy(ceph_cluster, nfs_service_id, info_client=client1)
+    failover = NfsMultiActiveFailover()
+    stick_kwargs = {"stick_table_interval": _poll_interval(config)}
+
+    deploy.deploy(
+        [nfs_spec, ingress_spec],
+        deploy_nodes,
+        expected_ingress_hosts=ingress_hosts,
+        **_deploy_kwargs(config, is_first_workflow),
+    )
+    haproxy.validate_entries(**stick_kwargs)
+
+    Ceph(client1).nfs.export.create(
+        fs_name=FS_NAME,
+        nfs_name=nfs_service_id,
+        nfs_export=EXPORT_NAME,
+        fs=FS_NAME,
+    )
+    NfsMultiActiveConfig.wait_until_export_visible(
+        client1,
+        nfs_service_id,
+        EXPORT_NAME,
+        interval=_poll_interval(config),
+    )
+
+    mounted_clients = []
+    for client in (client1, client2):
+        NfsMultiActiveClient.mount_via_vip(
+            client,
+            vip,
+            NFS_MOUNT,
+            EXPORT_NAME,
+            str(ingress_frontend_port),
+            NFS_VERSION,
+        )
+        mounted_clients.append(client)
+        haproxy.validate_entries(mounted_clients=mounted_clients, **stick_kwargs)
+
+    return {
+        "ceph_cluster": ceph_cluster,
+        "config": config,
+        "session_name": session_name,
+        "client1": client1,
+        "nfs_nodes": nfs_nodes,
+        "ingress_hosts": ingress_hosts,
+        "deploy_nodes": deploy_nodes,
+        "nfs_count": nfs_count,
+        "labels": labels,
+        "spare_host": spare_host,
+        "nfs_service_id": nfs_service_id,
+        "vip": vip,
+        "ingress_frontend_port": ingress_frontend_port,
+        "nfs_spec": nfs_spec,
+        "ingress_spec": ingress_spec,
+        "deploy": deploy,
+        "haproxy": haproxy,
+        "failover": failover,
+        "stick_kwargs": stick_kwargs,
+        "mounted_clients": mounted_clients,
+        "labels_applied": True,
+        "export_created": True,
+        "cluster_deployed": True,
+        "placement": placement,
+    }
+
+
+def session_teardown(ctx):
+    """Unmount, delete export, remove cluster, and clear placement labels."""
+    client1 = ctx["client1"]
+    nfs_nodes = ctx["nfs_nodes"]
+    nfs_service_id = ctx["nfs_service_id"]
+    mounted_clients = ctx.get("mounted_clients") or []
+    placement = ctx.get("placement") or FAILOVER_PLACEMENT
+
+    try:
+        if mounted_clients:
+            NfsMultiActiveClient.unmount_and_delete_export(
+                mounted_clients, NFS_MOUNT, nfs_service_id, EXPORT_NAME
+            )
+        elif ctx.get("export_created"):
+            Ceph(client1).nfs.export.delete(nfs_service_id, EXPORT_NAME)
+    except Exception as exc:
+        log.warning("Mount/export cleanup failed: %s", exc)
+
+    if ctx.get("cluster_deployed"):
+        try:
+            NfsMultiActiveCleanup(ctx["ceph_cluster"]).remove_cluster(nfs_service_id)
+        except Exception as exc:
+            log.warning("NFS cluster cleanup failed: %s", exc)
+
+    if ctx.get("labels_applied"):
+        try:
+            NfsMultiActiveConfig.remove_placement_labels(
+                client1,
+                nfs_nodes,
+                placement["nfs"],
+                placement["ingress"],
+                ctx["labels"],
+            )
+            for spare_label in ctx["labels"].values():
+                client1.exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch host label rm {ctx['spare_host']} {spare_label}",
+                    check_ec=False,
+                )
+        except Exception as exc:
+            log.warning("Placement label cleanup failed: %s", exc)

--- a/tests/nfs/lib/multi_active/validation.py
+++ b/tests/nfs/lib/multi_active/validation.py
@@ -1,0 +1,411 @@
+"""Post-deploy cluster info and orchestrator daemon validation."""
+
+import json
+
+from ceph.waiter import WaitUntil
+from cli.ceph.ceph import Ceph
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError
+from tests.nfs.lib.multi_active.config import NfsMultiActiveConfig
+from tests.nfs.lib.multi_active.constants import log_section
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class NfsMultiActiveValidation:
+
+    def __init__(self, ceph_cluster, client):
+        self.ceph_cluster = ceph_cluster
+        self.client = client
+        self.installer = ceph_cluster.get_nodes("installer")[0]
+
+    def get_cluster_info(self, nfs_name):
+        return self.fetch_cluster_info(self.client, nfs_name)
+
+    @staticmethod
+    def fetch_cluster_info(client, nfs_name):
+        info = Ceph(client).nfs.cluster.info(nfs_name)
+        if not info:
+            raise OperationFailedError(
+                f"No cluster info returned for NFS cluster {nfs_name!r}"
+            )
+
+        cluster_info = info.get(nfs_name)
+        if cluster_info is None:
+            raise OperationFailedError(
+                f"Cluster {nfs_name!r} not found in nfs cluster info: {info!r}"
+            )
+
+        log.info("NFS cluster info for %s:\n%s", nfs_name, json.dumps(info, indent=2))
+        return cluster_info
+
+    @staticmethod
+    def assert_cluster_info(cluster_info, nfs_spec, ingress_spec):
+        nfs_name = nfs_spec["service_id"]
+        expected_backend_port = int(nfs_spec["spec"]["port"])
+
+        log_section(log, "NFS CLUSTER INFO VALIDATION")
+
+        backends = cluster_info.get("backend") or []
+        if not backends:
+            raise OperationFailedError(
+                f"NFS cluster info for {nfs_name!r} has no backend entries: "
+                f"{cluster_info!r}"
+            )
+
+        nfs_spec_body = nfs_spec.get("spec", {})
+        expected_monitoring_port = None
+        if nfs_spec_body.get("monitoring_port") is not None:
+            expected_monitoring_port = int(nfs_spec_body["monitoring_port"])
+        elif nfs_spec_body.get("enable_haproxy_protocol"):
+            expected_monitoring_port = expected_backend_port + 1
+
+        data_backends = []
+        for backend in backends:
+            hostname = backend.get("hostname", "unknown")
+            port = backend.get("port")
+            if port is None:
+                raise OperationFailedError(
+                    f"Backend entry for {hostname!r} is missing port: {backend!r}"
+                )
+            port_int = int(port)
+            if port_int == expected_backend_port:
+                data_backends.append(backend)
+                log.info(
+                    "Backend %s port %s matches NFS spec port %s",
+                    hostname,
+                    port,
+                    expected_backend_port,
+                )
+            elif (
+                expected_monitoring_port is not None
+                and port_int == expected_monitoring_port
+            ):
+                log.info(
+                    "Backend %s monitoring port %s accepted (data port %s)",
+                    hostname,
+                    port_int,
+                    expected_backend_port,
+                )
+            else:
+                raise OperationFailedError(
+                    f"Backend port mismatch on {hostname}: expected "
+                    f"{expected_backend_port}"
+                    f"{f' or monitoring port {expected_monitoring_port}' if expected_monitoring_port else ''}, "
+                    f"got {port!r}"
+                )
+
+        expected_nfs_count = int(nfs_spec["placement"]["count"])
+        if len(data_backends) != expected_nfs_count:
+            raise OperationFailedError(
+                f"Expected {expected_nfs_count} NFS data backends for {nfs_name!r}, "
+                f"found {len(data_backends)}: {data_backends!r}"
+            )
+
+        NfsMultiActiveValidation._assert_ingress_cluster_info(
+            cluster_info, ingress_spec
+        )
+        log.info("NFS cluster info validation passed for %s", nfs_name)
+
+    @staticmethod
+    def assert_colocation_cluster_info(cluster_info, nfs_spec, ingress_spec):
+        """Validate cluster info when NFS backends use distinct colocation data ports."""
+        nfs_name = nfs_spec["service_id"]
+        expected_ports = NfsMultiActiveConfig.expected_colocation_data_ports(nfs_spec)
+        expected_count = int(nfs_spec["placement"]["count"])
+
+        log_section(log, "NFS COLOCATION CLUSTER INFO VALIDATION")
+
+        backends = cluster_info.get("backend") or []
+        if len(backends) != expected_count:
+            raise OperationFailedError(
+                f"Expected {expected_count} NFS backends for {nfs_name!r}, "
+                f"found {len(backends)}: {backends!r}"
+            )
+
+        seen_ports = []
+        for backend in backends:
+            hostname = backend.get("hostname", "unknown")
+            port = backend.get("port")
+            if port is None:
+                raise OperationFailedError(
+                    f"Backend entry for {hostname!r} is missing port: {backend!r}"
+                )
+            port = int(port)
+            if port not in expected_ports:
+                raise OperationFailedError(
+                    f"Unexpected backend port on {hostname}: {port!r}, "
+                    f"expected one of {sorted(expected_ports)}"
+                )
+            seen_ports.append(port)
+            log.info(
+                "Backend %s port %s is a configured colocation data port",
+                hostname,
+                port,
+            )
+
+        log.info(
+            "Backend data ports %s are within expected set %s",
+            sorted(seen_ports),
+            sorted(expected_ports),
+        )
+
+        NfsMultiActiveValidation._assert_ingress_cluster_info(
+            cluster_info, ingress_spec
+        )
+        log.info("NFS colocation cluster info validation passed for %s", nfs_name)
+
+    def _node_by_hostname(self, hostname):
+        for node in self.ceph_cluster.node_list:
+            if getattr(node, "hostname", None) == hostname:
+                return node
+        raise OperationFailedError(f"Node {hostname!r} not found in cluster node list")
+
+    @staticmethod
+    def _assert_port_listening(node, port, label):
+        out, _ = node.exec_command(
+            sudo=True,
+            cmd=f"ss -H -tulpn sport = :{port}",
+            check_ec=False,
+        )
+        if not out or not str(out).strip():
+            raise OperationFailedError(
+                f"{label} port {port} is not listening on {node.hostname}"
+            )
+        log.info("%s port %s listening on %s", label, port, node.hostname)
+
+    def assert_colocation_ports_listening(self, cluster_info, nfs_spec):
+        """Verify NFS data ports from cluster info are listening on backend hosts.
+
+        Monitoring and cluster_qos ports are not checked here: colocated daemons on
+        this Ceph release may not publish spec monitoring_port values on the host
+        (orch reports a single service monitoring port; per-daemon exporters may
+        auto-increment or bind inside the container only).
+        """
+        expected_ports = NfsMultiActiveConfig.expected_colocation_data_ports(nfs_spec)
+        log_section(log, "COLOCATION DATA PORT LISTENING VALIDATION")
+        for backend in cluster_info.get("backend") or []:
+            hostname = backend.get("hostname")
+            data_port = int(backend.get("port"))
+            if data_port not in expected_ports:
+                raise OperationFailedError(
+                    f"Backend port {data_port} on {hostname!r} not in colocation spec"
+                )
+            node = self._node_by_hostname(hostname)
+            self._assert_port_listening(node, data_port, "NFS data")
+        log.info("Colocation data port listening validation passed")
+
+    def assert_orch_ps(
+        self,
+        nfs_spec,
+        ingress_spec,
+        expected_ingress_hosts=None,
+        timeout=None,
+    ):
+        nfs_name = nfs_spec["service_id"]
+        nfs_service = f"nfs.{nfs_name}"
+        ingress_service = f"ingress.nfs.{nfs_name}"
+        expected_nfs_count = int(nfs_spec["placement"]["count"])
+        ingress_placement = ingress_spec["placement"]
+        if "hosts" in ingress_placement:
+            expected_ingress_count = len(ingress_placement["hosts"])
+        elif expected_ingress_hosts is not None:
+            expected_ingress_count = len(expected_ingress_hosts)
+        else:
+            raise OperationFailedError(
+                "expected_ingress_hosts is required when ingress placement "
+                "uses a label"
+            )
+
+        log_section(log, "ORCH PS DAEMON VALIDATION")
+
+        def _check():
+            nfs_daemons = self.get_orch_ps_daemons(nfs_service)
+            self._validate_running_daemon_count(
+                "NFS", nfs_daemons, expected_nfs_count, nfs_service
+            )
+
+            ingress_daemons = self.get_orch_ps_daemons(ingress_service)
+
+            def _ingress_daemons(component):
+                return [
+                    daemon
+                    for daemon in ingress_daemons
+                    if self.daemon_component(daemon) == component
+                ]
+
+            haproxy_daemons = _ingress_daemons("haproxy")
+            keepalived_daemons = _ingress_daemons("keepalived")
+            self._validate_running_daemon_count(
+                "haproxy", haproxy_daemons, expected_ingress_count, ingress_service
+            )
+            self._validate_running_daemon_count(
+                "keepalived",
+                keepalived_daemons,
+                expected_ingress_count,
+                ingress_service,
+            )
+            if expected_ingress_hosts is not None:
+                running_haproxy = self.running_daemons(haproxy_daemons)
+                actual_hosts = {d.get("hostname") for d in running_haproxy}
+                expected_hosts = set(expected_ingress_hosts)
+                if actual_hosts != expected_hosts:
+                    raise OperationFailedError(
+                        f"Expected ingress haproxy on {sorted(expected_hosts)}, "
+                        f"found {sorted(actual_hosts)} for {ingress_service}"
+                    )
+            return nfs_daemons, ingress_daemons
+
+        if timeout:
+            last_error = None
+            for _ in WaitUntil(timeout=timeout, interval=10):
+                try:
+                    nfs_daemons, ingress_daemons = _check()
+                    last_error = None
+                    break
+                except OperationFailedError as exc:
+                    last_error = exc
+            if last_error is not None:
+                raise last_error
+        else:
+            nfs_daemons, ingress_daemons = _check()
+
+        log.info(
+            "orch ps for %s:\n%s",
+            nfs_service,
+            json.dumps(self._format_daemon_summary(nfs_daemons), indent=2),
+        )
+        log.info(
+            "orch ps for %s:\n%s",
+            ingress_service,
+            json.dumps(self._format_daemon_summary(ingress_daemons), indent=2),
+        )
+        log.info(
+            "Orch ps validation passed: %d NFS, %d haproxy, %d keepalived daemons "
+            "running",
+            expected_nfs_count,
+            expected_ingress_count,
+            expected_ingress_count,
+        )
+
+    def get_orch_ps_daemons(self, service_name):
+        raw = CephAdm(self.installer).ceph.orch.ps(
+            format="json", service_name=service_name
+        )
+        if not raw:
+            return []
+        if isinstance(raw, str):
+            return json.loads(raw.strip())
+        return json.loads(raw.read().decode().strip())
+
+    @staticmethod
+    def running_daemons(daemons):
+        return [
+            daemon
+            for daemon in daemons
+            if str(daemon.get("status_desc", "")).strip().lower() == "running"
+        ]
+
+    @staticmethod
+    def daemon_component(daemon):
+        daemon_type = str(daemon.get("daemon_type", "")).lower()
+        if daemon_type in ("haproxy", "keepalived", "nfs"):
+            return daemon_type
+
+        daemon_name = daemon.get("daemon_name") or daemon.get("name") or ""
+        for component in ("haproxy", "keepalived", "nfs"):
+            if daemon_name.startswith(f"{component}."):
+                return component
+        return None
+
+    @staticmethod
+    def backend_ips(cluster_info):
+        backends = cluster_info.get("backend") or []
+        return {backend.get("ip") for backend in backends if backend.get("ip")}
+
+    @staticmethod
+    def _expected_ingress_mode(ingress_spec):
+        if ingress_spec.get("spec", {}).get("enable_haproxy_protocol"):
+            return "haproxy-protocol"
+        return "haproxy-standard"
+
+    @staticmethod
+    def _assert_ingress_cluster_info(cluster_info, ingress_spec):
+        ingress = ingress_spec["spec"]
+        ingress_checks = {
+            "ingress_mode": (
+                cluster_info.get("ingress_mode"),
+                NfsMultiActiveValidation._expected_ingress_mode(ingress_spec),
+            ),
+            "monitor_port": (
+                cluster_info.get("monitor_port"),
+                int(ingress["monitor_port"]),
+            ),
+            "port": (cluster_info.get("port"), int(ingress["frontend_port"])),
+            "virtual_ip": (cluster_info.get("virtual_ip"), ingress["virtual_ip"]),
+        }
+
+        for field, (actual, expected) in ingress_checks.items():
+            if field == "virtual_ip":
+                if not NfsMultiActiveValidation._virtual_ip_matches(expected, actual):
+                    raise OperationFailedError(
+                        f"Cluster info virtual_ip mismatch: expected {expected!r}, "
+                        f"got {actual!r}"
+                    )
+            elif field in ("monitor_port", "port"):
+                if actual is None:
+                    raise OperationFailedError(
+                        f"Cluster info missing {field!r}; expected {expected!r}"
+                    )
+                if int(actual) != int(expected):
+                    raise OperationFailedError(
+                        f"Cluster info {field} mismatch: expected {expected!r}, "
+                        f"got {actual!r}"
+                    )
+            elif actual != expected:
+                raise OperationFailedError(
+                    f"Cluster info {field} mismatch: expected {expected!r}, "
+                    f"got {actual!r}"
+                )
+            log.info("Cluster info %s=%s matches ingress spec", field, actual)
+
+    @staticmethod
+    def _virtual_ip_matches(expected, actual):
+        if expected == actual:
+            return True
+        if expected is None or actual is None:
+            return False
+        return str(expected).split("/")[0] == str(actual).split("/")[0]
+
+    def _validate_running_daemon_count(
+        self, label, daemons, expected_count, service_name
+    ):
+        running = self.running_daemons(daemons)
+        if len(running) != expected_count:
+            raise OperationFailedError(
+                f"Expected {expected_count} running {label} daemon(s) for "
+                f"{service_name}, found {len(running)}: "
+                f"{self._format_daemon_summary(daemons)}"
+            )
+
+        for daemon in running:
+            log.info(
+                "%s daemon running: %s on %s",
+                label,
+                daemon.get("daemon_name") or daemon.get("name"),
+                daemon.get("hostname"),
+            )
+        log.info("%d %s daemon(s) running for %s", expected_count, label, service_name)
+
+    @staticmethod
+    def _format_daemon_summary(daemons):
+        return [
+            {
+                "name": daemon.get("daemon_name") or daemon.get("name"),
+                "hostname": daemon.get("hostname"),
+                "status_desc": daemon.get("status_desc"),
+                "daemon_type": daemon.get("daemon_type"),
+            }
+            for daemon in daemons
+        ]

--- a/tests/nfs/multi_active/test_nfs_multi_active_colocation_ports.py
+++ b/tests/nfs/multi_active/test_nfs_multi_active_colocation_ports.py
@@ -1,0 +1,730 @@
+from datetime import datetime
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError
+from tests.nfs.lib.multi_active import (
+    NfsMultiActiveCleanup,
+    NfsMultiActiveClient,
+    NfsMultiActiveConfig,
+    NfsMultiActiveDeploy,
+    NfsMultiActiveFailover,
+    NfsMultiActiveHaproxy,
+    init_crash_monitoring,
+    wait_for_ceph_health,
+)
+from tests.nfs.lib.multi_active.placement import (
+    COLOCATION_PLACEMENT,
+    resolve_placement_hosts,
+)
+from tests.nfs.multi_active.test_nfs_multi_active_failover import (
+    _assert_post_failover_backends,
+    _log_workflow_timings,
+    _resolve_failover_plan,
+    _run_failover_steps,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+from tests.nfs.lib.multi_active.constants import (
+    BG_IO_JOIN_TIMEOUT,
+    BG_IO_RUNTIME,
+    BG_IO_START_DELAY,
+    DEPLOY_TIMEOUT,
+    EXPORT_NAME,
+    HEALTH_CHECK_INTERVAL,
+    MARKER_IO_TIMEOUT,
+    MIN_NFS_NODES,
+    NFS_MOUNT,
+    NFS_VERSION,
+    POLL_INTERVAL_SEC,
+    SERVICE_ID_PREFIX,
+    TC4_NFS_COUNT,
+)
+
+NFS_SERVICE_ID_PREFIX = SERVICE_ID_PREFIX["colocation"]
+NFS_DAEMON_COUNT = TC4_NFS_COUNT
+_VIP1 = 1
+
+
+def _resolve_workflow_vip(config, workflow_cfg):
+    """Return suite VIP (``vip`` is 1-based index into config ``vips``)."""
+    vips = NfsMultiActiveConfig.get_vips(config)
+    vip_slot = workflow_cfg.get("vip", _VIP1)
+    if not isinstance(vip_slot, int) or vip_slot < 1:
+        raise ConfigError(
+            f"Workflow vip slot must be a positive integer, got {vip_slot!r}"
+        )
+    if vip_slot > len(vips):
+        raise ConfigError(
+            f"Workflow requests vip{vip_slot} but suite config has "
+            f"{len(vips)} VIP(s): {vips}"
+        )
+    return vips[vip_slot - 1]
+
+
+_PLACEMENT = COLOCATION_PLACEMENT
+
+_COLOC_PORTS_1 = {
+    "port": 2169,
+    "monitoring_port": 9507,
+    "colocation_ports": [
+        {"data_port": 3169, "monitoring_port": 9517, "cluster_qos_port": 32311},
+        {"data_port": 4169, "monitoring_port": 9527, "cluster_qos_port": 33311},
+        {"data_port": 5169, "monitoring_port": 9537, "cluster_qos_port": 34311},
+    ],
+}
+_COLOC_PORTS_2 = {
+    "port": 2269,
+    "monitoring_port": 9607,
+    "colocation_ports": [
+        {"data_port": 3269, "monitoring_port": 9617, "cluster_qos_port": 32411},
+        {"data_port": 4269, "monitoring_port": 9627, "cluster_qos_port": 33411},
+        {"data_port": 5269, "monitoring_port": 9637, "cluster_qos_port": 34411},
+    ],
+}
+
+COLOCATION_WORKFLOWS = {
+    "same_host_colocation": {
+        "tc": "TC-A1",
+        "desc": "Deploy colocated NFS daemons (count=4, 2 per host) and validate VIP IO",
+        "deploy_only": True,
+        "vip": 2,
+        "nfs_count": 4,
+        "placement": _PLACEMENT,
+        "colocation": _COLOC_PORTS_1,
+        "ingress_ports": (2249, 9349),
+    },
+    "colocation_nfs_failover": {
+        "tc": "TC-C1",
+        "desc": (
+            "Background IO via VIP while stick-table-pinned colocated NFS backend "
+            "host is label-drained to spare"
+        ),
+        "vip": 1,
+        "nfs_count": 4,
+        "placement": _PLACEMENT,
+        "colocation": _COLOC_PORTS_2,
+        "ingress_ports": (2259, 9359),
+        "failover": {"target": "nfs"},
+    },
+    "colocation_ingress_failover": {
+        "tc": "TC-C2",
+        "desc": (
+            "Background IO via VIP while keepalived VIP-holder ingress fails over "
+            "with colocated NFS backends"
+        ),
+        "vip": 2,
+        "nfs_count": 4,
+        "placement": _PLACEMENT,
+        "colocation": {
+            "port": 2369,
+            "monitoring_port": 9707,
+            "colocation_ports": [
+                {"data_port": 3369, "monitoring_port": 9717, "cluster_qos_port": 32511},
+                {"data_port": 4369, "monitoring_port": 9727, "cluster_qos_port": 33511},
+                {"data_port": 5369, "monitoring_port": 9737, "cluster_qos_port": 34511},
+            ],
+        },
+        "ingress_ports": (2269, 9369),
+        "failover": {"target": "ingress"},
+    },
+    "colocation_dual_client_failover": {
+        "tc": "TC-C4",
+        "desc": (
+            "Both clients run background IO on distinct colocation backends; primary client's "
+            "backend host is label-drained to spare while peer IO continues"
+        ),
+        "dual_client_io": True,
+        "vip": 1,
+        "nfs_count": 4,
+        "placement": _PLACEMENT,
+        "colocation": {
+            "port": 2469,
+            "monitoring_port": 9807,
+            "colocation_ports": [
+                {"data_port": 3469, "monitoring_port": 9817, "cluster_qos_port": 32611},
+                {"data_port": 4469, "monitoring_port": 9827, "cluster_qos_port": 33611},
+                {"data_port": 5469, "monitoring_port": 9837, "cluster_qos_port": 34611},
+            ],
+        },
+        "ingress_ports": (2279, 9379),
+        "failover": {"target": "nfs"},
+    },
+}
+
+
+def _log_workflow_start(workflow, step, total):
+    wf = COLOCATION_WORKFLOWS[workflow]
+    log.info(
+        "\n" + "=" * 70 + "\n  %s (%s)\n  %s\n" + "=" * 70,
+        f"Workflow {step} of {total}: {workflow}",
+        wf.get("tc", workflow),
+        wf["desc"],
+    )
+
+
+def _poll_interval(config):
+    return int(config.get("poll_interval_sec", POLL_INTERVAL_SEC))
+
+
+def _deploy_kwargs(config, is_first_workflow):
+    poll_interval = _poll_interval(config)
+    kwargs = {
+        "deploy_timeout": DEPLOY_TIMEOUT,
+        "ingress_poll_interval": poll_interval,
+        "colocation_validation": True,
+    }
+    if not is_first_workflow:
+        kwargs.update(
+            {
+                "skip_mgr_enable": True,
+            }
+        )
+    return kwargs
+
+
+def _resolve_hosts(workflow, config, nfs_nodes):
+    """Return (nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, spare_host)."""
+    wf = COLOCATION_WORKFLOWS[workflow]
+    placement = wf["placement"]
+    nfs_count = int(config.get("nfs_count", wf.get("nfs_count", NFS_DAEMON_COUNT)))
+    nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, spare_host = (
+        resolve_placement_hosts(
+            nfs_nodes,
+            placement,
+            config,
+            nfs_count=nfs_count,
+            include_spare=not wf.get("deploy_only"),
+        )
+    )
+    if nfs_count > len(nfs_hosts) * 2:
+        raise ConfigError(
+            f"nfs_count ({nfs_count}) exceeds colocation capacity for workflow "
+            f"{workflow!r} (pool size {len(nfs_hosts)})"
+        )
+    return nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, spare_host
+
+
+def _build_specs(workflow, nfs_hosts, nfs_count, nfs_service_id, vip, labels, config):
+    wf = COLOCATION_WORKFLOWS[workflow]
+    coloc = wf["colocation"]
+    ingress_frontend_port, ingress_monitor_port = wf["ingress_ports"]
+    nfs_spec = NfsMultiActiveConfig.build_nfs_colocation_spec(
+        nfs_hosts,
+        nfs_count,
+        nfs_service_id,
+        coloc["port"],
+        coloc["monitoring_port"],
+        coloc["colocation_ports"],
+        label=labels["nfs"],
+    )
+    ingress_spec = NfsMultiActiveConfig.build_ingress_spec(
+        vip,
+        nfs_service_id,
+        ingress_frontend_port,
+        ingress_monitor_port,
+        config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+        label=labels["ingress"],
+    )
+    return nfs_spec, ingress_spec, ingress_frontend_port
+
+
+def _validate_colocation_cluster(
+    deploy, nfs_spec, ingress_spec, nfs_service_id, ingress_hosts, timeout=None
+):
+    cluster_info = deploy.validator.get_cluster_info(nfs_service_id)
+    deploy.validator.assert_colocation_cluster_info(
+        cluster_info, nfs_spec, ingress_spec
+    )
+    deploy.validator.assert_colocation_ports_listening(cluster_info, nfs_spec)
+    deploy.validator.assert_orch_ps(
+        nfs_spec,
+        ingress_spec,
+        expected_ingress_hosts=ingress_hosts,
+        timeout=timeout,
+    )
+    return cluster_info
+
+
+def _now():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _run_deploy_workflow(ceph_cluster, config, workflow, is_first_workflow=True):
+    """Deploy colocation NFS, mount via VIP, validate stick table and basic IO."""
+    client1, client2 = ceph_cluster.get_nodes("client")[:2]
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    poll_interval = _poll_interval(config)
+    wf = COLOCATION_WORKFLOWS[workflow]
+
+    nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, _spare = _resolve_hosts(
+        workflow, config, nfs_nodes
+    )
+    placement = wf["placement"]
+    nfs_service_id = (
+        f"{NFS_SERVICE_ID_PREFIX}-{workflow}-"
+        f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+    vip = _resolve_workflow_vip(config, wf)
+    mounted_clients = []
+    export_created = False
+    cluster_deployed = False
+    labels_applied = False
+
+    log.info("NFS service id: %s, VIP: %s", nfs_service_id, vip)
+    log.info(
+        "Colocation NFS count=%s pool=%s; ingress pool=%s; ports=%s ingress=%s",
+        nfs_count,
+        nfs_hosts,
+        ingress_hosts,
+        wf["colocation"],
+        wf["ingress_ports"],
+    )
+
+    try:
+        NfsMultiActiveConfig.apply_placement_labels(
+            client1,
+            nfs_nodes,
+            placement["nfs"],
+            placement["ingress"],
+            labels,
+        )
+        labels_applied = True
+
+        nfs_spec, ingress_spec, ingress_frontend_port = _build_specs(
+            workflow, nfs_hosts, nfs_count, nfs_service_id, vip, labels, config
+        )
+        specs = [nfs_spec, ingress_spec]
+        haproxy = NfsMultiActiveHaproxy(
+            ceph_cluster, nfs_service_id, info_client=client1
+        )
+        deploy = NfsMultiActiveDeploy(ceph_cluster, nfs_service_id, vip, client=client1)
+
+        deploy.deploy(
+            specs,
+            deploy_nodes,
+            expected_ingress_hosts=ingress_hosts,
+            **_deploy_kwargs(config, is_first_workflow),
+        )
+        cluster_deployed = True
+        haproxy.validate_entries(stick_table_interval=poll_interval)
+
+        Ceph(client1).nfs.export.create(
+            fs_name="cephfs",
+            nfs_name=nfs_service_id,
+            nfs_export=EXPORT_NAME,
+            fs="cephfs",
+        )
+        NfsMultiActiveConfig.wait_until_export_visible(
+            client1, nfs_service_id, EXPORT_NAME, interval=poll_interval
+        )
+        export_created = True
+
+        for client in (client1, client2):
+            NfsMultiActiveClient.mount_via_vip(
+                client,
+                vip,
+                NFS_MOUNT,
+                EXPORT_NAME,
+                str(ingress_frontend_port),
+                NFS_VERSION,
+            )
+            mounted_clients.append(client)
+            haproxy.validate_entries(
+                mounted_clients=mounted_clients,
+                stick_table_interval=poll_interval,
+            )
+
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir=workflow,
+        )
+        haproxy.validate_entries(
+            mounted_clients=mounted_clients,
+            stick_table_interval=poll_interval,
+        )
+        return 0
+    except Exception as e:
+        log.error("Colocation deploy workflow failed (%s): %s", workflow, e)
+        return 1
+    finally:
+        try:
+            if mounted_clients:
+                NfsMultiActiveClient.unmount_and_delete_export(
+                    mounted_clients, NFS_MOUNT, nfs_service_id, EXPORT_NAME
+                )
+            elif export_created:
+                Ceph(client1).nfs.export.delete(nfs_service_id, EXPORT_NAME)
+        except Exception as e:
+            log.warning("Mount/export cleanup failed: %s", e)
+
+        if cluster_deployed:
+            try:
+                NfsMultiActiveCleanup(ceph_cluster).remove_cluster(nfs_service_id)
+            except Exception as e:
+                log.warning("NFS cluster cleanup failed: %s", e)
+
+        if labels_applied:
+            try:
+                NfsMultiActiveConfig.remove_placement_labels(
+                    client1,
+                    nfs_nodes,
+                    placement["nfs"],
+                    placement["ingress"],
+                    labels,
+                )
+            except Exception as e:
+                log.warning("Placement label cleanup failed: %s", e)
+
+
+def _run_failover_workflow(ceph_cluster, config, workflow):
+    """Deploy colocation NFS, run background IO during label failover, validate recovery."""
+    client1, client2 = ceph_cluster.get_nodes("client")[:2]
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    poll_interval = _poll_interval(config)
+    wf = COLOCATION_WORKFLOWS[workflow]
+    placement = wf["placement"]
+    failover_cfg = wf["failover"]
+    dual_client_io = wf.get("dual_client_io", False)
+
+    nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, spare_host = (
+        _resolve_hosts(workflow, config, nfs_nodes)
+    )
+    nfs_service_id = (
+        f"{NFS_SERVICE_ID_PREFIX}-{workflow}-"
+        f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+    vip = _resolve_workflow_vip(config, wf)
+    nfs_label = labels["nfs"]
+    ingress_label = labels["ingress"]
+
+    mounted_clients = []
+    export_created = False
+    cluster_deployed = False
+    labels_applied = False
+    primary_io_client = None
+    io_sessions = None
+    io_thread = None
+    io_error_box = None
+    io_dir = None
+    timings = {}
+
+    log.info(
+        "NFS service id: %s, VIP: %s, spare: %s, failover: %s",
+        nfs_service_id,
+        vip,
+        spare_host,
+        failover_cfg["target"],
+    )
+
+    try:
+        NfsMultiActiveConfig.apply_placement_labels(
+            client1,
+            nfs_nodes,
+            placement["nfs"],
+            placement["ingress"],
+            labels,
+        )
+        labels_applied = True
+
+        nfs_spec, ingress_spec, ingress_frontend_port = _build_specs(
+            workflow, nfs_hosts, nfs_count, nfs_service_id, vip, labels, config
+        )
+        specs = [nfs_spec, ingress_spec]
+        deploy = NfsMultiActiveDeploy(ceph_cluster, nfs_service_id, vip, client=client1)
+        haproxy = NfsMultiActiveHaproxy(
+            ceph_cluster, nfs_service_id, info_client=client1
+        )
+        failover = NfsMultiActiveFailover()
+
+        deploy.deploy(
+            specs,
+            deploy_nodes,
+            deploy_timeout=DEPLOY_TIMEOUT,
+            expected_ingress_hosts=ingress_hosts,
+            colocation_validation=True,
+        )
+        cluster_deployed = True
+        haproxy.validate_entries(stick_table_interval=poll_interval)
+
+        Ceph(client1).nfs.export.create(
+            fs_name="cephfs",
+            nfs_name=nfs_service_id,
+            nfs_export=EXPORT_NAME,
+            fs="cephfs",
+        )
+        NfsMultiActiveConfig.wait_until_export_visible(
+            client1, nfs_service_id, EXPORT_NAME, interval=poll_interval
+        )
+        export_created = True
+
+        for client in (client1, client2):
+            NfsMultiActiveClient.mount_via_vip(
+                client,
+                vip,
+                NFS_MOUNT,
+                EXPORT_NAME,
+                str(ingress_frontend_port),
+                NFS_VERSION,
+            )
+            mounted_clients.append(client)
+            haproxy.validate_entries(
+                mounted_clients=mounted_clients,
+                stick_table_interval=poll_interval,
+            )
+
+        (
+            io_clients,
+            primary_io_client,
+            _pinned_backend,
+            removed_nfs_host,
+            removed_ingress_host,
+            expected_ingress,
+        ) = _resolve_failover_plan(
+            haproxy,
+            failover,
+            ceph_cluster,
+            vip,
+            mounted_clients,
+            spare_host,
+            ingress_hosts,
+            failover_cfg["target"],
+            dual_client_io=dual_client_io,
+        )
+
+        io_runtime = NfsMultiActiveConfig.io_runtime(config, default=BG_IO_RUNTIME)
+        if dual_client_io:
+            io_sessions = NfsMultiActiveClient.run_background_io_on_clients(
+                io_clients,
+                NFS_MOUNT,
+                config,
+                io_subdir=workflow,
+                runtime=io_runtime,
+            )
+            io_dir = next(
+                session_io_dir
+                for client, _, _, session_io_dir in io_sessions
+                if client == primary_io_client
+            )
+        else:
+            io_thread, io_error_box, io_dir = NfsMultiActiveClient.run_background_io(
+                primary_io_client,
+                NFS_MOUNT,
+                config,
+                io_subdir=workflow,
+                runtime=io_runtime,
+            )
+        timings["io_start"] = _now()
+        sleep(BG_IO_START_DELAY)
+
+        target = failover_cfg["target"]
+        removed_nfs_host, removed_ingress_host, expected_ingress = _run_failover_steps(
+            target,
+            failover,
+            deploy,
+            ceph_cluster,
+            vip,
+            client1,
+            nfs_spec,
+            ingress_spec,
+            nfs_service_id,
+            deploy_nodes,
+            nfs_count,
+            nfs_label,
+            ingress_label,
+            ingress_hosts,
+            spare_host,
+            DEPLOY_TIMEOUT,
+            removed_nfs_host,
+            removed_ingress_host,
+            expected_ingress,
+            config,
+            timings=timings,
+            dual_client_io=dual_client_io,
+            io_sessions=io_sessions,
+            io_thread=io_thread,
+            io_error_box=io_error_box,
+            primary_io_client=primary_io_client,
+            io_dir=io_dir,
+        )
+
+        cluster_info = _validate_colocation_cluster(
+            deploy,
+            nfs_spec,
+            ingress_spec,
+            nfs_service_id,
+            expected_ingress,
+            timeout=DEPLOY_TIMEOUT,
+        )
+        haproxy.validate_entries(
+            mounted_clients=mounted_clients,
+            timings=timings,
+            stick_table_interval=poll_interval,
+        )
+
+        backend_hostnames = {
+            backend.get("hostname")
+            for backend in cluster_info.get("backend") or []
+            if backend.get("hostname")
+        }
+        _assert_post_failover_backends(
+            target, spare_host, removed_nfs_host, backend_hostnames
+        )
+
+        if dual_client_io:
+            NfsMultiActiveClient.assert_io_completed_on_clients(
+                io_sessions,
+                nfs_mount=NFS_MOUNT,
+                config=config,
+                wait_io_resume_timeout=0,
+                join_timeout=BG_IO_JOIN_TIMEOUT,
+                timings=timings,
+            )
+        else:
+            NfsMultiActiveClient.assert_io_completed(
+                io_thread,
+                io_error_box,
+                config=config,
+                stop_client=primary_io_client,
+                io_dir=io_dir,
+                nfs_mount=NFS_MOUNT,
+                wait_io_resume_timeout=0,
+                join_timeout=BG_IO_JOIN_TIMEOUT,
+                timings=timings,
+            )
+        timings["io_end"] = _now()
+
+        marker = f"{io_dir}/post-failover-marker"
+        marker_client = next(c for c in mounted_clients if c != primary_io_client)
+        marker_client.exec_command(
+            sudo=True,
+            cmd=(
+                f"timeout {MARKER_IO_TIMEOUT} sh -c "
+                f"'echo failover-ok-{workflow} > {marker}'"
+            ),
+            timeout=MARKER_IO_TIMEOUT + 10,
+        )
+        out, _ = primary_io_client.exec_command(
+            sudo=True,
+            cmd=f"timeout {MARKER_IO_TIMEOUT} cat {marker}",
+            timeout=MARKER_IO_TIMEOUT + 10,
+        )
+        if "failover-ok" not in (out or ""):
+            raise ConfigError(
+                "Cross-client marker read failed after colocation failover"
+            )
+
+        log.info("Colocation failover workflow %s completed successfully", workflow)
+        _log_workflow_timings(timings)
+        return 0
+    except Exception as e:
+        log.error("Colocation failover workflow failed (%s): %s", workflow, e)
+        return 1
+    finally:
+        try:
+            if dual_client_io and io_sessions:
+                NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+                for _, thread, _, _ in io_sessions:
+                    thread.join(timeout=30)
+            elif io_thread is not None and io_thread.is_alive() and primary_io_client:
+                NfsMultiActiveClient.stop_background_io(
+                    primary_io_client, io_dir, config, io_error_box
+                )
+                io_thread.join(timeout=30)
+        except Exception as e:
+            log.warning("Background IO stop failed: %s", e)
+
+        try:
+            if mounted_clients:
+                NfsMultiActiveClient.unmount_and_delete_export(
+                    mounted_clients, NFS_MOUNT, nfs_service_id, EXPORT_NAME
+                )
+            elif export_created:
+                Ceph(client1).nfs.export.delete(nfs_service_id, EXPORT_NAME)
+        except Exception as e:
+            log.warning("Mount/export cleanup failed: %s", e)
+
+        if cluster_deployed:
+            try:
+                NfsMultiActiveCleanup(ceph_cluster).remove_cluster(nfs_service_id)
+            except Exception as e:
+                log.warning("NFS cluster cleanup failed: %s", e)
+
+        if labels_applied:
+            try:
+                NfsMultiActiveConfig.remove_placement_labels(
+                    client1,
+                    nfs_nodes,
+                    placement["nfs"],
+                    placement["ingress"],
+                    labels,
+                )
+                for spare_label in (labels["nfs"], labels["ingress"]):
+                    client1.exec_command(
+                        sudo=True,
+                        cmd=f"ceph orch host label rm {spare_host} {spare_label}",
+                        check_ec=False,
+                    )
+            except Exception as e:
+                log.warning("Placement label cleanup failed: %s", e)
+
+
+def _run_workflow(ceph_cluster, config, workflow, step, total, is_first_workflow):
+    _log_workflow_start(workflow, step, total)
+    if COLOCATION_WORKFLOWS[workflow].get("deploy_only"):
+        return _run_deploy_workflow(
+            ceph_cluster, config, workflow, is_first_workflow=is_first_workflow
+        )
+    return _run_failover_workflow(ceph_cluster, config, workflow)
+
+
+def run(ceph_cluster, **kw):
+    """Run NFS Multi-Active colocation port deploy and failover workflows."""
+    config = kw.get("config") or {}
+    init_crash_monitoring(config)
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+
+    if len(clients) < 2:
+        raise ConfigError("Colocation tests require at least 2 clients")
+    if len(nfs_nodes) < MIN_NFS_NODES:
+        raise ConfigError(
+            f"Need at least {MIN_NFS_NODES} NFS-capable nodes, found {len(nfs_nodes)}"
+        )
+
+    workflows = (
+        [config["workflow"]] if config.get("workflow") else list(COLOCATION_WORKFLOWS)
+    )
+    for step, workflow in enumerate(workflows, start=1):
+        if workflow not in COLOCATION_WORKFLOWS:
+            raise ConfigError(
+                f"Unknown workflow {workflow!r}; valid: "
+                f"{', '.join(COLOCATION_WORKFLOWS)}"
+            )
+        rc = _run_workflow(
+            ceph_cluster,
+            config,
+            workflow,
+            step,
+            len(workflows),
+            is_first_workflow=(step == 1),
+        )
+        if rc != 0:
+            return rc
+        try:
+            tc = COLOCATION_WORKFLOWS[workflow].get("tc", workflow)
+            wait_for_ceph_health(ceph_cluster, config, context=f"post-{tc}")
+        except ConfigError as e:
+            log.error("Post-%s health check failed: %s", tc, e)
+            return 1
+    try:
+        wait_for_ceph_health(ceph_cluster, config, context="post-suite")
+    except ConfigError as e:
+        log.error("Post-suite stabilization failed: %s", e)
+        return 1
+    return 0

--- a/tests/nfs/multi_active/test_nfs_multi_active_daemon_disruption.py
+++ b/tests/nfs/multi_active/test_nfs_multi_active_daemon_disruption.py
@@ -1,0 +1,572 @@
+"""NFS Multi-Active daemon disruption during background IO (single deploy, DR-1..DR-7)."""
+
+from time import sleep
+
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active import (
+    NfsMultiActiveClient,
+    client_backend_mappings,
+    init_crash_monitoring,
+    io_runtime,
+    io_tool_label,
+    session_setup,
+    session_teardown,
+    stop_phase_io,
+    wait_for_ceph_health,
+)
+from tests.nfs.lib.multi_active.constants import (
+    BG_IO_RESUME_TIMEOUT,
+    DEPLOY_TIMEOUT,
+    MARKER_IO_TIMEOUT,
+    MIN_NFS_NODES,
+    NFS_MOUNT,
+    SERVICE_ID_PREFIX,
+)
+from tests.nfs.lib.multi_active.daemon_disruption import NfsMultiActiveDaemonDisruption
+from tests.nfs.multi_active.test_nfs_multi_active_failover import (
+    _VIP2,
+    _log_workflow_timings,
+    _now,
+    _validate_failover_cluster_state,
+    _wait_io_resume,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+NFS_SERVICE_ID_PREFIX = SERVICE_ID_PREFIX["daemon_disruption"]
+
+# Standard 2 NFS + 2 ingress placement; one cluster for all workflows.
+_PORTS = (17401, 17501, 20301)
+DAEMON_DISRUPTION_IO_WARMUP = 10
+
+# Execution order: least → most disruptive; DR-1..DR-7 match phase sequence in logs.
+DAEMON_DISRUPTION_WORKFLOWS = {
+    "dr1_nfs_restart_secondary": {
+        "tc": "DR-1",
+        "desc": "Restart NFS on non-pinned backend; IO should continue.",
+        "daemon": "nfs",
+        "action": "restart",
+        "target": "secondary_nfs",
+    },
+    "dr2_nfs_restart_pinned": {
+        "tc": "DR-2",
+        "desc": "Restart NFS on stick-table-pinned backend.",
+        "daemon": "nfs",
+        "action": "restart",
+        "target": "pinned_nfs",
+    },
+    "dr3_nfs_stop_start_pinned": {
+        "tc": "DR-3",
+        "desc": "Stop then start NFS on pinned backend.",
+        "daemon": "nfs",
+        "action": "stop_start",
+        "target": "pinned_nfs",
+    },
+    "dr4_haproxy_restart_standby": {
+        "tc": "DR-4",
+        "desc": "Restart haproxy on standby ingress; IO should continue.",
+        "daemon": "haproxy",
+        "action": "restart",
+        "target": "standby_ingress",
+    },
+    "dr5_haproxy_restart_vip": {
+        "tc": "DR-5",
+        "desc": "Restart haproxy on VIP-holder ingress.",
+        "daemon": "haproxy",
+        "action": "restart",
+        "target": "vip_ingress",
+    },
+    "dr6_ingress_stop_start_vip": {
+        "tc": "DR-6",
+        "desc": (
+            "Stop then start haproxy and keepalived on VIP-holder ingress; "
+            "IO should continue via standby ingress failover."
+        ),
+        "daemons": ("haproxy", "keepalived"),
+        "stop_order": ("haproxy", "keepalived"),
+        "start_order": ("keepalived", "haproxy"),
+        "action": "ingress_stop_start_failover",
+        "target": "vip_ingress",
+    },
+    "dr7_keepalived_restart_vip": {
+        "tc": "DR-7",
+        "desc": "Restart keepalived on VIP-holder ingress.",
+        "daemon": "keepalived",
+        "action": "restart",
+        "target": "vip_ingress",
+    },
+}
+
+DAEMON_DISRUPTION_PHASES = [
+    "dr1_nfs_restart_secondary",
+    "dr2_nfs_restart_pinned",
+    "dr3_nfs_stop_start_pinned",
+    "dr4_haproxy_restart_standby",
+    "dr5_haproxy_restart_vip",
+    "dr6_ingress_stop_start_vip",
+    "dr7_keepalived_restart_vip",
+]
+
+
+def _resolve_target_host(ctx, target):
+    """Return (hostname, primary_io_client) for the workflow target."""
+    failover = ctx["failover"]
+    mappings = client_backend_mappings(
+        ctx["haproxy"], ctx["mounted_clients"], ctx["spare_host"]
+    )
+    primary_io_client, pinned_nfs = mappings[0]
+
+    if target == "pinned_nfs":
+        return pinned_nfs, primary_io_client
+
+    if target == "secondary_nfs":
+        cluster_info = ctx["deploy"].validator.get_cluster_info(ctx["nfs_service_id"])
+        backends = {
+            backend.get("hostname")
+            for backend in cluster_info.get("backend", [])
+            if backend.get("hostname")
+        }
+        secondary = next(
+            (host for host in sorted(backends) if host != pinned_nfs),
+            None,
+        )
+        if not secondary:
+            raise ConfigError(f"No secondary NFS backend found (pinned={pinned_nfs!r})")
+        return secondary, primary_io_client
+
+    if target == "vip_ingress":
+        return (
+            failover.get_active_ingress_host(
+                ctx["ceph_cluster"], ctx["vip"], ctx["ingress_hosts"]
+            ),
+            primary_io_client,
+        )
+
+    if target == "standby_ingress":
+        return (
+            failover.get_standby_ingress_host(
+                ctx["ceph_cluster"], ctx["vip"], ctx["ingress_hosts"]
+            ),
+            primary_io_client,
+        )
+
+    raise ConfigError(f"Unsupported disruption target {target!r}")
+
+
+def _wait_daemon_healthy(ctx, workflow, timings):
+    validator = ctx["deploy"].validator
+    nfs_name = ctx["nfs_service_id"]
+    if workflow.get("daemon") == "nfs":
+        ctx["failover"].wait_nfs_daemons(
+            validator,
+            nfs_name,
+            ctx["nfs_count"],
+            timeout=DEPLOY_TIMEOUT,
+            timings=timings,
+        )
+    else:
+        ctx["failover"].wait_ingress_daemons(
+            validator,
+            nfs_name,
+            len(ctx["ingress_hosts"]),
+            timeout=DEPLOY_TIMEOUT,
+            timings=timings,
+        )
+
+
+def _workflow_daemon_label(workflow):
+    daemon = workflow.get("daemon")
+    if daemon:
+        return daemon
+    return "+".join(workflow.get("daemons", ()))
+
+
+def _io_sessions(ctx):
+    return [
+        (
+            ctx["primary_io_client"],
+            ctx["io_thread"],
+            ctx["io_error_box"],
+            ctx["io_dir"],
+        )
+    ]
+
+
+def _start_session_io(ctx):
+    """Start one background IO stream for the full daemon-disruption session."""
+    mappings = client_backend_mappings(
+        ctx["haproxy"], ctx["mounted_clients"], ctx["spare_host"]
+    )
+    primary_io_client, _pinned_nfs = mappings[0]
+    io_dir = f"{NFS_MOUNT.rstrip('/')}/{ctx['session_name']}"
+    io_thread, io_error_box, io_dir = NfsMultiActiveClient.run_background_io(
+        primary_io_client,
+        NFS_MOUNT,
+        ctx["config"],
+        io_subdir=ctx["session_name"],
+        runtime=io_runtime(ctx["config"]),
+    )
+    ctx["primary_io_client"] = primary_io_client
+    ctx["io_thread"] = io_thread
+    ctx["io_error_box"] = io_error_box
+    ctx["io_dir"] = io_dir
+    ctx["io_started_at"] = _now()
+    log.info(
+        "Session background IO started on %s at %s; warming up %ss",
+        primary_io_client.hostname,
+        io_dir,
+        DAEMON_DISRUPTION_IO_WARMUP,
+    )
+    sleep(DAEMON_DISRUPTION_IO_WARMUP)
+
+
+def _stop_session_io(ctx):
+    """Stop session background IO during teardown."""
+    if not ctx.get("io_thread"):
+        return
+    stop_phase_io(
+        ctx["config"],
+        False,
+        None,
+        ctx["io_thread"],
+        ctx["io_error_box"],
+        ctx["primary_io_client"],
+        ctx["io_dir"],
+    )
+    ctx["io_thread"] = None
+
+
+def _wait_io_resume_after_action(
+    ctx, config, timings, timings_key, trigger_timing_key, stage
+):
+    _wait_io_resume(
+        config,
+        False,
+        None,
+        ctx["io_thread"],
+        ctx["io_error_box"],
+        ctx["primary_io_client"],
+        ctx["io_dir"],
+        timings,
+        timings_key=timings_key,
+        trigger_timing_key=trigger_timing_key,
+        stage=stage,
+    )
+
+
+def _stabilize_between_phases(ceph_cluster, config, workflow_tc):
+    """Verify Ceph health before the next disruption phase."""
+    wait_for_ceph_health(ceph_cluster, config, context=f"post-{workflow_tc}")
+
+
+def _verify_io_continues(ctx, config, timings, timings_key, stage):
+    """Confirm background IO remains responsive (no stall expected)."""
+    io_tool = io_tool_label(config)
+    log.info(
+        "Verifying background %s IO is unaffected while target daemons are stopped (%s)",
+        io_tool,
+        stage,
+    )
+    _wait_io_resume(
+        config,
+        False,
+        None,
+        ctx["io_thread"],
+        ctx["io_error_box"],
+        ctx["primary_io_client"],
+        ctx["io_dir"],
+        timings,
+        timings_key=timings_key,
+        trigger_timing_key=None,
+        stage=stage,
+    )
+
+
+def _run_restart_disruption(
+    ctx, workflow, timings, timings_key, trigger_timing_key, stage, target_host
+):
+    """Restart daemon, wait for target daemon running, wait for health, then confirm IO resume."""
+    timings[trigger_timing_key] = _now()
+    daemon_name, started_before = NfsMultiActiveDaemonDisruption.apply(
+        ctx["client1"],
+        ctx["deploy"].validator,
+        ctx["nfs_service_id"],
+        target_host,
+        workflow["daemon"],
+        workflow["action"],
+    )
+    NfsMultiActiveDaemonDisruption.wait_restarted(
+        ctx["deploy"].validator,
+        ctx["nfs_service_id"],
+        target_host,
+        workflow["daemon"],
+        daemon_name,
+        started_before,
+        timeout=DEPLOY_TIMEOUT,
+    )
+    _wait_daemon_healthy(ctx, workflow, timings)
+    _wait_io_resume_after_action(
+        ctx,
+        ctx["config"],
+        timings,
+        timings_key,
+        trigger_timing_key,
+        stage,
+    )
+
+
+def _run_stop_start_disruption(ctx, workflow, timings, timings_key, target_host, stage):
+    """Stop daemon, confirm IO stall, start daemon, then confirm IO resume."""
+    sessions = _io_sessions(ctx)
+    start_trigger_key = f"{timings_key}_start_triggered_at"
+    validator = ctx["deploy"].validator
+    orch_client = ctx["client1"]
+    nfs_service_id = ctx["nfs_service_id"]
+    component = workflow["daemon"]
+
+    timings[f"{timings_key}_stop_triggered_at"] = _now()
+    daemon_name = NfsMultiActiveDaemonDisruption.stop(
+        orch_client,
+        validator,
+        nfs_service_id,
+        target_host,
+        component,
+    )
+
+    NfsMultiActiveClient.wait_for_background_io_stall(
+        sessions,
+        NFS_MOUNT,
+        ctx["config"],
+        timeout=BG_IO_RESUME_TIMEOUT,
+        timings=timings,
+    )
+    timings[f"{timings_key}_stalled_at"] = _now()
+
+    timings[start_trigger_key] = _now()
+    NfsMultiActiveDaemonDisruption.start(
+        orch_client, daemon_name, target_host, component
+    )
+    NfsMultiActiveDaemonDisruption.wait_running(
+        validator,
+        nfs_service_id,
+        target_host,
+        component,
+        daemon_name=daemon_name,
+        timeout=DEPLOY_TIMEOUT,
+    )
+    _wait_daemon_healthy(ctx, workflow, timings)
+    _wait_io_resume_after_action(
+        ctx,
+        ctx["config"],
+        timings,
+        timings_key,
+        start_trigger_key,
+        f"{stage} resume",
+    )
+
+
+def _run_ingress_failover_stop_start_disruption(
+    ctx, workflow, timings, timings_key, target_host, stage
+):
+    """Stop VIP-holder ingress daemons, confirm stopped + IO continues, then start both."""
+    start_trigger_key = f"{timings_key}_start_triggered_at"
+    validator = ctx["deploy"].validator
+    orch_client = ctx["client1"]
+    nfs_service_id = ctx["nfs_service_id"]
+    stop_order = workflow["stop_order"]
+    start_order = workflow["start_order"]
+
+    timings[f"{timings_key}_stop_triggered_at"] = _now()
+    daemon_names = {}
+    for component in stop_order:
+        daemon_names[component] = NfsMultiActiveDaemonDisruption.stop(
+            orch_client,
+            validator,
+            nfs_service_id,
+            target_host,
+            component,
+        )
+        NfsMultiActiveDaemonDisruption.wait_stopped(
+            validator,
+            nfs_service_id,
+            target_host,
+            component,
+            daemon_name=daemon_names[component],
+            timeout=DEPLOY_TIMEOUT,
+        )
+
+    _verify_io_continues(
+        ctx,
+        ctx["config"],
+        timings,
+        f"{timings_key}_while_stopped",
+        f"{stage} while stopped",
+    )
+
+    timings[start_trigger_key] = _now()
+    for component in start_order:
+        daemon_name = daemon_names[component]
+        NfsMultiActiveDaemonDisruption.start(
+            orch_client, daemon_name, target_host, component
+        )
+        NfsMultiActiveDaemonDisruption.wait_running(
+            validator,
+            nfs_service_id,
+            target_host,
+            component,
+            daemon_name=daemon_name,
+            timeout=DEPLOY_TIMEOUT,
+        )
+    _wait_daemon_healthy(ctx, workflow, timings)
+    _wait_io_resume_after_action(
+        ctx,
+        ctx["config"],
+        timings,
+        timings_key,
+        start_trigger_key,
+        f"{stage} resume",
+    )
+
+
+def _validate_disruption_cluster_state(ctx, target_host, timings):
+    """Post-disruption validation: cluster health, stick table, no label-drain checks."""
+    _validate_failover_cluster_state(
+        ctx["deploy"],
+        ctx["haproxy"],
+        ctx["nfs_spec"],
+        ctx["ingress_spec"],
+        ctx["nfs_service_id"],
+        list(ctx["ingress_hosts"]),
+        ctx["mounted_clients"],
+        "reboot",
+        ctx["spare_host"],
+        target_host,
+        timings,
+        stick_kwargs=ctx["stick_kwargs"],
+    )
+
+
+def _run_disruption_phase(ctx, workflow_key, phase_step, phase_total):
+    workflow = DAEMON_DISRUPTION_WORKFLOWS[workflow_key]
+    config = ctx["config"]
+    timings = {"io_start": ctx.get("io_started_at", _now())}
+    target_host, _primary_io_client = _resolve_target_host(ctx, workflow["target"])
+
+    if not ctx.get("io_thread") or not ctx["io_thread"].is_alive():
+        raise OperationFailedError(
+            f"Session background IO is not running before {workflow_key}"
+        )
+
+    log.info(
+        "\n" + "=" * 70 + "\n"
+        "Daemon disruption phase %s/%s | %s | %s on %s | io_tool=%s\n"
+        "%s\n" + "=" * 70,
+        phase_step,
+        phase_total,
+        workflow["tc"],
+        _workflow_daemon_label(workflow),
+        target_host,
+        io_tool_label(config),
+        workflow["desc"],
+    )
+
+    trigger_key = f"disruption_{workflow_key}_triggered_at"
+    timings_key = f"io_resume_{workflow_key}"
+    stage = f"{workflow['tc']} {_workflow_daemon_label(workflow)} {workflow['action']}"
+
+    if workflow["action"] == "ingress_stop_start_failover":
+        _run_ingress_failover_stop_start_disruption(
+            ctx, workflow, timings, timings_key, target_host, stage
+        )
+    elif workflow["action"] == "stop_start":
+        _run_stop_start_disruption(
+            ctx, workflow, timings, timings_key, target_host, stage
+        )
+    else:
+        _run_restart_disruption(
+            ctx, workflow, timings, timings_key, trigger_key, stage, target_host
+        )
+
+    _validate_disruption_cluster_state(ctx, target_host, timings)
+
+    marker = f"{ctx['io_dir']}/post-disruption-marker-{workflow_key}"
+    marker_client = next(
+        c for c in ctx["mounted_clients"] if c != ctx["primary_io_client"]
+    )
+    marker_client.exec_command(
+        sudo=True,
+        cmd=(
+            f"timeout {MARKER_IO_TIMEOUT} sh -c "
+            f"'echo disruption-ok-{workflow_key} > {marker}'"
+        ),
+        timeout=MARKER_IO_TIMEOUT + 10,
+    )
+    out, _ = ctx["primary_io_client"].exec_command(
+        sudo=True,
+        cmd=f"timeout {MARKER_IO_TIMEOUT} cat {marker}",
+        timeout=MARKER_IO_TIMEOUT + 10,
+    )
+    if "disruption-ok" not in (out or ""):
+        raise ConfigError(f"Cross-client marker read failed after {workflow_key}")
+
+    timings["io_end"] = _now()
+    _log_workflow_timings(timings)
+    log.info("Phase %s (%s) completed", workflow_key, workflow["tc"])
+
+
+def run(ceph_cluster, **kw):
+    """Deploy once, run DR-1..DR-7 daemon disruptions, then cleanup."""
+    config = kw.get("config") or {}
+    init_crash_monitoring(config)
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+
+    if len(clients) < 2:
+        raise ConfigError("Daemon disruption requires at least 2 clients")
+    if len(nfs_nodes) < MIN_NFS_NODES:
+        raise ConfigError(
+            f"Need at least {MIN_NFS_NODES} NFS-capable nodes, found {len(nfs_nodes)}"
+        )
+
+    phases = config.get("workflows") or DAEMON_DISRUPTION_PHASES
+    for workflow_key in phases:
+        if workflow_key not in DAEMON_DISRUPTION_WORKFLOWS:
+            raise ConfigError(f"Unknown daemon disruption workflow {workflow_key!r}")
+
+    log.info(
+        "NFS Multi-Active daemon disruption | %d phase(s) on one cluster | io_tool=%s",
+        len(phases),
+        io_tool_label(config),
+    )
+
+    ctx = None
+    try:
+        ctx = session_setup(
+            ceph_cluster,
+            config,
+            f"{NFS_SERVICE_ID_PREFIX}-daemon-disruption",
+            _VIP2,
+            _PORTS,
+            is_first_workflow=True,
+            service_id_prefix=NFS_SERVICE_ID_PREFIX,
+        )
+        _start_session_io(ctx)
+        for phase_idx, workflow_key in enumerate(phases, start=1):
+            _run_disruption_phase(ctx, workflow_key, phase_idx, len(phases))
+            workflow_tc = DAEMON_DISRUPTION_WORKFLOWS[workflow_key]["tc"]
+            try:
+                _stabilize_between_phases(ceph_cluster, config, workflow_tc)
+            except ConfigError as e:
+                log.error("Post-%s health check failed: %s", workflow_tc, e)
+                return 1
+        log.info("Daemon disruption session completed successfully")
+        return 0
+    except Exception as e:
+        log.error("Daemon disruption session failed: %s", e)
+        return 1
+    finally:
+        if ctx is not None:
+            _stop_session_io(ctx)
+            session_teardown(ctx)
+        wait_for_ceph_health(ceph_cluster, config, context="post-suite")

--- a/tests/nfs/multi_active/test_nfs_multi_active_failover.py
+++ b/tests/nfs/multi_active/test_nfs_multi_active_failover.py
@@ -1,0 +1,2056 @@
+from datetime import datetime
+from threading import Thread
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.nfs.lib.multi_active import (
+    NfsMultiActiveCleanup,
+    NfsMultiActiveClient,
+    NfsMultiActiveConfig,
+    NfsMultiActiveDeploy,
+    NfsMultiActiveFailover,
+    NfsMultiActiveHaproxy,
+    init_crash_monitoring,
+    session_setup,
+    session_teardown,
+    wait_for_ceph_health,
+)
+from tests.nfs.lib.multi_active.placement import (
+    FAILOVER_PLACEMENT,
+    resolve_placement_hosts,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+"""
+NFS Multi-Active failover suite (baremetal).
+
+Four sessions (one deploy/teardown each); phases reuse the same cluster within a session.
+
+  Session 1 ``label_single_client`` (TC-1)
+    - label_dual_failover: NFS then ingress label drain during single-client background IO
+
+  Session 2 ``label_dual_client`` (TC-2, TC-3)
+    - Phase 1 label_dual_failover_dual_io: dual-client IO; primary NFS + VIP ingress drain
+    - restore baseline placement + remount
+    - Phase 2 label_secondary_failover_dual_io: secondary NFS + standby ingress drain
+
+  Session 3 ``roundtrip_reboot`` (TC-4, TC-5)
+    - Phase 1 label_roundtrip_failover: NFS and ingress label out-and-back
+    - remount
+    - Phase 2 reboot_failover: reboot pinned NFS backend then VIP-holder ingress
+
+  Session 4 ``dual_cluster`` (TC-6)
+    - dual_cluster_vip_failover: two HA clusters; sequential ingress failover A then B
+
+Suite config ``io_tool``: ``dd`` (default) or ``fio`` for background IO during failover.
+"""
+
+from tests.nfs.lib.multi_active.constants import (
+    BG_IO_JOIN_TIMEOUT,
+    BG_IO_RESUME_TIMEOUT,
+    BG_IO_RUNTIME,
+    BG_IO_START_DELAY,
+    DEPLOY_TIMEOUT,
+    EXPORT_NAME,
+    HEALTH_CHECK_INTERVAL,
+    MARKER_IO_TIMEOUT,
+    MIN_NFS_NODES,
+    NFS_MOUNT,
+    NFS_MOUNT_A,
+    NFS_MOUNT_B,
+    NFS_VERSION,
+    POLL_INTERVAL_SEC,
+    SERVICE_ID_PREFIX,
+)
+
+NFS_SERVICE_ID_PREFIX = SERVICE_ID_PREFIX["failover"]
+
+# Failover phase definitions (TC-1..TC-6). Each phase runs inside a session.
+_PLACEMENT = FAILOVER_PLACEMENT
+_SPARE = FAILOVER_PLACEMENT["spare"]
+
+# Suite config ``vips`` list index (1-based) per session.
+_VIP1 = 1
+_VIP2 = 2
+
+FAILOVER_WORKFLOWS = {
+    "label_dual_failover": {
+        "tc": "TC-1",
+        "desc": (
+            "Single-client background IO with sequential NFS backend then "
+            "keepalived VIP-holder ingress label failover."
+        ),
+        "steps": (
+            "Start background IO on the stick-table-pinned primary client",
+            "NFS label drain: pinned backend -> spare; orch apply nfs spec; wait IO resume",
+            "Ingress label drain: VIP holder -> spare; orch apply ingress spec; wait IO resume",
+            "Validate cluster info, orch ps, stick table, and post-failover backends",
+            "Cross-client post-failover marker write/read",
+        ),
+        "ports": (15601, 15701, 19851),
+        "placement": _PLACEMENT,
+        "failover": {"target": "dual", "spare": _SPARE},
+        "vip": _VIP1,
+    },
+    "label_dual_failover_dual_io": {
+        "tc": "TC-2",
+        "desc": (
+            "Dual-client background IO on distinct stick-table backends; sequential "
+            "primary NFS backend then VIP-holder ingress label failover."
+        ),
+        "steps": (
+            "Start background IO on both clients (distinct stick-table backends)",
+            "NFS label drain: primary client's pinned backend -> spare; wait IO resume",
+            "Ingress label drain: keepalived VIP holder -> spare; wait IO resume",
+            "Validate cluster info, orch ps, stick table, and backends",
+            "Cross-client post-failover marker write/read",
+        ),
+        "dual_client_io": True,
+        "ports": (16201, 16301, 20001),
+        "placement": _PLACEMENT,
+        "failover": {"target": "dual", "spare": _SPARE},
+        "vip": _VIP2,
+    },
+    "label_secondary_failover_dual_io": {
+        "tc": "TC-3",
+        "desc": (
+            "Dual-client background IO; drain non-primary NFS backend and "
+            "non-VIP-holder (standby) ingress to spare."
+        ),
+        "steps": (
+            "Start background IO on both clients",
+            "NFS label drain: secondary (non-primary) backend -> spare; wait IO resume",
+            "Ingress label drain: standby ingress (not VIP holder) -> spare; wait IO resume",
+            "Validate cluster info, orch ps, stick table, and backends",
+            "Cross-client post-failover marker write/read",
+        ),
+        "dual_client_io": True,
+        "ports": (16401, 16501, 20051),
+        "placement": _PLACEMENT,
+        "failover": {"target": "secondary_nfs_standby_ingress", "spare": _SPARE},
+        "vip": _VIP1,
+    },
+    "label_roundtrip_failover": {
+        "tc": "TC-4",
+        "desc": (
+            "Single-client background IO; NFS backend and ingress VIP-holder "
+            "each label-drain to spare and return to the original host."
+        ),
+        "steps": (
+            "Start background IO on stick-table-pinned primary client",
+            "NFS roundtrip: pinned backend -> spare -> original; IO resume after each apply",
+            "Ingress roundtrip: VIP holder -> spare -> original; IO resume after each apply",
+            "Validate cluster info, orch ps, stick table, and backends",
+            "Cross-client post-failover marker write/read",
+        ),
+        "ports": (16601, 16701, 20101),
+        "placement": _PLACEMENT,
+        "failover": {"target": "roundtrip", "spare": _SPARE},
+        "vip": _VIP2,
+    },
+    "reboot_failover": {
+        "tc": "TC-5",
+        "desc": (
+            "Single-client background IO; reboot stick-table-pinned NFS backend "
+            "then reboot keepalived VIP-holder ingress node."
+        ),
+        "steps": (
+            "Start background IO on stick-table-pinned primary client",
+            "Reboot pinned NFS backend; poll IO resume from reboot issue; validate cluster",
+            "Reboot VIP-holder ingress node; poll IO resume from reboot issue; validate cluster",
+            "Cross-client post-failover marker write/read",
+        ),
+        "ports": (16801, 16901, 20151),
+        "placement": _PLACEMENT,
+        "failover": {"target": "reboot", "spare": _SPARE},
+        "vip": _VIP1,
+    },
+    "dual_cluster_vip_failover": {
+        "tc": "TC-6",
+        "desc": (
+            "Two NFS multi-active clusters (VIP A and VIP B); client1 IO on cluster A "
+            "and client2 IO on cluster B; sequential VIP-holder ingress label failover."
+        ),
+        "steps": (
+            "Deploy cluster A (VIP A) and cluster B (VIP B); mount and start IO on each client",
+            "Cluster A: ingress label drain VIP holder -> spare; wait IO resume on client1",
+            "Assert cluster B IO still running (peer isolation)",
+            "Cluster B: ingress label drain VIP holder -> host drained from cluster A; wait IO resume",
+            "Assert cluster A IO still running; complete IO and post-failover markers on both",
+        ),
+        "dual_cluster": True,
+        "ports_a": (17001, 17101, 20201),
+        "ports_b": (17201, 17301, 20251),
+        "placement": _PLACEMENT,
+        "failover": {"target": "dual_cluster_ingress", "spare": _SPARE},
+    },
+}
+
+# Failover sessions: one deploy/mount/teardown per session; phases share the cluster.
+FAILOVER_SESSIONS = [
+    {
+        "name": "label_single_client",
+        "tc": "TC-1",
+        "desc": "Single-client sequential NFS + ingress label failover.",
+        "vip": _VIP1,
+        "ports": (15601, 15701, 19851),
+        "phases": ["label_dual_failover"],
+    },
+    {
+        "name": "label_dual_client",
+        "tc": "TC-2, TC-3",
+        "desc": (
+            "Dual-client primary NFS + ingress failover, then secondary NFS + "
+            "standby ingress failover (baseline restore + remount between phases)."
+        ),
+        "vip": _VIP2,
+        "ports": (16201, 16301, 20001),
+        "phases": [
+            "label_dual_failover_dual_io",
+            "label_secondary_failover_dual_io",
+        ],
+        "restore_between_phases": True,
+        "remount_between_phases": True,
+    },
+    {
+        "name": "roundtrip_reboot",
+        "tc": "TC-4, TC-5",
+        "desc": (
+            "Label roundtrip (NFS + ingress out-and-back), then reboot pinned "
+            "NFS backend and VIP-holder ingress (remount between phases)."
+        ),
+        "vip": _VIP1,
+        "ports": (16801, 16901, 20151),
+        "phases": ["label_roundtrip_failover", "reboot_failover"],
+        "remount_between_phases": True,
+    },
+    {
+        "name": "dual_cluster",
+        "tc": "TC-6",
+        "desc": "Two HA clusters with sequential ingress VIP failover on each.",
+        "dual_cluster": True,
+        "workflow": "dual_cluster_vip_failover",
+    },
+]
+
+
+def _poll_interval(config):
+    return int(config.get("poll_interval_sec", POLL_INTERVAL_SEC))
+
+
+def _io_runtime(config):
+    return NfsMultiActiveConfig.io_runtime(config, default=BG_IO_RUNTIME)
+
+
+def _io_tool_label(config):
+    return NfsMultiActiveConfig.resolve_io_tool(config)
+
+
+def _io_mode_label(config, dual_client_io=False, dual_cluster=False):
+    tool = _io_tool_label(config)
+    if dual_cluster:
+        return f"dual-cluster {tool} (client1 on VIP A, client2 on VIP B)"
+    if dual_client_io:
+        return f"dual-client {tool}"
+    return f"single-client {tool}"
+
+
+def _deploy_kwargs(config, is_first_session):
+    """Build deploy kwargs; skip one-time setup on subsequent sessions."""
+    kwargs = {
+        "deploy_timeout": DEPLOY_TIMEOUT,
+        "ingress_poll_interval": _poll_interval(config),
+    }
+    if not is_first_session:
+        kwargs.update(
+            {
+                "skip_mgr_enable": True,
+            }
+        )
+    return kwargs
+
+
+def _format_steps(steps):
+    return "\n".join(f"    {idx}. {step}" for idx, step in enumerate(steps, start=1))
+
+
+def _phase_workflow_label(workflow_key):
+    wf = FAILOVER_WORKFLOWS[workflow_key]
+    return f"{wf.get('tc', '?')} ({workflow_key})"
+
+
+def _session_phase_summary(session):
+    if session.get("dual_cluster"):
+        workflow = session["workflow"]
+        return _phase_workflow_label(workflow)
+    return " -> ".join(_phase_workflow_label(p) for p in session.get("phases", []))
+
+
+def _log_phase_banner(
+    workflow_key, phase_step, phase_total, nfs_count, ingress_count, target, config=None
+):
+    wf = FAILOVER_WORKFLOWS[workflow_key]
+    config = config or {}
+    io_mode = _io_mode_label(
+        config,
+        dual_client_io=wf.get("dual_client_io", False),
+        dual_cluster=wf.get("dual_cluster", False),
+    )
+    fail_types = {
+        "dual": "sequential NFS backend then VIP-holder ingress label drain",
+        "secondary_nfs_standby_ingress": (
+            "non-primary NFS backend then standby ingress label drain"
+        ),
+        "roundtrip": "NFS and ingress label roundtrip (out to spare and back)",
+        "reboot": "stick-table NFS backend reboot then VIP-holder ingress reboot",
+        "dual_cluster_ingress": (
+            "cluster A VIP-holder ingress drain, then cluster B VIP-holder ingress drain"
+        ),
+    }
+    steps = wf.get("steps") or ()
+    steps_block = f"\nSteps:\n{_format_steps(steps)}\n" if steps else "\n"
+    log.info(
+        "\n" + "=" * 70 + "\n"
+        "Phase %d of %d: %s\n"
+        "%s\n"
+        "IO: %s\n"
+        "NFS daemons: %s | Ingress hosts: %s\n"
+        "Failover: %s\n"
+        f"{steps_block}" + "=" * 70,
+        phase_step,
+        phase_total,
+        _phase_workflow_label(workflow_key),
+        wf.get("desc", ""),
+        io_mode,
+        nfs_count,
+        ingress_count,
+        fail_types.get(target, target),
+    )
+
+
+def _log_workflow_banner(
+    workflow_key, phase_step, phase_total, nfs_count, ingress_count, target, config=None
+):
+    """Backward-compatible alias for dual-cluster session entry."""
+    _log_phase_banner(
+        workflow_key, phase_step, phase_total, nfs_count, ingress_count, target, config
+    )
+
+
+def _resolve_placement_hosts(config, nfs_nodes, spare_slice=None):
+    """Return hosts for the standard failover-session placement."""
+    kwargs = {}
+    if spare_slice is not None:
+        kwargs["spare_slice"] = spare_slice
+    return resolve_placement_hosts(nfs_nodes, FAILOVER_PLACEMENT, config, **kwargs)
+
+
+def _ingress_hosts_after_failover(ingress_hosts, remove_host, spare_host):
+    return [host for host in ingress_hosts if host != remove_host] + [spare_host]
+
+
+def _client_backend_mappings(haproxy, mounted_clients, spare_host):
+    """Return [(client, pinned_backend), ...] for clients not pinned to spare."""
+    mappings = []
+    for client in mounted_clients:
+        backend = haproxy.get_client_backend_hostname(client)
+        if backend == spare_host:
+            continue
+        mappings.append((client, backend))
+    if not mappings:
+        raise ConfigError(
+            f"No mounted client pinned to a non-spare backend (spare={spare_host!r})"
+        )
+    return mappings
+
+
+def _log_stick_table_nfs_target(mappings, primary_client, pinned, spare_host):
+    """Log NFS failover host derived from HAProxy stick-table pinning."""
+    log.info(
+        "NFS failover target (HAProxy stick table): primary client %s pinned to "
+        "backend %s; label drain %s -> %s",
+        primary_client.hostname,
+        pinned,
+        pinned,
+        spare_host,
+    )
+    for client, backend in mappings:
+        if client == primary_client:
+            continue
+        log.info(
+            "  Stick table: client %s pinned to backend %s",
+            client.hostname,
+            backend,
+        )
+
+
+def _log_vip_ingress_target(vip, active_ingress, spare_host):
+    """Log ingress failover host derived from keepalived VIP ownership."""
+    log.info(
+        "Ingress failover target (keepalived VIP %s): VIP holder %s; "
+        "label drain %s -> %s",
+        vip,
+        active_ingress,
+        active_ingress,
+        spare_host,
+    )
+
+
+def _log_colocated_nfs_ingress_note(pinned, active_ingress):
+    if pinned == active_ingress:
+        log.info(
+            "Colocated node %s: stick-table NFS backend and keepalived VIP holder "
+            "are the same host (selected independently)",
+            pinned,
+        )
+
+
+def _resolve_failover_plan(
+    haproxy,
+    failover,
+    ceph_cluster,
+    vip,
+    mounted_clients,
+    spare_host,
+    ingress_hosts,
+    target,
+    dual_client_io=False,
+):
+    """
+    Build the failover plan before starting background IO.
+
+    Primary client (mappings[0]) is stick-table-pinned to the NFS backend being
+    removed for nfs/dual. Ingress/dual: ingress target is the keepalived VIP holder
+    (``ip addr`` on ingress pool hosts). When ``dual_client_io`` is set, IO runs
+    on every mapped client.
+
+    Returns (io_clients, primary_io_client, pinned_backend, removed_nfs_host,
+    removed_ingress_host, expected_ingress).
+    """
+    mappings = _client_backend_mappings(haproxy, mounted_clients, spare_host)
+    primary_client, pinned = mappings[0]
+    io_clients = (
+        [client for client, _ in mappings] if dual_client_io else [primary_client]
+    )
+    io_hosts = ", ".join(
+        f"{client.hostname}->{backend}" for client, backend in mappings
+    )
+
+    if target == "nfs":
+        _log_stick_table_nfs_target(mappings, primary_client, pinned, spare_host)
+        log.info(
+            "Failover plan (nfs): background IO on [%s]; NFS-only label drain",
+            io_hosts,
+        )
+        return io_clients, primary_client, pinned, pinned, None, list(ingress_hosts)
+
+    if target == "ingress":
+        _log_stick_table_nfs_target(mappings, primary_client, pinned, spare_host)
+        active_ingress = failover.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts={spare_host}
+        )
+        expected_ingress = _ingress_hosts_after_failover(
+            ingress_hosts, active_ingress, spare_host
+        )
+        _log_vip_ingress_target(vip, active_ingress, spare_host)
+        log.info(
+            "Failover plan (ingress): background IO on [%s]; ingress-only label drain",
+            io_hosts,
+        )
+        return (
+            io_clients,
+            primary_client,
+            pinned,
+            None,
+            active_ingress,
+            expected_ingress,
+        )
+
+    if target == "dual":
+        _log_stick_table_nfs_target(mappings, primary_client, pinned, spare_host)
+        active_ingress = failover.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts={spare_host}
+        )
+        expected_ingress = _ingress_hosts_after_failover(
+            ingress_hosts, active_ingress, spare_host
+        )
+        _log_vip_ingress_target(vip, active_ingress, spare_host)
+        _log_colocated_nfs_ingress_note(pinned, active_ingress)
+        log.info(
+            "Failover plan (dual): background IO on [%s]; sequential NFS then ingress "
+            "label drain (IO resume required between steps)",
+            io_hosts,
+        )
+        return (
+            io_clients,
+            primary_client,
+            pinned,
+            pinned,
+            active_ingress,
+            expected_ingress,
+        )
+
+    if target == "secondary_nfs_standby_ingress":
+        if not dual_client_io or len(mappings) < 2:
+            raise ConfigError(
+                "secondary_nfs_standby_ingress requires dual_client_io and "
+                "two clients on distinct backends"
+            )
+        secondary_client, secondary_backend = mappings[1]
+        if secondary_backend == pinned:
+            raise ConfigError(
+                "Both clients pinned to the same NFS backend; need distinct backends"
+            )
+        standby_ingress = failover.get_standby_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts={spare_host}
+        )
+        expected_ingress = _ingress_hosts_after_failover(
+            ingress_hosts, standby_ingress, spare_host
+        )
+        _log_stick_table_nfs_target(
+            mappings, primary_client, secondary_backend, spare_host
+        )
+        _log_vip_ingress_target(vip, standby_ingress, spare_host)
+        log.info(
+            "Failover plan (secondary): background IO on both clients; sequential non-primary "
+            "NFS then standby ingress label drain (IO resume required between steps)"
+        )
+        return (
+            [client for client, _ in mappings],
+            primary_client,
+            secondary_backend,
+            secondary_backend,
+            standby_ingress,
+            expected_ingress,
+        )
+
+    if target == "roundtrip":
+        active_ingress = failover.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts={spare_host}
+        )
+        log.info(
+            "Failover plan (roundtrip): background IO on %s; nfs %s <-> %s; ingress %s <-> %s",
+            primary_client.hostname,
+            pinned,
+            spare_host,
+            active_ingress,
+            spare_host,
+        )
+        return (
+            [primary_client],
+            primary_client,
+            pinned,
+            pinned,
+            active_ingress,
+            list(ingress_hosts),
+        )
+
+    if target == "reboot":
+        active_ingress = failover.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts={spare_host}
+        )
+        log.info(
+            "Failover plan (reboot): background IO on %s; reboot nfs %s then ingress %s",
+            primary_client.hostname,
+            pinned,
+            active_ingress,
+        )
+        return (
+            [primary_client],
+            primary_client,
+            pinned,
+            pinned,
+            active_ingress,
+            list(ingress_hosts),
+        )
+
+    raise ConfigError(f"Unsupported failover target {target!r}")
+
+
+def _now():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _duration_since(trigger_time):
+    """Return elapsed seconds from a ``%Y-%m-%d %H:%M:%S`` timestamp string."""
+    if not trigger_time:
+        return None
+    try:
+        started = datetime.strptime(trigger_time, "%Y-%m-%d %H:%M:%S")
+    except (TypeError, ValueError):
+        return None
+    return (datetime.now() - started).total_seconds()
+
+
+def _log_workflow_timings(timings):
+    log.info(
+        "\n" + "*" * 70 + "\n"
+        "Background IO start time: %s\n"
+        "Failover triggered at (NFS orch apply): %s\n"
+        "IO resumed at (after NFS orch apply): %s\n"
+        "IO recovery time after NFS orch apply: %s\n"
+        "NFS daemons ready after failover: %s\n"
+        "Failover triggered at (ingress orch apply): %s\n"
+        "IO resumed at (after ingress orch apply): %s\n"
+        "IO recovery time after ingress orch apply: %s\n"
+        "Ingress daemons ready after failover: %s\n"
+        "Failover triggered at (final orch apply): %s\n"
+        "Stick table ready after failover: %s\n"
+        "IO resume wait time (final): %s\n"
+        "Background IO end time: %s\n" + "*" * 70,
+        timings.get("io_start", "N/A"),
+        timings.get("nfs_failover_triggered_at", "N/A"),
+        timings.get("io_resume_after_nfs_at", "N/A"),
+        timings.get("io_resume_after_nfs", "N/A"),
+        timings.get("nfs_ready", "N/A"),
+        timings.get("ingress_failover_triggered_at", "N/A"),
+        timings.get("io_resume_at", "N/A"),
+        timings.get("io_resume", "N/A"),
+        timings.get("ingress_ready", "N/A"),
+        timings.get("failover_triggered_at", "N/A"),
+        timings.get("stick_table", "N/A"),
+        timings.get("io_resume_final", timings.get("io_resume", "N/A")),
+        timings.get("io_end", "N/A"),
+    )
+
+
+def _wait_io_resume(
+    config,
+    dual_client_io,
+    io_sessions,
+    io_thread,
+    io_error_box,
+    primary_io_client,
+    io_dir,
+    timings,
+    timings_key="io_resume",
+    trigger_timing_key=None,
+    stage="failover",
+):
+    """Wait for background IO (dd or fio) to resume immediately after orch apply."""
+    io_tool = _io_tool_label(config)
+    log.info(
+        "Verifying background %s IO has resumed before continuing (%s)",
+        io_tool,
+        stage,
+    )
+    resume_timings = {}
+    triggered_at = (
+        timings.get(trigger_timing_key) if timings and trigger_timing_key else None
+    )
+    if dual_client_io:
+        if not io_sessions:
+            log.info(
+                "No dual-client %s sessions; skipping IO resume wait (%s)",
+                io_tool,
+                stage,
+            )
+            if timings is not None:
+                timings[timings_key] = f"skipped (no {io_tool} sessions)"
+            return
+        NfsMultiActiveClient.wait_for_background_io_resume(
+            io_sessions,
+            NFS_MOUNT,
+            config,
+            timeout=BG_IO_RESUME_TIMEOUT,
+            timings=resume_timings,
+            triggered_at=triggered_at,
+        )
+    elif io_thread is not None and io_thread.is_alive():
+        NfsMultiActiveClient.wait_for_background_io_resume(
+            [(primary_io_client, io_thread, io_error_box, io_dir)],
+            NFS_MOUNT,
+            config,
+            timeout=BG_IO_RESUME_TIMEOUT,
+            timings=resume_timings,
+            triggered_at=triggered_at,
+        )
+    else:
+        log.info(
+            "Background %s not running; skipping IO resume wait (%s)",
+            io_tool,
+            stage,
+        )
+        if timings is not None:
+            timings[timings_key] = f"skipped ({io_tool} not running)"
+        return
+
+    if timings is None:
+        return
+
+    resumed_at = _now()
+    timings[f"{timings_key}_at"] = resumed_at
+    trigger_time = timings.get(trigger_timing_key) if trigger_timing_key else None
+    recovery_seconds = _duration_since(trigger_time)
+    if recovery_seconds is not None:
+        timings[timings_key] = f"{recovery_seconds:.1f}s"
+        log.info(
+            "IO resumed at %s; recovery time since trigger (%s): %.1fs",
+            resumed_at,
+            trigger_timing_key or "trigger",
+            recovery_seconds,
+        )
+    else:
+        timings[timings_key] = resume_timings.get("io_resume", "N/A")
+
+
+def _record_failover_trigger(timings, trigger_timing_key):
+    if timings is not None and trigger_timing_key:
+        timings[trigger_timing_key] = _now()
+
+
+def _run_reboot_failover_with_io_resume(
+    config,
+    dual_client_io,
+    io_sessions,
+    io_thread,
+    io_error_box,
+    primary_io_client,
+    io_dir,
+    timings,
+    timings_key,
+    trigger_timing_key,
+    stage,
+    reboot_action,
+):
+    """Poll IO resume from reboot issue while waiting for node/daemon recovery."""
+    _record_failover_trigger(timings, trigger_timing_key)
+    io_resume_error = {"exc": None}
+
+    def _io_wait():
+        try:
+            _wait_io_resume(
+                config,
+                dual_client_io,
+                io_sessions,
+                io_thread,
+                io_error_box,
+                primary_io_client,
+                io_dir,
+                timings,
+                timings_key=timings_key,
+                trigger_timing_key=trigger_timing_key,
+                stage=stage,
+            )
+        except Exception as exc:
+            io_resume_error["exc"] = exc
+
+    io_wait_thread = Thread(target=_io_wait, daemon=True)
+    io_wait_thread.start()
+    try:
+        reboot_action()
+    finally:
+        io_wait_thread.join(timeout=BG_IO_RESUME_TIMEOUT + 120)
+        if io_wait_thread.is_alive():
+            raise OperationFailedError(
+                f"IO resume wait did not finish within budget after {stage}"
+            )
+        if io_resume_error["exc"] is not None:
+            raise io_resume_error["exc"]
+
+
+def _run_reboot_failover_sequence(
+    ctx,
+    config,
+    dual_client_io,
+    io_sessions,
+    io_thread,
+    io_error_box,
+    primary_io_client,
+    io_dir,
+    removed_nfs_host,
+    removed_ingress_host,
+    expected_ingress,
+    timings,
+):
+    """Reboot NFS backend then ingress with parallel IO resume and per-step validation."""
+    _run_reboot_failover_with_io_resume(
+        config,
+        dual_client_io,
+        io_sessions,
+        io_thread,
+        io_error_box,
+        primary_io_client,
+        io_dir,
+        timings,
+        timings_key="io_resume_after_nfs",
+        trigger_timing_key="nfs_failover_triggered_at",
+        stage="NFS backend reboot",
+        reboot_action=lambda: ctx["failover"].reboot_and_wait_nfs(
+            ctx["ceph_cluster"],
+            ctx["deploy"].validator,
+            ctx["nfs_service_id"],
+            removed_nfs_host,
+            ctx["nfs_count"],
+            deploy_timeout=DEPLOY_TIMEOUT,
+            timings=timings,
+        ),
+    )
+    _validate_failover_cluster_state(
+        ctx["deploy"],
+        ctx["haproxy"],
+        ctx["nfs_spec"],
+        ctx["ingress_spec"],
+        ctx["nfs_service_id"],
+        expected_ingress,
+        ctx["mounted_clients"],
+        "reboot",
+        ctx["spare_host"],
+        removed_nfs_host,
+        timings,
+        stick_kwargs=ctx["stick_kwargs"],
+    )
+
+    _run_reboot_failover_with_io_resume(
+        config,
+        dual_client_io,
+        io_sessions,
+        io_thread,
+        io_error_box,
+        primary_io_client,
+        io_dir,
+        timings,
+        timings_key="io_resume",
+        trigger_timing_key="ingress_failover_triggered_at",
+        stage="ingress reboot",
+        reboot_action=lambda: ctx["failover"].reboot_and_wait_ingress(
+            ctx["ceph_cluster"],
+            ctx["deploy"].validator,
+            ctx["nfs_service_id"],
+            removed_ingress_host,
+            ctx["vip"],
+            ctx["ingress_hosts"],
+            len(ctx["ingress_hosts"]),
+            deploy_timeout=DEPLOY_TIMEOUT,
+            timings=timings,
+        ),
+    )
+    _validate_failover_cluster_state(
+        ctx["deploy"],
+        ctx["haproxy"],
+        ctx["nfs_spec"],
+        ctx["ingress_spec"],
+        ctx["nfs_service_id"],
+        expected_ingress,
+        ctx["mounted_clients"],
+        "reboot",
+        ctx["spare_host"],
+        removed_nfs_host,
+        timings,
+        stick_kwargs=ctx["stick_kwargs"],
+    )
+
+
+def _io_resume_callback(
+    config,
+    dual_client_io,
+    io_sessions,
+    io_thread,
+    io_error_box,
+    primary_io_client,
+    io_dir,
+    timings,
+    timings_key,
+    trigger_timing_key,
+    stage,
+):
+    """Return a post-orch-apply callback that waits for IO to resume."""
+
+    def _callback():
+        _wait_io_resume(
+            config,
+            dual_client_io,
+            io_sessions,
+            io_thread,
+            io_error_box,
+            primary_io_client,
+            io_dir,
+            timings,
+            timings_key=timings_key,
+            trigger_timing_key=trigger_timing_key,
+            stage=stage,
+        )
+
+    return _callback
+
+
+def _validate_failover_cluster_state(
+    deploy,
+    haproxy,
+    nfs_spec,
+    ingress_spec,
+    nfs_service_id,
+    expected_ingress,
+    mounted_clients,
+    target,
+    spare_host,
+    removed_nfs_host,
+    timings,
+    stick_kwargs=None,
+):
+    """Run post-IO-resume cluster, orch, stick-table, and backend validations."""
+    cluster_info = deploy.validator.get_cluster_info(nfs_service_id)
+    deploy.validator.assert_cluster_info(cluster_info, nfs_spec, ingress_spec)
+    deploy.validator.assert_orch_ps(
+        nfs_spec,
+        ingress_spec,
+        expected_ingress_hosts=expected_ingress,
+        timeout=DEPLOY_TIMEOUT,
+    )
+    haproxy.validate_entries(
+        mounted_clients=mounted_clients,
+        timings=timings,
+        **(stick_kwargs or {}),
+    )
+    backend_hostnames = {
+        backend.get("hostname")
+        for backend in cluster_info.get("backend") or []
+        if backend.get("hostname")
+    }
+    _assert_post_failover_backends(
+        target, spare_host, removed_nfs_host, backend_hostnames
+    )
+    return cluster_info
+
+
+def _run_failover_steps(
+    target,
+    failover,
+    deploy,
+    ceph_cluster,
+    vip,
+    orch_client,
+    nfs_spec,
+    ingress_spec,
+    nfs_service_id,
+    deploy_nodes,
+    nfs_count,
+    nfs_label,
+    ingress_label,
+    ingress_hosts,
+    spare_host,
+    deploy_timeout,
+    removed_nfs_host,
+    removed_ingress_host,
+    expected_ingress,
+    config,
+    timings=None,
+    dual_client_io=False,
+    io_sessions=None,
+    io_thread=None,
+    io_error_box=None,
+    primary_io_client=None,
+    io_dir=None,
+):
+    """Run nfs/ingress label failover, roundtrip, secondary, or reboot steps."""
+    io_resume_after_nfs = _io_resume_callback(
+        config,
+        dual_client_io,
+        io_sessions,
+        io_thread,
+        io_error_box,
+        primary_io_client,
+        io_dir,
+        timings,
+        timings_key="io_resume_after_nfs",
+        trigger_timing_key="nfs_failover_triggered_at",
+        stage="NFS orch apply",
+    )
+    io_resume_after_ingress = _io_resume_callback(
+        config,
+        dual_client_io,
+        io_sessions,
+        io_thread,
+        io_error_box,
+        primary_io_client,
+        io_dir,
+        timings,
+        timings_key="io_resume",
+        trigger_timing_key="ingress_failover_triggered_at",
+        stage="ingress orch apply",
+    )
+    io_resume_after_apply = _io_resume_callback(
+        config,
+        dual_client_io,
+        io_sessions,
+        io_thread,
+        io_error_box,
+        primary_io_client,
+        io_dir,
+        timings,
+        timings_key="io_resume",
+        trigger_timing_key="failover_triggered_at",
+        stage="orch apply",
+    )
+
+    if target == "secondary_nfs_standby_ingress":
+        log.info(
+            "Starting NFS label failover (secondary backend): drain %s -> %s",
+            removed_nfs_host,
+            spare_host,
+        )
+        failover.failover_nfs_by_label(
+            orch_client,
+            deploy,
+            nfs_spec,
+            deploy_nodes,
+            removed_nfs_host,
+            spare_host,
+            nfs_label,
+            nfs_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=io_resume_after_nfs,
+        )
+        log.info(
+            "Starting ingress label failover (standby): drain %s -> %s",
+            removed_ingress_host,
+            spare_host,
+        )
+        failover.failover_ingress_by_label(
+            orch_client,
+            deploy,
+            ingress_spec,
+            nfs_service_id,
+            deploy_nodes,
+            removed_ingress_host,
+            spare_host,
+            ingress_label,
+            len(expected_ingress),
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=io_resume_after_ingress,
+        )
+        return removed_nfs_host, removed_ingress_host, expected_ingress
+
+    if target == "roundtrip":
+        failover.failover_nfs_roundtrip(
+            orch_client,
+            deploy,
+            nfs_spec,
+            deploy_nodes,
+            removed_nfs_host,
+            spare_host,
+            nfs_label,
+            nfs_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=io_resume_after_apply,
+        )
+        failover.failover_ingress_roundtrip(
+            orch_client,
+            deploy,
+            ingress_spec,
+            nfs_service_id,
+            deploy_nodes,
+            removed_ingress_host,
+            spare_host,
+            ingress_label,
+            len(ingress_hosts),
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=io_resume_after_apply,
+        )
+        return removed_nfs_host, removed_ingress_host, list(ingress_hosts)
+
+    if target in ("nfs", "dual"):
+        log.info(
+            "Starting NFS label failover (stick-table backend): drain %s -> %s",
+            removed_nfs_host,
+            spare_host,
+        )
+        failover.failover_nfs_by_label(
+            orch_client,
+            deploy,
+            nfs_spec,
+            deploy_nodes,
+            removed_nfs_host,
+            spare_host,
+            nfs_label,
+            nfs_count,
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=(
+                io_resume_after_nfs if target == "dual" else io_resume_after_apply
+            ),
+        )
+
+    if target == "dual":
+        # Re-resolve VIP holder after NFS failover before ingress drain.
+        active_ingress = failover.get_active_ingress_host(
+            ceph_cluster, vip, ingress_hosts, exclude_hosts={spare_host}
+        )
+        expected_ingress = _ingress_hosts_after_failover(
+            ingress_hosts, active_ingress, spare_host
+        )
+        log.info(
+            "Starting ingress label failover (VIP holder): drain %s -> %s",
+            active_ingress,
+            spare_host,
+        )
+        failover.failover_ingress_by_label(
+            orch_client,
+            deploy,
+            ingress_spec,
+            nfs_service_id,
+            deploy_nodes,
+            active_ingress,
+            spare_host,
+            ingress_label,
+            len(expected_ingress),
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=io_resume_after_ingress,
+        )
+        removed_ingress_host = active_ingress
+
+    elif target == "ingress":
+        log.info(
+            "Starting ingress label failover (VIP holder): drain %s -> %s",
+            removed_ingress_host,
+            spare_host,
+        )
+        failover.failover_ingress_by_label(
+            orch_client,
+            deploy,
+            ingress_spec,
+            nfs_service_id,
+            deploy_nodes,
+            removed_ingress_host,
+            spare_host,
+            ingress_label,
+            len(expected_ingress),
+            deploy_timeout=deploy_timeout,
+            timings=timings,
+            post_apply_callback=io_resume_after_apply,
+        )
+
+    return removed_nfs_host, removed_ingress_host, expected_ingress
+
+
+def _assert_post_failover_backends(
+    target, spare_host, removed_nfs_host, backend_hostnames
+):
+    if target in ("nfs", "dual", "secondary_nfs_standby_ingress"):
+        if spare_host not in backend_hostnames:
+            raise ConfigError(
+                f"Spare host {spare_host!r} not in cluster info backends: "
+                f"{backend_hostnames}"
+            )
+        if removed_nfs_host in backend_hostnames:
+            raise ConfigError(
+                f"Failed-out NFS host {removed_nfs_host!r} still in backends"
+            )
+    elif target == "roundtrip":
+        if spare_host in backend_hostnames:
+            raise ConfigError(
+                f"Spare host {spare_host!r} still in NFS backends after roundtrip"
+            )
+    elif target == "ingress":
+        if spare_host in backend_hostnames:
+            raise ConfigError(f"Spare host {spare_host!r} unexpectedly in NFS backends")
+
+
+def _assert_io_still_running(session, label, config):
+    client, thread, error_box, _io_dir = session
+    io_tool = _io_tool_label(config)
+    if not thread.is_alive():
+        exc = error_box.get("exc")
+        raise ConfigError(
+            f"{label} {io_tool} on {client.hostname} stopped unexpectedly"
+            + (f": {exc}" if exc else "")
+        )
+    log.info(
+        "%s %s still running on %s after peer-cluster failover",
+        label,
+        io_tool,
+        client.hostname,
+    )
+
+
+def _validate_cluster_after_ingress_failover(
+    deploy,
+    nfs_spec,
+    ingress_spec,
+    nfs_service_id,
+    expected_ingress,
+    haproxy,
+    mounted_clients,
+    timings,
+):
+    cluster_info = deploy.validator.get_cluster_info(nfs_service_id)
+    deploy.validator.assert_cluster_info(cluster_info, nfs_spec, ingress_spec)
+    deploy.validator.assert_orch_ps(
+        nfs_spec,
+        ingress_spec,
+        expected_ingress_hosts=expected_ingress,
+        timeout=DEPLOY_TIMEOUT,
+    )
+    haproxy.validate_entries(mounted_clients=mounted_clients, timings=timings)
+
+
+def _log_session_banner(session, session_step, session_total, phase_workflow=None):
+    phase_line = ""
+    if phase_workflow:
+        wf = FAILOVER_WORKFLOWS[phase_workflow]
+        phase_line = (
+            f"Starting phase: {_phase_workflow_label(phase_workflow)}\n"
+            f"{wf.get('desc', '')}\n"
+        )
+    between = []
+    if session.get("restore_between_phases"):
+        between.append("restore baseline placement")
+    if session.get("remount_between_phases"):
+        between.append("remount clients via VIP")
+    between_line = ""
+    if between and phase_workflow:
+        between_line = f"Between-phase actions: {', '.join(between)}\n"
+    vip_slot = session.get("vip", "n/a")
+    ports = session.get("ports", "dual-cluster ports")
+    log.info(
+        "\n" + "=" * 70 + "\n"
+        "Failover session %d of %d: %s (%s)\n"
+        "%s\n"
+        "Phases: %s\n"
+        "VIP slot: vip%s | ports: %s\n"
+        f"{between_line}"
+        f"{phase_line}" + "=" * 70,
+        session_step,
+        session_total,
+        session["name"],
+        session.get("tc", ""),
+        session.get("desc", ""),
+        _session_phase_summary(session),
+        vip_slot,
+        ports,
+    )
+
+
+def _log_suite_start(sessions, config):
+    io_tool = _io_tool_label(config or {})
+    log.info(
+        "\n" + "#" * 70 + "\n"
+        "NFS Multi-Active failover suite (%d sessions) | io_tool=%s\n"
+        + "\n".join(
+            f"  {idx}. {s['name']} ({s.get('tc', '')}): {_session_phase_summary(s)}"
+            for idx, s in enumerate(sessions, start=1)
+        )
+        + "\n"
+        + "#" * 70,
+        len(sessions),
+        io_tool,
+    )
+
+
+def _stop_phase_io(
+    config,
+    dual_client_io,
+    io_sessions,
+    io_thread,
+    io_error_box,
+    primary_io_client,
+    io_dir,
+):
+    """Stop background IO after a failover phase completes."""
+    if dual_client_io and io_sessions:
+        NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+        for _, thread, _, _ in io_sessions:
+            thread.join(timeout=30)
+    elif (
+        io_thread is not None and io_thread.is_alive() and primary_io_client and io_dir
+    ):
+        NfsMultiActiveClient.stop_background_io(
+            primary_io_client, io_dir, config, io_error_box
+        )
+        io_thread.join(timeout=30)
+
+
+def _session_setup(
+    ceph_cluster, config, session_name, vip_slot, ports, is_first_workflow
+):
+    """Deploy NFS multi-active once for a failover session."""
+    return session_setup(
+        ceph_cluster,
+        config,
+        session_name,
+        vip_slot,
+        ports,
+        is_first_workflow,
+        service_id_prefix=NFS_SERVICE_ID_PREFIX,
+        placement=_PLACEMENT,
+        spare_slice=_SPARE,
+    )
+
+
+def _session_teardown(ctx):
+    session_teardown(ctx)
+
+
+def _run_failover_phase(ctx, workflow_key, phase_step=1, phase_total=1):
+    """Run one failover phase on an existing session cluster (IO + failover + validate)."""
+    workflow_cfg = FAILOVER_WORKFLOWS[workflow_key]
+    failover_cfg = workflow_cfg["failover"]
+    dual_client_io = workflow_cfg.get("dual_client_io", False)
+    target = failover_cfg["target"]
+    config = ctx["config"]
+    io_runtime = _io_runtime(config)
+    timings = {}
+
+    _log_phase_banner(
+        workflow_key,
+        phase_step,
+        phase_total,
+        ctx["nfs_count"],
+        len(ctx["ingress_hosts"]),
+        target,
+        config,
+    )
+    log.info(
+        "Session %s | phase %s/%s | %s | service=%s | VIP=%s | io_tool=%s",
+        ctx["session_name"],
+        phase_step,
+        phase_total,
+        workflow_cfg.get("tc", workflow_key),
+        ctx["nfs_service_id"],
+        ctx["vip"],
+        _io_tool_label(config),
+    )
+
+    (
+        io_clients,
+        primary_io_client,
+        _pinned_backend,
+        removed_nfs_host,
+        removed_ingress_host,
+        expected_ingress,
+    ) = _resolve_failover_plan(
+        ctx["haproxy"],
+        ctx["failover"],
+        ctx["ceph_cluster"],
+        ctx["vip"],
+        ctx["mounted_clients"],
+        ctx["spare_host"],
+        ctx["ingress_hosts"],
+        target,
+        dual_client_io=dual_client_io,
+    )
+
+    io_sessions = None
+    io_thread = None
+    io_error_box = None
+    io_dir = None
+    io_subdir = f"{ctx['session_name']}/{workflow_key}"
+
+    if dual_client_io:
+        io_sessions = NfsMultiActiveClient.run_background_io_on_clients(
+            io_clients,
+            NFS_MOUNT,
+            config,
+            io_subdir=io_subdir,
+            runtime=io_runtime,
+        )
+        io_dir = next(
+            session_io_dir
+            for client, _, _, session_io_dir in io_sessions
+            if client == primary_io_client
+        )
+    else:
+        io_thread, io_error_box, io_dir = NfsMultiActiveClient.run_background_io(
+            primary_io_client,
+            NFS_MOUNT,
+            config,
+            io_subdir=io_subdir,
+            runtime=io_runtime,
+        )
+    timings["io_start"] = _now()
+    sleep(BG_IO_START_DELAY)
+
+    if target == "reboot":
+        _run_reboot_failover_sequence(
+            ctx,
+            config,
+            dual_client_io,
+            io_sessions,
+            io_thread,
+            io_error_box,
+            primary_io_client,
+            io_dir,
+            removed_nfs_host,
+            removed_ingress_host,
+            expected_ingress,
+            timings,
+        )
+    else:
+        removed_nfs_host, removed_ingress_host, expected_ingress = _run_failover_steps(
+            target,
+            ctx["failover"],
+            ctx["deploy"],
+            ctx["ceph_cluster"],
+            ctx["vip"],
+            primary_io_client,
+            ctx["nfs_spec"],
+            ctx["ingress_spec"],
+            ctx["nfs_service_id"],
+            ctx["deploy_nodes"],
+            ctx["nfs_count"],
+            ctx["labels"]["nfs"],
+            ctx["labels"]["ingress"],
+            ctx["ingress_hosts"],
+            ctx["spare_host"],
+            DEPLOY_TIMEOUT,
+            removed_nfs_host,
+            removed_ingress_host,
+            expected_ingress,
+            config,
+            timings=timings,
+            dual_client_io=dual_client_io,
+            io_sessions=io_sessions,
+            io_thread=io_thread,
+            io_error_box=io_error_box,
+            primary_io_client=primary_io_client,
+            io_dir=io_dir,
+        )
+        _validate_failover_cluster_state(
+            ctx["deploy"],
+            ctx["haproxy"],
+            ctx["nfs_spec"],
+            ctx["ingress_spec"],
+            ctx["nfs_service_id"],
+            expected_ingress,
+            ctx["mounted_clients"],
+            target,
+            ctx["spare_host"],
+            removed_nfs_host,
+            timings,
+            stick_kwargs=ctx["stick_kwargs"],
+        )
+
+    if dual_client_io:
+        NfsMultiActiveClient.assert_io_completed_on_clients(
+            io_sessions,
+            nfs_mount=NFS_MOUNT,
+            config=config,
+            wait_io_resume_timeout=0,
+            join_timeout=BG_IO_JOIN_TIMEOUT,
+            timings=timings,
+        )
+    else:
+        NfsMultiActiveClient.assert_io_completed(
+            io_thread,
+            io_error_box,
+            config=config,
+            stop_client=primary_io_client,
+            io_dir=io_dir,
+            nfs_mount=NFS_MOUNT,
+            wait_io_resume_timeout=0,
+            join_timeout=BG_IO_JOIN_TIMEOUT,
+            timings=timings,
+        )
+    timings["io_end"] = _now()
+
+    marker = f"{io_dir}/post-failover-marker"
+    marker_client = next(c for c in ctx["mounted_clients"] if c != primary_io_client)
+    marker_client.exec_command(
+        sudo=True,
+        cmd=(
+            f"timeout {MARKER_IO_TIMEOUT} sh -c "
+            f"'echo failover-ok-{workflow_key} > {marker}'"
+        ),
+        timeout=MARKER_IO_TIMEOUT + 10,
+    )
+    out, _ = primary_io_client.exec_command(
+        sudo=True,
+        cmd=f"timeout {MARKER_IO_TIMEOUT} cat {marker}",
+        timeout=MARKER_IO_TIMEOUT + 10,
+    )
+    if "failover-ok" not in (out or ""):
+        raise ConfigError("Cross-client marker read failed after failover")
+
+    _stop_phase_io(
+        config,
+        dual_client_io,
+        io_sessions,
+        io_thread,
+        io_error_box,
+        primary_io_client,
+        io_dir,
+    )
+
+    log.info(
+        "Phase %s (%s) completed in session %s",
+        workflow_key,
+        workflow_cfg.get("tc", workflow_key),
+        ctx["session_name"],
+    )
+    _log_workflow_timings(timings)
+    return 0
+
+
+def _run_failover_session(
+    ceph_cluster, config, session, session_step, session_total, is_first_suite_deploy
+):
+    """Run one failover session (deploy once, one or more phases)."""
+    if session.get("dual_cluster"):
+        _log_session_banner(session, session_step, session_total)
+        rc = _run_dual_cluster_vip_failover_workflow(
+            ceph_cluster,
+            config,
+            session["workflow"],
+            step=session_step,
+            total=session_total,
+            is_first_workflow=is_first_suite_deploy,
+        )
+        if rc != 0:
+            return rc
+        try:
+            phase_tc = FAILOVER_WORKFLOWS[session["workflow"]]["tc"]
+            wait_for_ceph_health(ceph_cluster, config, context=f"post-{phase_tc}")
+        except ConfigError as e:
+            log.error("Post-%s health check failed: %s", phase_tc, e)
+            return 1
+        return 0
+
+    _log_session_banner(session, session_step, session_total)
+    ctx = None
+    try:
+        ctx = _session_setup(
+            ceph_cluster,
+            config,
+            session["name"],
+            session["vip"],
+            session["ports"],
+            is_first_suite_deploy,
+        )
+        phases = session["phases"]
+        for phase_idx, phase_workflow in enumerate(phases):
+            if phase_idx > 0:
+                if session.get("restore_between_phases"):
+                    log.info(
+                        "Between phases in session %s: restoring baseline placement",
+                        session["name"],
+                    )
+                    ctx["failover"].restore_baseline_placement(
+                        ctx["client1"],
+                        ctx["deploy"],
+                        ctx["nfs_nodes"],
+                        ctx["nfs_spec"],
+                        ctx["ingress_spec"],
+                        ctx["nfs_service_id"],
+                        _PLACEMENT,
+                        ctx["labels"],
+                        ctx["spare_host"],
+                        ctx["nfs_count"],
+                        ctx["ingress_hosts"],
+                        ctx["deploy_nodes"],
+                        deploy_timeout=DEPLOY_TIMEOUT,
+                    )
+                if session.get("remount_between_phases"):
+                    log.info(
+                        "Between phases in session %s: remounting clients via VIP",
+                        session["name"],
+                    )
+                    NfsMultiActiveClient.remount_clients_via_vip(
+                        ctx["mounted_clients"],
+                        ctx["vip"],
+                        NFS_MOUNT,
+                        EXPORT_NAME,
+                        ctx["ingress_frontend_port"],
+                        NFS_VERSION,
+                    )
+                    ctx["haproxy"].validate_entries(
+                        mounted_clients=ctx["mounted_clients"],
+                        **ctx["stick_kwargs"],
+                    )
+
+            _log_session_banner(
+                session,
+                session_step,
+                session_total,
+                phase_workflow=phase_workflow,
+            )
+            _run_failover_phase(
+                ctx,
+                phase_workflow,
+                phase_step=phase_idx + 1,
+                phase_total=len(phases),
+            )
+            try:
+                phase_tc = FAILOVER_WORKFLOWS[phase_workflow]["tc"]
+                wait_for_ceph_health(ceph_cluster, config, context=f"post-{phase_tc}")
+            except ConfigError as e:
+                log.error("Post-%s health check failed: %s", phase_tc, e)
+                return 1
+
+        log.info("Failover session %s completed successfully", session["name"])
+        return 0
+    except Exception as e:
+        log.error("Failover session %s failed: %s", session["name"], e)
+        return 1
+    finally:
+        if ctx is not None:
+            _session_teardown(ctx)
+
+
+def _run_failover_suite(ceph_cluster, config):
+    """Run all failover sessions."""
+    sessions = config.get("sessions") or FAILOVER_SESSIONS
+    _log_suite_start(sessions, config)
+    for session_step, session in enumerate(sessions, start=1):
+        if session_step > 1:
+            try:
+                _stabilize_between_sessions(ceph_cluster, config)
+            except ConfigError as e:
+                log.error("Inter-session stabilization failed: %s", e)
+                return 1
+        rc = _run_failover_session(
+            ceph_cluster,
+            config,
+            session,
+            session_step,
+            len(sessions),
+            is_first_suite_deploy=(session_step == 1),
+        )
+        if rc != 0:
+            return rc
+    try:
+        wait_for_ceph_health(ceph_cluster, config, context="post-suite")
+    except ConfigError as e:
+        log.error("Post-suite health check failed: %s", e)
+        return 1
+    return 0
+
+
+def _run_dual_cluster_vip_failover_workflow(
+    ceph_cluster, config, workflow, step=1, total=1, is_first_workflow=True
+):
+    """Deploy two NFS clusters; fail ingress on A then B with background IO validation."""
+    client1, client2 = ceph_cluster.get_nodes("client")[:2]
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    workflow_cfg = FAILOVER_WORKFLOWS[workflow]
+
+    vips = NfsMultiActiveConfig.get_vips(config)
+    if len(vips) < 2:
+        raise ConfigError(
+            "dual_cluster_vip_failover requires at least 2 VIPs in suite config"
+        )
+    vip_a, vip_b = vips[0], vips[1]
+
+    nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, labels, spare_host = (
+        _resolve_placement_hosts(config, nfs_nodes)
+    )
+    nfs_backend_port_a, ingress_frontend_port_a, ingress_monitor_port_a = workflow_cfg[
+        "ports_a"
+    ]
+    nfs_backend_port_b, ingress_frontend_port_b, ingress_monitor_port_b = workflow_cfg[
+        "ports_b"
+    ]
+    ts = datetime.now().strftime("%Y%m%d%H%M%S")
+    nfs_service_id_a = f"{NFS_SERVICE_ID_PREFIX}-vip-a-{ts}"
+    nfs_service_id_b = f"{NFS_SERVICE_ID_PREFIX}-vip-b-{ts}"
+    nfs_label = labels["nfs"]
+    ingress_label = labels["ingress"]
+
+    mounted_a = []
+    mounted_b = []
+    export_a_created = export_b_created = False
+    clusters_deployed = False
+    labels_applied = False
+    io_session_a = io_session_b = None
+    io_dir_a = io_dir_b = None
+    active_ingress_a = None
+    b_failover_spare = None
+    timings = {}
+
+    _log_workflow_banner(
+        workflow,
+        step,
+        total,
+        nfs_count,
+        len(ingress_hosts),
+        workflow_cfg["failover"]["target"],
+        config,
+    )
+    log.info(
+        "Dual cluster: A=%s VIP=%s mount=%s | B=%s VIP=%s mount=%s | spare=%s | io_tool=%s",
+        nfs_service_id_a,
+        vip_a,
+        NFS_MOUNT_A,
+        nfs_service_id_b,
+        vip_b,
+        NFS_MOUNT_B,
+        spare_host,
+        _io_tool_label(config),
+    )
+
+    try:
+        NfsMultiActiveConfig.apply_placement_labels(
+            client1,
+            nfs_nodes,
+            _PLACEMENT["nfs"],
+            _PLACEMENT["ingress"],
+            labels,
+        )
+        labels_applied = True
+
+        nfs_spec_a = NfsMultiActiveConfig.build_nfs_spec(
+            nfs_hosts,
+            nfs_count,
+            nfs_service_id_a,
+            nfs_backend_port_a,
+            label=nfs_label,
+        )
+        ingress_spec_a = NfsMultiActiveConfig.build_ingress_spec(
+            vip_a,
+            nfs_service_id_a,
+            ingress_frontend_port_a,
+            ingress_monitor_port_a,
+            config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+            label=ingress_label,
+        )
+        nfs_spec_b = NfsMultiActiveConfig.build_nfs_spec(
+            nfs_hosts,
+            nfs_count,
+            nfs_service_id_b,
+            nfs_backend_port_b,
+            label=nfs_label,
+        )
+        ingress_spec_b = NfsMultiActiveConfig.build_ingress_spec(
+            vip_b,
+            nfs_service_id_b,
+            ingress_frontend_port_b,
+            ingress_monitor_port_b,
+            config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+            label=ingress_label,
+        )
+        all_specs = [nfs_spec_a, ingress_spec_a, nfs_spec_b, ingress_spec_b]
+
+        deploy_a = NfsMultiActiveDeploy(
+            ceph_cluster, nfs_service_id_a, vip_a, client=client1
+        )
+        deploy_b = NfsMultiActiveDeploy(
+            ceph_cluster, nfs_service_id_b, vip_b, client=client1
+        )
+        haproxy_a = NfsMultiActiveHaproxy(
+            ceph_cluster, nfs_service_id_a, info_client=client1
+        )
+        haproxy_b = NfsMultiActiveHaproxy(
+            ceph_cluster, nfs_service_id_b, info_client=client1
+        )
+        failover = NfsMultiActiveFailover()
+        deploy_kwargs = _deploy_kwargs(config, is_first_workflow)
+        stick_kwargs = {"stick_table_interval": _poll_interval(config)}
+
+        clusters_deployed = True
+        deploy_a.deploy(
+            all_specs,
+            deploy_nodes,
+            ingress_wait_targets=[
+                (nfs_service_id_a, vip_a),
+                (nfs_service_id_b, vip_b),
+            ],
+            cluster_validations=[
+                (nfs_spec_a, ingress_spec_a, ingress_hosts),
+                (nfs_spec_b, ingress_spec_b, ingress_hosts),
+            ],
+            **deploy_kwargs,
+        )
+        haproxy_a.validate_entries(**stick_kwargs)
+        haproxy_b.validate_entries(**stick_kwargs)
+
+        for nfs_name in (nfs_service_id_a, nfs_service_id_b):
+            Ceph(client1).nfs.export.create(
+                fs_name="cephfs",
+                nfs_name=nfs_name,
+                nfs_export=EXPORT_NAME,
+                fs="cephfs",
+            )
+            NfsMultiActiveConfig.wait_until_export_visible(
+                client1,
+                nfs_name,
+                EXPORT_NAME,
+                interval=_poll_interval(config),
+            )
+        export_a_created = export_b_created = True
+
+        NfsMultiActiveClient.mount_via_vip(
+            client1,
+            vip_a,
+            NFS_MOUNT_A,
+            EXPORT_NAME,
+            str(ingress_frontend_port_a),
+            NFS_VERSION,
+        )
+        mounted_a.append(client1)
+        haproxy_a.validate_entries(mounted_clients=mounted_a, **stick_kwargs)
+
+        NfsMultiActiveClient.mount_via_vip(
+            client2,
+            vip_b,
+            NFS_MOUNT_B,
+            EXPORT_NAME,
+            str(ingress_frontend_port_b),
+            NFS_VERSION,
+        )
+        mounted_b.append(client2)
+        haproxy_b.validate_entries(mounted_clients=mounted_b, **stick_kwargs)
+
+        io_runtime = _io_runtime(config)
+        thread_a, error_box_a, io_dir_a = NfsMultiActiveClient.run_background_io(
+            client1, NFS_MOUNT_A, config, io_subdir=f"{workflow}/a", runtime=io_runtime
+        )
+        thread_b, error_box_b, io_dir_b = NfsMultiActiveClient.run_background_io(
+            client2, NFS_MOUNT_B, config, io_subdir=f"{workflow}/b", runtime=io_runtime
+        )
+        io_session_a = (client1, thread_a, error_box_a, io_dir_a)
+        io_session_b = (client2, thread_b, error_box_b, io_dir_b)
+        client_a, thread_a, error_box_a, io_dir_a = io_session_a
+        client_b, thread_b, error_box_b, io_dir_b = io_session_b
+        timings["io_start"] = _now()
+        sleep(BG_IO_START_DELAY)
+
+        # --- Cluster A ingress failover ---
+        active_ingress_a = failover.get_active_ingress_host(
+            ceph_cluster, vip_a, ingress_hosts, exclude_hosts={spare_host}
+        )
+        expected_ingress_a = _ingress_hosts_after_failover(
+            ingress_hosts, active_ingress_a, spare_host
+        )
+        log.info(
+            "Cluster A ingress failover (TC-6 step 2): VIP %s holder %s -> spare %s",
+            vip_a,
+            active_ingress_a,
+            spare_host,
+        )
+        failover.failover_ingress_by_label(
+            client1,
+            deploy_a,
+            ingress_spec_a,
+            nfs_service_id_a,
+            deploy_nodes,
+            active_ingress_a,
+            spare_host,
+            ingress_label,
+            len(expected_ingress_a),
+            deploy_timeout=DEPLOY_TIMEOUT,
+            timings=timings,
+        )
+        NfsMultiActiveClient.wait_for_background_io_resume(
+            [io_session_a],
+            NFS_MOUNT_A,
+            config,
+            timeout=BG_IO_RESUME_TIMEOUT,
+            timings=timings,
+        )
+        _assert_io_still_running(io_session_b, "Cluster B peer", config)
+        _validate_cluster_after_ingress_failover(
+            deploy_a,
+            nfs_spec_a,
+            ingress_spec_a,
+            nfs_service_id_a,
+            expected_ingress_a,
+            haproxy_a,
+            mounted_a,
+            timings,
+        )
+
+        # --- Cluster B ingress failover (spare = host drained from cluster A) ---
+        b_failover_spare = active_ingress_a
+        active_ingress_b = failover.get_active_ingress_host(
+            ceph_cluster,
+            vip_b,
+            expected_ingress_a,
+            exclude_hosts={b_failover_spare},
+        )
+        expected_ingress_b = _ingress_hosts_after_failover(
+            expected_ingress_a, active_ingress_b, b_failover_spare
+        )
+        log.info(
+            "Cluster B ingress failover (TC-6 step 4): VIP %s holder %s -> %s",
+            vip_b,
+            active_ingress_b,
+            b_failover_spare,
+        )
+        failover.failover_ingress_by_label(
+            client1,
+            deploy_b,
+            ingress_spec_b,
+            nfs_service_id_b,
+            deploy_nodes,
+            active_ingress_b,
+            b_failover_spare,
+            ingress_label,
+            len(expected_ingress_b),
+            deploy_timeout=DEPLOY_TIMEOUT,
+            timings=timings,
+        )
+        NfsMultiActiveClient.wait_for_background_io_resume(
+            [io_session_b],
+            NFS_MOUNT_B,
+            config,
+            timeout=BG_IO_RESUME_TIMEOUT,
+            timings=timings,
+        )
+        _assert_io_still_running(io_session_a, "Cluster A peer", config)
+        _validate_cluster_after_ingress_failover(
+            deploy_b,
+            nfs_spec_b,
+            ingress_spec_b,
+            nfs_service_id_b,
+            expected_ingress_b,
+            haproxy_b,
+            mounted_b,
+            timings,
+        )
+
+        NfsMultiActiveClient.assert_io_completed(
+            thread_a,
+            error_box_a,
+            config=config,
+            stop_client=client_a,
+            io_dir=io_dir_a,
+            nfs_mount=NFS_MOUNT_A,
+            wait_io_resume_timeout=BG_IO_RESUME_TIMEOUT,
+            join_timeout=BG_IO_JOIN_TIMEOUT,
+            timings=timings,
+        )
+        NfsMultiActiveClient.assert_io_completed(
+            thread_b,
+            error_box_b,
+            config=config,
+            stop_client=client_b,
+            io_dir=io_dir_b,
+            nfs_mount=NFS_MOUNT_B,
+            wait_io_resume_timeout=BG_IO_RESUME_TIMEOUT,
+            join_timeout=BG_IO_JOIN_TIMEOUT,
+            timings=timings,
+        )
+        timings["io_end"] = _now()
+
+        for marker_client, marker_dir, marker_tag in (
+            (client_a, io_dir_a, "a"),
+            (client_b, io_dir_b, "b"),
+        ):
+            marker = f"{marker_dir}/post-failover-marker"
+            marker_client.exec_command(
+                sudo=True,
+                cmd=(
+                    f"timeout {MARKER_IO_TIMEOUT} sh -c "
+                    f"'echo failover-ok-{workflow}-{marker_tag} > {marker}'"
+                ),
+                timeout=MARKER_IO_TIMEOUT + 10,
+            )
+            out, _ = marker_client.exec_command(
+                sudo=True,
+                cmd=f"timeout {MARKER_IO_TIMEOUT} cat {marker}",
+                timeout=MARKER_IO_TIMEOUT + 10,
+            )
+            if "failover-ok" not in (out or ""):
+                raise ConfigError(
+                    f"Post-failover marker read failed on cluster {marker_tag.upper()}"
+                )
+
+        log.info(
+            "Failover session dual_cluster (%s) completed successfully",
+            workflow_cfg.get("tc", "TC-6"),
+        )
+        _log_workflow_timings(timings)
+        return 0
+    except Exception as e:
+        log.error(
+            "Failover session dual_cluster (%s) failed: %s",
+            workflow_cfg.get("tc", "TC-6"),
+            e,
+        )
+        return 1
+    finally:
+        for session in (io_session_a, io_session_b):
+            if not session:
+                continue
+            client, thread, error_box, io_dir = session
+            try:
+                if thread.is_alive():
+                    NfsMultiActiveClient.stop_background_io(
+                        client, io_dir, config, error_box
+                    )
+                    thread.join(timeout=30)
+            except Exception as e:
+                log.warning("Background IO stop failed on %s: %s", client.hostname, e)
+
+        try:
+            if mounted_a:
+                NfsMultiActiveClient.unmount_and_delete_export(
+                    mounted_a, NFS_MOUNT_A, nfs_service_id_a, EXPORT_NAME
+                )
+            elif export_a_created:
+                Ceph(client1).nfs.export.delete(nfs_service_id_a, EXPORT_NAME)
+        except Exception as e:
+            log.warning("Cluster A mount/export cleanup failed: %s", e)
+
+        try:
+            if mounted_b:
+                NfsMultiActiveClient.unmount_and_delete_export(
+                    mounted_b, NFS_MOUNT_B, nfs_service_id_b, EXPORT_NAME
+                )
+            elif export_b_created:
+                Ceph(client1).nfs.export.delete(nfs_service_id_b, EXPORT_NAME)
+        except Exception as e:
+            log.warning("Cluster B mount/export cleanup failed: %s", e)
+
+        if clusters_deployed:
+            for svc_id in (nfs_service_id_a, nfs_service_id_b):
+                try:
+                    NfsMultiActiveCleanup(ceph_cluster).remove_cluster(svc_id)
+                except Exception as e:
+                    log.warning("NFS cluster %s cleanup failed: %s", svc_id, e)
+
+        if labels_applied:
+            try:
+                NfsMultiActiveConfig.remove_placement_labels(
+                    client1,
+                    nfs_nodes,
+                    _PLACEMENT["nfs"],
+                    _PLACEMENT["ingress"],
+                    labels,
+                )
+                for spare_label in (labels["nfs"], labels["ingress"]):
+                    client1.exec_command(
+                        sudo=True,
+                        cmd=f"ceph orch host label rm {spare_host} {spare_label}",
+                        check_ec=False,
+                    )
+                    if b_failover_spare and b_failover_spare != spare_host:
+                        client1.exec_command(
+                            sudo=True,
+                            cmd=(
+                                f"ceph orch host label rm {b_failover_spare} "
+                                f"{spare_label}"
+                            ),
+                            check_ec=False,
+                        )
+            except Exception as e:
+                log.warning("Placement label cleanup failed: %s", e)
+
+
+def _stabilize_between_sessions(ceph_cluster, config=None):
+    """Verify Ceph health before the next failover session."""
+    wait_for_ceph_health(ceph_cluster, config, context="inter-session")
+
+
+def run(ceph_cluster, **kw):
+    """Run NFS Multi-Active failover sessions."""
+    config = kw.get("config") or {}
+    init_crash_monitoring(config)
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+
+    if len(clients) < 2:
+        raise ConfigError("Failover validation requires at least 2 clients")
+    if len(nfs_nodes) < MIN_NFS_NODES:
+        raise ConfigError(
+            f"Need at least {MIN_NFS_NODES} NFS-capable nodes, found {len(nfs_nodes)}"
+        )
+
+    return _run_failover_suite(ceph_cluster, config)

--- a/tests/nfs/multi_active/test_nfs_multi_active_functional.py
+++ b/tests/nfs/multi_active/test_nfs_multi_active_functional.py
@@ -1,0 +1,362 @@
+from datetime import datetime
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError
+from tests.nfs.lib.multi_active import (
+    NfsMultiActiveCleanup,
+    NfsMultiActiveClient,
+    NfsMultiActiveConfig,
+    NfsMultiActiveDeploy,
+    NfsMultiActiveHaproxy,
+    init_crash_monitoring,
+    wait_for_ceph_health,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+from tests.nfs.lib.multi_active.constants import (
+    DEPLOY_TIMEOUT,
+    EXPORT_NAME,
+    HEALTH_CHECK_INTERVAL,
+    MIN_NFS_NODES,
+    NFS_DAEMON_COUNT,
+    NFS_MOUNT,
+    NFS_VERSION,
+    POLL_INTERVAL_SEC,
+    SERVICE_ID_PREFIX,
+)
+
+NFS_SERVICE_ID_PREFIX = SERVICE_ID_PREFIX["functional"]
+
+# Bindable user port range (IANA 1024–65535).
+GLOBAL_PORT_MIN = 1024
+GLOBAL_PORT_MAX = 65535
+
+# Each workflow: desc, ports (backend, frontend, monitor), placement (nfs/ingress slices).
+# Ports use the 13xxx–15xxx / 19xxx ranges to avoid well-known services (2049, 3000,
+# 4000, 5000, 6000, 8000, 9000, 9090, 10000, etc.) on baremetal lab nodes.
+WORKFLOWS = {
+    "same_hosts": {
+        "desc": "NFS and ingress on the same 2 hosts",
+        "ports": (3333, 2049, 9000),
+        "placement": {"min_nodes": 2, "nfs": (0, 2), "ingress": (0, 2)},
+    },
+    "split_hosts": {
+        "desc": "NFS and ingress on disjoint host sets",
+        "ports": (13650, 13750, 19350),
+        "placement": {"min_nodes": 4, "nfs": (0, 2), "ingress": (2, 4)},
+    },
+    "partial_overlap": {
+        "desc": "NFS on A,B; ingress on B,C (one shared host)",
+        "ports": (14001, 14101, 19401),
+        "placement": {"min_nodes": 3, "nfs": (0, 2), "ingress": (1, 3)},
+    },
+    "nfs_only_pool": {
+        "desc": "NFS count=2 on pool A,B,C; ingress on A,B only",
+        "ports": (14201, 14301, 19451),
+        "placement": {"min_nodes": 3, "nfs": (0, 3), "ingress": (0, 2)},
+    },
+    "ingress_wider": {
+        "desc": "NFS on A,B; ingress on A,B,C",
+        "ports": (14401, 14501, 19501),
+        "placement": {"min_nodes": 3, "nfs": (0, 2), "ingress": (0, 3)},
+    },
+    "single_ingress": {
+        "desc": "NFS count=2 on A,B; ingress on A only",
+        "ports": (14601, 14701, 19551),
+        "placement": {"min_nodes": 2, "nfs": (0, 2), "ingress": (0, 1)},
+    },
+    "count_lt_hosts": {
+        "desc": "NFS count=2 on pool A,B,C; ingress on B,C",
+        "ports": (14801, GLOBAL_PORT_MAX, 19601),
+        "placement": {"min_nodes": 3, "nfs": (0, 3), "ingress": (1, 3)},
+    },
+    "label_placement": {
+        "desc": "NFS on A,B; ingress on B,C via placement labels",
+        "ports": (15001, 15101, 19701),
+        "placement": {
+            "min_nodes": 3,
+            "nfs": (0, 2),
+            "ingress": (1, 3),
+            "labels": {"nfs": "nfs-ma-nfs", "ingress": "nfs-ma-ingress"},
+        },
+    },
+}
+
+
+def _log_workflow_start(workflow, step, total):
+    log.info(
+        "\n" + "=" * 70 + "\n  %s\n" + "=" * 70,
+        f"Workflow {step} of {total}: {workflow}\n  {WORKFLOWS[workflow]['desc']}",
+    )
+
+
+def _hostnames(nodes):
+    return [node.hostname for node in nodes]
+
+
+def _unique_nodes(*node_groups):
+    seen = set()
+    ordered = []
+    for group in node_groups:
+        for node in group:
+            key = node.hostname
+            if key not in seen:
+                seen.add(key)
+                ordered.append(node)
+    return ordered
+
+
+def _poll_interval(config):
+    return int(config.get("poll_interval_sec", POLL_INTERVAL_SEC))
+
+
+def _deploy_kwargs(config, is_first_workflow):
+    """Build deploy kwargs; skip one-time setup on subsequent workflows."""
+    poll_interval = _poll_interval(config)
+    kwargs = {
+        "deploy_timeout": DEPLOY_TIMEOUT,
+        "ingress_poll_interval": poll_interval,
+    }
+    if not is_first_workflow:
+        kwargs.update(
+            {
+                "skip_mgr_enable": True,
+            }
+        )
+    return kwargs
+
+
+def _resolve_hosts(workflow, config, nfs_nodes):
+    """Return (nfs_placement_hosts, ingress_hosts, deploy_nodes, nfs_count, labels)."""
+    placement = WORKFLOWS[workflow]["placement"]
+    nfs_count = int(config.get("nfs_count", NFS_DAEMON_COUNT))
+    nfs_start, nfs_end = placement["nfs"]
+    ingress_start, ingress_end = placement["ingress"]
+
+    if len(nfs_nodes) < placement["min_nodes"]:
+        raise ConfigError(
+            f"{workflow} needs {placement['min_nodes']} NFS-capable nodes, "
+            f"found {len(nfs_nodes)}"
+        )
+
+    nfs_sel = nfs_nodes[nfs_start:nfs_end]
+    ingress_sel = nfs_nodes[ingress_start:ingress_end]
+    if nfs_count > len(nfs_sel):
+        raise ConfigError(
+            f"nfs_count ({nfs_count}) exceeds NFS host pool ({len(nfs_sel)}) "
+            f"for workflow {workflow!r}"
+        )
+
+    return (
+        _hostnames(nfs_sel),
+        _hostnames(ingress_sel),
+        _unique_nodes(nfs_sel, ingress_sel),
+        nfs_count,
+        placement.get("labels"),
+    )
+
+
+def _run_ha_stick_table(ceph_cluster, config, workflow, is_first_workflow=True):
+    """Deploy HA and validate stick table for one placement workflow."""
+    client1, client2 = ceph_cluster.get_nodes("client")[:2]
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    poll_interval = _poll_interval(config)
+
+    nfs_hosts, ingress_hosts, deploy_nodes, nfs_count, placement_labels = (
+        _resolve_hosts(workflow, config, nfs_nodes)
+    )
+    placement = WORKFLOWS[workflow]["placement"]
+    nfs_backend_port, ingress_frontend_port, ingress_monitor_port = WORKFLOWS[workflow][
+        "ports"
+    ]
+    nfs_service_id = (
+        f"{NFS_SERVICE_ID_PREFIX}-{workflow}-"
+        f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+    vip = NfsMultiActiveConfig.get_vips(config)[0]
+    mounted_clients = []
+    export_created = False
+    cluster_deployed = False
+    labels_applied = False
+
+    log.info("NFS service id: %s, VIP: %s", nfs_service_id, vip)
+    if placement_labels:
+        log.info(
+            "NFS count=%s label=%r (pool %s); ingress label=%r (pool %s)",
+            nfs_count,
+            placement_labels["nfs"],
+            nfs_hosts,
+            placement_labels["ingress"],
+            ingress_hosts,
+        )
+    else:
+        log.info(
+            "NFS count=%s placement hosts=%s; ingress hosts=%s",
+            nfs_count,
+            nfs_hosts,
+            ingress_hosts,
+        )
+    log.info(
+        "Ports: nfs_backend=%s ingress_frontend=%s ingress_monitor=%s",
+        nfs_backend_port,
+        ingress_frontend_port,
+        ingress_monitor_port,
+    )
+
+    try:
+        if placement_labels:
+            NfsMultiActiveConfig.apply_placement_labels(
+                client1,
+                nfs_nodes,
+                placement["nfs"],
+                placement["ingress"],
+                placement_labels,
+            )
+            labels_applied = True
+
+        nfs_label = placement_labels["nfs"] if placement_labels else None
+        ingress_label = placement_labels["ingress"] if placement_labels else None
+        specs = [
+            NfsMultiActiveConfig.build_nfs_spec(
+                nfs_hosts,
+                nfs_count,
+                nfs_service_id,
+                nfs_backend_port,
+                label=nfs_label,
+            ),
+            NfsMultiActiveConfig.build_ingress_spec(
+                vip,
+                nfs_service_id,
+                ingress_frontend_port,
+                ingress_monitor_port,
+                config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+                ingress_hostnames=None if ingress_label else ingress_hosts,
+                label=ingress_label,
+            ),
+        ]
+        haproxy = NfsMultiActiveHaproxy(
+            ceph_cluster, nfs_service_id, info_client=client1
+        )
+        stick_kwargs = {"stick_table_interval": poll_interval}
+
+        deploy_kwargs = _deploy_kwargs(config, is_first_workflow)
+        if ingress_label:
+            deploy_kwargs["expected_ingress_hosts"] = ingress_hosts
+
+        cluster_deployed = True
+        NfsMultiActiveDeploy(ceph_cluster, nfs_service_id, vip, client=client1).deploy(
+            specs, deploy_nodes, **deploy_kwargs
+        )
+        haproxy.validate_entries(**stick_kwargs)
+
+        Ceph(client1).nfs.export.create(
+            fs_name="cephfs",
+            nfs_name=nfs_service_id,
+            nfs_export=EXPORT_NAME,
+            fs="cephfs",
+        )
+        NfsMultiActiveConfig.wait_until_export_visible(
+            client1,
+            nfs_service_id,
+            EXPORT_NAME,
+            interval=poll_interval,
+        )
+        export_created = True
+
+        for client in (client1, client2):
+            NfsMultiActiveClient.mount_via_vip(
+                client,
+                vip,
+                NFS_MOUNT,
+                EXPORT_NAME,
+                str(ingress_frontend_port),
+                NFS_VERSION,
+            )
+            mounted_clients.append(client)
+            haproxy.validate_entries(mounted_clients=mounted_clients, **stick_kwargs)
+
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir=workflow,
+        )
+        haproxy.validate_entries(mounted_clients=mounted_clients, **stick_kwargs)
+
+        return 0
+    except Exception as e:
+        log.error("NFS Multi-Active test failed (%s): %s", workflow, e)
+        return 1
+    finally:
+        try:
+            if mounted_clients:
+                NfsMultiActiveClient.unmount_and_delete_export(
+                    mounted_clients, NFS_MOUNT, nfs_service_id, EXPORT_NAME
+                )
+            elif export_created:
+                Ceph(client1).nfs.export.delete(nfs_service_id, EXPORT_NAME)
+        except Exception as e:
+            log.warning("Mount/export cleanup failed: %s", e)
+
+        if cluster_deployed:
+            try:
+                NfsMultiActiveCleanup(ceph_cluster).remove_cluster(nfs_service_id)
+            except Exception as e:
+                log.warning("NFS cluster cleanup failed: %s", e)
+
+        if labels_applied:
+            try:
+                NfsMultiActiveConfig.remove_placement_labels(
+                    client1,
+                    nfs_nodes,
+                    placement["nfs"],
+                    placement["ingress"],
+                    placement_labels,
+                )
+            except Exception as e:
+                log.warning("Placement label cleanup failed: %s", e)
+
+
+def run(ceph_cluster, **kw):
+    """Run all multi-active HA placement workflows (see WORKFLOWS)."""
+    config = kw.get("config") or {}
+    init_crash_monitoring(config)
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+
+    if len(clients) < 2:
+        raise ConfigError("Stick table mount validation requires at least 2 clients")
+    if len(nfs_nodes) < MIN_NFS_NODES:
+        raise ConfigError(
+            f"Need at least {MIN_NFS_NODES} NFS-capable nodes, found {len(nfs_nodes)}"
+        )
+
+    workflows = [config["workflow"]] if config.get("workflow") else list(WORKFLOWS)
+    for step, workflow in enumerate(workflows, start=1):
+        if workflow not in WORKFLOWS:
+            raise ConfigError(
+                f"Unknown workflow {workflow!r}; valid: {', '.join(WORKFLOWS)}"
+            )
+        _log_workflow_start(workflow, step, len(workflows))
+        rc = _run_ha_stick_table(
+            ceph_cluster,
+            config,
+            workflow,
+            is_first_workflow=(step == 1),
+        )
+        if rc != 0:
+            return rc
+        try:
+            wait_for_ceph_health(ceph_cluster, config, context=f"post-{workflow}")
+        except ConfigError as e:
+            log.error("Post-%s health check failed: %s", workflow, e)
+            return 1
+    try:
+        wait_for_ceph_health(ceph_cluster, config, context="post-suite")
+    except ConfigError as e:
+        log.error("Post-suite stabilization failed: %s", e)
+        return 1
+    return 0

--- a/tests/nfs/multi_active/test_nfs_multi_active_integration.py
+++ b/tests/nfs/multi_active/test_nfs_multi_active_integration.py
@@ -1,0 +1,1363 @@
+"""NFS Multi-Active integration tests with CephFS (TC-1..)."""
+
+from datetime import datetime
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from tests.nfs.lib.multi_active import (
+    NfsMultiActiveCleanup,
+    NfsMultiActiveClient,
+    NfsMultiActiveConfig,
+    NfsMultiActiveDelegation,
+    NfsMultiActiveDeploy,
+    NfsMultiActiveFailover,
+    NfsMultiActiveHaproxy,
+    NfsMultiActiveQos,
+    init_crash_monitoring,
+    wait_for_ceph_health,
+)
+from tests.nfs.lib.multi_active.constants import (
+    DEFAULT_QOS_OPERATION,
+    DEFAULT_QOS_TYPE,
+    DEFAULT_TC3_DELEGATION_HOLD_READY_SEC,
+    DEFAULT_TC3_DELEGATION_HOLD_SEC,
+    DEFAULT_TC3_DELEGATION_RELEASE_WAIT_SEC,
+    DEFAULT_TC3_REDEPLOY_WAIT,
+    DEFAULT_TC3_SERVICE_WAIT_TIMEOUT,
+    DEFAULT_TC4_QOS_TYPE,
+    DEPLOY_TIMEOUT,
+    EXPORT_NAME,
+    FS_NAME,
+    HEALTH_CHECK_INTERVAL,
+    INTEGRATION_PORTS,
+    IO_JOIN_TIMEOUT,
+    IO_RESUME_TIMEOUT,
+    IO_WARMUP_SEC,
+    NFS_DAEMON_COUNT,
+    NFS_MOUNT,
+    NFS_VERSION,
+    POLL_INTERVAL_SEC,
+    QOS_SETTLE_SEC,
+    SERVICE_ID_PREFIX,
+    TC4_COLOCATION,
+    TC4_INGRESS_PORTS,
+    TC4_LABELS,
+    TC4_NFS_COUNT,
+)
+from tests.nfs.lib.multi_active.placement import (
+    COLOCATION_PLACEMENT,
+    INTEGRATION_PLACEMENT,
+    resolve_integration_hosts,
+    resolve_placement_hosts,
+)
+from tests.nfs.nfs_delegation_operations import (
+    kill_delegation_holds,
+    release_delegation_hold_gracefully,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+NFS_SERVICE_ID_PREFIX = SERVICE_ID_PREFIX["integration"]
+_INTEGRATION_PLACEMENT = INTEGRATION_PLACEMENT
+_PORTS = INTEGRATION_PORTS
+_TC4_NFS_COUNT = TC4_NFS_COUNT
+_TC4_COLOCATION = TC4_COLOCATION
+_TC4_INGRESS_PORTS = TC4_INGRESS_PORTS
+_TC4_LABELS = TC4_LABELS
+
+INTEGRATION_WORKFLOWS = {
+    "tc1_mds_failover_dual_client_fio": {
+        "tc": "TC-1",
+        "vip": 1,
+        "desc": (
+            "Deploy NFS multi-active, mount two clients, run FIO, fail over MDS "
+            "via cephfs_common_lib, validate MDS failover and IO resume."
+        ),
+    },
+    "tc2_cqos_pershare_failover_io": {
+        "tc": "TC-2",
+        "vip": 1,
+        "desc": (
+            "Configure per-share CQoS on the export, validate bandwidth limits, "
+            "run FIO, trigger NFS backend label failover, verify QoS persistence "
+            "and IO resume with no limit violations."
+        ),
+    },
+    "tc3_rw_delegation_failover_io": {
+        "tc": "TC-3",
+        "vip": 1,
+        "desc": (
+            "Reuse integration HA cluster, set export-level RW delegation, "
+            "validate delegation via Ganesha logs on VIP mount, hold delegation "
+            "before NFS backend failover, verify post-failover access, then IO resume."
+        ),
+    },
+    "tc4_cqos_perclient_colocation_io": {
+        "tc": "TC-4",
+        "vip": 2,
+        "desc": (
+            "Deploy colocated NFS instances on the same node(s), enable per-client "
+            "CQoS, run dual-client IO, and validate per-client QoS isolation with "
+            "no cross-impact between colocated NFS backends."
+        ),
+    },
+}
+
+
+def _resolve_integration_vip(config, workflow=None, vip_slot=None):
+    """Return VIP for an integration workflow (1-based slot into config vips)."""
+    vips = NfsMultiActiveConfig.get_vips(config)
+    if vip_slot is None:
+        vip_slot = int((workflow or {}).get("vip", config.get("vip", 1)))
+    slot = int(vip_slot)
+    if slot < 1 or slot > len(vips):
+        raise ConfigError(
+            f"Integration workflow vip slot must be 1..{len(vips)}, got {slot!r}"
+        )
+    return vips[slot - 1]
+
+
+class IntegrationClusterSession:
+    """Cluster state shared between TC-1..TC-4 in one integration session."""
+
+    def __init__(self):
+        self.ceph_cluster = None
+        self.config = None
+        self.client1 = None
+        self.client2 = None
+        self.nfs_nodes = None
+        self.nfs_hosts = None
+        self.ingress_hosts = None
+        self.deploy_nodes = None
+        self.spare_host = None
+        self.nfs_service_id = None
+        self.vip = None
+        self.nfs_backend_port = None
+        self.ingress_frontend_port = None
+        self.ingress_monitor_port = None
+        self.labels = None
+        self.nfs_count = NFS_DAEMON_COUNT
+        self.deploy_timeout = DEPLOY_TIMEOUT
+        self.poll_interval = POLL_INTERVAL_SEC
+        self.nfs_spec = None
+        self.ingress_spec = None
+        self.deploy = None
+        self.haproxy = None
+        self.failover = None
+        self.colocation = False
+        self.cluster_deployed = False
+        self.export_created = False
+        self.labels_applied = False
+        self.mounted_clients = []
+        self.qos_enabled = False
+        self.cluster_qos_enabled = False
+        self.qos_baseline_get = None
+        self.qos_baseline_block = None
+        self.io_sessions = []
+        self.timings = {}
+        self.delegation_logging_template_backup = False
+        self.delegation_cephadm = None
+        self.delegation_installer = None
+        self.nfs_cmd_host = None
+
+    def cleanup(self):
+        config = self.config or {}
+        if self.client1:
+            try:
+                kill_delegation_holds(self.client1)
+            except Exception as exc:
+                log.warning("Delegation hold cleanup failed on client1: %s", exc)
+        if self.client2:
+            try:
+                kill_delegation_holds(self.client2)
+            except Exception as exc:
+                log.warning("Delegation hold cleanup failed on client2: %s", exc)
+        if self.io_sessions:
+            try:
+                NfsMultiActiveClient.stop_background_io_on_clients(
+                    self.io_sessions, config
+                )
+                for _client, thread, _error_box, _io_dir in self.io_sessions:
+                    thread.join(timeout=IO_JOIN_TIMEOUT)
+            except Exception as exc:
+                log.warning("IO session cleanup failed: %s", exc)
+            self.io_sessions = []
+
+        client1 = self.client1
+        if client1 and self.nfs_service_id:
+            try:
+                NfsMultiActiveQos.disable(self)
+            except Exception as exc:
+                log.warning("QoS cleanup failed: %s", exc)
+
+        try:
+            if self.mounted_clients:
+                NfsMultiActiveClient.unmount_and_delete_export(
+                    self.mounted_clients,
+                    NFS_MOUNT,
+                    self.nfs_service_id,
+                    EXPORT_NAME,
+                )
+            elif self.export_created and client1 and self.nfs_service_id:
+                Ceph(client1).nfs.export.delete(self.nfs_service_id, EXPORT_NAME)
+        except Exception as exc:
+            log.warning("Mount/export cleanup failed: %s", exc)
+
+        client1 = self.client1
+        if (
+            self.delegation_logging_template_backup
+            and self.nfs_cmd_host
+            and self.delegation_cephadm
+            and self.delegation_installer
+            and self.nfs_service_id
+        ):
+            cluster_ids = [self.nfs_service_id]
+            try:
+                redeploy_wait = int(
+                    (self.config or {}).get(
+                        "tc3_redeploy_wait", DEFAULT_TC3_REDEPLOY_WAIT
+                    )
+                )
+                service_wait = int(
+                    (self.config or {}).get(
+                        "tc3_service_wait_timeout",
+                        DEFAULT_TC3_SERVICE_WAIT_TIMEOUT,
+                    )
+                )
+                NfsMultiActiveDelegation.restore_ganesha_debug_logging(
+                    self.nfs_cmd_host,
+                    self.delegation_cephadm,
+                    self.delegation_installer,
+                    cluster_ids,
+                    self.delegation_logging_template_backup,
+                    redeploy_wait=redeploy_wait,
+                    service_wait_timeout=service_wait,
+                )
+            except Exception as exc:
+                log.warning("Ganesha debug logging restore failed: %s", exc)
+            self.delegation_logging_template_backup = False
+
+        if self.labels_applied and client1 and self.nfs_nodes and self.labels:
+            try:
+                placement = _INTEGRATION_PLACEMENT
+                NfsMultiActiveConfig.clear_placement_labels(
+                    client1,
+                    self.nfs_nodes,
+                    self.labels,
+                )
+                NfsMultiActiveConfig.remove_placement_labels(
+                    client1,
+                    self.nfs_nodes,
+                    placement["nfs"],
+                    placement["ingress"],
+                    self.labels,
+                )
+            except Exception as exc:
+                log.warning("Placement label cleanup failed: %s", exc)
+            self.labels_applied = False
+
+        if self.cluster_deployed and self.nfs_service_id:
+            try:
+                NfsMultiActiveCleanup(self.ceph_cluster).remove_cluster(
+                    self.nfs_service_id
+                )
+            except Exception as exc:
+                log.warning("NFS cluster cleanup failed: %s", exc)
+            self.cluster_deployed = False
+        self.colocation = False
+
+
+def _ensure_two_active_mdss(cephfs_common, client, fs_name):
+    """Raise max_mds when needed so rolling_mds_failover can succeed."""
+    active = cephfs_common.get_active_mdss(client, fs_name)
+    if len(active) >= 2:
+        log.info("CephFS already has %d active MDS: %s", len(active), active)
+        return active
+    log.info("Setting %s max_mds=2 for MDS failover test", fs_name)
+    client.exec_command(sudo=True, cmd=f"ceph fs set {fs_name} max_mds 2")
+    if cephfs_common.wait_for_two_active_mds(client, fs_name):
+        raise OperationFailedError(f"Timed out waiting for 2 active MDS on {fs_name!r}")
+    active = cephfs_common.get_active_mdss(client, fs_name)
+    log.info("Active MDS after max_mds=2: %s", active)
+    return active
+
+
+def _validate_mds_failover(active_before, active_after):
+    if not active_after:
+        raise OperationFailedError("No active MDS after failover")
+    if set(active_before) == set(active_after):
+        raise OperationFailedError(
+            f"MDS failover did not change active set: before={active_before} "
+            f"after={active_after}"
+        )
+    log.info(
+        "MDS failover validated: before=%s after=%s",
+        active_before,
+        active_after,
+    )
+
+
+def bootstrap_integration_cluster(ceph_cluster, config, session, case_id, vip_slot=1):
+    """Deploy label-based NFS multi-active cluster when session is not bootstrapped."""
+    if session.cluster_deployed:
+        log.info("%s reusing integration cluster %s", case_id, session.nfs_service_id)
+        return
+
+    clients = ceph_cluster.get_nodes("client")
+    if len(clients) < 2:
+        raise ConfigError("Integration tests require at least 2 client nodes")
+    client1, client2 = clients[0], clients[1]
+    nfs_nodes = NfsMultiActiveConfig.sorted_nfs_nodes(ceph_cluster)
+    nfs_hosts, ingress_hosts, deploy_nodes, spare_host = resolve_integration_hosts(
+        nfs_nodes
+    )
+    nfs_backend_port, ingress_frontend_port, ingress_monitor_port = _PORTS
+    placement = _INTEGRATION_PLACEMENT
+    labels = placement["labels"]
+    nfs_count = int(config.get("nfs_count", NFS_DAEMON_COUNT))
+    nfs_service_id = (
+        f"{NFS_SERVICE_ID_PREFIX}-int-" f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+    vip = _resolve_integration_vip(config, vip_slot=vip_slot)
+    poll_interval = int(config.get("poll_interval_sec", POLL_INTERVAL_SEC))
+    deploy_timeout = int(config.get("deploy_timeout", DEPLOY_TIMEOUT))
+
+    session.ceph_cluster = ceph_cluster
+    session.config = config
+    session.client1 = client1
+    session.client2 = client2
+    session.nfs_nodes = nfs_nodes
+    session.nfs_hosts = nfs_hosts
+    session.ingress_hosts = ingress_hosts
+    session.deploy_nodes = deploy_nodes
+    session.spare_host = spare_host
+    session.nfs_service_id = nfs_service_id
+    session.vip = vip
+    session.nfs_backend_port = nfs_backend_port
+    session.ingress_frontend_port = ingress_frontend_port
+    session.ingress_monitor_port = ingress_monitor_port
+    session.labels = labels
+    session.nfs_count = nfs_count
+    session.deploy_timeout = deploy_timeout
+    session.poll_interval = poll_interval
+    session.colocation = False
+
+    nfs_spec = NfsMultiActiveConfig.build_nfs_spec(
+        nfs_hosts,
+        nfs_count,
+        nfs_service_id,
+        nfs_backend_port,
+        label=labels["nfs"],
+    )
+    ingress_spec = NfsMultiActiveConfig.build_ingress_spec(
+        vip,
+        nfs_service_id,
+        ingress_frontend_port,
+        ingress_monitor_port,
+        config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+        label=labels["ingress"],
+    )
+    session.nfs_spec = nfs_spec
+    session.ingress_spec = ingress_spec
+    session.deploy = NfsMultiActiveDeploy(
+        ceph_cluster, nfs_service_id, vip, client=client1
+    )
+    session.haproxy = NfsMultiActiveHaproxy(
+        ceph_cluster, nfs_service_id, info_client=client1
+    )
+    session.failover = NfsMultiActiveFailover()
+
+    log.info(
+        "%s deploy: nfs=%s ingress=%s spare=%s VIP=%s (slot %s) service_id=%s",
+        case_id,
+        nfs_hosts,
+        ingress_hosts,
+        spare_host,
+        vip,
+        vip_slot,
+        nfs_service_id,
+    )
+
+    NfsMultiActiveConfig.clear_placement_labels(client1, nfs_nodes, labels)
+    NfsMultiActiveConfig.apply_placement_labels(
+        client1,
+        nfs_nodes,
+        placement["nfs"],
+        placement["ingress"],
+        labels,
+    )
+    session.labels_applied = True
+    session.deploy.deploy(
+        [nfs_spec, ingress_spec],
+        deploy_nodes,
+        deploy_timeout=deploy_timeout,
+        expected_ingress_hosts=ingress_hosts,
+        ingress_poll_interval=poll_interval,
+    )
+    session.cluster_deployed = True
+
+    Ceph(client1).nfs.export.create(
+        fs_name=FS_NAME,
+        nfs_name=nfs_service_id,
+        nfs_export=EXPORT_NAME,
+        fs=FS_NAME,
+    )
+    NfsMultiActiveConfig.wait_until_export_visible(
+        client1,
+        nfs_service_id,
+        EXPORT_NAME,
+        interval=poll_interval,
+    )
+    session.export_created = True
+
+    for client in (client1, client2):
+        NfsMultiActiveClient.mount_via_vip(
+            client,
+            vip,
+            NFS_MOUNT,
+            EXPORT_NAME,
+            str(ingress_frontend_port),
+            NFS_VERSION,
+        )
+        session.mounted_clients.append(client)
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            stick_table_interval=poll_interval,
+        )
+
+
+def _ensure_tc4_colocation_cluster(ceph_cluster, config, session, case_id, vip_slot=2):
+    """Deploy or reuse a colocated multi-NFS cluster for TC-4."""
+    if session.cluster_deployed and session.colocation:
+        log.info("%s reusing colocation cluster %s", case_id, session.nfs_service_id)
+        return
+    if session.cluster_deployed:
+        log.info(
+            "%s replacing prior integration cluster with colocation deploy", case_id
+        )
+        session.cleanup()
+    bootstrap_tc4_colocation_cluster(
+        ceph_cluster, config, session, case_id, vip_slot=vip_slot
+    )
+
+
+def bootstrap_tc4_colocation_cluster(
+    ceph_cluster, config, session, case_id, vip_slot=2
+):
+    """Deploy colocated NFS instances (multiple daemons per node) for TC-4."""
+    clients = ceph_cluster.get_nodes("client")
+    if len(clients) < 2:
+        raise ConfigError("TC-4 requires at least 2 client nodes")
+    client1, client2 = clients[0], clients[1]
+    nfs_nodes = NfsMultiActiveConfig.sorted_nfs_nodes(ceph_cluster)
+    placement = COLOCATION_PLACEMENT
+    nfs_hosts, ingress_hosts, deploy_nodes, _, _, spare_host = resolve_placement_hosts(
+        nfs_nodes, placement, config
+    )
+    nfs_sel_count = len(nfs_hosts)
+    nfs_count = int(config.get("tc4_nfs_count", _TC4_NFS_COUNT))
+    if nfs_count > nfs_sel_count * 2:
+        raise ConfigError(
+            f"tc4_nfs_count ({nfs_count}) exceeds colocation capacity on "
+            f"{nfs_sel_count} NFS host(s)"
+        )
+
+    labels = _TC4_LABELS
+    ingress_frontend_port, ingress_monitor_port = _TC4_INGRESS_PORTS
+    coloc = _TC4_COLOCATION
+    nfs_service_id = (
+        f"{NFS_SERVICE_ID_PREFIX}-int-tc4-" f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+    vip = _resolve_integration_vip(config, vip_slot=vip_slot)
+    poll_interval = int(config.get("poll_interval_sec", POLL_INTERVAL_SEC))
+    deploy_timeout = int(config.get("deploy_timeout", DEPLOY_TIMEOUT))
+
+    session.ceph_cluster = ceph_cluster
+    session.config = config
+    session.client1 = client1
+    session.client2 = client2
+    session.nfs_nodes = nfs_nodes
+    session.nfs_hosts = nfs_hosts
+    session.ingress_hosts = ingress_hosts
+    session.deploy_nodes = deploy_nodes
+    session.spare_host = spare_host
+    session.nfs_service_id = nfs_service_id
+    session.vip = vip
+    session.nfs_backend_port = coloc["port"]
+    session.ingress_frontend_port = ingress_frontend_port
+    session.ingress_monitor_port = ingress_monitor_port
+    session.labels = labels
+    session.nfs_count = nfs_count
+    session.deploy_timeout = deploy_timeout
+    session.poll_interval = poll_interval
+    session.colocation = True
+    session.mounted_clients = []
+    session.qos_enabled = False
+    session.cluster_qos_enabled = False
+    session.qos_baseline_get = None
+    session.qos_baseline_block = None
+
+    nfs_spec = NfsMultiActiveConfig.build_nfs_colocation_spec(
+        nfs_hosts,
+        nfs_count,
+        nfs_service_id,
+        coloc["port"],
+        coloc["monitoring_port"],
+        coloc["colocation_ports"],
+        label=labels["nfs"],
+    )
+    ingress_spec = NfsMultiActiveConfig.build_ingress_spec(
+        vip,
+        nfs_service_id,
+        ingress_frontend_port,
+        ingress_monitor_port,
+        config.get("health_check_interval", HEALTH_CHECK_INTERVAL),
+        label=labels["ingress"],
+    )
+    session.nfs_spec = nfs_spec
+    session.ingress_spec = ingress_spec
+    session.deploy = NfsMultiActiveDeploy(
+        ceph_cluster, nfs_service_id, vip, client=client1
+    )
+    session.haproxy = NfsMultiActiveHaproxy(
+        ceph_cluster, nfs_service_id, info_client=client1
+    )
+    session.failover = NfsMultiActiveFailover()
+
+    log.info(
+        "%s colocation deploy: nfs=%s ingress=%s count=%s VIP=%s (slot %s) service_id=%s",
+        case_id,
+        nfs_hosts,
+        ingress_hosts,
+        nfs_count,
+        vip,
+        vip_slot,
+        nfs_service_id,
+    )
+
+    NfsMultiActiveConfig.clear_placement_labels(client1, nfs_nodes, labels)
+    NfsMultiActiveConfig.apply_placement_labels(
+        client1,
+        nfs_nodes,
+        placement["nfs"],
+        placement["ingress"],
+        labels,
+    )
+    session.labels_applied = True
+    session.deploy.deploy(
+        [nfs_spec, ingress_spec],
+        deploy_nodes,
+        deploy_timeout=deploy_timeout,
+        expected_ingress_hosts=ingress_hosts,
+        ingress_poll_interval=poll_interval,
+        colocation_validation=True,
+    )
+    session.cluster_deployed = True
+
+    cluster_info = session.deploy.validator.get_cluster_info(nfs_service_id)
+    session.deploy.validator.assert_colocation_cluster_info(
+        cluster_info, nfs_spec, ingress_spec
+    )
+    session.deploy.validator.assert_colocation_ports_listening(cluster_info, nfs_spec)
+
+    Ceph(client1).nfs.export.create(
+        fs_name=FS_NAME,
+        nfs_name=nfs_service_id,
+        nfs_export=EXPORT_NAME,
+        fs=FS_NAME,
+    )
+    NfsMultiActiveConfig.wait_until_export_visible(
+        client1,
+        nfs_service_id,
+        EXPORT_NAME,
+        interval=poll_interval,
+    )
+    session.export_created = True
+
+    stick_kwargs = {"stick_table_interval": poll_interval}
+    for client in (client1, client2):
+        NfsMultiActiveClient.mount_via_vip(
+            client,
+            vip,
+            NFS_MOUNT,
+            EXPORT_NAME,
+            str(ingress_frontend_port),
+            NFS_VERSION,
+        )
+        session.mounted_clients.append(client)
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+
+
+def run_tc1_mds_failover_dual_client_fio(
+    ceph_cluster, config, case_id, session=None, vip_slot=1
+):
+    """TC-1: NFS HA deploy, dual-client FIO, CephFS MDS failover, IO resume."""
+    session = session or IntegrationClusterSession()
+    bootstrap_integration_cluster(
+        ceph_cluster, config, session, case_id, vip_slot=vip_slot
+    )
+
+    client1 = session.client1
+    client2 = session.client2
+    poll_interval = session.poll_interval
+    io_warmup = int(config.get("mds_failover_io_warmup", IO_WARMUP_SEC))
+    io_resume_timeout = int(config.get("io_resume_timeout", IO_RESUME_TIMEOUT))
+    stick_kwargs = {"stick_table_interval": poll_interval}
+    timings = session.timings
+    io_sessions = []
+
+    try:
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir="tc1_pre_mds_failover",
+        )
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+
+        io_sessions = NfsMultiActiveClient.run_background_io_on_clients(
+            session.mounted_clients,
+            NFS_MOUNT,
+            config,
+            io_subdir="tc1_mds_failover_io",
+        )
+        if io_warmup > 0:
+            log.info("FIO warmup %ss before MDS failover", io_warmup)
+            sleep(io_warmup)
+        for client, thread, error_box, _io_dir in io_sessions:
+            if error_box.get("exc"):
+                raise OperationFailedError(
+                    f"Background IO failed on {client.hostname}: {error_box['exc']}"
+                )
+            if not thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO stopped during warmup on {client.hostname}"
+                )
+
+        cephfs_common = CephFSCommonUtils(ceph_cluster)
+        active_before = _ensure_two_active_mdss(cephfs_common, client1, FS_NAME)
+        log.info("%s active MDS before failover: %s", case_id, active_before)
+
+        timings["mds_failover_triggered_at"] = datetime.now().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        if cephfs_common.rolling_mds_failover(client1, FS_NAME, mds_fail_cnt=1):
+            raise OperationFailedError("rolling_mds_failover failed")
+
+        active_after = cephfs_common.get_active_mdss(client1, FS_NAME)
+        log.info("%s active MDS after failover: %s", case_id, active_after)
+        _validate_mds_failover(active_before, active_after)
+
+        NfsMultiActiveClient.wait_for_background_io_resume(
+            io_sessions,
+            NFS_MOUNT,
+            config,
+            timeout=io_resume_timeout,
+            timings=timings,
+            triggered_at=timings.get("mds_failover_triggered_at"),
+        )
+        log.info("%s background IO resumed after MDS failover", case_id)
+
+        NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+        for _client, thread, error_box, _io_dir in io_sessions:
+            thread.join(timeout=IO_JOIN_TIMEOUT)
+            if thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO on {_client.hostname} did not stop within "
+                    f"{IO_JOIN_TIMEOUT}s"
+                )
+            if error_box.get("exc") and not error_box.get("stopped"):
+                raise OperationFailedError(
+                    f"Background IO failed on {_client.hostname}: {error_box['exc']}"
+                )
+        io_sessions = []
+
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir="tc1_post_mds_failover",
+        )
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+
+        log.info("%s passed", case_id)
+        return 0
+    except Exception as exc:
+        log.error("%s failed: %s", case_id, exc)
+        return 1
+    finally:
+        if io_sessions:
+            try:
+                NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+                for _client, thread, _error_box, _io_dir in io_sessions:
+                    thread.join(timeout=IO_JOIN_TIMEOUT)
+            except Exception as exc:
+                log.warning("TC-1 IO session cleanup failed: %s", exc)
+
+
+def run_tc2_cqos_pershare_failover_io(ceph_cluster, config, case_id, session=None):
+    """TC-2: per-share CQoS, IO workload, NFS failover, QoS + IO validation."""
+    session = session or IntegrationClusterSession()
+    bootstrap_integration_cluster(ceph_cluster, config, session, case_id)
+
+    client1 = session.client1
+    client2 = session.client2
+    export_bw = NfsMultiActiveQos.export_bw_config(config)
+    cluster_bw = NfsMultiActiveQos.cluster_bw_config(config)
+    qos_type = config.get("qos_type", DEFAULT_QOS_TYPE)
+    qos_operation = config.get("qos_operation") or config.get(
+        "control", DEFAULT_QOS_OPERATION
+    )
+    poll_interval = session.poll_interval
+    io_warmup = int(config.get("cqos_failover_io_warmup", IO_WARMUP_SEC))
+    io_resume_timeout = int(config.get("io_resume_timeout", IO_RESUME_TIMEOUT))
+    qos_settle = int(
+        config.get("tc2_qos_settle", config.get("qos_settle", QOS_SETTLE_SEC))
+    )
+    stick_kwargs = {"stick_table_interval": poll_interval}
+    timings = session.timings
+    io_sessions = []
+
+    try:
+        NfsMultiActiveQos.enable(
+            session,
+            cluster_bw,
+            export_bw,
+            qos_type,
+            qos_operation,
+        )
+        qos_get, qos_block = NfsMultiActiveQos.wait_ready(
+            client1,
+            session.nfs_service_id,
+            export_bw,
+            qos_type,
+            "pre_failover",
+            config=config,
+        )
+        session.qos_baseline_get = qos_get
+        session.qos_baseline_block = qos_block
+        backend_host, backend_port = session.haproxy.get_client_backend_endpoint(
+            client1
+        )
+        log.info(
+            "TC-2 QoS speed via VIP %s (pinned backend %s:%s, pre_failover)",
+            NFS_MOUNT,
+            backend_host,
+            backend_port,
+        )
+        if qos_settle > 0:
+            log.info("TC-2 QoS settle %ss before speed validation", qos_settle)
+            sleep(qos_settle)
+        NfsMultiActiveQos.validate_speeds(
+            client1, NFS_MOUNT, export_bw, qos_type, "pre_failover"
+        )
+
+        io_sessions = NfsMultiActiveClient.run_background_io_on_clients(
+            session.mounted_clients,
+            NFS_MOUNT,
+            config,
+            io_subdir="tc2_cqos_failover_io",
+        )
+        session.io_sessions = io_sessions
+        if io_warmup > 0:
+            log.info("FIO warmup %ss before NFS failover", io_warmup)
+            sleep(io_warmup)
+        for client, thread, error_box, _io_dir in io_sessions:
+            if error_box.get("exc"):
+                raise OperationFailedError(
+                    f"Background IO failed on {client.hostname}: {error_box['exc']}"
+                )
+            if not thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO stopped during warmup on {client.hostname}"
+                )
+
+        pinned_nfs = session.haproxy.get_client_backend_hostname(client1)
+        log.info(
+            "%s NFS failover: drain pinned backend %s -> spare %s",
+            case_id,
+            pinned_nfs,
+            session.spare_host,
+        )
+        timings["nfs_failover_triggered_at"] = datetime.now().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+        def _wait_io_after_nfs_failover():
+            NfsMultiActiveClient.wait_for_background_io_resume(
+                io_sessions,
+                NFS_MOUNT,
+                config,
+                timeout=io_resume_timeout,
+                timings=timings,
+                triggered_at=timings.get("nfs_failover_triggered_at"),
+            )
+
+        session.failover.failover_nfs_by_label(
+            client1,
+            session.deploy,
+            session.nfs_spec,
+            session.deploy_nodes,
+            pinned_nfs,
+            session.spare_host,
+            session.labels["nfs"],
+            session.nfs_count,
+            deploy_timeout=session.deploy_timeout,
+            timings=timings,
+            timings_trigger_key="nfs_failover_triggered_at",
+            post_apply_callback=_wait_io_after_nfs_failover,
+        )
+        log.info("%s background IO resumed after NFS failover", case_id)
+
+        NfsMultiActiveQos.validate_persisted(
+            client1,
+            session.nfs_service_id,
+            export_bw,
+            qos_type,
+            session.qos_baseline_get,
+            session.qos_baseline_block,
+            "post_failover",
+        )
+
+        NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+        for _client, thread, error_box, _io_dir in io_sessions:
+            thread.join(timeout=IO_JOIN_TIMEOUT)
+            if thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO on {_client.hostname} did not stop within "
+                    f"{IO_JOIN_TIMEOUT}s"
+                )
+            if error_box.get("exc") and not error_box.get("stopped"):
+                raise OperationFailedError(
+                    f"Background IO failed on {_client.hostname}: {error_box['exc']}"
+                )
+        io_sessions = []
+        session.io_sessions = []
+
+        backend_host, backend_port = session.haproxy.get_client_backend_endpoint(
+            client1
+        )
+        log.info(
+            "TC-2 QoS speed via VIP %s (pinned backend %s:%s, post_failover)",
+            NFS_MOUNT,
+            backend_host,
+            backend_port,
+        )
+        NfsMultiActiveQos.validate_speeds(
+            client1, NFS_MOUNT, export_bw, qos_type, "post_failover"
+        )
+
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir="tc2_post_failover",
+        )
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+
+        log.info("%s passed", case_id)
+        return 0
+    except Exception as exc:
+        log.error("%s failed: %s", case_id, exc)
+        return 1
+    finally:
+        if io_sessions:
+            try:
+                NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+                for _client, thread, _error_box, _io_dir in io_sessions:
+                    thread.join(timeout=IO_JOIN_TIMEOUT)
+            except Exception as exc:
+                log.warning("TC-2 IO session cleanup failed: %s", exc)
+            session.io_sessions = []
+
+
+def run_tc4_cqos_perclient_colocation_io(
+    ceph_cluster, config, case_id, session=None, vip_slot=2
+):
+    """TC-4: per-client CQoS on colocated NFS instances with dual-client isolation."""
+    session = session or IntegrationClusterSession()
+    _ensure_tc4_colocation_cluster(
+        ceph_cluster, config, session, case_id, vip_slot=vip_slot
+    )
+
+    client1 = session.client1
+    client2 = session.client2
+    export_bw = NfsMultiActiveQos.tc4_export_bw_config(config)
+    cluster_bw = NfsMultiActiveQos.tc4_cluster_bw_config(config)
+    client_bw = export_bw
+    qos_type = config.get("tc4_qos_type", config.get("qos_type", DEFAULT_TC4_QOS_TYPE))
+    qos_operation = config.get("qos_operation") or config.get(
+        "control", DEFAULT_QOS_OPERATION
+    )
+    qos_settle = int(
+        config.get("tc4_qos_settle", config.get("qos_settle", QOS_SETTLE_SEC))
+    )
+    poll_interval = session.poll_interval
+    io_warmup = int(config.get("tc4_io_warmup", IO_WARMUP_SEC))
+    stick_kwargs = {"stick_table_interval": poll_interval}
+    clients = [client1, client2]
+    io_sessions = []
+
+    try:
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+        NfsMultiActiveQos.assert_colocated_client_isolation(session, case_id)
+
+        NfsMultiActiveQos.enable(
+            session,
+            cluster_bw,
+            export_bw,
+            qos_type,
+            qos_operation,
+        )
+        qos_get, qos_block = NfsMultiActiveQos.wait_ready(
+            client1,
+            session.nfs_service_id,
+            export_bw,
+            qos_type,
+            "pre_io",
+            config=config,
+        )
+        session.qos_enabled = qos_type != "PerClient"
+        session.qos_baseline_get = qos_get
+        session.qos_baseline_block = qos_block
+        if qos_settle > 0:
+            log.info("TC-4 QoS settle %ss before speed validation", qos_settle)
+            sleep(qos_settle)
+
+        NfsMultiActiveQos.validate_perclient_speeds(
+            clients,
+            NFS_MOUNT,
+            client_bw,
+            qos_type,
+            "pre_io",
+            session=session,
+        )
+
+        io_sessions = NfsMultiActiveClient.run_background_io_on_clients(
+            session.mounted_clients,
+            NFS_MOUNT,
+            config,
+            io_subdir="tc4_perclient_colocation_io",
+        )
+        session.io_sessions = io_sessions
+        if io_warmup > 0:
+            log.info("FIO warmup %ss before post-IO QoS validation", io_warmup)
+            sleep(io_warmup)
+        for client, thread, error_box, _io_dir in io_sessions:
+            if error_box.get("exc"):
+                raise OperationFailedError(
+                    f"Background IO failed on {client.hostname}: {error_box['exc']}"
+                )
+            if not thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO stopped during warmup on {client.hostname}"
+                )
+
+        NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+        for _client, thread, error_box, _io_dir in io_sessions:
+            thread.join(timeout=IO_JOIN_TIMEOUT)
+            if thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO on {_client.hostname} did not stop within "
+                    f"{IO_JOIN_TIMEOUT}s"
+                )
+            if error_box.get("exc") and not error_box.get("stopped"):
+                raise OperationFailedError(
+                    f"Background IO failed on {_client.hostname}: {error_box['exc']}"
+                )
+        io_sessions = []
+        session.io_sessions = []
+
+        NfsMultiActiveQos.assert_colocated_client_isolation(session, case_id)
+        NfsMultiActiveQos.validate_persisted(
+            client1,
+            session.nfs_service_id,
+            client_bw,
+            qos_type,
+            session.qos_baseline_get,
+            session.qos_baseline_block,
+            "post_io",
+        )
+        NfsMultiActiveQos.validate_perclient_speeds(
+            clients,
+            NFS_MOUNT,
+            client_bw,
+            qos_type,
+            "post_io",
+            session=session,
+        )
+
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir="tc4_post_io",
+        )
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+
+        log.info("%s passed", case_id)
+        return 0
+    except Exception as exc:
+        log.error("%s failed: %s", case_id, exc)
+        return 1
+    finally:
+        if io_sessions:
+            try:
+                NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+                for _client, thread, _error_box, _io_dir in io_sessions:
+                    thread.join(timeout=IO_JOIN_TIMEOUT)
+            except Exception as exc:
+                log.warning("TC-4 IO session cleanup failed: %s", exc)
+            session.io_sessions = []
+
+
+def _prepare_tc3_session(ceph_cluster, config, session, case_id, vip_slot=1):
+    """Reuse the TC-1/TC-2 integration cluster for TC-3 delegation tests."""
+    if session.cluster_deployed and session.colocation:
+        log.info(
+            "%s replacing colocation cluster with integration layout for TC-3",
+            case_id,
+        )
+        session.cleanup()
+    bootstrap_integration_cluster(
+        ceph_cluster, config, session, case_id, vip_slot=vip_slot
+    )
+    session.nfs_cmd_host = session.nfs_nodes[0]
+    if session.qos_enabled or session.cluster_qos_enabled:
+        log.info("%s disabling QoS from prior phase before delegation tests", case_id)
+        NfsMultiActiveQos.disable(session)
+        session.qos_baseline_get = None
+        session.qos_baseline_block = None
+
+
+def _mount_tc3_clients_on_vip(session):
+    """Mount both integration clients on the cluster VIP."""
+    if len(session.mounted_clients) >= 2:
+        return
+    for client in (session.client1, session.client2):
+        if client in session.mounted_clients:
+            continue
+        NfsMultiActiveClient.mount_via_vip(
+            client,
+            session.vip,
+            NFS_MOUNT,
+            EXPORT_NAME,
+            str(session.ingress_frontend_port),
+            NFS_VERSION,
+        )
+        session.mounted_clients.append(client)
+    session.haproxy.validate_entries(
+        mounted_clients=session.mounted_clients,
+        stick_table_interval=session.poll_interval,
+    )
+
+
+def _tc3_delegation_rel_path(config, tag):
+    base = config.get("tc3_delegation_rel_path", "tc3_delegation")
+    return "%s/%s" % (base, tag)
+
+
+def _tc3_delegation_hold_kwargs(config):
+    return {
+        "hold_seconds": int(
+            config.get("tc3_delegation_hold_seconds", DEFAULT_TC3_DELEGATION_HOLD_SEC)
+        ),
+        "hold_ready_seconds": int(
+            config.get(
+                "tc3_delegation_hold_ready_seconds",
+                DEFAULT_TC3_DELEGATION_HOLD_READY_SEC,
+            )
+        ),
+    }
+
+
+def _run_tc3_delegation_log_validation(session, client1, config, tag):
+    """Validate export-level RW delegation via Ganesha logs on the VIP mount."""
+    backend_hostname = session.haproxy.get_client_backend_hostname(client1)
+    NfsMultiActiveDelegation.assert_rw_delegation_ganesha_logs(
+        client1,
+        session.delegation_installer,
+        session.nfs_service_id,
+        session.nfs_nodes,
+        backend_hostname,
+        NFS_MOUNT,
+        config,
+        tag,
+    )
+
+
+def run_tc3_rw_delegation_failover_io(
+    ceph_cluster, config, case_id, session=None, vip_slot=1
+):
+    """TC-3: VIP-only delegation hold across NFS backend failover."""
+    session = session or IntegrationClusterSession()
+    _prepare_tc3_session(ceph_cluster, config, session, case_id, vip_slot=vip_slot)
+
+    client1 = session.client1
+    client2 = session.client2
+    nfs_cmd_host = session.nfs_cmd_host
+    poll_interval = session.poll_interval
+    io_warmup = int(config.get("tc3_failover_io_warmup", IO_WARMUP_SEC))
+    io_resume_timeout = int(config.get("io_resume_timeout", IO_RESUME_TIMEOUT))
+    redeploy_wait = int(config.get("tc3_redeploy_wait", DEFAULT_TC3_REDEPLOY_WAIT))
+    service_wait = int(
+        config.get("tc3_service_wait_timeout", DEFAULT_TC3_SERVICE_WAIT_TIMEOUT)
+    )
+    stick_kwargs = {"stick_table_interval": poll_interval}
+    timings = session.timings
+    io_sessions = []
+    cluster_ids = [session.nfs_service_id]
+
+    try:
+        NfsMultiActiveDelegation.prepare_nfs_hosts(ceph_cluster, session.nfs_nodes)
+        (
+            session.delegation_logging_template_backup,
+            session.delegation_cephadm,
+            session.delegation_installer,
+        ) = NfsMultiActiveDelegation.enable_ganesha_debug_logging_for_clusters(
+            nfs_cmd_host,
+            ceph_cluster,
+            cluster_ids,
+            redeploy_wait=redeploy_wait,
+            service_wait_timeout=service_wait,
+        )
+        NfsMultiActiveDelegation.enable_rw_export(
+            nfs_cmd_host, session.nfs_service_id, EXPORT_NAME
+        )
+        NfsMultiActiveDelegation.assert_cluster_services_running(
+            client1, session.nfs_service_id, "TC-3 cluster"
+        )
+
+        _mount_tc3_clients_on_vip(session)
+        _run_tc3_delegation_log_validation(session, client1, config, "pre_failover")
+        hold_path, hold_seed = NfsMultiActiveDelegation.hold_rw_delegation_on_mount(
+            client1,
+            NFS_MOUNT,
+            _tc3_delegation_rel_path(config, "failover_hold"),
+            **_tc3_delegation_hold_kwargs(config),
+        )
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+
+        io_sessions = NfsMultiActiveClient.run_background_io_on_clients(
+            session.mounted_clients,
+            NFS_MOUNT,
+            config,
+            io_subdir="tc3_delegation_failover_io",
+        )
+        session.io_sessions = io_sessions
+        if io_warmup > 0:
+            log.info("FIO warmup %ss before NFS failover", io_warmup)
+            sleep(io_warmup)
+        for client, thread, error_box, _io_dir in io_sessions:
+            if error_box.get("exc"):
+                raise OperationFailedError(
+                    f"Background IO failed on {client.hostname}: {error_box['exc']}"
+                )
+            if not thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO stopped during warmup on {client.hostname}"
+                )
+
+        pinned_nfs = session.haproxy.get_client_backend_hostname(client1)
+        log.info(
+            "%s NFS failover: drain pinned backend %s -> spare %s",
+            case_id,
+            pinned_nfs,
+            session.spare_host,
+        )
+        timings["nfs_failover_triggered_at"] = datetime.now().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+        def _wait_io_after_nfs_failover():
+            NfsMultiActiveClient.wait_for_background_io_resume(
+                io_sessions,
+                NFS_MOUNT,
+                config,
+                timeout=io_resume_timeout,
+                timings=timings,
+                triggered_at=timings.get("nfs_failover_triggered_at"),
+            )
+
+        session.failover.failover_nfs_by_label(
+            client1,
+            session.deploy,
+            session.nfs_spec,
+            session.deploy_nodes,
+            pinned_nfs,
+            session.spare_host,
+            session.labels["nfs"],
+            session.nfs_count,
+            deploy_timeout=session.deploy_timeout,
+            timings=timings,
+            timings_trigger_key="nfs_failover_triggered_at",
+            post_apply_callback=_wait_io_after_nfs_failover,
+        )
+        log.info("%s background IO resumed after NFS failover", case_id)
+
+        NfsMultiActiveDelegation.assert_delegation_access_after_failover(
+            client1, client2, hold_path, hold_seed
+        )
+        release_wait = int(
+            config.get(
+                "tc3_delegation_release_wait",
+                DEFAULT_TC3_DELEGATION_RELEASE_WAIT_SEC,
+            )
+        )
+        release_delegation_hold_gracefully(client1, term_wait_seconds=release_wait)
+        _run_tc3_delegation_log_validation(session, client1, config, "post_failover")
+
+        NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+        for _client, thread, error_box, _io_dir in io_sessions:
+            thread.join(timeout=IO_JOIN_TIMEOUT)
+            if thread.is_alive():
+                raise OperationFailedError(
+                    f"Background IO on {_client.hostname} did not stop within "
+                    f"{IO_JOIN_TIMEOUT}s"
+                )
+            if error_box.get("exc") and not error_box.get("stopped"):
+                raise OperationFailedError(
+                    f"Background IO failed on {_client.hostname}: {error_box['exc']}"
+                )
+        io_sessions = []
+        session.io_sessions = []
+
+        NfsMultiActiveDelegation.assert_export_delegation(
+            nfs_cmd_host, session.nfs_service_id, EXPORT_NAME, "rw"
+        )
+        NfsMultiActiveClient.run_basic_io(
+            client1,
+            client2,
+            NFS_MOUNT,
+            file_count=int(config.get("io_file_count", 2)),
+            io_subdir="tc3_post_failover",
+        )
+        session.haproxy.validate_entries(
+            mounted_clients=session.mounted_clients,
+            **stick_kwargs,
+        )
+        NfsMultiActiveDelegation.assert_cluster_services_running(
+            client1, session.nfs_service_id, "TC-3 cluster post-failover"
+        )
+
+        log.info("%s passed", case_id)
+        return 0
+    except Exception as exc:
+        log.error("%s failed: %s", case_id, exc)
+        return 1
+    finally:
+        if io_sessions:
+            try:
+                NfsMultiActiveClient.stop_background_io_on_clients(io_sessions, config)
+                for _client, thread, _error_box, _io_dir in io_sessions:
+                    thread.join(timeout=IO_JOIN_TIMEOUT)
+            except Exception as exc:
+                log.warning("TC-3 IO session cleanup failed: %s", exc)
+            session.io_sessions = []
+
+
+def run(ceph_cluster, **kw):
+    """Run NFS Multi-Active integration workflows (TC-1..)."""
+    config = kw.get("config") or {}
+    init_crash_monitoring(config)
+    phases = config.get("workflows") or list(INTEGRATION_WORKFLOWS)
+    for workflow_key in phases:
+        if workflow_key not in INTEGRATION_WORKFLOWS:
+            raise ConfigError(f"Unknown integration workflow {workflow_key!r}")
+
+    session = IntegrationClusterSession()
+    log.info("NFS Multi-Active integration tests | %d phase(s)", len(phases))
+    try:
+        for phase_idx, workflow_key in enumerate(phases, start=1):
+            workflow = INTEGRATION_WORKFLOWS[workflow_key]
+            vip_slot = int(workflow.get("vip", 1))
+            log.info(
+                "\n" + "=" * 70 + "\n"
+                "Integration phase %s/%s | %s | %s | VIP slot %s\n"
+                "%s\n" + "=" * 70,
+                phase_idx,
+                len(phases),
+                workflow["tc"],
+                workflow_key,
+                vip_slot,
+                workflow["desc"],
+            )
+            if workflow_key == "tc1_mds_failover_dual_client_fio":
+                rc = run_tc1_mds_failover_dual_client_fio(
+                    ceph_cluster,
+                    config,
+                    workflow["tc"],
+                    session=session,
+                    vip_slot=vip_slot,
+                )
+            elif workflow_key == "tc2_cqos_pershare_failover_io":
+                rc = run_tc2_cqos_pershare_failover_io(
+                    ceph_cluster, config, workflow["tc"], session=session
+                )
+            elif workflow_key == "tc3_rw_delegation_failover_io":
+                rc = run_tc3_rw_delegation_failover_io(
+                    ceph_cluster,
+                    config,
+                    workflow["tc"],
+                    session=session,
+                    vip_slot=vip_slot,
+                )
+            elif workflow_key == "tc4_cqos_perclient_colocation_io":
+                rc = run_tc4_cqos_perclient_colocation_io(
+                    ceph_cluster,
+                    config,
+                    workflow["tc"],
+                    session=session,
+                    vip_slot=vip_slot,
+                )
+            else:
+                raise ConfigError(
+                    f"No runner registered for integration workflow {workflow_key!r}"
+                )
+            if rc != 0:
+                return rc
+            try:
+                wait_for_ceph_health(
+                    ceph_cluster, config, context=f"post-{workflow['tc']}"
+                )
+            except ConfigError as exc:
+                log.error("Post-%s health check failed: %s", workflow["tc"], exc)
+                return 1
+
+        try:
+            wait_for_ceph_health(ceph_cluster, config, context="post-suite")
+        except ConfigError as exc:
+            log.error("Post-suite health check failed: %s", exc)
+            return 1
+        log.info("NFS Multi-Active integration test session completed successfully")
+        return 0
+    finally:
+        session.cleanup()

--- a/tests/nfs/multi_active/test_nfs_multi_active_negative.py
+++ b/tests/nfs/multi_active/test_nfs_multi_active_negative.py
@@ -1,0 +1,277 @@
+"""NFS Multi-Active ingress negative orchestrator apply tests (NEG-1..NEG-5)."""
+
+from datetime import datetime
+
+from cli.exceptions import ConfigError
+from tests.nfs.lib.multi_active import init_crash_monitoring, wait_for_ceph_health
+from tests.nfs.lib.multi_active.config import NfsMultiActiveConfig
+from tests.nfs.lib.multi_active.export_restriction import (
+    NfsMultiActiveExportRestriction,
+)
+from tests.nfs.lib.multi_active.ingress_negative import NfsMultiActiveIngressNegative
+from utility.log import Log
+
+log = Log(__name__)
+
+NFS_SERVICE_ID_PREFIX = "cephfs-nfs-neg"
+MIN_NFS_NODES = 2
+DEFAULT_FRONTEND_PORT = 17601
+DEFAULT_MONITOR_PORT = 17701
+NEG_APPLY_TIMEOUT = 120
+
+NEGATIVE_WORKFLOWS = {
+    "neg1_ingress_without_backend_service": {
+        "tc": "NEG-1",
+        "desc": "Ingress spec without backend_service must fail validation.",
+        "mutator": "_mutate_neg1_missing_backend_service",
+        "validator": "validation_failure",
+        "expected_errors": ("Cannot add ingress: No backend_service specified",),
+        "vip": 2,
+        "frontend_port": 17601,
+        "monitor_port": 17701,
+    },
+    "neg2_backend_service_nonexistent": {
+        "tc": "NEG-2",
+        "desc": "Ingress with backend_service nfs.nonexistent must fail or stay unhealthy.",
+        "mutator": "_mutate_neg2_nonexistent_backend",
+        "validator": "apply_failed_or_unhealthy",
+        "vip": 1,
+        "frontend_port": 17602,
+        "monitor_port": 17702,
+    },
+    "neg3_ingress_schema_typo": {
+        "tc": "NEG-3",
+        "desc": "Ingress spec with invalid service_type / unknown keys must fail schema validation.",
+        "mutator": "_mutate_neg3_schema_typo",
+        "validator": "validation_failure",
+        "expected_errors": (
+            "ServiceSpec: __init__() got an unexpected keyword argument 'backend_service'",
+        ),
+        "vip": 2,
+        "frontend_port": 17603,
+        "monitor_port": 17703,
+    },
+    "neg4_ip_export_restriction_haproxy_failover": {
+        "tc": "NEG-4",
+        "desc": (
+            "IP-based export restrictions with HAProxy protocol; background IO "
+            "resumes across ingress and NFS failover; remount and IO re-check "
+            "after each phase."
+        ),
+        "validator": "ip_export_restriction_failover",
+        "vip": 1,
+    },
+    "neg5_ganesha_crash_io_resume": {
+        "tc": "NEG-5",
+        "desc": (
+            "SIGKILL ganesha on the pinned NFS backend while background IO runs; "
+            "IO continues, the NFS service restarts, then remount and IO re-check. "
+            "Reuses NEG-4 cluster state when run in sequence, or deploys its own "
+            "cluster when run standalone."
+        ),
+        "validator": "ganesha_crash_io_resume",
+        "vip": 1,
+    },
+}
+
+
+def _mutate_neg1_missing_backend_service(spec):
+    spec["spec"].pop("backend_service", None)
+
+
+def _mutate_neg2_nonexistent_backend(spec):
+    spec["spec"]["backend_service"] = "nfs.nonexistent"
+
+
+def _mutate_neg3_schema_typo(spec):
+    spec["service_type"] = "ingress_typo"
+    spec["unknown_spec_key"] = "not-allowed"
+
+
+_MUTATORS = {
+    "_mutate_neg1_missing_backend_service": _mutate_neg1_missing_backend_service,
+    "_mutate_neg2_nonexistent_backend": _mutate_neg2_nonexistent_backend,
+    "_mutate_neg3_schema_typo": _mutate_neg3_schema_typo,
+}
+
+
+def _resolve_vip(config, workflow):
+    vips = NfsMultiActiveConfig.get_vips(config)
+    slot = int(workflow.get("vip", config.get("vip", 1)))
+    if slot < 1 or slot > len(vips):
+        raise ConfigError(
+            f"Negative test vip slot must be 1..{len(vips)}, got {slot!r}"
+        )
+    return vips[slot - 1]
+
+
+def _ingress_hosts(ceph_cluster, config):
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    min_nodes = int(config.get("min_ingress_hosts", MIN_NFS_NODES))
+    if len(nfs_nodes) < min_nodes:
+        raise ConfigError(
+            f"Ingress negative tests need at least {min_nodes} NFS-capable nodes, "
+            f"found {len(nfs_nodes)}"
+        )
+    count = int(config.get("ingress_host_count", 2))
+    return [node.hostname for node in nfs_nodes[:count]]
+
+
+def _build_negative_spec(config, ceph_cluster, workflow_key):
+    workflow = NEGATIVE_WORKFLOWS[workflow_key]
+    nfs_name = (
+        f"{NFS_SERVICE_ID_PREFIX}-{workflow_key}-"
+        f"{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    )
+    vip = _resolve_vip(config, workflow)
+    ingress_hosts = _ingress_hosts(ceph_cluster, config)
+    frontend_port = int(
+        workflow.get(
+            "frontend_port", config.get("frontend_port", DEFAULT_FRONTEND_PORT)
+        )
+    )
+    monitor_port = int(
+        workflow.get("monitor_port", config.get("monitor_port", DEFAULT_MONITOR_PORT))
+    )
+
+    spec = NfsMultiActiveIngressNegative.build_base_ingress_spec(
+        nfs_name,
+        vip,
+        ingress_hosts,
+        frontend_port,
+        monitor_port,
+    )
+    mutator = _MUTATORS[workflow["mutator"]]
+    mutator(spec)
+    return nfs_name, spec
+
+
+def _run_negative_workflow(
+    ceph_cluster, config, workflow_key, phase_step, phase_total, neg_export_session
+):
+    workflow = NEGATIVE_WORKFLOWS[workflow_key]
+    installer = ceph_cluster.get_nodes("installer")[0]
+
+    log.info(
+        "\n" + "=" * 70 + "\n" "Negative phase %s/%s | %s | %s\n" "%s\n" + "=" * 70,
+        phase_step,
+        phase_total,
+        workflow["tc"],
+        workflow_key,
+        workflow["desc"],
+    )
+
+    if workflow["validator"] == "ip_export_restriction_failover":
+        neg_export_session[0] = (
+            NfsMultiActiveExportRestriction.run_neg4_ip_export_restriction_haproxy_failover(
+                ceph_cluster,
+                config,
+                workflow["tc"],
+            )
+        )
+        log.info("%s (%s) passed", workflow_key, workflow["tc"])
+        return
+
+    if workflow["validator"] == "ganesha_crash_io_resume":
+        neg_export_session[0] = (
+            NfsMultiActiveExportRestriction.run_neg5_ganesha_crash_with_io(
+                ceph_cluster,
+                config,
+                workflow["tc"],
+                session=neg_export_session[0],
+            )
+        )
+        log.info("%s (%s) passed", workflow_key, workflow["tc"])
+        return
+
+    nfs_name, spec = _build_negative_spec(config, ceph_cluster, workflow_key)
+    service_name = f"ingress.nfs.{nfs_name}"
+
+    result = NfsMultiActiveIngressNegative.apply_specs(installer, [spec])
+    try:
+        if workflow["validator"] == "validation_failure":
+            NfsMultiActiveIngressNegative.assert_apply_validation_failure(
+                result,
+                workflow["tc"],
+                expected_errors=workflow.get("expected_errors", ()),
+            )
+        elif workflow["validator"] == "apply_failed_or_unhealthy":
+            NfsMultiActiveIngressNegative.assert_apply_failed_or_ingress_unhealthy(
+                installer,
+                result,
+                service_name,
+                workflow["tc"],
+                timeout=int(config.get("ingress_unhealthy_timeout", NEG_APPLY_TIMEOUT)),
+                expected_errors=workflow.get("expected_errors", ()),
+            )
+        else:
+            raise ConfigError(
+                f"Unsupported negative validator {workflow['validator']!r}"
+            )
+    finally:
+        if result.exit_code == 0:
+            NfsMultiActiveIngressNegative.remove_ingress_service(
+                installer, service_name
+            )
+
+    log.info("%s (%s) passed", workflow_key, workflow["tc"])
+
+
+def run(ceph_cluster, **kw):
+    """Run NEG-1..NEG-5 ingress negative workflows in one session."""
+    config = kw.get("config") or {}
+    init_crash_monitoring(config)
+    phases = config.get("workflows") or list(NEGATIVE_WORKFLOWS)
+    for workflow_key in phases:
+        if workflow_key not in NEGATIVE_WORKFLOWS:
+            raise ConfigError(f"Unknown negative workflow {workflow_key!r}")
+
+    neg4_key = "neg4_ip_export_restriction_haproxy_failover"
+    neg5_key = "neg5_ganesha_crash_io_resume"
+    if neg4_key in phases and neg5_key in phases:
+        if phases.index(neg4_key) >= phases.index(neg5_key):
+            raise ConfigError(
+                "NEG-5 must run after NEG-4 when both are in the workflow list"
+            )
+
+    log.info(
+        "NFS Multi-Active ingress negative tests | %d phase(s)",
+        len(phases),
+    )
+
+    neg_export_session = [None]
+    try:
+        for phase_idx, workflow_key in enumerate(phases, start=1):
+            _run_negative_workflow(
+                ceph_cluster,
+                config,
+                workflow_key,
+                phase_idx,
+                len(phases),
+                neg_export_session,
+            )
+            workflow = NEGATIVE_WORKFLOWS[workflow_key]
+            try:
+                wait_for_ceph_health(
+                    ceph_cluster, config, context=f"post-{workflow['tc']}"
+                )
+            except ConfigError as exc:
+                log.error("Post-%s health check failed: %s", workflow["tc"], exc)
+                return 1
+
+        try:
+            wait_for_ceph_health(ceph_cluster, config, context="post-suite")
+        except ConfigError as exc:
+            log.error("Post-suite health check failed: %s", exc)
+            return 1
+        log.info("Ingress negative test session completed successfully")
+        return 0
+    except Exception as exc:
+        log.error("Ingress negative test session failed: %s", exc)
+        return 1
+    finally:
+        if neg_export_session[0] is not None:
+            try:
+                neg_export_session[0].cleanup()
+            except Exception as exc:
+                log.warning("NEG-4/5 shared cluster cleanup failed: %s", exc)

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -1007,7 +1007,12 @@ def _first_kmip_pem(val):
 
 
 def create_nfs_via_file_and_verify(
-    installer_node, nfs_objects, timeout, nfs_nodes=None, cluster_nodes=None
+    installer_node,
+    nfs_objects,
+    timeout,
+    nfs_nodes=None,
+    cluster_nodes=None,
+    **kwargs,
 ):
     """
     Create a temporary YAML file with NFS Ganesha configuration.
@@ -1019,6 +1024,8 @@ def create_nfs_via_file_and_verify(
         cluster_nodes: Optional full cluster node list; when ``nfs_nodes`` does not
             resolve to any host, used with ``ceph orch ps`` via
             ``_resolve_nfs_nodes_for_service_ids`` to find Ganesha daemon nodes.
+        **kwargs: Optional ``timings`` dict and ``timings_key`` str to record when
+            ``ceph orch apply`` completes.
     Returns:
         bool: True if apply and verification succeeded, else False.
     """
@@ -1054,6 +1061,18 @@ def create_nfs_via_file_and_verify(
         CephAdm(installer_node, mount="/tmp/").ceph.orch.apply(
             input=remote_spec, check_ec=True, pos_args=pos_args
         )
+        timings = kwargs.get("timings")
+        timings_key = kwargs.get("timings_key")
+        if timings is not None and timings_key:
+            from datetime import datetime
+
+            triggered_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            timings[timings_key] = triggered_at
+            log.info(
+                "Orchestrator apply recorded at %s (key=%s)",
+                triggered_at,
+                timings_key,
+            )
         verify_nfs_ganesha_service(node=installer_node, timeout=timeout)
         log.info("NFS Ganesha spec file applied successfully.")
         nodes_for_coredump = None


### PR DESCRIPTION

## Code written by Cursor

Covers functional deploy, failover, colocation, negative, daemon disruption, and integration (CQoS/delegation) workflows via orchestrator specs and VIP mounts.

## Summary

Add a comprehensive NFS Multi-Active (MA) HA test framework for baremetal clusters, with a shared helper library and six suite modules covering deployment, failover, colocation, negative paths, daemon disruption, and integration scenarios (CQoS, delegation, MDS failover).

Tests deploy NFS + ingress via orchestrator specs (host or label placement), mount clients through VIP, validate HAProxy stick tables, run background IO (dd/fio) during failovers, and include coredump/health gates between phases.

## Changes

### New shared library (`tests/nfs/lib/multi_active/`)

| Module | Purpose |
|--------|---------|
| `config.py` | NFS/ingress spec builders, VIP resolution, label placement |
| `deploy.py` | Deploy and re-apply orchestrator specs |
| `failover.py` | Label swap + spec re-apply for NFS/ingress failover |
| `haproxy.py` | Stick-table validation and client→backend pinning |
| `client.py` / `client_io.py` | VIP mount/remount, background dd/fio IO, resume probes |
| `qos.py` | PerShare / PerClient CQoS enablement and VIP speed validation |
| `delegation.py` | RW delegation log validation |
| `validation.py` | orch ps, cluster info, colocation port checks |
| `cleanup.py` / `common.py` | Teardown, crash monitoring, health waits |
| `placement.py` | Host-slice geometry for functional/failover/integration/colocation |
| `export_restriction.py` / `ingress_negative.py` / `daemon_disruption.py` | Specialized workflow helpers |

### New test modules (`tests/nfs/multi_active/`)

| Module | Coverage |
|--------|----------|
| `test_nfs_multi_active_functional.py` | 8 deploy workflows — same/split/overlap hosts, label placement, custom ports |
| `test_nfs_multi_active_failover.py` | TC-1..[TC-6](https://redhat.atlassian.net/browse/TC-6) — label failover, dual-client IO, roundtrip, reboot, dual-cluster VIP |
| `test_nfs_multi_active_colocation_ports.py` | TC-A1, TC-C1/C2/C4 — colocated NFS daemons, custom data/monitoring/QoS ports |
| `test_nfs_multi_active_negative.py` | NEG-1..NEG-5 — invalid ingress apply, export IP restrictions, SIGKILL recovery |
| `test_nfs_multi_active_daemon_disruption.py` | DR-1..[DR-7](https://redhat.atlassian.net/browse/DR-7) — nfs/haproxy/keepalived restart and stop/start during IO |
| `test_nfs_multi_active_integration.py` | TC-1..[TC-4](https://redhat.atlassian.net/browse/TC-4) shared session — MDS failover, per-share CQoS, RW delegation, per-client colocation CQoS |

### Suite and config

- `suites/tentacle/nfs/baremetal/tier1-nfs-multi-active-ha.yaml` — full baremetal pipeline (bootstrap, 3 clients, all 6 modules)
- `conf/baremetal/nfs_grim_multi_active.yaml` — 7-node grim lab inventory (4 NFS + 3 clients)

### Supporting changes

- `cli/ceph/nfs/export/qos.py` — add `enable_per_client()` for export-level per-client QoS
- `tests/nfs/nfs_operations.py` — optional `timings` / `timings_key` on `create_nfs_via_file_and_verify()` for failover timing

### Integration test notes

- [TC-2](https://redhat.atlassian.net/browse/TC-2) (per-share CQoS + NFS label failover + VIP FIO) is currently the active integration workflow
- TC-1, TC-3, [TC-4](https://redhat.atlassian.net/browse/TC-4) are present but commented out pending **IBMCEPH-16488** (Ganesha SIGSEGV in `ceph_fsal_release()` during CQoS shutdown on MA re-apply)
- Integration suite entry includes `comments: Known issue IBMCEPH-16488`

## Test plan

- [x] Functional — 8 placement/port workflows on grim baremetal (`terminal_output_grim61_2.log`)
- [x] Colocation — TC-A1, TC-C1/C2/C4 with VIP mount and label failover
- [x] Negative — NEG-1..NEG-5 ingress/export restriction flows
- [x] Daemon disruption — DR-1..[DR-7](https://redhat.atlassian.net/browse/DR-7) (health check skipped per suite config)
- [x] Failover — TC-1..[TC-6](https://redhat.atlassian.net/browse/TC-6) label/reboot/dual-cluster sessions
- [x] Integration [TC-2](https://redhat.atlassian.net/browse/TC-2) — per-share CQoS via VIP mount; manual repro confirms IBMCEPH-16488 coredump on non-drained backend during orch re-apply
- [ ] TC-1/TC-3/TC-4 integration — blocked on IBMCEPH-16488 fix

## Polarion:

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632225

## Logs: 

Attached - [run_full_1.zip](https://github.com/user-attachments/files/29899119/run_full_1.zip)

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
