### PR TITLE
fix for nfs failures in SQUID-NFS-GANESHA-REGRESSION-CI-IBM-19.2.1-382

### DIFF
--- a/suites/squid/nfs/tier1-nfs-ganesha-v4-2.yaml
+++ b/suites/squid/nfs/tier1-nfs-ganesha-v4-2.yaml
@@ -308,7 +308,7 @@ tests:
           service_type: nfs
           service_id: nfs
           placement:
-            host_pattern: '*'
+            label: nfs
           spec:
             port: 62000
             monitoring_port: 62500

--- a/tests/nfs/test_deploy_multiple_nfs_ganesha_concurrently.py
+++ b/tests/nfs/test_deploy_multiple_nfs_ganesha_concurrently.py
@@ -22,6 +22,12 @@ def run(ceph_cluster, **kw):
     installer = ceph_cluster.get_nodes(role="installer")[0]
     original_config = config.get("spec", None)
     timeout = int(config.get("timeout", 300))
+    # cluster_qos_port is Tentacle+ only; enable via suite config when needed
+    use_cluster_qos = bool(
+        config.get("enable_cluster_qos_port")
+        or (original_config or {}).get("spec", {}).get("cluster_qos_port") is not None
+    )
+    ports_per_instance = 3 if use_cluster_qos else 2
     # Allow some time for the cluster to stabilize
 
     # If the setup doesn't have required number of clients, exit.
@@ -50,9 +56,8 @@ def run(ceph_cluster, **kw):
         return free_ports
 
     try:
-        # Find 12 free ports (6 services * 2 ports each)
         all_nfs_nodes = ceph_cluster.get_nodes("nfs")
-        needed_ports = nfs_instance_number * 3
+        needed_ports = nfs_instance_number * ports_per_instance
         free_ports = get_free_ports(all_nfs_nodes, needed_ports, 52000)
 
         if len(free_ports) < needed_ports:
@@ -60,9 +65,9 @@ def run(ceph_cluster, **kw):
 
         new_objects = []
         for i in range(nfs_instance_number):
-            nfs_port = free_ports[i * 2]
-            mon_port = free_ports[i * 2 + 1]
-            cQoS_port = free_ports[i * 2 + 2]
+            base = i * ports_per_instance
+            nfs_port = free_ports[base]
+            mon_port = free_ports[base + 1]
 
             new_object = {
                 "service_type": original_config["service_type"],
@@ -71,9 +76,10 @@ def run(ceph_cluster, **kw):
                 "spec": {
                     "port": nfs_port,
                     "monitoring_port": mon_port,
-                    "cluster_qos_port": cQoS_port,
                 },
             }
+            if use_cluster_qos:
+                new_object["spec"]["cluster_qos_port"] = free_ports[base + 2]
             new_objects.append(new_object)
         log.info(
             f"New NFS Ganesha objects to be created with dynamic ports: {new_objects}"


### PR DESCRIPTION
fix for Deploy multiple nfs ganesha servers concurrently and verify
tests failed in 8.1 build 19.2.1-382


logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/8.1/rhel-9/executor/19.2.1-382/nfs/281/logs/tier1_nfs_ganesha_v4_2/
