### PR TITLE
TFA fix for node-exporter error in health checks

### DIFF
--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -70,9 +70,9 @@ class CephFSCommonUtils(FsUtils):
                     )
                     log.warning("Cluster health can be OK, current state : %s", out)
                     ceph_healthy = 1
-                elif "node-exporter" in str(out) and "is in unknown state" in str(out):
+                elif "node-exporter" in str(out):
                     log.warning(
-                        "node-exporter is in unknown state; redeploying. Health detail: %s",
+                        "node-exporter is in unknown/error state; redeploying. Health detail: %s",
                         out,
                     )
                     client.exec_command(


### PR DESCRIPTION
# Description
Jira: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-24813
Fix description:
Previously, during health check after deploy, 'node-exporter is in unknown state' was the warning seen, but with latest run https://149.81.216.83/view/Executor/job/tentacle-test-executor/2362/, 'node-exporter is in error state' is the warning message seen. So keeping the reg-ex match string upto 'node-exporter' to plan for redeploy.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
