### PR TITLE
Add CEPH-83632905 LC noncurrent expiration restart test to lifecycle …

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -308,3 +308,12 @@ tests:
         script-name: ../s3cmd/test_lifecycle_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_lc_version_suspended_expired_delete_marker.yaml
 
+  - test:
+      name: Test LC noncurrent expiration after rgw_lc_debug_interval restart
+      desc: Test LC noncurrent expiration after rgw_lc_debug_interval restart
+      polarion-id: CEPH-83632905
+      module: sanity_rgw.py
+      config:
+        script-name: test_lc_noncurrent_exp_restart.py
+        config-file-name: test_lc_noncurrent_exp_restart.yaml
+

--- a/suites/tentacle/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -299,3 +299,12 @@ tests:
         script-name: ../s3cmd/test_lifecycle_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_lc_version_suspended_expired_delete_marker.yaml
 
+  - test:
+      name: Test LC noncurrent expiration after rgw_lc_debug_interval restart
+      desc: Test LC noncurrent expiration after rgw_lc_debug_interval restart
+      polarion-id: CEPH-83632905
+      module: sanity_rgw.py
+      config:
+        script-name: test_lc_noncurrent_exp_restart.py
+        config-file-name: test_lc_noncurrent_exp_restart.yaml
+


### PR DESCRIPTION
…suites

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

RGW LC processing crashes while deleting noncurrent versions on a versioned bucket

Logs

9.1 - http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-BW5P1Z/ - Falled log due to crash occurs

19.2.1-375(8.1z7)
http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-YCRYEY/ - Failed log due to crash occurs

19.2.1-379(8.1z8)
http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-FZ4U3B/ - Pass log

Jira: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-24752


