### PR TITLE
Add rhel latest release inventories for live Testing

### DIFF
--- a/conf/inventory/ibm-eu-live-rhel-10-latest.yaml
+++ b/conf/inventory/ibm-eu-live-rhel-10-latest.yaml
@@ -1,1 +1,1 @@
-ibm-eu-rhel-10.1-live.yaml
+ibm-eu-rhel-10.2-live.yaml

--- a/conf/inventory/ibm-eu-live-rhel-9-latest.yaml
+++ b/conf/inventory/ibm-eu-live-rhel-9-latest.yaml
@@ -1,1 +1,1 @@
-ibm-eu-rhel-9.7-live.yaml
+ibm-eu-rhel-9.8-live.yaml

--- a/conf/inventory/ibm-eu-rhel-10.2-live-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2-live-rgw.yaml
@@ -42,5 +42,8 @@ instance:
       - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
       - dnf clean all
       - dnf install -yq lvm2 chrony yum-utils podman net-snmp-utils net-snmp python3-devel wget
+      - mkdir -p /root/rgw_rpms
+      - curl -L --fail -k -o /root/rgw_rpms/oathtool.rpm https://dl.fedoraproject.org/pub/epel/10.2/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el10_0.x86_64.rpm
+      - curl -L --fail -k -o /root/rgw_rpms/jdk.rpm https://download.oracle.com/java/25/latest/jdk-25_linux-x64_bin.rpm
       - dnf update -y
       - touch /ceph-qa-ready

--- a/conf/inventory/ibm-eu-rhel-10.2-live.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2-live.yaml
@@ -1,0 +1,46 @@
+---
+version_id: 10.2
+id: rhel
+instance:
+  create:
+    image-name: rhel-102-server-amd64-kvm
+    private_key: ceph-qe-sa-svc
+
+  setup: |
+    #cloud-config
+    no_ssh_fingerprints: true
+    disable_root: false
+    ssh_pwauth: true
+
+     # Refresh package metadata (package upgrades are done via `dnf update -y` below)
+    package_update: true
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(root) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwmsOkNX16LikH7spbmVVOLhGOSsNSlAYSk0ifhLpaO
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPoKGCTzMmNvHFY4THKNpZYFLeEgB7Do8y2JAEy+ZvIZ ceph-qe-sa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
+
+    chpasswd:
+      expire: false
+      users:
+        - name: cephuser
+          password: $y$j9T$PxJ09a3yVNnPj0Veb8QDT.$bdWoyLq1IdGwlimyJC98P5OsSFE2w7.9ac68z4eoa01
+        - name: root
+          password: $y$j9T$L0/xJyxgqCPIezC0dp/0/0$KawKfTR2FhliH9YrG4/30wot90M3xtF03K1XwGnYz2A
+
+    runcmd:
+      - timedatectl set-timezone Etc/UTC
+      - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.conf
+      - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+      - dnf clean all
+      - dnf install -yq lvm2 chrony yum-utils podman net-snmp-utils net-snmp python3-devel wget
+      - dnf update -y
+      - touch /ceph-qa-ready

--- a/conf/inventory/ibm-eu-rhel-9.8-live-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-live-rgw.yaml
@@ -1,9 +1,9 @@
 ---
-version_id: 10.2
+version_id: 9.8
 id: rhel
 instance:
   create:
-    image-name: rhel-102-server-amd64-kvm
+    image-name: rhel-98-server-amd64-kvm
     private_key: ceph-qe-sa-svc
 
   setup: |
@@ -43,4 +43,7 @@ instance:
       - dnf clean all
       - dnf install -yq lvm2 chrony yum-utils podman net-snmp-utils net-snmp python3-devel wget
       - dnf update -y
+      - mkdir -p /root/rgw_rpms
+      - curl --fail -L -k -o /root/rgw_rpms/jdk.rpm https://download.oracle.com/java/25/latest/jdk-25_linux-x64_bin.rpm
+      - curl --fail -L -k -o /root/rgw_rpms/oathtool.rpm https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
       - touch /ceph-qa-ready

--- a/conf/inventory/ibm-eu-rhel-9.8-live.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-live.yaml
@@ -12,7 +12,7 @@ instance:
     disable_root: false
     ssh_pwauth: true
 
-     # Refresh package metadata (package upgrades are done via `dnf update -y` below)
+    # Refresh package metadata (package upgrades are done via `dnf update -y` below)
     package_update: true
 
     groups:

--- a/conf/inventory/ibm-eu-rhel-9.8-live.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-live.yaml
@@ -1,0 +1,46 @@
+---
+version_id: 9.8
+id: rhel
+instance:
+  create:
+    image-name: rhel-98-server-amd64-kvm
+    private_key: ceph-qe-sa-svc
+
+  setup: |
+    #cloud-config
+    no_ssh_fingerprints: true
+    disable_root: false
+    ssh_pwauth: true
+
+     # Refresh package metadata (package upgrades are done via `dnf update -y` below)
+    package_update: true
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(root) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwmsOkNX16LikH7spbmVVOLhGOSsNSlAYSk0ifhLpaO
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPoKGCTzMmNvHFY4THKNpZYFLeEgB7Do8y2JAEy+ZvIZ ceph-qe-sa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
+
+    chpasswd:
+      expire: false
+      users:
+        - name: cephuser
+          password: $y$j9T$PxJ09a3yVNnPj0Veb8QDT.$bdWoyLq1IdGwlimyJC98P5OsSFE2w7.9ac68z4eoa01
+        - name: root
+          password: $y$j9T$L0/xJyxgqCPIezC0dp/0/0$KawKfTR2FhliH9YrG4/30wot90M3xtF03K1XwGnYz2A
+
+    runcmd:
+      - timedatectl set-timezone Etc/UTC
+      - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.conf
+      - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+      - dnf clean all
+      - dnf install -yq lvm2 chrony yum-utils podman net-snmp-utils net-snmp python3-devel wget
+      - dnf update -y
+      - touch /ceph-qa-ready


### PR DESCRIPTION
<p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This PR adds new “live testing” inventory definitions for IBM EU RHEL images, extending the existing inventory set to cover RHEL 9.8 and 10.2 in the same style as the existing 9.7/10.1 live inventories.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; font-weight: 600;">Changes:</strong></p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding-left: 2em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box;">Add<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ibm-eu-rhel-9.8-live.yaml</code><span> </span>inventory with cloud-init setup and package bootstrapping steps.</li><li style="box-sizing: border-box; margin-top: 0.25em;">Add<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ibm-eu-rhel-10.2-live.yaml</code><span> </span>inventory with equivalent cloud-init setup and package bootstrapping steps.</li></ul><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Reviewed changes</h3><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Copilot reviewed 4 out of 4 changed files in this pull request and generated 6 comments.</p><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
File | Description
-- | --
conf/inventory/ibm-eu-rhel-9.8-live.yaml | New live-test inventory for IBM EU RHEL 9.8 KVM image with cloud-init provisioning.
conf/inventory/ibm-eu-rhel-10.2-live.yaml | New live-test inventory for IBM EU RHEL 10.2 KVM image with cloud-init provisioning.

</markdown-accessiblity-table>