### PR TITLE
TFA fixes for upgrade suite

### DIFF
--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
@@ -125,7 +125,7 @@ tests:
         crash_setup: 1
         daemon_list: ['mds', 'osd', 'mgr', 'mon','nfs']
   - test:
-      abort-on-fail: false
+      abort-on-fail: true
       desc: Creates all the fs related components before upgrade
       module: cephfs_upgrade.upgrade_pre_req.py
       name: "creation of Prerequisites for Upgrade"

--- a/tests/cephfs/cephfs_mirroring/snapdiff_perf_improvements_across_releases.py
+++ b/tests/cephfs/cephfs_mirroring/snapdiff_perf_improvements_across_releases.py
@@ -1,10 +1,12 @@
 import concurrent.futures
 import os
+import re
 import signal
 import time
 import traceback
 
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from utility.log import Log
 
 
@@ -92,18 +94,34 @@ def run(ceph_cluster, **kw):
                 subvol_name=subvol,
                 group_name=subvol_group_name,
             )
-
-        mount_paths, subvol_paths, export_binding = (
-            fs_mirroring_utils.mount_subvolumes_snapdiff(
-                source_client=source_clients[0],
-                fs_util_ceph1=fs_util_ceph1,
-                default_fs=source_fs,
-                subvolume_names=subvolume_names,
-                subvol_group_name=subvol_group_name,
-                nfs_server=nfs_server,
-                nfs_name=nfs_name,
+        try:
+            mount_paths, subvol_paths, export_binding = (
+                fs_mirroring_utils.mount_subvolumes_snapdiff(
+                    source_client=source_clients[0],
+                    fs_util_ceph1=fs_util_ceph1,
+                    default_fs=source_fs,
+                    subvolume_names=subvolume_names,
+                    subvol_group_name=subvol_group_name,
+                    nfs_server=nfs_server,
+                    nfs_name=nfs_name,
+                )
             )
-        )
+        except Exception as e:
+            log.error(f"Error mounting subvolumes: {e}")
+            if re.search(r"mount\.nfs:[\s\S]*Connection refused", str(e)):
+                nfs_nodes = ceph_cluster_dict.get("ceph1").get_ceph_objects("nfs")
+                cephfs_common_utils = CephFSCommonUtils(ceph_cluster)
+                try:
+                    cephfs_common_utils.nfs_debug_logs(
+                        source_clients[0],
+                        nfs_name,
+                        log_dir,
+                        nfs_nodes,
+                        dump_output=True,
+                    )
+                except Exception as log_ex:
+                    log.error("Failed to collect NFS container debug logs: %s", log_ex)
+            raise Exception("Mount operation failed")
         log.info(f"Mount Paths : {mount_paths}")
         log.info(f"Sub Volume Paths : {subvol_paths}")
 

--- a/tests/cephfs/cephfs_system/cephfs_system_utils.py
+++ b/tests/cephfs/cephfs_system/cephfs_system_utils.py
@@ -131,6 +131,7 @@ class CephFSSystemUtils(object):
             "mgr": self.mgrs,
             "mon": self.mons,
             "osd": self.osds,
+            "nfs": self.nfss,
         }
         log_base_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
 

--- a/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
@@ -21,7 +21,6 @@ def run(ceph_cluster, **kw):
     3. Fail active mds with interval for 2 min each
     4. Perform this till upgrade in progress
     5. Check if there are any crash occurred
-
     """
     try:
         fs_util = FsUtils(ceph_cluster)
@@ -36,7 +35,7 @@ def run(ceph_cluster, **kw):
         fs_name = "cephfs"
         log.info("Wait for Upgrade to start")
         time.sleep(120)
-        retry_exec_command = retry(CommandFailed, tries=3, delay=30)(
+        retry_exec_command = retry(CommandFailed, tries=10, delay=30, backoff=1)(
             client1.exec_command
         )
         # while True:

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -5,7 +5,9 @@ This is cephfs utilsV1 extension to include further common reusable methods for 
 
 import datetime
 import json
+import os
 import random
+import re
 import secrets
 import string
 import time
@@ -79,7 +81,6 @@ class CephFSCommonUtils(FsUtils):
                     try:
                         self.validate_services(client, "node-exporter")
                         log.info("node-exporter service is up after redeploy")
-                        ceph_healthy = 1
                     except CommandFailed as ex:
                         log.error(
                             "node-exporter did not come up after redeploy: %s", ex
@@ -103,6 +104,27 @@ class CephFSCommonUtils(FsUtils):
                 wait_time,
                 out,
             )
+            if "SLOW_OPS" in out:
+                log.warning("SLOW_OPS detected in ceph health: %s", out)
+                daemon_names = re.findall(r"((?:mds|mgr|mon|osd)\.[\w.-]+)", str(out))
+                # Preserve order while removing duplicates
+                unique_daemons = list(dict.fromkeys(daemon_names))
+                if not unique_daemons:
+                    log.warning(
+                        "SLOW_OPS present but no mds/mgr/mon/osd daemon name "
+                        "matched in health detail"
+                    )
+                for daemon_name in unique_daemons:
+                    log.info(
+                        "Collecting ops dump for daemon with slow ops: %s",
+                        daemon_name,
+                    )
+                    ops_out, _ = client.exec_command(
+                        sudo=True,
+                        cmd=f"ceph tell {daemon_name} ops",
+                        check_ec=False,
+                    )
+                    log.info("ceph daemon %s ops output:\n%s", daemon_name, ops_out)
             return 1
         return 0
 
@@ -761,4 +783,105 @@ class CephFSCommonUtils(FsUtils):
         except Exception as ex:
             log.warning("Filesystem volume cleanup skipped or partial: %s", ex)
             return 1
+        return 0
+
+    def nfs_debug_logs(self, client, nfs_name, log_dir, nfs_nodes, dump_output=False):
+        """
+        This method will collect NFS debug logs and copy to log directory
+        Args:
+            client: Client object to execute the command
+            nfs_name: NFS name
+            log_dir: Log directory
+            nfs_nodes: NFS nodes
+        Returns:
+            0 on success, 1 on failure
+        """
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=(f"ceph orch ls --service_name nfs.{nfs_name};ceph health detail"),
+            check_ec=False,
+        )
+        log.info(f"NFS Service Status and Health Detail: {out}")
+        log.info(
+            "Collecting NFS container debug logs from NFS nodes " "after mount failure"
+        )
+        nfs_log_dst = os.path.join(log_dir, "nfs_container_logs")
+        os.makedirs(nfs_log_dst, exist_ok=True)
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=(f"ceph orch ps --service_name nfs.{nfs_name} " "--format json"),
+            check_ec=False,
+        )
+        daemons = json.loads(out) if out and out.strip() else []
+        if not daemons:
+            log.warning(
+                "No NFS daemons found for service nfs.%s while "
+                "collecting container logs",
+                nfs_name,
+            )
+        for daemon in daemons:
+            daemon_name = daemon.get("daemon_name")
+            hostname = daemon.get("hostname")
+            container_id = daemon.get("container_id", "")
+            if not daemon_name or not hostname:
+                continue
+            nfs_node = next(
+                (n for n in nfs_nodes if n.node.hostname == hostname),
+                None,
+            )
+            if not nfs_node:
+                log.warning(
+                    "NFS node object not found for hostname %s",
+                    hostname,
+                )
+                continue
+            remote_log = f"/tmp/{daemon_name}_cephadm.log"
+            nfs_node.exec_command(
+                sudo=True,
+                cmd=f"cephadm logs --name {daemon_name} > {remote_log}",
+                check_ec=False,
+            )
+            if dump_output:
+                out, _ = nfs_node.exec_command(
+                    sudo=True,
+                    cmd=f"ls -l {remote_log}",
+                    check_ec=False,
+                )
+                log.info(f"NFS container logs file: {out}")
+                out, _ = nfs_node.exec_command(
+                    sudo=True,
+                    cmd=f"cephadm logs --name {daemon_name}",
+                    check_ec=False,
+                )
+                log.info(f"NFS container logs: {out}")
+            local_log = os.path.join(
+                nfs_log_dst, f"{daemon_name}_{hostname}_cephadm.log"
+            )
+            nfs_node.download_file(src=remote_log, dst=local_log, sudo=True)
+            log.info(
+                "Copied NFS cephadm container log for %s to %s",
+                daemon_name,
+                local_log,
+            )
+            if container_id:
+                remote_podman_log = f"/tmp/{daemon_name}_podman.log"
+                nfs_node.exec_command(
+                    sudo=True,
+                    cmd=(f"podman logs {container_id} " f"> {remote_podman_log} 2>&1"),
+                    check_ec=False,
+                )
+                local_podman_log = os.path.join(
+                    nfs_log_dst,
+                    f"{daemon_name}_{hostname}_podman.log",
+                )
+                nfs_node.download_file(
+                    src=remote_podman_log,
+                    dst=local_podman_log,
+                    sudo=True,
+                )
+                log.info(
+                    "Copied NFS podman container log for %s to %s",
+                    daemon_name,
+                    local_podman_log,
+                )
         return 0


### PR DESCRIPTION
# Description

TFA fix for upgrade suite, pre-upgrade test failure in health check

Jira:
https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-24813

Fixes:
    Add nfs nodes in crash setup
    Add check for Slow ops, if found, dump daemon ops to help debug.
    Add code to collect nfs debug logs if nfs mount fails post upgrade in mirroring upgrade suite

Logs: Could not get a successful run in jenkins due to other failure, https://149.81.216.83/view/Executor/job/tentacle-test-executor/2351/
Mirroring upgrade suite : https://149.81.216.83/view/Executor/job/tentacle-test-executor/2356/
CephFS 7.1-> 9.1 upgrade : https://149.81.216.83/view/Executor/job/tentacle-test-executor/2360
Restarted https://149.81.216.83/view/Executor/job/tentacle-test-executor/2362/ as previous run failed in upgrade due to timeout.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
