### PR TITLE
TFA Ingress fix - Auto populate the Virtual IP and Subnet Option from free available IPs

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -2,6 +2,7 @@
 Contains helper functions that can used across the module.
 """
 
+import ipaddress
 import json
 import os
 import tempfile
@@ -171,6 +172,54 @@ class GenerateServiceSpec:
         gw = node_sub.split("/")[0]
         cidr = node_sub.split("/")[1]
         return gw, cidr
+
+    def _get_cluster_subnets(self):
+        """Return unique node subnets from the cluster."""
+        subnets = []
+        for node in self.cluster.get_nodes():
+            subnet = getattr(node, "subnet", None)
+            if subnet and subnet not in subnets:
+                subnets.append(subnet)
+        return subnets
+
+    def _allocate_ingress_vip(self, placement_hosts=None):
+        """
+        Pick an unused IP from the host subnet for keepalived VIP.
+
+        Prefers the subnet of placement hosts when available so the VIP is on
+        the same L2/L3 domain as the ingress NICs (required on IBMC where
+        reserved floating IPs are outside the VM private CIDR).
+        """
+        subnet = None
+        if placement_hosts:
+            for node in self.cluster.get_nodes():
+                if node.hostname in placement_hosts and getattr(node, "subnet", None):
+                    subnet = node.subnet
+                    break
+        if not subnet:
+            subnets = self._get_cluster_subnets()
+            if not subnets:
+                raise ValueError("virtual_ip: auto set but no node subnets found")
+            subnet = subnets[0]
+
+        network = ipaddress.ip_network(subnet, strict=False)
+        used = set()
+        for node in self.cluster.get_nodes():
+            ip = getattr(node, "ip_address", None)
+            if ip:
+                used.add(str(ipaddress.ip_address(ip)))
+
+        allocated = getattr(self.cluster, "_cephci_allocated_ingress_vips", set())
+        # Prefer high addresses to stay clear of gateway / DHCP low range
+        for host_ip in reversed(list(network.hosts())):
+            ip_str = str(host_ip)
+            if ip_str in used or ip_str in allocated:
+                continue
+            allocated.add(ip_str)
+            self.cluster._cephci_allocated_ingress_vips = allocated
+            return f"{ip_str}/{network.prefixlen}"
+
+        raise ValueError(f"virtual_ip: auto found no free address in {subnet}")
 
     def get_hostnames(self, node_names):
         """
@@ -711,7 +760,8 @@ class GenerateServiceSpec:
                   label: rgw
                 spec:
                   backend_service: rgw.ceph-scale-test-y7nmci-node2
-                  virtual_ip: 10.0.208.0/22
+                  virtual_ip: auto | <ip>/<prefix>   # auto = unused host-subnet IP
+                  virtual_interface_networks: auto | [<cidr>, ...]
                   frontend_port: 8000
                   monitor_port: 1967
                   ssl_cert: create-cert | <contents of crt>
@@ -724,7 +774,24 @@ class GenerateServiceSpec:
         if node_names:
             spec["placement"]["hosts"] = self.get_hostnames(node_names)
 
-        if spec["spec"].get("ssl_cert") == "create-cert":
+        # Opt-in only: suite must set virtual_ip / virtual_interface_networks: auto
+        ingress_spec = spec.setdefault("spec", {})
+        if ingress_spec.get("virtual_ip") == "auto":
+            ingress_spec["virtual_ip"] = self._allocate_ingress_vip(
+                placement_hosts=spec["placement"].get("hosts")
+            )
+            LOG.info("Resolved virtual_ip: auto -> %s", ingress_spec["virtual_ip"])
+
+        if ingress_spec.get("virtual_interface_networks") == "auto":
+            subnets = self._get_cluster_subnets()
+            if not subnets:
+                raise ValueError(
+                    "virtual_interface_networks: auto set but no node subnets found"
+                )
+            ingress_spec["virtual_interface_networks"] = subnets
+            LOG.info("Resolved virtual_interface_networks: auto -> %s", subnets)
+
+        if ingress_spec.get("ssl_cert") == "create-cert":
             subject = {
                 "common_name": spec["placement"]["hosts"][0],
                 "ip_address": self.cluster.get_node_by_hostname(
@@ -734,10 +801,8 @@ class GenerateServiceSpec:
             key, cert, ca = generate_self_signed_certificate(subject=subject)
             pem = key + cert + ca
             cert_value = "|\n" + pem
-            spec["spec"]["ssl_cert"] = "\n    ".join(cert_value.split("\n"))
+            ingress_spec["ssl_cert"] = "\n    ".join(cert_value.split("\n"))
             LOG.debug(pem)
-            vip_node = get_node_by_id(self.cluster, node_names[0])
-            _, vip_cidr = self.get_gateway_cidr(vip_node)
 
         return template.render(spec=spec)
 

--- a/suites/reef/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -163,11 +163,12 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 10.0.195.174/24 # floating ip1 in rhos-01
+                    virtual_ip: auto  # unused IP from host subnet (IBMC-safe)
+                    virtual_interface_networks: auto
                     frontend_port: 443
                     monitor_port: 1967
                     ssl: true
-                    certificate_source: cephadm-signed
+                    ssl_cert: create-cert  # certificate_source unsupported on reef
 
   - test:
       name: Deploy RGW Ingress daemon
@@ -190,6 +191,7 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 10.0.195.111/24 # floating ip2 in rhos-01
+                    virtual_ip: auto  # unused IP from host subnet (IBMC-safe)
+                    virtual_interface_networks: auto
                     frontend_port: 8083
-                    monitor_port: 1967
+                    monitor_port: 1968

--- a/suites/squid/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -164,11 +164,12 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 10.0.195.174/24 # floating ip1 in rhos-01
+                    virtual_ip: auto  # unused IP from host subnet (IBMC-safe)
+                    virtual_interface_networks: auto
                     frontend_port: 443
                     monitor_port: 1967
                     ssl: true
-                    certificate_source: cephadm-signed
+                    ssl_cert: create-cert  # certificate_source unsupported on squid
 
   - test:
       name: Deploy RGW Ingress daemon
@@ -191,9 +192,10 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 10.0.195.111/24 # floating ip2 in rhos-01
+                    virtual_ip: auto  # unused IP from host subnet (IBMC-safe)
+                    virtual_interface_networks: auto
                     frontend_port: 8083
-                    monitor_port: 1967
+                    monitor_port: 1968
 
   - test:
       abort-on-fail: true

--- a/suites/tentacle/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -133,7 +133,8 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 10.245.128.250/18 # floating ip1 in ibmc env
+                    virtual_ip: auto  # unused IP from host subnet (IBMC-safe)
+                    virtual_interface_networks: auto
                     frontend_port: 443
                     monitor_port: 1967
                     ssl: true
@@ -160,9 +161,10 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 10.245.128.251/18 # floating ip2 in ibmc env
+                    virtual_ip: auto  # unused IP from host subnet (IBMC-safe)
+                    virtual_interface_networks: auto
                     frontend_port: 8083
-                    monitor_port: 1967
+                    monitor_port: 1968
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
# Description

The Ingress service spec deployement was inconsistent due to Virtual IP  being hardcoded and at times failed due to inaccessiblity of IP range . 

Solution :

Fix IBMC RGW multi-realm ingress deploy failures where hardcoded floating VIPs (10.245.128.x/18) sit outside the VM private CIDR (10.243.x.0/22), so keepalived never starts haproxy/keepalived daemons (0/4).

Add opt-in virtual_ip: auto and virtual_interface_networks: auto in generate_ingress_spec to allocate an unused host-subnet VIP and fill NIC networks from the run’s node subnets.

Update tentacle / squid / reef tier-2_rgw_ingress_multi_realm.yaml to use the auto VIP/network options.
On squid/reef, use ssl_cert: create-cert for SSL ingress (certificate_source is rejected on 8.1/7.1) ( cephadm-signed * Not supported )

 Keep certificate_source: cephadm-signed on tentacle.

Pass Logs : https://magna002.ceph.redhat.com/ceph-qe-logs/sohan/tfa-ingress
