### PR TITLE
Skipping BYOK Sanity test for AWS

### DIFF
--- a/tests/nfs/byok/test_byok_single_multi_restart.py
+++ b/tests/nfs/byok/test_byok_single_multi_restart.py
@@ -177,6 +177,11 @@ def run(ceph_cluster, **kw):
     custom_data = kw.get("test_data", {})
     cephci_data = get_cephci_config()
 
+    cloud_type = str(config.get("cloud-type", "")).lower()
+    if cloud_type == "aws":
+        log.info("Skipping BYOK single/multi restart test: not supported on AWS")
+        return 0
+
     # Cluster nodes and setup
     nfs_nodes = ceph_cluster.get_nodes("nfs")
     nfs_node = nfs_nodes[0]  # Use the first NFS node for certificate operations


### PR DESCRIPTION
# Description
The PR  skips BYOK testcase in Sanity on AWS as there is no GKLM server Available

Run Logs: 
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-324/nfs/2343/logs/tier0_nfs_ganesha_func_sanity/

