### PR TITLE
Remove period pull after realm pull in tentacle RGW MS suites [Extended regression only]

### DIFF
--- a/suites/tentacle/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/tentacle/rgw/migrate_default_single_to_multisite.yaml
@@ -203,7 +203,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node6}:5000 --access-key a123 --secret s123 --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node6}:5000 --access-key a123 --secret s123"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node6}:5000 --access-key a123 --secret s123 "
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.rgw.default rgw_realm india"

--- a/suites/tentacle/rgw/sanity_rgw_multisite.yaml
+++ b/suites/tentacle/rgw/sanity_rgw_multisite.yaml
@@ -156,7 +156,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/tentacle/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -163,7 +163,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -251,7 +251,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_3_way_ms_failover.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_3_way_ms_failover.yaml
@@ -335,7 +335,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node3}:81 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node3}:81 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node3}:81,http://{node_ip:node4}:81 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph orch restart {service_name:shared.sec.io}"
@@ -525,7 +524,6 @@ tests:
             cephadm: true
             commands:
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-sec#node3}:81 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-sec#node3}:81 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone tertiary --endpoints http://{node_ip:node3}:81,http://{node_ip:node4}:81 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph orch restart {service_name:shared.ter.io}"

--- a/suites/tentacle/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
@@ -235,7 +235,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph orch restart {service_name:shared.sec.io}"

--- a/suites/tentacle/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms-archive.yaml
@@ -204,7 +204,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
@@ -217,7 +216,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --tier-type=archive"
               - "radosgw-admin zone modify  --rgw-realm india --rgw-zonegroup shared --rgw-zone archive  --sync-from-all false --sync-from-rm secondary --sync-from primary"
               - "radosgw-admin period update --rgw-realm india --commit"

--- a/suites/tentacle/rgw/tier-2_rgw_ms-archive_resharding_granular_sync.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms-archive_resharding_granular_sync.yaml
@@ -204,7 +204,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
@@ -217,7 +216,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --tier-type=archive"
               - "radosgw-admin zone modify  --rgw-realm india --rgw-zonegroup shared --rgw-zone archive  --sync-from-all false --sync-from-rm secondary --sync-from primary"
               - "radosgw-admin period update --rgw-realm india --commit"

--- a/suites/tentacle/rgw/tier-2_rgw_ms-bucket-location.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms-bucket-location.yaml
@@ -340,7 +340,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node3}:80 --access-key 3way123 --secret 3way123 --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node3}:80 --access-key 3way123 --secret 3way123"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node3}:80 --access-key 3way123 --secret 3way123"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.shared.sec.sync rgw_realm india"
@@ -358,7 +357,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node3}:80 --access-key 3way123 --secret 3way123 --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node3}:80 --access-key 3way123 --secret 3way123"
               - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup zg2 --endpoints http://{node_ip:node3}:80 --default"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup zg2 --rgw-zone tertiary --endpoints http://{node_ip:node3}:80 --access-key 3way123 --secret 3way123"
               - "radosgw-admin period update --rgw-realm india --commit"

--- a/suites/tentacle/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -303,7 +303,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node4}:5000 --access-key a123 --secret s123 --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node4}:5000 --access-key a123 --secret s123"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node3}:80,http://{node_ip:node4}:80 --access-key a123 --secret s123"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.shared.sec rgw_realm india"
@@ -319,7 +318,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node4}:5000 --access-key a123 --secret s123 --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node4}:5000 --access-key a123 --secret s123"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://{node_ip:node3}:80,http://{node_ip:node4}:80 --access-key a123 --secret s123 --tier-type=archive"
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --rgw-realm india --commit"

--- a/suites/tentacle/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -221,7 +221,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
@@ -251,7 +251,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_ms_lua.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_lua.yaml
@@ -310,7 +310,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node1}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node1}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node1}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph orch restart {service_name:shared.sec.io}"

--- a/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
@@ -253,7 +253,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_ms_with_haproxy_ec_22_4.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_with_haproxy_ec_22_4.yaml
@@ -219,7 +219,6 @@ tests:
             cephadm: true
             commands:
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node4}:5000 --access-key a123 --secret s123 --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node4}:5000 --access-key a123 --secret s123"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node3}:80,http://{node_ip:node4}:80 --access-key a123 --secret s123"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.shared.sec rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -250,7 +250,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node6}:5000 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -290,7 +290,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"

--- a/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -192,7 +192,6 @@ tests:
             commands:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints https://{node_ip:node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw rgw_verify_ssl False"

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -319,7 +319,6 @@ tests:
             cephadm: true
             commands:
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node7}:443,https://{node_ip:ceph-pri#node7}:8443 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node7}:443,https://{node_ip:ceph-pri#node7}:8443 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints https://{node_ip:node7}:443,https://{node_ip:node7}:8443 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"

--- a/suites/tentacle/rgw/tier-2_ssl_rgw_ms_msr_8+6.yaml
+++ b/suites/tentacle/rgw/tier-2_ssl_rgw_ms_msr_8+6.yaml
@@ -285,7 +285,6 @@ tests:
             commands:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
               - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints https://{node_ip:node4} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"

--- a/suites/tentacle/rgw/tier-3_rgw_3AZ_ec_ms_test.yaml
+++ b/suites/tentacle/rgw/tier-3_rgw_3AZ_ec_ms_test.yaml
@@ -299,7 +299,6 @@ tests:
             commands:
               - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"


### PR DESCRIPTION


BUg: https://ibm-ceph.atlassian.net/browse/IBMCEPH-16303 

Removed the secondary-side radosgw-admin period pull that runs immediately after realm pull in selected tentacle RGW multisite suites.

On 9.2, this extra period pull is terminating multisite setup with `(2) No such file or directory ` even though realm pull succeeds. The period is already pulled as part of realm pull, so the follow-up period pull is not necessary and is removed for now to unblock MS suite runs.

Multisite setup now continues from realm pull directly to zone create / period update and the remaining config steps.

pass logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.2/rhel-10/executor/20.2.2-124/rgw/2402/logs/tier_2_rgw_ms_archive/

