### PR TITLE
Add NVMeoF auto-listeners and refresh-network E2E suite (ISCE-2203 / ISCE-5078)

### DIFF
--- a/ceph/nvmeof/cli/v1/gateway.py
+++ b/ceph/nvmeof/cli/v1/gateway.py
@@ -18,5 +18,9 @@ class Gateway:
     def set_log_level(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "set_log_level", **kwargs)
 
+    def refresh_network(self, **kwargs):
+        """Re-evaluate subsystem network masks and update auto-listeners."""
+        return self.base.run_nvme_cli(self.name, "refresh_network", **kwargs)
+
     def version(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "version", **kwargs)

--- a/ceph/nvmeof/cli/v1/subsystem.py
+++ b/ceph/nvmeof/cli/v1/subsystem.py
@@ -19,3 +19,11 @@ class Subsystem:
 
     def list(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "list", **kwargs)
+
+    def add_network(self, **kwargs):
+        """Add a network mask to a subsystem (auto-create listeners in subnet)."""
+        return self.base.run_nvme_cli(self.name, "add_network", **kwargs)
+
+    def del_network(self, **kwargs):
+        """Delete a network mask from a subsystem."""
+        return self.base.run_nvme_cli(self.name, "del_network", **kwargs)

--- a/ceph/nvmeof/cli/v2/gateway.py
+++ b/ceph/nvmeof/cli/v2/gateway.py
@@ -19,5 +19,9 @@ class Gateway:
     def set_log_level(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "set_log_level", **kwargs)
 
+    def refresh_network(self, **kwargs):
+        """Re-evaluate subsystem network masks and update auto-listeners."""
+        return self.base.run_nvme_cli(self.name, "refresh_network", **kwargs)
+
     def version(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "version", **kwargs)

--- a/ceph/nvmeof/cli/v2/subsystem.py
+++ b/ceph/nvmeof/cli/v2/subsystem.py
@@ -28,3 +28,11 @@ class Subsystem:
 
     def list(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "list", **kwargs)
+
+    def add_network(self, **kwargs):
+        """Add a network mask to a subsystem (auto-create listeners in subnet)."""
+        return self.base.run_nvme_cli(self.name, "add_network", **kwargs)
+
+    def del_network(self, **kwargs):
+        """Delete a network mask from a subsystem."""
+        return self.base.run_nvme_cli(self.name, "del_network", **kwargs)

--- a/conf/tentacle/nvmeof/ceph_nvmeof_refresh-network-baremetal.yaml
+++ b/conf/tentacle/nvmeof/ceph_nvmeof_refresh-network-baremetal.yaml
@@ -1,0 +1,145 @@
+# Baremetal cluster for NVMeoF Auto-listeners + Refresh Network (ISCE-2203 / ISCE-5078)
+#
+# Minimum requirement: each NVMeoF GW node has >= 2 non-loopback IPv4 interfaces.
+# The suite discovers them via `ip a` (no hardcoded iface names):
+#   - primary   = IPv4 hosting the GW (node ip below)
+#   - secondary = another IPv4 on a different iface (used for add_network / refresh)
+#
+# Update hostname / ip / root_password / volumes to match the lab.
+#
+# Suggested run:
+#   conf/tentacle/nvmeof/ceph_nvmeof_refresh-network-baremetal.yaml
+#   suites/tentacle/nvmeof/tier-2_nvmeof_e2e_refresh-network.yaml
+---
+globals:
+  - ceph-cluster:
+      name: ceph
+      networks:
+        public:
+          - 10.64.0.0/23
+      nodes:
+        - hostname: tala002
+          id: node1
+          ip: 10.64.0.188
+          root_password: passwd
+          role:
+            - mon
+            - mgr
+            - installer
+            - _admin
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala003
+          id: node2
+          ip: 10.64.0.189
+          root_password: passwd
+          role:
+            - mon
+            - osd
+            - mgr
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala004
+          id: node3
+          ip: 10.64.0.190
+          root_password: passwd
+          role:
+            - mon
+            - osd
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala005
+          id: node4
+          ip: 10.64.0.191
+          root_password: passwd
+          role:
+            - osd
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        # 4x NVMeoF gateways — each must expose >= 2 IPv4 interfaces
+        - hostname: tala010
+          id: node5
+          ip: 10.64.0.196
+          root_password: passwd
+          role:
+            - nvmeof-gw
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala011
+          id: node6
+          ip: 10.64.0.197
+          root_password: passwd
+          role:
+            - nvmeof-gw
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala012
+          id: node7
+          ip: 10.64.0.198
+          root_password: passwd
+          role:
+            - nvmeof-gw
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala013
+          id: node8
+          ip: 10.64.0.199
+          root_password: passwd
+          role:
+            - nvmeof-gw
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+
+        - hostname: tala001
+          id: node9
+          ip: 10.64.0.187
+          root_password: passwd
+          role:
+            - client

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_refresh-network.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_refresh-network.yaml
@@ -1,0 +1,161 @@
+# Holistic E2E: NVMeoF Auto-add listeners (ISCE-2203) + Refresh Network (ISCE-5078)
+#
+# cluster configuration file:
+#   conf/tentacle/nvmeof/ceph_nvmeof_refresh-network-baremetal.yaml
+#
+# Generic dual-IPv4 discovery (no hardcoded iface names like eno8303/virtual):
+#   On each GW, parse `ip a` / `ip -o -4 addr`:
+#     - require >= 2 non-loopback IPv4 interfaces
+#     - primary   = IPv4 hosting the GW (node.ip_address)
+#     - secondary = IPv4 on another iface (common iface name across GWs preferred)
+#   network-masks = minimal CIDR covering those IP sets
+#
+# Flow:
+#   1. Create 4 subsystems with calculated primary network-mask
+#   2. Validate auto listeners on all subsystems + scale-down/up
+#   3. Take secondary iface IPv4s DOWN on all GWs, then add_network(secondary)
+#      → mask present, no secondary listeners yet
+#   4. Bring secondary UP → scoped refresh_network → ADD secondary listeners
+#   5. nvme list-subsys + IO
+#   6. Secondary DOWN → scoped refresh → DELETE secondary listeners
+#   7. list-subsys + IO
+#   8. Secondary UP → scoped refresh → ADD again → list-subsys + IO
+#   9. del_network → scoped refresh → secondary gone
+#  10. Dummy out-of-subnet add_network + refresh → listeners unchanged
+#
+# Optional overrides under refresh_network:
+#   secondary_iface / primary_network_mask / secondary_network_mask /
+#   dummy_network_mask / refresh_subsystem
+
+tests:
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node9
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup clients for NVMeoF tests
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_nodes:
+          - node5
+          - node6
+          - node7
+          - node8
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: group1
+        install: true
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        cleanup:
+          - initiators
+          - subsystems
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              count: 4
+              size: 1T
+              ns_create_image: true
+            listener_port: 4420
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              count: 4
+              size: 1T
+              ns_create_image: true
+            listener_port: 4420
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            bdevs:
+              count: 4
+              size: 1T
+              ns_create_image: true
+            listener_port: 4420
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            bdevs:
+              count: 4
+              size: 1T
+              ns_create_image: true
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - node: node9
+            nqn: connect-all
+            listener_port: 4420
+        load_balancing:
+          - scale_down: ["node8"]
+          - scale_up: ["node8"]
+        refresh_network:
+          refresh_subsystem: nqn.2016-06.io.spdk:cnode1
+      desc: >
+        Holistic E2E for NVMeoF auto-add listeners (ISCE-2203) and
+        scoped refresh network (ISCE-5078) with generic dual-IPv4 discovery
+      destroy-cluster: false
+      module: test_ceph_nvmeof_refresh_network.py
+      name: NVMeoF auto-listeners and refresh-network E2E

--- a/tests/nvmeof/test_ceph_nvmeof_refresh_network.py
+++ b/tests/nvmeof/test_ceph_nvmeof_refresh_network.py
@@ -1,0 +1,715 @@
+"""
+Holistic E2E for NVMeoF Auto-add listeners (ISCE-2203) and
+Refresh Network for Auto Listeners (ISCE-5078).
+
+Generic dual-IPv4 baremetal flow (no hardcoded iface names):
+  1. Discover IPv4 interfaces via ``ip a`` on each GW (require >= 2)
+  2. Primary = IPv4 hosting the GW (node.ip_address) → minimal network-mask
+  3. Secondary = next IPv4 set on another iface → minimal secondary mask
+  4. Create 4 subsystems with primary mask → validate auto listeners
+  5. Scale-down / scale-up → validate auto listeners
+  6. Take secondary iface IPv4s DOWN on all GWs, then add_network(secondary)
+     → mask present but NO secondary listeners (IPs gone)
+  7. Bring secondary IPv4s UP; scoped refresh_network → ADD secondary listeners
+  8. Initiator ``nvme list-subsys`` + IO
+  9. Take secondary DOWN; scoped refresh → DELETE secondary listeners
+ 10. list-subsys + IO
+ 11. Bring secondary UP; scoped refresh → ADD again
+ 12. del_network + scoped refresh → secondary listeners gone
+ 13. Dummy out-of-subnet add_network + refresh → listeners unchanged
+
+Why iface flap: add_network while secondary IPs are live can pre-create
+listeners, so refresh would be a no-op. Flapping IPs forces refresh to be
+the mechanism that adds/removes auto-listeners (ISCE-5078 intent).
+
+CLI notes:
+  - ``gateway refresh_network --subsystem <nqn>`` is required and local to one GW
+"""
+
+import ipaddress
+import time
+from copy import deepcopy
+
+from looseversion import LooseVersion
+
+from ceph.ceph import Ceph
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id, get_nodes_by_ids
+from tests.nvmeof.workflows.gateway_entities import (
+    configure_gw_entities,
+    disconnect_initiators,
+    teardown,
+    validate_listeners,
+)
+from tests.nvmeof.workflows.initiator import NVMeInitiator
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import (
+    check_and_set_nvme_cli_image,
+    discover_gateway_network_roles,
+    get_listener_traddrs,
+    get_subsystem_network_masks,
+    refresh_gateway_network,
+    secondary_iface_state_on_gateways,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster, run_fio
+
+LOG = Log(__name__)
+
+
+def _redeploy_gateways(nvme_service, gw_node_ids):
+    """Redeploy NVMeoF service on the given gateway node ids (scale up/down)."""
+    if not isinstance(gw_node_ids, list):
+        gw_node_ids = [gw_node_ids]
+    LOG.info(f"Redeploying NVMeoF gateways on: {gw_node_ids}")
+    nvme_service.config["gw_nodes"] = gw_node_ids
+    nvme_service.gw_nodes = get_nodes_by_ids(nvme_service.ceph_cluster, gw_node_ids)
+    nvme_service.deploy()
+    nvme_service.gateways = []
+    nvme_service.init_gateways()
+    return nvme_service.gateways
+
+
+def _run_io(ceph_cluster, gateway, initiator_cfg):
+    """Connect initiator and run a short FIO workload."""
+    client = get_node_by_id(ceph_cluster, initiator_cfg["node"])
+    initiator = NVMeInitiator(client)
+    cfg = {
+        "nqn": initiator_cfg.get("nqn", "connect-all"),
+        "listener_port": initiator_cfg.get("listener_port", 4420),
+    }
+    initiator.connect_targets(gateway, cfg)
+    _log_nvme_list_subsys(client)
+    paths = initiator.list_devices()
+    if not paths:
+        raise RuntimeError(f"No NVMe devices on {client.hostname}")
+
+    io_args = initiator_cfg.get("io_args", {"size": "100M", "runtime": 30})
+    with parallel() as p:
+        for path in paths:
+            p.spawn(
+                run_fio,
+                **{
+                    **io_args,
+                    "device_name": path,
+                    "client_node": client,
+                    "long_running": True,
+                    "cmd_timeout": "notimeout",
+                },
+            )
+        for op in p:
+            if isinstance(op, int) and op != 0:
+                raise RuntimeError(f"FIO failed with exit code: {op}")
+    disconnect_initiators(None, node=client)
+    return paths
+
+
+def _log_nvme_list_subsys(client):
+    """Capture initiator path view for logs (ISCE-5078 validation aid)."""
+    out, err = client.exec_command(cmd="nvme list-subsys", sudo=True, check_ec=False)
+    LOG.info(
+        f"[{client.hostname}] nvme list-subsys:\n{(out or '').strip()}\n"
+        f"stderr={(err or '').strip()}"
+    )
+
+
+def _log_list_subsys_all(ceph_cluster, initiator_cfgs):
+    for init_cfg in initiator_cfgs or []:
+        client = get_node_by_id(ceph_cluster, init_cfg["node"])
+        _log_nvme_list_subsys(client)
+
+
+def _assert_secondary_listeners(listeners, secondary_ips, present, context):
+    """Assert secondary IPs are present or absent in a listener traddr list."""
+    for ip in secondary_ips:
+        if present and ip not in listeners:
+            raise RuntimeError(
+                f"Expected secondary listener {ip} {context}; have {listeners}"
+            )
+        if not present and ip in listeners:
+            raise RuntimeError(
+                f"Secondary listener {ip} unexpectedly present {context}; "
+                f"have {listeners}"
+            )
+
+
+def _assert_primary_listeners(listeners, primary_ips, context):
+    for ip in primary_ips:
+        if ip not in listeners:
+            raise RuntimeError(
+                f"Primary listener {ip} missing {context}; have {listeners}"
+            )
+
+
+def _primary_listener_ips(gateways):
+    """Primary IPs used for auto-listeners at subsystem create."""
+    return sorted(
+        {gw.node.ip_address for gw in gateways if getattr(gw.node, "ip_address", None)}
+    )
+
+
+def _expected_auto_listeners(gateways, listener_port):
+    expected = []
+    for gateway in gateways:
+        expected.append(
+            {
+                "traddr": gateway.node.ip_address,
+                "trsvcid": listener_port,
+                "host-name": gateway.node.hostname,
+            }
+        )
+    return expected
+
+
+def _validate_auto_listeners(nvme_service, nqn, listener_port):
+    """Ensure each GW has an auto-listener on its primary IP for the subsystem."""
+    gateway = nvme_service.gateways[0]
+    expected = _expected_auto_listeners(nvme_service.gateways, listener_port)
+    validate_listeners(gateway, expected, nqn)
+    LOG.info(
+        f"Auto-listeners validated for {nqn}: {get_listener_traddrs(gateway, nqn)}"
+    )
+
+
+def _validate_all_subsystems_auto_listeners(nvme_service, subsystems):
+    """Validate primary auto-listeners on every configured subsystem."""
+    for sub in subsystems:
+        nqn = sub["nqn"]
+        port = sub.get("listener_port", 4420)
+        _validate_auto_listeners(nvme_service, nqn, port)
+
+
+def _assert_refresh_ok(result, context):
+    if result.get("status", 0) not in (0, "0", None):
+        raise RuntimeError(f"refresh_network failed ({context}): {result}")
+
+
+def _refresh_subsystem_on_all_gateways(gateways, nqn, context):
+    """
+    Run refresh_network for ONE subsystem on EACH gateway separately.
+
+    CLI is local to a single gateway and requires --subsystem, so each GW must
+    be refreshed independently for that subsystem only.
+    """
+    LOG.info(
+        f"refresh_network for subsystem {nqn} on each gateway separately ({context})"
+    )
+    for gw in gateways:
+        LOG.info(f"  -> {gw.node.hostname}: refresh_network --subsystem {nqn}")
+        result = refresh_gateway_network(gw, nqn)
+        _assert_refresh_ok(result, f"{context} on {gw.node.hostname} for {nqn}")
+
+
+def _snapshot_listeners(gateway, nqns):
+    """Return {nqn: [traddrs]} for the given subsystems."""
+    return {nqn: get_listener_traddrs(gateway, nqn) for nqn in nqns}
+
+
+def _assert_listeners_unchanged(before, after, context):
+    """Fail if any subsystem listener set changed."""
+    for nqn in before:
+        if after.get(nqn) != before[nqn]:
+            raise RuntimeError(
+                f"Listeners changed after {context} on {nqn}: "
+                f"{before[nqn]} -> {after.get(nqn)}"
+            )
+
+
+def _pick_dummy_network_mask(refresh_cfg, primary_mask, secondary_mask, gw_ips):
+    """
+    Pick an out-of-subnet dummy mask that does not cover any GW IPv4.
+
+    Default: RFC5737 TEST-NET-1 ``192.0.2.0/24``. Override via
+    ``refresh_network.dummy_network_mask``.
+    """
+    dummy = refresh_cfg.get("dummy_network_mask", "192.0.2.0/24")
+    try:
+        net = ipaddress.ip_network(dummy, strict=False)
+    except ValueError as exc:
+        raise ValueError(f"Invalid dummy_network_mask {dummy}: {exc}") from exc
+
+    if str(net) in (primary_mask, secondary_mask):
+        raise RuntimeError(
+            f"dummy_network_mask {net} collides with primary/secondary masks"
+        )
+    for ip in gw_ips:
+        if ipaddress.ip_address(ip) in net:
+            raise RuntimeError(
+                f"dummy_network_mask {net} covers GW IP {ip}; pick another CIDR"
+            )
+    return str(net)
+
+
+def _add_network_all(gateway, nqns, network_mask):
+    """Add network-mask to every subsystem."""
+    for nqn in nqns:
+        LOG.info(f"add_network {network_mask} on subsystem {nqn}")
+        gateway.subsystem.add_network(
+            **{"args": {"subsystem": nqn, "network-mask": network_mask}}
+        )
+        masks = get_subsystem_network_masks(gateway, nqn)
+        if network_mask not in masks:
+            raise RuntimeError(f"Failed to add {network_mask} to {nqn}; have {masks}")
+
+
+def _del_network_all(gateway, nqns, network_mask):
+    """Delete network-mask from every subsystem."""
+    for nqn in nqns:
+        LOG.info(f"del_network {network_mask} on subsystem {nqn}")
+        gateway.subsystem.del_network(
+            **{"args": {"subsystem": nqn, "network-mask": network_mask}}
+        )
+        masks = get_subsystem_network_masks(gateway, nqn)
+        if network_mask in masks:
+            raise RuntimeError(
+                f"Network mask {network_mask} still present on {nqn}: {masks}"
+            )
+
+
+def _resolve_networks(gateways, refresh_cfg):
+    """
+    Discover primary/secondary IPv4 roles from ``ip a`` on GW nodes.
+
+    Optional suite overrides:
+      refresh_network.secondary_iface
+      refresh_network.secondary_network_mask
+      refresh_network.primary_network_mask
+    """
+    roles = discover_gateway_network_roles(
+        gateways, secondary_iface=refresh_cfg.get("secondary_iface")
+    )
+    primary_mask = refresh_cfg.get("primary_network_mask") or roles["primary_mask"]
+    secondary_mask = (
+        refresh_cfg.get("secondary_network_mask") or roles["secondary_mask"]
+    )
+    if not primary_mask or not secondary_mask:
+        raise RuntimeError(
+            f"Unable to derive network masks from GW ip a "
+            f"(primary={primary_mask}, secondary={secondary_mask})"
+        )
+    if primary_mask == secondary_mask:
+        raise RuntimeError(
+            f"Primary and secondary network masks resolved to the same CIDR "
+            f"{primary_mask}; GWs need IPv4s in two distinct subnets"
+        )
+    return {
+        "primary_ips": roles["primary_ips"],
+        "secondary_ips": roles["secondary_ips"],
+        "primary_mask": primary_mask,
+        "secondary_mask": secondary_mask,
+        "secondary_iface": roles["secondary_iface"],
+        "per_gateway": roles["per_gateway"],
+    }
+
+
+def test_refresh_network_auto_listeners(ceph_cluster, config, rbd_obj):
+    """
+    Multi-subsystem ISCE-2203 + ISCE-5078 workflow with generic iface discovery.
+
+    Suite config:
+      subsystems: 4 entries
+      refresh_network:
+        refresh_subsystem: nqn to refresh (required for scoped validation)
+        secondary_iface / primary_network_mask / secondary_network_mask: optional
+        dummy_network_mask: optional out-of-subnet CIDR (default 192.0.2.0/24)
+    """
+    nvme_service = NVMeService(config, ceph_cluster)
+
+    if config.get("install"):
+        LOG.info("Deploying NVMeoF gateway service")
+        nvme_service.deploy()
+
+    nvme_service.init_gateways()
+    ceph_version = get_ceph_version_from_cluster(nvme_service.clients[0])
+    if LooseVersion(ceph_version) < LooseVersion("20.2.1"):
+        raise RuntimeError(
+            "Auto-listeners / refresh_network require ceph >= 20.2.1 "
+            f"(found {ceph_version})"
+        )
+
+    subsystems = config["subsystems"]
+    if len(subsystems) < 2:
+        raise ValueError("At least 2 subsystems required (prefer 4) for scoped refresh")
+
+    all_nqns = [s["nqn"] for s in subsystems]
+    refresh_cfg = config.get("refresh_network", {}) or {}
+
+    networks = _resolve_networks(nvme_service.gateways, refresh_cfg)
+    primary_mask = networks["primary_mask"]
+    secondary_mask = networks["secondary_mask"]
+    primary_ips = networks["primary_ips"]
+    secondary_ip_list = networks["secondary_ips"]
+
+    for sub in subsystems:
+        sub["network_mask"] = primary_mask
+
+    refresh_nqn = refresh_cfg.get("refresh_subsystem") or all_nqns[0]
+    if refresh_nqn not in all_nqns:
+        raise ValueError(
+            f"refresh_network.refresh_subsystem {refresh_nqn} "
+            f"not in configured subsystems {all_nqns}"
+        )
+    other_nqns = [nqn for nqn in all_nqns if nqn != refresh_nqn]
+
+    LOG.info(
+        f"Configuring {len(subsystems)} subsystems with discovered primary "
+        f"network-mask {primary_mask}; secondary_mask={secondary_mask}; "
+        f"refresh scoped to {refresh_nqn} only"
+    )
+    configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+    gateway = nvme_service.gateways[0]
+
+    # --- ISCE-2203: auto listeners on all subsystems (primary IPv4) ---
+    _validate_all_subsystems_auto_listeners(nvme_service, subsystems)
+    for nqn in all_nqns:
+        masks = get_subsystem_network_masks(gateway, nqn)
+        if primary_mask not in masks:
+            raise RuntimeError(
+                f"Expected primary network_mask {primary_mask} on {nqn}, have {masks}"
+            )
+
+    LOG.info(f"Primary auto-listeners OK on all subsystems; primary_ips={primary_ips}")
+
+    LOG.info("Run IO after primary auto-listeners")
+    for init_cfg in config.get("initiators", []):
+        _run_io(ceph_cluster, gateway, init_cfg)
+
+    # --- ISCE-2203: scale-down / scale-up ---
+    all_gw_nodes = list(config.get("gw_nodes", []))
+    for step in config.get("load_balancing", []):
+        if step.get("scale_down"):
+            remaining = [
+                n
+                for n in nvme_service.config["gw_nodes"]
+                if n not in step["scale_down"]
+            ]
+            LOG.info(
+                f"Scale-down gateways {step['scale_down']} -> remaining {remaining}"
+            )
+            _redeploy_gateways(nvme_service, remaining)
+            time.sleep(15)
+            _validate_all_subsystems_auto_listeners(nvme_service, subsystems)
+        if step.get("scale_up"):
+            scaled = list(
+                dict.fromkeys(list(nvme_service.config["gw_nodes"]) + step["scale_up"])
+            )
+            if set(step["scale_up"]).issubset(set(all_gw_nodes)):
+                scaled = list(dict.fromkeys(all_gw_nodes))
+            LOG.info(f"Scale-up gateways {step['scale_up']} -> {scaled}")
+            _redeploy_gateways(nvme_service, scaled)
+            time.sleep(15)
+            _validate_all_subsystems_auto_listeners(nvme_service, subsystems)
+
+    gateway = nvme_service.gateways[0]
+    # Re-discover after scale (GW set / IPs may have changed)
+    networks = _resolve_networks(nvme_service.gateways, refresh_cfg)
+    primary_ips = networks["primary_ips"]
+    secondary_ip_list = networks["secondary_ips"]
+    # Keep original primary_mask used at subsystem create; secondary may be recalculated
+    if not refresh_cfg.get("secondary_network_mask"):
+        secondary_mask = networks["secondary_mask"]
+
+    # ------------------------------------------------------------------
+    # ISCE-5078: exercise refresh via secondary iface IP flap
+    # add_network while IPs are live can pre-create listeners; take IPs
+    # down first so only refresh_network adds/removes them.
+    # Always restore secondary IPv4s in finally so a mid-section failure
+    # does not leave GWs without secondary addresses for later jobs.
+    # ------------------------------------------------------------------
+    try:
+        LOG.info(
+            f"Taking secondary iface IPv4s DOWN on all GWs before add_network "
+            f"(mask={secondary_mask}, ips={secondary_ip_list})"
+        )
+        secondary_iface_state_on_gateways(nvme_service.gateways, networks, state="down")
+
+        LOG.info(
+            f"add_network {secondary_mask} on ALL subsystems while secondary IPs are down"
+        )
+        _add_network_all(gateway, all_nqns, secondary_mask)
+        for nqn in all_nqns:
+            masks = get_subsystem_network_masks(gateway, nqn)
+            if primary_mask not in masks or secondary_mask not in masks:
+                raise RuntimeError(
+                    f"Expected both masks on {nqn} after add_network; have {masks}"
+                )
+            _assert_secondary_listeners(
+                get_listener_traddrs(gateway, nqn),
+                secondary_ip_list,
+                present=False,
+                context=f"after add_network with secondary DOWN on {nqn}",
+            )
+        LOG.info("add_network OK: secondary mask present, no secondary listeners yet")
+
+        LOG.info(
+            "Bringing secondary iface IPv4s UP on all GWs (listeners should stay stale)"
+        )
+        secondary_iface_state_on_gateways(nvme_service.gateways, networks, state="up")
+        time.sleep(5)
+
+        listeners_before_refresh = _snapshot_listeners(gateway, all_nqns)
+        for nqn in all_nqns:
+            _assert_secondary_listeners(
+                listeners_before_refresh[nqn],
+                secondary_ip_list,
+                present=False,
+                context=(
+                    f"after secondary UP but BEFORE refresh on {nqn} "
+                    f"(refresh must be what adds listeners)"
+                ),
+            )
+
+        # --- refresh ONLY one subsystem, on EACH gateway → ADD secondary ---
+        _refresh_subsystem_on_all_gateways(
+            nvme_service.gateways, refresh_nqn, "post-secondary-up"
+        )
+        listeners_after_refresh = _snapshot_listeners(gateway, all_nqns)
+        _assert_primary_listeners(
+            listeners_after_refresh[refresh_nqn],
+            primary_ips,
+            f"on refreshed {refresh_nqn} after secondary-up refresh",
+        )
+        _assert_secondary_listeners(
+            listeners_after_refresh[refresh_nqn],
+            secondary_ip_list,
+            present=True,
+            context=f"on refreshed {refresh_nqn} after secondary-up refresh",
+        )
+        for nqn in other_nqns:
+            if listeners_after_refresh[nqn] != listeners_before_refresh[nqn]:
+                raise RuntimeError(
+                    f"Listeners on non-refreshed subsystem {nqn} changed after "
+                    f"refresh of {refresh_nqn}: {listeners_before_refresh[nqn]} -> "
+                    f"{listeners_after_refresh[nqn]}"
+                )
+            _assert_secondary_listeners(
+                listeners_after_refresh[nqn],
+                secondary_ip_list,
+                present=False,
+                context=f"on non-refreshed {nqn} (scoped --subsystem)",
+            )
+        LOG.info(
+            f"Scoped refresh ADD OK on {refresh_nqn}; secondary={secondary_ip_list}; "
+            f"other subsystems unchanged"
+        )
+
+        LOG.info(
+            "Initiator list-subsys + IO after secondary listeners added via refresh"
+        )
+        _log_list_subsys_all(ceph_cluster, config.get("initiators", []))
+        for init_cfg in config.get("initiators", []):
+            _run_io(ceph_cluster, gateway, init_cfg)
+
+        # --- secondary DOWN → refresh → DELETE secondary listeners ---
+        LOG.info(
+            "Taking secondary iface IPv4s DOWN; refresh should remove secondary listeners"
+        )
+        secondary_iface_state_on_gateways(nvme_service.gateways, networks, state="down")
+        time.sleep(5)
+        listeners_before_down_refresh = _snapshot_listeners(gateway, all_nqns)
+        # Stale until refresh: secondary should still be listed on refresh_nqn
+        _assert_secondary_listeners(
+            listeners_before_down_refresh[refresh_nqn],
+            secondary_ip_list,
+            present=True,
+            context=(
+                f"on {refresh_nqn} after secondary DOWN but BEFORE refresh "
+                f"(stale listeners until refresh)"
+            ),
+        )
+
+        _refresh_subsystem_on_all_gateways(
+            nvme_service.gateways, refresh_nqn, "post-secondary-down"
+        )
+        listeners_after_down_refresh = _snapshot_listeners(gateway, all_nqns)
+        _assert_primary_listeners(
+            listeners_after_down_refresh[refresh_nqn],
+            primary_ips,
+            f"on {refresh_nqn} after secondary-down refresh",
+        )
+        _assert_secondary_listeners(
+            listeners_after_down_refresh[refresh_nqn],
+            secondary_ip_list,
+            present=False,
+            context=f"on {refresh_nqn} after secondary-down refresh",
+        )
+        for nqn in other_nqns:
+            if listeners_after_down_refresh[nqn] != listeners_before_down_refresh[nqn]:
+                raise RuntimeError(
+                    f"Listeners on non-refreshed subsystem {nqn} changed after "
+                    f"down-refresh of {refresh_nqn}"
+                )
+        LOG.info(f"Scoped refresh DELETE OK on {refresh_nqn} after secondary DOWN")
+
+        LOG.info(
+            "Initiator list-subsys + IO after secondary listeners removed via refresh"
+        )
+        _log_list_subsys_all(ceph_cluster, config.get("initiators", []))
+        for init_cfg in config.get("initiators", []):
+            _run_io(ceph_cluster, gateway, init_cfg)
+
+        # --- secondary UP again → refresh → ADD secondary listeners ---
+        LOG.info(
+            "Bringing secondary iface IPv4s UP again; refresh should re-add listeners"
+        )
+        secondary_iface_state_on_gateways(nvme_service.gateways, networks, state="up")
+        time.sleep(5)
+        _refresh_subsystem_on_all_gateways(
+            nvme_service.gateways, refresh_nqn, "post-secondary-up-again"
+        )
+        listeners_after_reup = _snapshot_listeners(gateway, all_nqns)
+        _assert_secondary_listeners(
+            listeners_after_reup[refresh_nqn],
+            secondary_ip_list,
+            present=True,
+            context=f"on {refresh_nqn} after secondary re-UP refresh",
+        )
+        for nqn in other_nqns:
+            _assert_secondary_listeners(
+                listeners_after_reup[nqn],
+                secondary_ip_list,
+                present=False,
+                context=f"on non-refreshed {nqn} after secondary re-UP",
+            )
+
+        LOG.info("Initiator list-subsys + IO after secondary listeners re-added")
+        _log_list_subsys_all(ceph_cluster, config.get("initiators", []))
+        for init_cfg in config.get("initiators", []):
+            _run_io(ceph_cluster, gateway, init_cfg)
+
+        # --- del_network on ALL subsystems → scoped refresh cleans secondary ---
+        LOG.info(f"del_network {secondary_mask} on ALL subsystems")
+        _del_network_all(gateway, all_nqns, secondary_mask)
+        for nqn in all_nqns:
+            masks = get_subsystem_network_masks(gateway, nqn)
+            if secondary_mask in masks:
+                raise RuntimeError(f"{secondary_mask} still on {nqn}: {masks}")
+            if primary_mask not in masks:
+                raise RuntimeError(f"Primary mask missing on {nqn} after del: {masks}")
+
+        listeners_before_del_refresh = _snapshot_listeners(gateway, all_nqns)
+        _refresh_subsystem_on_all_gateways(
+            nvme_service.gateways, refresh_nqn, "post-del-network"
+        )
+        listeners_after_del_refresh = _snapshot_listeners(gateway, all_nqns)
+        _assert_secondary_listeners(
+            listeners_after_del_refresh[refresh_nqn],
+            secondary_ip_list,
+            present=False,
+            context=f"on {refresh_nqn} after del_network+refresh",
+        )
+        _assert_primary_listeners(
+            listeners_after_del_refresh[refresh_nqn],
+            primary_ips,
+            f"on {refresh_nqn} after del_network+refresh",
+        )
+        for nqn in other_nqns:
+            if listeners_after_del_refresh[nqn] != listeners_before_del_refresh[nqn]:
+                raise RuntimeError(
+                    f"Listeners on non-refreshed subsystem {nqn} changed after "
+                    f"del refresh of {refresh_nqn}: "
+                    f"{listeners_before_del_refresh[nqn]} -> "
+                    f"{listeners_after_del_refresh[nqn]}"
+                )
+
+        LOG.info(
+            f"del_network + scoped refresh OK on {refresh_nqn}; "
+            f"primary listeners remain; other subsystems untouched"
+        )
+    finally:
+        # Always restore secondary IPv4s (even on assertion/refresh failure)
+        try:
+            LOG.info(
+                "Restoring secondary iface IPv4s on all GWs "
+                "(post ISCE-5078 flap, success or failure)"
+            )
+            secondary_iface_state_on_gateways(
+                nvme_service.gateways, networks, state="up"
+            )
+        except Exception as restore_exc:  # noqa: BLE001
+            LOG.warning(f"Secondary iface restore after IP flap section: {restore_exc}")
+
+    # --- Dummy out-of-subnet network (last): refresh must NOT change listeners ---
+    dummy_mask = _pick_dummy_network_mask(
+        refresh_cfg,
+        primary_mask,
+        secondary_mask,
+        primary_ips + secondary_ip_list,
+    )
+    LOG.info(
+        f"add_network dummy out-of-subnet mask {dummy_mask} on ALL subsystems; "
+        f"scoped refresh must leave listeners unchanged"
+    )
+    _add_network_all(gateway, all_nqns, dummy_mask)
+    listeners_before_dummy = _snapshot_listeners(gateway, all_nqns)
+    _refresh_subsystem_on_all_gateways(
+        nvme_service.gateways, refresh_nqn, "post-dummy-add-network"
+    )
+    listeners_after_dummy = _snapshot_listeners(gateway, all_nqns)
+    _assert_listeners_unchanged(
+        listeners_before_dummy,
+        listeners_after_dummy,
+        f"dummy add_network+refresh ({dummy_mask})",
+    )
+    LOG.info(
+        f"Dummy network {dummy_mask}: listeners unchanged after scoped refresh "
+        f"on {refresh_nqn}"
+    )
+    _del_network_all(gateway, all_nqns, dummy_mask)
+    listeners_before_dummy_del = _snapshot_listeners(gateway, all_nqns)
+    _refresh_subsystem_on_all_gateways(
+        nvme_service.gateways, refresh_nqn, "post-dummy-del-network"
+    )
+    listeners_after_dummy_del = _snapshot_listeners(gateway, all_nqns)
+    _assert_listeners_unchanged(
+        listeners_before_dummy_del,
+        listeners_after_dummy_del,
+        f"dummy del_network+refresh ({dummy_mask})",
+    )
+    LOG.info(
+        f"Dummy network {dummy_mask} removed; listeners still unchanged after refresh"
+    )
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Entry point for cephci suite execution."""
+    LOG.info("Starting NVMeoF Auto-listeners + Refresh Network holistic E2E")
+    config = deepcopy(kwargs["config"])
+    rbd_pools = initial_rbd_config(**kwargs)
+    if not rbd_pools or not rbd_pools.get("rbd_reppool"):
+        LOG.error(
+            "RBD pool setup failed (initial_rbd_config returned %s). "
+            "Check earlier 'Pool creation failed' logs — usually "
+            "`ceph osd pool create <pool> 64 64` failed because the pool "
+            "already exists, the cluster lacks capacity for 64 PGs, or "
+            "ceph CLI access from the client node failed.",
+            rbd_pools,
+        )
+        return 1
+    rbd_obj = rbd_pools["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    try:
+        if config.get("cleanup-only"):
+            nvme_service = NVMeService(config, ceph_cluster)
+            nvme_service.init_gateways()
+            return teardown(nvme_service, rbd_obj)
+
+        test_refresh_network_auto_listeners(ceph_cluster, config, rbd_obj)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        LOG.error(f"Refresh-network / auto-listeners E2E failed: {exc}")
+        return 1
+    finally:
+        if config.get("cleanup") and not config.get("cleanup-only"):
+            try:
+                nvme_service = nvme_service or NVMeService(config, ceph_cluster)
+                if not getattr(nvme_service, "gateways", None):
+                    nvme_service.init_gateways()
+                teardown(nvme_service, rbd_obj)
+            except Exception as cleanup_exc:  # noqa: BLE001
+                LOG.warning(f"Teardown warning: {cleanup_exc}")

--- a/tests/nvmeof/workflows/gateway_entities.py
+++ b/tests/nvmeof/workflows/gateway_entities.py
@@ -138,7 +138,12 @@ def configure_subsystems(nvme_service, ceph_cluster=None, subsystem_config=None)
                 args["port"] = sub_cfg.get("listener_port")
             if sub_cfg.get("secure_listener"):
                 args["secure_listeners"] = sub_cfg.get("secure_listener")
-            args["network-mask"] = get_network_mask(nvme_service.gateways)
+            # Prefer suite-defined network-mask; else derive from GW primary IPs
+            args["network-mask"] = (
+                sub_cfg.get("network_mask")
+                or sub_cfg.get("network-mask")
+                or get_network_mask(nvme_service.gateways)
+            )
 
         gateway.subsystem.add(**{"args": args})
 
@@ -419,6 +424,21 @@ def configure_namespaces(gateway, config, opt_args={}, rbd_obj=None):
             validate_namespaces(gateway, expected_namespaces, nqn)
 
 
+def _hostnames_match(actual, expected):
+    """
+    Compare listener hostnames allowing short vs FQDN forms.
+
+    Baremetal cephci nodes often use ``hostname -s`` (e.g. tala010) while
+    NVMeoF auto-listeners register the cluster host FQDN
+    (e.g. tala010.ceph.tuc.ibm.com).
+    """
+    if actual == expected:
+        return True
+    if not actual or not expected:
+        return False
+    return str(actual).split(".")[0] == str(expected).split(".")[0]
+
+
 def validate_listeners(gateway, expected_listeners, nqn):
     """
     Validate that all the expected listeners are correctly configured in the gateway.
@@ -438,7 +458,9 @@ def validate_listeners(gateway, expected_listeners, nqn):
                 listener.get("traddr") == expected_listener.get("traddr")
                 and str(listener.get("trsvcid"))
                 == str(expected_listener.get("trsvcid"))
-                and listener.get("host_name") == expected_listener.get("host-name")
+                and _hostnames_match(
+                    listener.get("host_name"), expected_listener.get("host-name")
+                )
             ):
                 match_found = True
                 break

--- a/tests/nvmeof/workflows/nvme_utils.py
+++ b/tests/nvmeof/workflows/nvme_utils.py
@@ -725,21 +725,457 @@ def fetch_lb_groups(gateways, nodes):
     return lb_group_ids
 
 
-def get_network_mask(gateways):
-    ips = []
+def get_minimal_network_mask(ips):
+    """
+    Derive the tightest IPv4 network mask that covers all given IPs.
 
-    for gateway in gateways:
-        gw_ip = getattr(gateway.node, "ip_address", None)
-        if gw_ip:
-            ips.append(ipaddress.ip_address(gw_ip))
+    Uses XOR of min/max addresses to find the minimal prefix length.
+    """
     if not ips:
         return None
 
-    ip_ints = [int(ip) for ip in ips]
+    addrs = [ipaddress.ip_address(ip) for ip in ips]
+    ip_ints = [int(ip) for ip in addrs]
     min_ip = min(ip_ints)
     max_ip = max(ip_ints)
-    diff = min_ip ^ max_ip  # XOR min & max → find differing bits → derive prefix length
-    prefix_len = 32 - diff.bit_length()  # Build subnet from first IP + prefix length
+    diff = min_ip ^ max_ip  # XOR min & max → differing bits → prefix length
+    prefix_len = 32 - diff.bit_length()
 
-    network = ipaddress.ip_network(f"{ips[0]}/{prefix_len}", strict=False)
+    network = ipaddress.ip_network(f"{addrs[0]}/{prefix_len}", strict=False)
     return str(network)
+
+
+def get_network_mask(gateways):
+    """Derive minimal network-mask from gateway primary IPs."""
+    ips = []
+    for gateway in gateways:
+        gw_ip = getattr(gateway.node, "ip_address", None)
+        if gw_ip:
+            ips.append(gw_ip)
+    return get_minimal_network_mask(ips)
+
+
+def list_listeners(gateway, nqn):
+    """Return listener dicts for a subsystem."""
+    args = {"base_cmd_args": {"format": "json"}, "args": {"subsystem": nqn}}
+    out, _ = gateway.listener.list(**args)
+    if not out:
+        return []
+    data = json.loads(out)
+    return data.get("listeners", [])
+
+
+def get_listener_traddrs(gateway, nqn):
+    """Return sorted listener traddrs for a subsystem."""
+    return sorted(
+        {
+            listener.get("traddr")
+            for listener in list_listeners(gateway, nqn)
+            if listener.get("traddr")
+        }
+    )
+
+
+def get_subsystem_network_masks(gateway, nqn):
+    """Return network_mask list configured on a subsystem."""
+    args = {"base_cmd_args": {"format": "json"}, "args": {"subsystem": nqn}}
+    out, _ = gateway.subsystem.list(**args)
+    if not out:
+        return []
+    data = json.loads(out)
+    for subsystem in data.get("subsystems", []):
+        if subsystem.get("nqn") == nqn:
+            masks = subsystem.get("network_mask") or []
+            if isinstance(masks, str):
+                return [masks] if masks else []
+            return list(masks)
+    raise ValueError(f"Subsystem {nqn} not found while fetching network masks")
+
+
+def get_ipv4_on_interface(node, iface):
+    """Return the first IPv4 address configured on iface, or None."""
+    out, _ = node.exec_command(
+        cmd=f"ip -o -4 addr show dev {iface} | awk '{{print $4}}'",
+        sudo=True,
+        check_ec=False,
+    )
+    line = (out or "").strip().splitlines()
+    if not line:
+        return None
+    return line[0].split("/")[0]
+
+
+def list_iface_ipv4_cidrs(node, iface):
+    """Return IPv4 CIDRs currently configured on ``iface`` (e.g. ['10.64.94.1/27'])."""
+    out, _ = node.exec_command(
+        cmd=f"ip -o -4 addr show dev {iface} | awk '{{print $4}}'",
+        sudo=True,
+        check_ec=False,
+    )
+    return [line.strip() for line in (out or "").strip().splitlines() if line.strip()]
+
+
+def _nmcli_available(node):
+    out, _ = node.exec_command(cmd="command -v nmcli", check_ec=False)
+    return bool((out or "").strip())
+
+
+def interface_exists(node, iface):
+    """Return True if network device ``iface`` is present (even if DOWN)."""
+    out, err = node.exec_command(
+        cmd=f"ip link show dev {iface}",
+        sudo=True,
+        check_ec=False,
+    )
+    text = f"{out or ''}{err or ''}".lower()
+    if "does not exist" in text or "cannot find device" in text:
+        return False
+    # ip link show prints the iface name on success
+    return iface in (out or "")
+
+
+def _ensure_interface_present(node, iface):
+    """
+    Ensure ``iface`` exists. Never use ``nmcli device disconnect`` — that can
+    delete VLAN/virtual devices (e.g. virtual@eno12399np0).
+
+    If the device is missing, try bringing an NM connection profile back up.
+    """
+    if interface_exists(node, iface):
+        return
+
+    LOG.warning(
+        f"[{node.hostname}] iface {iface} is missing; attempting NM connection restore"
+    )
+    if _nmcli_available(node):
+        # Prefer connection profile named like the iface, then any profile bound to it
+        for cmd in (
+            f"nmcli connection up id {iface}",
+            f"nmcli connection up {iface}",
+            f"nmcli -g NAME,DEVICE connection show | awk -F: -v d={iface} '$2==d{{print $1; exit}}' "
+            f"| xargs -r nmcli connection up id",
+        ):
+            node.exec_command(cmd=cmd, sudo=True, check_ec=False)
+            if interface_exists(node, iface):
+                LOG.info(f"[{node.hostname}] restored iface {iface} via nmcli")
+                return
+
+    raise RuntimeError(
+        f"[{node.hostname}] secondary iface {iface} no longer exists. "
+        f"Do not use nmcli device disconnect / ip link delete on VLAN/virtual "
+        f"NICs — recreate the iface (e.g. nmcli connection up <profile> or "
+        f"re-add the VLAN on the parent), then re-run the test."
+    )
+
+
+def take_interface_ipv4s_down(node, iface, saved_cidrs=None):
+    """
+    Remove IPv4 addresses from ``iface`` only — keep the device itself.
+
+    Intentionally avoids ``nmcli device disconnect`` and ``ip link set down``,
+    which can destroy VLAN/virtual interfaces (lab: virtual@parent disappears).
+    """
+    if not interface_exists(node, iface):
+        raise RuntimeError(
+            f"[{node.hostname}] cannot remove IPv4s: iface {iface} does not exist"
+        )
+
+    cidrs = (
+        list(saved_cidrs)
+        if saved_cidrs is not None
+        else list_iface_ipv4_cidrs(node, iface)
+    )
+    LOG.info(
+        f"[{node.hostname}] removing IPv4s from {iface} (keep device; cidrs={cidrs})"
+    )
+    for cidr in cidrs:
+        node.exec_command(
+            cmd=f"ip addr del {cidr} dev {iface}",
+            sudo=True,
+            check_ec=False,
+        )
+    # Safety: clear any remaining IPv4s without deleting the link
+    node.exec_command(cmd=f"ip -4 addr flush dev {iface}", sudo=True, check_ec=False)
+
+    if not interface_exists(node, iface):
+        raise RuntimeError(
+            f"[{node.hostname}] iface {iface} disappeared after IPv4 removal — "
+            f"unexpected; check lab networking"
+        )
+
+    remaining = list_iface_ipv4_cidrs(node, iface)
+    if remaining:
+        raise RuntimeError(
+            f"[{node.hostname}] expected no IPv4 on {iface} after addr del; still {remaining}"
+        )
+    return cidrs
+
+
+def bring_interface_ipv4s_up(node, iface, cidrs, timeout=60):
+    """
+    Re-apply saved IPv4 CIDRs on ``iface`` (device must already exist or be
+    restorable via NM connection profile).
+    """
+    if not cidrs:
+        raise ValueError(f"[{node.hostname}] no CIDRs to restore on {iface}")
+
+    LOG.info(f"[{node.hostname}] restoring IPv4s on {iface} (cidrs={cidrs})")
+    _ensure_interface_present(node, iface)
+    node.exec_command(cmd=f"ip link set {iface} up", sudo=True, check_ec=False)
+
+    present = set(list_iface_ipv4_cidrs(node, iface))
+    for cidr in cidrs:
+        if cidr not in present:
+            node.exec_command(
+                cmd=f"ip addr add {cidr} dev {iface}",
+                sudo=True,
+                check_ec=False,
+            )
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        present_ips = {c.split("/")[0] for c in list_iface_ipv4_cidrs(node, iface)}
+        expected_ips = {c.split("/")[0] for c in cidrs}
+        if expected_ips.issubset(present_ips):
+            LOG.info(f"[{node.hostname}] {iface} IPv4s restored: {sorted(present_ips)}")
+            return
+        time.sleep(2)
+
+    raise RuntimeError(
+        f"[{node.hostname}] timed out waiting for {iface} IPv4s {cidrs}; "
+        f"have {list_iface_ipv4_cidrs(node, iface)}; "
+        f"iface_exists={interface_exists(node, iface)}"
+    )
+
+
+def secondary_iface_state_on_gateways(gateways, networks, state):
+    """
+    Apply secondary IPv4 remove/restore across all gateways.
+
+    ``networks`` is the dict from ``discover_gateway_network_roles``.
+    For ``state='down'``, stores saved CIDRs on each per_gateway entry under
+    ``secondary_cidrs``. For ``state='up'``, restores from that.
+    """
+    if state not in ("up", "down"):
+        raise ValueError(f"state must be 'up' or 'down', got {state}")
+
+    for gw in gateways:
+        host = gw.node.hostname
+        info = networks["per_gateway"][host]
+        secondary = info.get("secondary") or {}
+        iface = secondary.get("iface")
+        if not iface:
+            raise RuntimeError(f"[{host}] no secondary iface in discovered roles")
+
+        if state == "down":
+            cidrs = take_interface_ipv4s_down(
+                gw.node, iface, saved_cidrs=info.get("secondary_cidrs")
+            )
+            info["secondary_cidrs"] = cidrs
+        else:
+            cidrs = info.get("secondary_cidrs")
+            if not cidrs:
+                # Fall back to discovered secondary CIDR
+                cidr = secondary.get("cidr")
+                cidrs = [cidr] if cidr else []
+            bring_interface_ipv4s_up(gw.node, iface, cidrs)
+
+
+def list_node_ipv4_addrs(node):
+    """
+    Discover non-loopback IPv4 addresses on a node via ``ip -o -4 addr``.
+
+    Returns:
+        list[dict]: [{"iface": "eno8303", "ip": "10.64.0.192", "prefix": "23"}, ...]
+    """
+    out, _ = node.exec_command(
+        cmd="ip -o -4 addr show | awk '{print $2,$4}'",
+        sudo=True,
+    )
+    addrs = []
+    seen = set()
+    for line in (out or "").strip().splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        iface, cidr = parts[0], parts[1]
+        iface = iface.split("@")[0]
+        if iface == "lo" or iface.startswith("lo:"):
+            continue
+        ip = cidr.split("/")[0]
+        prefix = cidr.split("/")[1] if "/" in cidr else None
+        key = (iface, ip)
+        if key in seen:
+            continue
+        seen.add(key)
+        addrs.append({"iface": iface, "ip": ip, "prefix": prefix, "cidr": cidr})
+    return addrs
+
+
+def classify_gateway_ipv4s(node, primary_ip=None):
+    """
+    Split node IPv4s into GW-primary vs secondary.
+
+    Primary = interface hosting ``primary_ip`` (defaults to node.ip_address).
+    Secondary = another IPv4-bearing interface (minimum requirement: 2 IPv4 ifaces).
+
+    Returns:
+        dict with keys primary, secondaries (list), all
+    """
+    primary_ip = primary_ip or getattr(node, "ip_address", None)
+    addrs = list_node_ipv4_addrs(node)
+    ifaces_with_ip = {}
+    for entry in addrs:
+        ifaces_with_ip.setdefault(entry["iface"], []).append(entry)
+
+    if len(ifaces_with_ip) < 2:
+        raise RuntimeError(
+            f"{node.hostname} needs at least 2 IPv4 interfaces for refresh-network "
+            f"E2E; found {sorted(ifaces_with_ip.keys()) or 'none'}"
+        )
+
+    primary = None
+    for entry in addrs:
+        if primary_ip and entry["ip"] == primary_ip:
+            primary = entry
+            break
+    if not primary:
+        # Fall back to first iface if primary_ip not found on any iface
+        first_iface = sorted(ifaces_with_ip.keys())[0]
+        primary = ifaces_with_ip[first_iface][0]
+        LOG.warning(
+            f"[{node.hostname}] primary IP {primary_ip} not found in ip a; "
+            f"using {primary['iface']}/{primary['ip']}"
+        )
+
+    secondaries = [
+        entry
+        for entry in addrs
+        if entry["iface"] != primary["iface"] and entry["ip"] != primary["ip"]
+    ]
+    if not secondaries:
+        raise RuntimeError(
+            f"{node.hostname}: no secondary IPv4 found besides primary "
+            f"{primary['iface']}/{primary['ip']}"
+        )
+
+    return {"primary": primary, "secondaries": secondaries, "all": addrs}
+
+
+def discover_gateway_network_roles(gateways, secondary_iface=None):
+    """
+    Discover primary/secondary IPv4 roles across gateway nodes.
+
+    - Primary IPs: each GW's hosted address (node.ip_address / matching iface)
+    - Secondary IPs: IPv4s on a non-primary iface
+      Prefer a common secondary iface name present on all GWs; otherwise use
+      the first secondary IPv4 on each GW. Optional ``secondary_iface`` forces
+      the iface name.
+
+    Returns:
+        dict:
+          primary_ips, secondary_ips, primary_mask, secondary_mask,
+          per_gateway (hostname -> {primary, secondary})
+    """
+    per_gateway = {}
+    secondary_iface_candidates = None
+
+    for gw in gateways:
+        classified = classify_gateway_ipv4s(gw.node)
+        per_gateway[gw.node.hostname] = {
+            "primary": classified["primary"],
+            "secondaries": classified["secondaries"],
+        }
+        names = {s["iface"] for s in classified["secondaries"]}
+        secondary_iface_candidates = (
+            names
+            if secondary_iface_candidates is None
+            else secondary_iface_candidates & names
+        )
+        LOG.info(
+            f"[{gw.node.hostname}] ip a IPv4 roles: primary="
+            f"{classified['primary']['iface']}/{classified['primary']['ip']}, "
+            f"secondaries="
+            f"{[(s['iface'], s['ip']) for s in classified['secondaries']]}"
+        )
+
+    if secondary_iface:
+        chosen_secondary_iface = secondary_iface
+    elif secondary_iface_candidates:
+        chosen_secondary_iface = sorted(secondary_iface_candidates)[0]
+    else:
+        chosen_secondary_iface = None
+
+    primary_ips = []
+    secondary_ips = []
+    secondary_map = {}
+
+    for gw in gateways:
+        host = gw.node.hostname
+        info = per_gateway[host]
+        primary_ips.append(info["primary"]["ip"])
+
+        secondary = None
+        if chosen_secondary_iface:
+            for entry in info["secondaries"]:
+                if entry["iface"] == chosen_secondary_iface:
+                    secondary = entry
+                    break
+            if not secondary:
+                raise RuntimeError(
+                    f"{host}: configured/chosen secondary iface "
+                    f"'{chosen_secondary_iface}' has no IPv4"
+                )
+        else:
+            secondary = info["secondaries"][0]
+
+        secondary_map[host] = secondary
+        secondary_ips.append(secondary["ip"])
+        per_gateway[host]["secondary"] = secondary
+
+    primary_mask = get_minimal_network_mask(primary_ips)
+    secondary_mask = get_minimal_network_mask(secondary_ips)
+
+    LOG.info(
+        f"Discovered GW networks: primary_mask={primary_mask} "
+        f"from {sorted(set(primary_ips))}; secondary_mask={secondary_mask} "
+        f"from {sorted(set(secondary_ips))} "
+        f"(secondary_iface={chosen_secondary_iface or 'per-node first secondary'})"
+    )
+
+    return {
+        "primary_ips": sorted(set(primary_ips)),
+        "secondary_ips": sorted(set(secondary_ips)),
+        "primary_mask": primary_mask,
+        "secondary_mask": secondary_mask,
+        "secondary_iface": chosen_secondary_iface,
+        "per_gateway": per_gateway,
+    }
+
+
+def refresh_gateway_network(gateway, nqn):
+    """
+    Run gateway refresh_network for a subsystem and return parsed JSON status.
+
+    Command: ceph nvmeof gateway refresh_network --subsystem <nqn>
+    """
+    args = {
+        "base_cmd_args": {"format": "json"},
+        "args": {"subsystem": nqn},
+    }
+    out, err = gateway.gateway.refresh_network(**args)
+    LOG.info(
+        f"[{gateway.node.hostname}] refresh_network for {nqn}: out={out}, err={err}"
+    )
+    if not out:
+        return {"status": 0, "added": [], "removed": [], "raw": out}
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        # Plain-text success path
+        return {
+            "status": 0 if "Successful" in (out or "") else 1,
+            "added": [],
+            "removed": [],
+            "raw": out,
+        }


### PR DESCRIPTION
## Summary

Adds a holistic E2E suite to qualify **NVMeoF Auto-add listeners (ISCE-2203)** and **Refresh Network for Auto Listeners (ISCE-5078)** on baremetal dual-IPv4 gateways.

The test deploys NVMeoF with **4 gateways** and **4 subsystems**, validates auto-listeners on subsystem create and GW scale-up/down, then exercises `add_network` / `del_network` while scoping `gateway refresh_network` to a **single subsystem** and running it **per gateway** (matching product CLI behavior: `--subsystem` required, refresh is local to one GW).

IPv4 roles and network masks are **discovered at runtime** via `ip a` on each GW (no hardcoded iface names like `eno8303` / `virtual`):
- **Primary** = IPv4 hosting the GW (`node.ip_address`)
- **Secondary** = IPv4 on another iface (≥2 non-loopback IPv4 ifaces required)
- Masks = minimal CIDR covering each IP set (optional suite overrides still supported)

**ISCE-5078 is exercised via secondary IPv4 remove/restore** (not VLAN/`nmcli device disconnect`, which can destroy `virtual@parent` devices). That ensures `add_network` cannot pre-create listeners while IPs are absent, so `refresh_network` is what adds/removes them.

Ends with a **dummy out-of-subnet** network (`192.0.2.0/24` by default) where refresh must leave listeners unchanged.

Hostname validation accepts short name ≡ FQDN (baremetal `hostname -s` vs Ceph host FQDN).

## What changed

**New**
- `suites/tentacle/nvmeof/tier-2_nvmeof_e2e_refresh-network.yaml` — E2E suite
- `conf/tentacle/nvmeof/ceph_nvmeof_refresh-network-baremetal.yaml` — baremetal dual-IPv4 conf template
- `tests/nvmeof/test_ceph_nvmeof_refresh_network.py` — test module

**Updated**
- `ceph/nvmeof/cli/v1|v2/gateway.py` — `refresh_network()`
- `ceph/nvmeof/cli/v1|v2/subsystem.py` — `add_network()` / `del_network()`
- `tests/nvmeof/workflows/nvme_utils.py` — `ip a` discovery, minimal-mask helpers, VLAN-safe IPv4 remove/restore, refresh helpers
- `tests/nvmeof/workflows/gateway_entities.py` — honor suite `network_mask`; short-vs-FQDN hostname match

## Test flow

1. Deploy Ceph + NVMeoF (4 GWs)
2. Discover primary/secondary IPv4s from `ip a` on GWs; calculate minimal primary/secondary network-masks
3. Create **4 subsystems** with calculated primary `network-mask`
4. Validate auto-listeners on all subsystems
5. Scale-down / scale-up → re-validate auto-listeners
6. **Remove secondary IPv4s** on all GWs (`ip addr del` / `ip -4 addr flush` — keep device)
7. `subsystem add_network` (secondary mask) on **all** subsystems → mask present, **no** secondary listeners
8. **Restore secondary IPv4s** → still no secondary listeners (proves refresh is required)
9. `gateway refresh_network --subsystem <one nqn>` on **each GW**
   - refreshed subsystem gains secondary listeners
   - other subsystems unchanged (proves `--subsystem` scoping)
10. Initiator `nvme list-subsys` + IO
11. Remove secondary IPv4s again → stale listeners until refresh → scoped refresh → secondary listeners deleted
12. `nvme list-subsys` + IO
13. Restore secondary IPv4s + scoped refresh → secondary listeners re-added
14. `nvme list-subsys` + IO
15. `subsystem del_network` (secondary) + scoped refresh → secondary gone; primary remain
16. Dummy out-of-subnet `add_network` + scoped refresh → listeners unchanged
17. Dummy `del_network` + scoped refresh → listeners still unchanged

## Test evidence

Baremetal run **PASSED** (`cephci-run-6ZZLQ6`):

- Gist (logs): https://gist.github.com/rahullepakshi/a9bb50f0e5aabcc361536f7005b1c373
- Includes: `startup.log`, `NVMeoF_auto-listeners_and_refresh-network_E2E_0.log`, `index.html`, `run_summary.json`

## Test plan

- [x] Confirm each GW has ≥2 non-loopback IPv4 interfaces
- [x] Run suite against Tentacle / Ceph ≥ 20.2.1 (run used 20.2.1-282.el10cp)
- [x] Verify secondary IPv4 remove/restore does not destroy VLAN/virtual device
- [x] Verify scoped refresh adds/removes secondary listeners only on `refresh_subsystem`
- [x] Confirm non-refreshed subsystems unchanged
- [x] Confirm dummy network refresh does not add/remove listeners
- [ ] Optional: pin `secondary_iface` / masks / `dummy_network_mask` / `refresh_subsystem` for lab variants