### PR TITLE
TFA fix for upgrade suite, pre-upgrade test failure in health check

### DIFF
--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
@@ -151,7 +151,20 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure client
-
+  - test:
+      abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      clusters:
+        ceph1:
+          config:
+            crash_setup: 1
+            daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']
+        ceph2:
+          config:
+            crash_setup: 1
+            daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']
   - test:
       abort-on-fail: false
       desc: "Pre-upgrade validate snapdiff perf on 10MB X 100 Files"
@@ -308,3 +321,18 @@ tests:
       module: cephfs_mirroring.validate_snapdiff_perf_results.py
       name: Validate sync duration of 10MB X 100 Files by comparing between 2 releases
       polarion-id: "CEPH-83595260"
+
+  - test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      clusters:
+        ceph1:
+          config:
+            crash_check: 1
+            daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']
+        ceph2:
+          config:
+            crash_check: 1
+            daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
@@ -118,6 +118,14 @@ tests:
       name: "configure client"
   - test:
       abort-on-fail: false
+      desc: "Setup Crash configuration"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-setup
+      config:
+        crash_setup: 1
+        daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']
+  - test:
+      abort-on-fail: false
       desc: Creates all the fs related components before upgrade
       module: cephfs_upgrade.upgrade_pre_req.py
       name: "creation of Prerequisites for Upgrade"
@@ -221,3 +229,11 @@ tests:
       module: quota.quota_bytes.py
       polarion-id: CEPH-83573399
       desc: Tests the Byte attr
+  - test:
+      abort-on-fail: false
+      desc: "Check for Crash"
+      module: cephfs_crash_util.py
+      name: cephfs-crash-check
+      config:
+        crash_check: 1
+        daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']

--- a/tests/cephfs/cephfs_crash_util.py
+++ b/tests/cephfs/cephfs_crash_util.py
@@ -42,7 +42,7 @@ def run(ceph_cluster, **kw):
         fs_system_utils = CephFSSystemUtils(ceph_cluster)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
-        client = clients[1]
+        client = clients[0]
         log.info("checking Pre-requisites")
 
         if not clients:

--- a/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
@@ -106,7 +106,9 @@ def wait_for_two_active_mds(client1, fs_name, max_wait_time=600, retry_interval=
         print("Timeout: Two active MDS not found within the specified time.")
     ```
     """
-    retry_exec_command = retry(CommandFailed, tries=3, delay=30)(client1.exec_command)
+    retry_exec_command = retry(CommandFailed, tries=10, delay=30, backoff=1)(
+        client1.exec_command
+    )
     start_time = time.time()
     while time.time() - start_time < max_wait_time:
         out, rc = retry_exec_command(

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -68,6 +68,23 @@ class CephFSCommonUtils(FsUtils):
                     )
                     log.warning("Cluster health can be OK, current state : %s", out)
                     ceph_healthy = 1
+                elif "node-exporter" in str(out) and "is in unknown state" in str(out):
+                    log.warning(
+                        "node-exporter is in unknown state; redeploying. Health detail: %s",
+                        out,
+                    )
+                    client.exec_command(
+                        sudo=True, cmd="ceph orch redeploy node-exporter"
+                    )
+                    try:
+                        self.validate_services(client, "node-exporter")
+                        log.info("node-exporter service is up after redeploy")
+                        ceph_healthy = 1
+                    except CommandFailed as ex:
+                        log.error(
+                            "node-exporter did not come up after redeploy: %s", ex
+                        )
+                        time.sleep(5)
                 else:
                     log.info(
                         "Wait for sometime to check if Cluster health can be OK, current state : %s",


### PR DESCRIPTION
# Description

Fix description:
1)Add fix to redeploy node-exporter if health_warn due to this,
upgrade prerequisites Passed log with fix: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/upgrade/20.2.1-323/cephfs/98/logs/Test_Cephfs_Upgrade_7x_to_9x/creation_of_Prerequisites_for_Upgrade_0.log

2) Add more retries for ceph fs status cmd to work in "cephfs_mds_failover.py" as it may continue to fail until mgr daemon is completely upgraded.

Upgrade suite passed log with changes: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/upgrade/20.2.1-323/cephfs/99/logs/Test_Cephfs_Upgrade_8_1x_to_9x/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
