### PR TITLE
Remove orch upgrade retries if mgr version is 8.1 and above

### DIFF
--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -115,7 +115,7 @@ class UpgradeMixin:
         cmd = ["ceph", "orch", "upgrade", "status"]
 
         # these additional checks are in place because the fix is currently
-        # available in only 9.1, once back-ported to all relevant versions,
+        # available in 8.1z8 and 9.1, once back-ported to all relevant versions,
         # retry mechanism can be removed completely
         # determine mgr version to decide retry logic
         # check if active mgr daemon has upgraded to 9.1 or above
@@ -128,9 +128,11 @@ class UpgradeMixin:
         LOG.debug("MGR common version: %s", mgr_version_common)
         LOG.debug("MGR downstream version: %s", mgr_version_downstream)
 
-        common_ver_check = mgr_version_common and Version(
+        common_ver_check = (
             mgr_version_common
-        ) >= Version("20.2.1")
+            and Version(mgr_version_common) >= Version("20.2.1")
+            or Version(mgr_version_common) == Version("19.2.1")
+        )
         downstream_ver_check = mgr_version_downstream and Version(
             mgr_version_downstream
         ) >= Version("9.9.1.0")

--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -115,7 +115,7 @@ class UpgradeMixin:
         cmd = ["ceph", "orch", "upgrade", "status"]
 
         # these additional checks are in place because the fix is currently
-        # available in only 9.1, once back-ported to all relevant versions,
+        # available in 8.1z8 and 9.1, once back-ported to all relevant versions,
         # retry mechanism can be removed completely
         # determine mgr version to decide retry logic
         # check if active mgr daemon has upgraded to 9.1 or above
@@ -128,9 +128,10 @@ class UpgradeMixin:
         LOG.debug("MGR common version: %s", mgr_version_common)
         LOG.debug("MGR downstream version: %s", mgr_version_downstream)
 
-        common_ver_check = mgr_version_common and Version(
-            mgr_version_common
-        ) >= Version("20.2.1")
+        common_ver_check = mgr_version_common and (
+            Version(mgr_version_common) >= Version("20.2.1")
+            or Version(mgr_version_common) == Version("19.2.1")
+        )
         downstream_ver_check = mgr_version_downstream and Version(
             mgr_version_downstream
         ) >= Version("9.9.1.0")


### PR DESCRIPTION
Retry logic was implemented as a workaround because ceph orch upgrade status command used to fail intermittently due to an issue in mgr loading all it's module during start-up. Refer: https://github.com/red-hat-storage/cephci/pull/4741

With the fix provided in 9.1 build-200, Manager daemons above this version should no longer fail. Refer: https://ibm-ceph.atlassian.net/browse/IBMCEPH-14325

PR for 9.1 - #5840 

Signed-off-by: Harsh Kumar [hakumar@redhat.com](mailto:hakumar@redhat.com)