### PR TITLE
fix: handle int sync_duration in validate_snapshot_sync_status

### DIFF
--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -981,8 +981,12 @@ class CephfsMirroringUtils(object):
                 if not last_synced_snap:
                     continue
                 if last_synced_snap.get("name") == snapshot_name:
-                    raw_duration = last_synced_snap.get("sync_duration", "")
-                    sync_duration = raw_duration.rstrip("s") if raw_duration else None
+                    raw_duration = last_synced_snap.get("sync_duration")
+                    sync_duration = (
+                        str(raw_duration).rstrip("s")
+                        if raw_duration is not None
+                        else None
+                    )
                     log.info(
                         "Snapshot %s synced: duration=%s, bytes=%s, files=%s",
                         snapshot_name,


### PR DESCRIPTION
Logs: http://10.64.24.74/logs/ceph-qe-logs//RH/9.1/rhel-10/regression/20.2.1-315/cephfs/99/logs/Test_Cephfs_Mirroring/