### PR TITLE
Add IBM EU RHEL 9.2 inventory file

### DIFF
--- a/conf/inventory/ibm-eu-rhel-9.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.2.yaml
@@ -1,0 +1,146 @@
+---
+version_id: 9.2
+id: rhel
+instance:
+  create:
+    image-name: rhel-92-server-amd64-kvm
+    private_key: ceph-qe-sa-svc
+
+  setup: |
+    #cloud-config
+    no_ssh_fingerprints: true
+    disable_root: false
+    ssh_pwauth: true
+
+    # We are forcing an update of the packages
+    package_update: true
+
+    # Create the base repositories
+    yum_repos:
+      appstream:
+        name: AppStream
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/2/AppStream/
+        enabled: true
+        gpgcheck: false
+      baseos:
+        name: BaseOS
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/2/BaseOS/
+        gpgcheck: false
+        enabled: true
+
+      crb:
+        name: codeready-builder
+        baseurl: http://nginx-vm-01.qe.ceph.lab/repos/9/2/CRB/
+        gpgcheck: false
+        enabled: true
+
+    # write the mirror registry details
+    write_files:
+      - content: |
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
+          prefix = "registry-proxy.engineering.redhat.com"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
+          prefix = "quay.io"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-stage"
+          prefix = "registry.stage.redhat.io"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/rh-prod"
+          prefix = "registry.redhat.io"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "cp.stg.icr.io"
+          insecure = true
+
+          [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
+          prefix = "cp.icr.io"
+          insecure = true
+        path: /etc/containers/registries.conf.d/nginx-vm-01.conf
+        owner: root:root
+        permissions: '0644'
+        defer: true
+      - content: |
+          net.core.default_qdisc=netem
+        path: /etc/sysctl.d/1000-qdisc.conf
+        owner: root:root
+        permissions: '0644'
+      - content: |
+          PermitRootLogin yes
+        path: /etc/ssh/sshd_config.d/50-cephci.conf
+        owner: root:root
+        permissions: '0644'
+      - content: |
+          {
+              "default": [
+                  {
+                      "type": "insecureAcceptAnything"
+                  }
+              ],
+              "transports": {
+                  "docker": {
+                      "registry.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "registry.stage.redhat.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ],
+                      "quay.io": [
+                          {
+                              "type": "insecureAcceptAnything"
+                          }
+                      ]
+                  }
+              }
+          }
+        path: /etc/containers/policy.json
+        owner: root:root
+        permissions: '0644'
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(root) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwmsOkNX16LikH7spbmVVOLhGOSsNSlAYSk0ifhLpaO
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPoKGCTzMmNvHFY4THKNpZYFLeEgB7Do8y2JAEy+ZvIZ ceph-qe-sa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
+
+    chpasswd:
+      expire: false
+      users:
+        - name: cephuser
+          password: $y$j9T$PxJ09a3yVNnPj0Veb8QDT.$bdWoyLq1IdGwlimyJC98P5OsSFE2w7.9ac68z4eoa01
+        - name: root
+          password: $y$j9T$L0/xJyxgqCPIezC0dp/0/0$KawKfTR2FhliH9YrG4/30wot90M3xtF03K1XwGnYz2A
+
+    runcmd:
+      - timedatectl set-timezone Etc/UTC
+      - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.conf
+      - sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+      - dnf clean all
+      - dnf install -yq lvm2 chrony yum-utils podman net-snmp-utils net-snmp python3-devel wget
+      - dnf update -y
+      - touch /ceph-qa-ready


### PR DESCRIPTION
Adding "conf/inventory/ibm-eu-rhel-9.2.yaml" for IBM EU RHEL 9.2 deployments

Uses image "rhel-92-server-amd64-kvm" with nginx-vm-01 repos ("/repos/9/2/") and registry mirrors
