### PR TITLE
End to End SSL passthrough, support IOs via Ingress Endpoint

### DIFF
--- a/conf/tentacle/rgw/tier-0_rgw_ingress.yaml
+++ b/conf/tentacle/rgw/tier-0_rgw_ingress.yaml
@@ -1,0 +1,45 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        disk-size: 15
+        no-of-volumes: 3
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+          - osd
+
+      node2:
+        disk-size: 15
+        no-of-volumes: 3
+        role:
+          - mgr
+          - mon
+          - osd
+
+      node3:
+        disk-size: 15
+        no-of-volumes: 3
+        role:
+          - mon
+          - mgr
+          - osd
+          - rgw
+
+      node4:
+        disk-size: 15
+        no-of-volumes: 3
+        role:
+          - osd
+          - rgw
+
+      node5:
+        role:
+          - ingress
+
+      node6:
+        role:
+          - client

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_regression_extended.yaml
@@ -1,10 +1,11 @@
-# Tier 1: RGW extension suites
+# Tier 2: RGW SSL regression extended suite with HAProxy SSL passthrough
 
-# This test suite is executed in QE pipeline. The primary objective of
-# the test suite is to evaluate the STS functionality of RGW.
+# This test suite deploys SSL-encrypted RGWs with HAProxy ingress in
+# SSL passthrough mode (HAProxy forwards TCP traffic as-is to SSL RGWs).
+# End-to-end: Client -> HTTPS -> HAProxy (TCP passthrough) -> HTTPS -> RGW (SSL backend)
 
-# Requires a 5 node cluster layout having only one node with RGW role.
-# global-conf: conf/tentacle/rgw/tier-0_rgw.yaml
+# Requires a 6-node cluster layout: 2 RGW nodes, 1 ingress node, and 1 client.
+# global-conf: conf/tentacle/rgw/tier-2_rgw_ssl_ingress.yaml
 
 tests:
   - test:
@@ -12,7 +13,6 @@ tests:
       desc: Install software pre-requisites for cluster deployment.
       module: install_prereq.py
       name: setup pre-requisites
-
   - test:
       abort-on-fail: true
       config:
@@ -61,16 +61,30 @@ tests:
                     nodes:
                       - node3
                       - node4
-                      - node5
                   spec:
                     ssl: true
                     generate_cert: true
-      desc: RHCS cluster deployment using cephadm.
+          - config:
+              command: shell
+              args:
+                - sleep
+                - "120"
+      desc: RHCS cluster deployment with SSL RGW.
       destroy-cluster: false
       module: test_cephadm.py
-      name: deploy cluster
+      name: deploy cluster with SSL RGW
       polarion-id: CEPH-83574478
-
+  - test:
+      abort-on-fail: true
+      name: Deploy ingress with SSL passthrough
+      desc: Deploy HAProxy ingress in TCP passthrough mode with floating VIP
+      polarion-id: CEPH-10363
+      module: test_ssl_ingress_deploy.py
+      config:
+        backend_service: rgw.rgw.ssl
+        frontend_port: 443
+        monitor_port: 1967
+        use_tcp_mode_over_rgw: true
   - test:
       name: Monitoring Services deployment
       desc: Add monitoring services using spec file.
@@ -115,47 +129,32 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure client
-
   - test:
       abort-on-fail: true
       config:
         roles:
           - rgw
           - client
-      desc: Copy cephadm root CA cert to rgw and client nodes
+          - ingress
+      desc: Copy cephadm root CA cert to rgw, client, and ingress nodes
       module: copy_cephadm_root_ca_cert.py
       name: copy cephadm root ca cert
       polarion-id: CEPH-10362
-
   - test:
-      name: Test NFS cluster and export create
-      desc: Test NFS cluster and export create
-      polarion-id: CEPH-83574597
-      module: sanity_rgw.py
+      name: Verify SSL passthrough via ingress VIP
+      desc: Verify HTTPS connectivity via HAProxy SSL passthrough to RGW
+      module: exec.py
       config:
-        run-on-rgw: true
-        script-name: ../nfs_ganesha/nfs_cluster.py
-        config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
+        sudo: true
+        role: installer
+        commands:
+          - "cephadm shell -- ceph orch ls ingress --format json"
+          - |
+            VIP=$(cat /tmp/ingress_vip)
+            curl -k -s -o /dev/null -w '%{http_code}' https://${VIP}:443
+          - "curl -k -s -o /dev/null -w '%{http_code}' https://{node_ip:node3}:443"
 
-  - test:
-      abort-on-fail: true
-      name: Test NFS V4 mount
-      desc: Test NFS V4 mount
-      polarion-id: CEPH-83574598
-      comments: known issue in 9.2-IBMCEPH-16569
-      module: sanity_rgw.py
-      config:
-        script-name: ../nfs_ganesha/nfs_cluster.py
-        config-file-name: ../../nfs_ganesha/config/nfs_mount_creation.yaml
-
-  - test:
-      name: NFS export delete
-      desc: NFS cluster and exports delete
-      polarion-id: CEPH-83574600 # also covers CEPH-83574601
-      module: sanity_rgw.py
-      config:
-        script-name: ../nfs_ganesha/nfs_cluster.py
-        config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+  # --- Ingress IO tests (use-ingress: true) ---
 
   - test:
       name: Test no crash during deleting bucket with aborted multipart upload
@@ -163,31 +162,45 @@ tests:
       polarion-id: CEPH-83574831
       module: sanity_rgw.py
       config:
+        use-ingress: true
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
-
   - test:
       name: Test functionality of bucket check fix
       desc: Test functionality of bucket check fix
       polarion-id: CEPH-83574832
       module: sanity_rgw.py
       config:
+        use-ingress: true
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
-
   - test:
       name: Test functionality of user stat reset
       desc: Test functionality of user stat reset
       polarion-id: CEPH-83575439
       module: sanity_rgw.py
       config:
+        use-ingress: true
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_user_stats_reset.yaml
 
-  # kafka broker type broker with persistent flag enabled
+  # Checksum tests using Go
+
   - test:
-      name: notify put,delete events with kafka_broker_persistent with rgw ssl
-      desc: notify put,delete events with kafka_broker_persistent with rgw ssl
+      name: Test checksum with Go script
+      desc: Test checksum using a Go script. RGW SSL is required for chunked uploads with trailing checksums.
+      module: sanity_rgw.py
+      polarion-id: CEPH-83591699
+      config:
+        use-ingress: true
+        script-name: ../go_scripts/test_rgw_using_go.py
+        config-file-name: ../../go_scripts/configs/test_checksum_using_go.yaml
+
+  # Kafka broker with persistent flag enabled
+
+  - test:
+      name: Notify put and delete events with persistent Kafka broker and RGW SSL
+      desc: Notify put and delete events with persistent Kafka broker and RGW SSL
       module: sanity_rgw.py
       polarion-id: CEPH-83574489
       config:
@@ -199,12 +212,32 @@ tests:
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
 
-  # checksum tests with go
+  # --- Non-ingress tests (NFS, run directly on RGW) ---
+
   - test:
-      name: test checksum with go script
-      desc: test checksum with go script. rgw ssl required for chunked upload with trailing checksum
+      name: Test NFS cluster and export create
+      desc: Test NFS cluster and export create
+      polarion-id: CEPH-83574597
       module: sanity_rgw.py
-      polarion-id: CEPH-83591699
       config:
-        script-name: ../go_scripts/test_rgw_using_go.py
-        config-file-name: ../../go_scripts/configs/test_checksum_using_go.yaml
+        run-on-rgw: true
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
+  - test:
+      abort-on-fail: true
+      name: Test NFS V4 mount
+      desc: Test NFS V4 mount
+      polarion-id: CEPH-83574598
+      comments: known issue in 9.2-IBMCEPH-16569
+      module: sanity_rgw.py
+      config:
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_mount_creation.yaml
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # Also covers CEPH-83574601
+      module: sanity_rgw.py
+      config:
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -127,6 +127,13 @@ def run(ceph_cluster, **kw):
     elif run_on_haproxy:
         exec_from = client_node
         append_param = ""
+    elif config.get("use-ingress"):
+        installer = ceph_cluster.get_ceph_object("installer")
+        vip_out, _ = installer.exec_command(cmd="cat /tmp/ingress_vip")
+        ingress_vip = vip_out.strip()
+        log.info(f"Using ingress VIP: {ingress_vip}")
+        exec_from = client_node
+        append_param = " --rgw-node " + ingress_vip
     else:
         exec_from = client_node
         append_param = " --rgw-node " + str(rgw_node.ip_address)
@@ -224,6 +231,20 @@ def run(ceph_cluster, **kw):
         f_name = f"/home/cephuser/{test_folder}" + config_dir + config_file_name
         remote_fp = exec_from.remote_file(file_name=f_name, file_mode="w", sudo=True)
         remote_fp.write(yaml.dump(test_config, default_flow_style=False))
+
+    if config.get("use-ingress"):
+        installer = ceph_cluster.get_ceph_object("installer")
+        vip_out, _ = installer.exec_command(cmd="cat /tmp/ingress_vip")
+        ingress_ip = vip_out.strip()
+        ingress_port = config.get("ingress-port", 443)
+        cfg_path = f"/home/cephuser/{test_folder}" + config_dir + config_file_name
+        out, _ = exec_from.exec_command(cmd=f"cat {cfg_path}")
+        cfg_data = yaml.safe_load(out)
+        cfg_data["config"]["endpoint_ip"] = ingress_ip
+        cfg_data["config"]["endpoint_port"] = ingress_port
+        remote_fp = exec_from.remote_file(file_name=cfg_path, file_mode="w", sudo=True)
+        remote_fp.write(yaml.dump(cfg_data, default_flow_style=False))
+        log.info(f"Injected ingress endpoint: {ingress_ip}:{ingress_port}")
 
     # Build env vars for test execution; inject IBM_CLOUD_API_KEY from env or cephci.yaml
     env_vars = list(config.get("env-vars", []))

--- a/tests/rgw/test_ssl_ingress_deploy.py
+++ b/tests/rgw/test_ssl_ingress_deploy.py
@@ -1,0 +1,163 @@
+"""
+Deploy HAProxy ingress in SSL passthrough mode with an OpenStack floating IP as VIP.
+
+Allocates a floating IP from OpenStack so the VIP is routable from all cluster
+nodes (OpenStack port-security blocks keepalived VIPs that aren't registered).
+Writes the VIP to /tmp/ingress_vip on the installer node for downstream tests.
+
+Suite config example::
+
+    - test:
+        module: test_ssl_ingress_deploy.py
+        config:
+          backend_service: rgw.rgw.ssl
+          frontend_port: 443
+          monitor_port: 1967
+          use_tcp_mode_over_rgw: true
+"""
+
+import json
+from time import sleep
+
+import yaml
+
+from compute.openstack import get_openstack_driver
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def _get_openstack_params(config):
+    """Extract OpenStack driver params from the osp_cred injected by run.py."""
+    osp_cred = config.get("osp_cred")
+    if not osp_cred:
+        raise ValueError("osp_cred not found in config; pass --osp-cred to run.py")
+    os_cred = osp_cred.get("globals", {}).get("openstack-credentials", {})
+    return {
+        "username": os_cred["username"],
+        "password": os_cred["password"],
+        "auth_url": os_cred["auth-url"],
+        "auth_version": os_cred["auth-version"],
+        "tenant_name": os_cred["tenant-name"],
+        "service_region": os_cred["service-region"],
+        "domain_name": os_cred["domain"],
+        "tenant_domain_id": os_cred["tenant-domain-id"],
+    }
+
+
+def _allocate_floating_ip(driver, ingress_node):
+    """Allocate an OpenStack floating IP on the ingress node's network."""
+    for node_obj in driver.list_nodes():
+        if ingress_node.private_ip in node_obj.private_ips:
+            network_pool = list(node_obj.extra.get("addresses").keys())
+            floating_ip = driver.ex_create_floating_ip(network_pool[0])
+            log.info(f"Allocated floating IP: {floating_ip.ip_address}")
+            return floating_ip
+    raise RuntimeError(
+        f"Could not find OpenStack node for ingress IP {ingress_node.private_ip}"
+    )
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config", {})
+    cloud_type = config.get("cloud-type", "openstack")
+
+    if cloud_type != "openstack":
+        log.error(f"Floating IP allocation not supported for cloud type: {cloud_type}")
+        return 1
+
+    installer = ceph_cluster.get_ceph_object("installer")
+    ingress_obj = ceph_cluster.get_ceph_object("ingress")
+    if not ingress_obj:
+        log.error("No node with 'ingress' role found in cluster config")
+        return 1
+    ingress_node = ingress_obj.node
+
+    os_params = _get_openstack_params(config)
+    driver = get_openstack_driver(**os_params)
+    floating_ip = None
+
+    try:
+        floating_ip = _allocate_floating_ip(driver, ingress_node)
+        vip = floating_ip.ip_address
+
+        backend_service = config.get("backend_service", "rgw.rgw.ssl")
+        frontend_port = config.get("frontend_port", 443)
+        monitor_port = config.get("monitor_port", 1967)
+        use_tcp = config.get("use_tcp_mode_over_rgw", True)
+
+        spec = {
+            "service_type": "ingress",
+            "service_id": backend_service,
+            "placement": {"hosts": [ingress_node.shortname]},
+            "spec": {
+                "backend_service": backend_service,
+                "virtual_ip": f"{vip}/32",
+                "frontend_port": frontend_port,
+                "monitor_port": monitor_port,
+                "use_tcp_mode_over_rgw": use_tcp,
+            },
+        }
+
+        spec_yaml = yaml.dump(spec, default_flow_style=False)
+        log.info(f"Ingress spec:\n{spec_yaml}")
+
+        spec_file = "/tmp/ingress_spec.yaml"
+        remote_fp = installer.remote_file(file_name=spec_file, file_mode="w", sudo=True)
+        remote_fp.write(spec_yaml)
+        remote_fp.flush()
+
+        installer.exec_command(
+            sudo=True,
+            cmd=f"cephadm shell --mount /tmp:/tmp -- ceph orch apply -i {spec_file}",
+        )
+        log.info("Ingress spec applied, waiting 60s for daemons to start")
+        sleep(60)
+
+        out, _ = installer.exec_command(
+            sudo=True,
+            cmd="cephadm shell -- ceph orch ls ingress --format json",
+        )
+        svc_list = json.loads(out)
+        if not svc_list:
+            log.error("No ingress service found after apply")
+            return 1
+
+        svc = svc_list[0]
+        running = svc.get("status", {}).get("running", 0)
+        size = svc.get("status", {}).get("size", 0)
+        log.info(f"Ingress service: {running}/{size} running, VIP={vip}")
+
+        if running < size:
+            log.warning(f"Ingress not fully up: {running}/{size}")
+
+        ingress_ip = str(ingress_node.ip_address)
+        ingress_node.exec_command(
+            sudo=True,
+            cmd=(
+                f"nft add table ip nat;"
+                f" nft add chain ip nat prerouting"
+                f" '{{ type nat hook prerouting priority -100; policy accept; }}';"
+                f" nft add rule ip nat prerouting"
+                f" ip daddr {ingress_ip} tcp dport {frontend_port}"
+                f" dnat to {vip}:{frontend_port}"
+            ),
+        )
+        log.info(
+            f"DNAT rule added (nftables): {ingress_ip}:{frontend_port} -> {vip}:{frontend_port}"
+        )
+
+        installer.exec_command(cmd=f"echo '{ingress_ip}' > /tmp/ingress_vip")
+        log.info(f"Ingress endpoint saved to /tmp/ingress_vip: {ingress_ip}")
+
+        return 0
+
+    except Exception:
+        log.exception("Failed to deploy ingress with floating IP")
+        if floating_ip:
+            try:
+                driver.ex_delete_floating_ip(floating_ip)
+                log.info("Cleaned up floating IP after failure")
+            except Exception:
+                log.warning("Failed to clean up floating IP")
+        return 1

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1690,6 +1690,11 @@ def check_build_overrides(
 
 def install_start_kafka(rgw_node, cloud_type):
     """Install kafka package and start zookeeper and kafka services."""
+    rgw_node.exec_command(
+        sudo=True,
+        cmd="java -version || yum install -y https://download.oracle.com/java/25/latest/jdk-25_linux-x64_bin.rpm",
+        long_running=True,
+    )
     install_kafka(rgw_node, cloud_type)
     start_kafka(rgw_node)
 


### PR DESCRIPTION

  **Summary**

  Enables end-to-end SSL testing through HAProxy ingress in TCP passthrough mode (client → HTTPS → HAProxy → HTTPS → RGW). Deploys ingress with a floating IP VIP, uses nftables DNAT for cross-node reachability, and routes S3 IO through the ingress endpoint.

  **Changes**

  - test_ssl_ingress_deploy.py (new) — Allocates floating IP, deploys ingress with use_tcp_mode_over_rgw: true, adds DNAT rule, saves VIP to /tmp/ingress_vip
  - sanity_rgw.py — Injects endpoint_ip/endpoint_port into test config when use-ingress: true
  - utility/utils.py — install_start_kafka now installs JDK before Kafka
  - conf/tentacle/rgw/tier-2_rgw_ssl_ingress.yaml (new) — 6-node cluster conf with dedicated ingress node (node5) and 2 RGW nodes (node3, node4)
  
  - ceph-qe-scripts (auth.py, resource_op.py, reusable.py, test_Mbuckets_with_Nobjects.py, test_LargeObjGet_GC.py, test_rgw_using_go.py, test_checksum.go) — Accept optional endpoint_ip/endpoint_port for routing IO via ingress; falls through to existing SSH discovery when not set
  
1. deployment logs 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZHUS95/
2. IOs with Ingress endpoint logs 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LN0K61
4. Regression logs 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CJOW2Z


overall logs 
9.2 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MSB17L
9.1  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TIRFRV

