### PR TITLE
CHanges in cephCI to containerize keystone deployment , agnostic of p…

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_single_site_regression.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_single_site_regression.yaml
@@ -275,7 +275,6 @@ tests:
       polarion-id: CEPH-10169
       module: sanity_rgw.py
       config:
-        install_keystone_ldap: true
         script-name: ../aws/test_keystone_auth.py
         config-file-name: ../../aws/configs/test_keystone_integration.yaml
 
@@ -286,7 +285,6 @@ tests:
       polarion-id: CEPH-83572657
       module: sanity_rgw.py
       config:
-        install_keystone_ldap: true
         script-name: ../s3_swift/test_swift_acl_with_keystone.py
         config-file-name: ../../s3_swift/configs/test_swift_acl_with_keystone.yaml
 

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -180,7 +180,7 @@ def run(ceph_cluster, **kw):
         configure_kafka_security(rgw_node, cloud_type)
 
     if install_keystone_ldap:
-        config_keystone_ldap(rgw_node, cloud_type)
+        config_keystone_ldap(rgw_node, client_node, cloud_type)
 
     out, err = exec_from.exec_command(cmd="ls -l venv", check_ec=False)
     if not out:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2038,18 +2038,16 @@ def configure_kafka_cluster_with_security(ceph_cluster, cloud_type):
     redeploy_rgw_service_for_kafka_security(rgw_node1)
 
 
-def config_keystone_ldap(rgw_node, cloud_type):
-    """Set the keystone config option on the cluster at startup"""
+def config_keystone_ldap(rgw_node, client_node, cloud_type):
+    """Set the keystone config option on the cluster at startup and run deploy_keystone_on_client.sh"""
     cephci_config = get_cephci_config()
     keystone_cfg = cephci_config.get("keystone", {})
     ldap_cfg = cephci_config.get("ldap", {})
     # OneCloud may share keystone/ldap with openstack; fallback if onecloud not configured
     lookup = cloud_type if cloud_type in keystone_cfg else "openstack"
-    keystone_server = keystone_cfg.get(lookup, keystone_cfg.get("openstack", {})).get(
-        "url"
-    )
+
     ldap_url = ldap_cfg.get(lookup, ldap_cfg.get("openstack", {})).get("url")
-    if not keystone_server or not ldap_url:
+    if not ldap_url:
         raise ConfigError(
             f"keystone/ldap config missing for cloud_type '{cloud_type}'. "
             "Add keystone.{cloud} and ldap.{cloud} to cephci config."
@@ -2059,11 +2057,39 @@ def config_keystone_ldap(rgw_node, cloud_type):
     rgw_name = out[0].split()[0]
     rgw_node.exec_command(
         sudo=True,
-        cmd=f"ceph config set client.{rgw_name} rgw_keystone_url {keystone_server}",
+        cmd=f"ceph config set client.{rgw_name} rgw_ldap_uri {ldap_url}",
     )
+
+    # Get deploy_keystone_on_client.sh from the rgw_configs repo and run it
+    clone_configs_repo(client_node, "rgw_configs")
+    final_repo_path = "/home/cephuser/configs/"
+    keystone_path = "/home/cephuser/configs/rgw/keystone/"
+
+    # Path to the deploy_keystone_on_client.sh script in the repo
+    script_path = os.path.join(
+        final_repo_path, "rgw", "keystone", "deploy_keystone_on_client.sh"
+    )
+
+    try:
+        # Read the script from the local repo
+        # Make the script executable and run it
+        client_node.exec_command(sudo=True, cmd="pip install podman-compose")
+        client_node.exec_command(
+            sudo=True, cmd="pip install python-openstackclient python-swiftclient"
+        )
+        client_node.exec_command(sudo=True, cmd=f"chmod +x {script_path}")
+        client_node.exec_command(sudo=True, cmd=f"{script_path} {keystone_path}")
+        log.info(
+            "Successfully deployed keystone on client using deploy_keystone_on_client.sh"
+        )
+    except BaseException as be:
+        log.debug(f"Failed to run deploy_keystone_on_client.sh: {be}")
+
+    client_ip = client_node.ip_address
+    keystone_server = f"http://{client_ip}:15000"
     rgw_node.exec_command(
         sudo=True,
-        cmd=f"ceph config set client.{rgw_name} rgw_ldap_uri {ldap_url}",
+        cmd=f"ceph config set client.{rgw_name} rgw_keystone_url {keystone_server}",
     )
     # Restart rgw service and wait for it to come up
     restart_rgw_and_wait(rgw_node, rgw_name)


### PR DESCRIPTION
…latform

To remove dependency on RHOSD or IBMC to host dependent services like keystone we have containerised it to deploy on the client_node when needed for every run.

This is one part of the changes , we need further changes in the scripts itself , which I will raise a separate PR on Ceph-qe-scripts. I will mark this DNM for now since we don't have a pass run.

Fail log: http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-0TB0UT/

