### PR TITLE
9.2 - nfs_stats -- adding version check to run from 9.2

### DIFF
--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -8,6 +8,8 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import quote
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from cli.ceph.ceph import Ceph
 from cli.cephadm.cephadm import CephAdm
@@ -33,6 +35,9 @@ CURL_TIMEOUT_OPTS = "--connect-timeout %s --max-time %s" % (
     CURL_CONNECT_TIMEOUT,
     CURL_MAX_TIME,
 )
+# Scalable Prometheus stats require RHCS 9.2+ / Ceph 20.2.2+ (Ganesha 9.7 FSAL).
+PROMETHEUS_STATS_MIN_UPSTREAM_BUILD = "20.2.2"
+PROMETHEUS_STATS_MIN_RHCS_BUILD = "9.2"
 CONF_KEY = "mgr/cephadm/services/nfs/ganesha.conf"
 DEFAULT_TEMPLATE_PATH = (
     "/usr/share/ceph/mgr/cephadm/templates/services/nfs/ganesha.conf.j2"
@@ -67,6 +72,122 @@ PROMETHEUS_CORE_PARAM_ALIASES = {
     key: _prometheus_param_aliases(key, canonical)
     for key, canonical in PROMETHEUS_GANESHA_PARAM_NAMES.items()
 }
+
+
+def _numeric_version_token(value):
+    """Extract Ceph/RHCS version digits only; ignore platform suffixes.
+
+    ``run.py`` appends the OS platform to rhbuild (e.g. ``20.2.2-rhel-9`` or
+    ``20.2.2-rhel-10``). Prometheus stats are gated on the Ceph version alone
+    (``20.2.2``), not on RHEL 9 vs RHEL 10.
+
+    Examples:
+      ``20.2.2-rhel-10``      -> ``20.2.2``
+      ``20.2.2-rhel-9``       -> ``20.2.2``
+      ``9.2-rhel-9``          -> ``9.2``
+      ``20.2.2-104.el10cp``   -> ``20.2.2``
+      ``main-rhel-9``         -> None (named release)
+    """
+    if not value:
+        return None
+    match = re.match(r"(\d+\.\d+(?:\.\d+)?)", str(value).strip())
+    return match.group(1) if match else None
+
+
+def _version_meets_prometheus_stats_min(version_token):
+    """Compare a numeric Ceph/RHCS version token against Prometheus stats minima."""
+    major = int(version_token.split(".")[0])
+    lv = LooseVersion(version_token)
+    if major < 10:
+        return lv >= LooseVersion(PROMETHEUS_STATS_MIN_RHCS_BUILD)
+    return lv >= LooseVersion(PROMETHEUS_STATS_MIN_UPSTREAM_BUILD)
+
+
+def prometheus_stats_supported_for_rhbuild(rhbuild, installed_version=None):
+    """
+    Return True when the Ceph/RHCS *version* supports Prometheus stats.
+
+    Only the numeric version is considered (e.g. ``20.2.2`` or ``9.2``).
+    Platform suffixes from ``run.py`` (``-rhel-9``, ``-rhel-10``, …) are
+    ignored — supported on both RHEL 9 and RHEL 10 when the Ceph version
+    meets the minimum.
+
+    Numeric RHCS builds (major < 10) require >= 9.2.
+    Numeric upstream/Ceph builds (major >= 10) require >= 20.2.2.
+
+    Named ``--release`` values (``main``, ``tentacle``, ``quincy``, …) are not
+    version numbers; *installed_version* from the cluster is used when present.
+    If the name cannot be resolved to a version, return True so the suite is not
+    silently skipped on current upstream distinct names.
+    """
+    token = _numeric_version_token(rhbuild)
+    if token:
+        return _version_meets_prometheus_stats_min(token)
+
+    installed_token = _numeric_version_token(installed_version)
+    if installed_token:
+        return _version_meets_prometheus_stats_min(installed_token)
+
+    if rhbuild:
+        # Named upstream release without a resolvable installed version.
+        log.info(
+            "rhbuild=%s is a named release and installed Ceph version is "
+            "unavailable; allowing NFS Prometheus stats suite to run",
+            rhbuild,
+        )
+        return True
+    return False
+
+
+def _installed_ceph_version_for_gate(ceph_cluster):
+    """Best-effort installed Ceph version string from the cluster, or None."""
+    if ceph_cluster is None:
+        return None
+    try:
+        from utility.utils import get_ceph_version_from_cluster
+
+        nodes = ceph_cluster.get_nodes(role="client") or ceph_cluster.get_nodes(
+            role="installer"
+        )
+        if not nodes:
+            return None
+        return get_ceph_version_from_cluster(nodes[0])
+    except Exception as exc:
+        log.warning("Unable to resolve installed Ceph version for gate: %s", exc)
+        return None
+
+
+def skip_prometheus_stats_tests_unless_supported(config=None, ceph_cluster=None):
+    """
+    Return True when NFS Prometheus stats tests should be skipped.
+
+    Uses ``config['rhbuild']`` (from cephci ``--rhbuild`` / ``--release``). For
+    named upstream releases, falls back to the installed cluster Ceph version.
+    Callers should ``return 0`` immediately when this is True.
+    """
+    config = config or {}
+    rhbuild = config.get("rhbuild")
+    installed_version = None
+    if not _numeric_version_token(rhbuild):
+        installed_version = _installed_ceph_version_for_gate(ceph_cluster)
+        if not installed_version:
+            # Optional hint from run.py when --upstream-build is numeric-ish.
+            installed_version = config.get("upstream_build")
+    if prometheus_stats_supported_for_rhbuild(
+        rhbuild, installed_version=installed_version
+    ):
+        return False
+    log.info(
+        "Skipping NFS Prometheus stats test: requires Ceph/RHCS version >= %s "
+        "(RHCS) or >= %s (upstream); rhbuild=%s (platform suffix ignored) "
+        "installed=%s",
+        PROMETHEUS_STATS_MIN_RHCS_BUILD,
+        PROMETHEUS_STATS_MIN_UPSTREAM_BUILD,
+        rhbuild,
+        installed_version,
+    )
+    return True
+
 
 # Ganesha 9.7 golden exposition (reference cluster 10.0.66.98:9587).
 # Core counters: rpcs_*, nfs_requests_total, client_requests_total, mdcache_cache_*.

--- a/tests/nfs/test_nfs_prometheus_stats.py
+++ b/tests/nfs/test_nfs_prometheus_stats.py
@@ -4,6 +4,8 @@ NFS-Ganesha Scalable Statistics (Prometheus) — CephCI automation.
 Each suite entry sets ``polarion-id`` on the test block (for reporting) and in
 ``config`` (for test dispatch). Internal plan IDs (S-01, F-02, etc.) are mapped
 in ``POLARION_TEST_IDS``.
+
+Requires RHCS ``--rhbuild`` >= 9.2 or Ceph >= 20.2.2. Older builds skip with exit 0.
 """
 
 from time import sleep
@@ -57,6 +59,7 @@ from tests.nfs.nfs_prometheus_stats_utils import (
     run_ganesha_stats_subcommands,
     scrape_prometheus_metrics,
     scrape_prometheus_metrics_http_code,
+    skip_prometheus_stats_tests_unless_supported,
     unmount_export,
     update_prometheus_ganesha_params,
     verify_client_label_present,
@@ -1274,17 +1277,45 @@ def test_n_01(ctx):
 
 
 def test_n_02(ctx):
+    """Non-/metrics path handling on the monitoring port.
+
+    Ganesha's Prometheus exporter is path-agnostic on Monitoring_Port and
+    commonly returns HTTP 200 with the same exposition for any URI (including
+    /not-metrics). Other implementations may return 404/403. Both are accepted.
+    Fail on an empty/broken 200 body, curl transport failure (HTTP code 000),
+    or any other unexpected status.
+    """
     code = scrape_prometheus_metrics_http_code(
         ctx.client, ctx.nfs_ip, ctx.monitoring_port, path="/not-metrics"
     )
+    if code == "000":
+        raise OperationFailedError(
+            "N-02: /not-metrics transport failure (curl http_code=000); "
+            "monitoring port may be down or unreachable"
+        )
     if code == "200":
-        raise OperationFailedError("N-02: /not-metrics unexpectedly returned HTTP 200")
-    if code not in ("404", "000", "403"):
-        log.info("Non-metrics path returned HTTP %s (acceptable non-200)", code)
-    log_test_passed(
-        "N-02",
-        "non-metrics path /not-metrics returned HTTP %s (not 200)" % code,
-    )
+        body = scrape_prometheus_metrics(
+            ctx.client, ctx.nfs_ip, ctx.monitoring_port, path="/not-metrics"
+        )
+        names = parse_prometheus_metrics(body)
+        if not names:
+            raise OperationFailedError(
+                "N-02: /not-metrics returned HTTP 200 but no parseable metrics"
+            )
+        log_test_passed(
+            "N-02",
+            "path-agnostic exporter: /not-metrics returned HTTP 200 with "
+            "%s metric families (Ganesha Monitoring_Port serves exposition "
+            "for any path)" % len(names),
+        )
+        return
+    if code in ("404", "403"):
+        log_test_passed(
+            "N-02",
+            "non-metrics path /not-metrics returned HTTP %s" % code,
+        )
+        return
+    raise OperationFailedError("N-02: /not-metrics returned unexpected HTTP %s" % code)
 
 
 def test_n_03(ctx):
@@ -1527,6 +1558,8 @@ def _log_subtest_result(
 
 def run(ceph_cluster, **kw):
     config = kw.get("config", {})
+    if skip_prometheus_stats_tests_unless_supported(config, ceph_cluster):
+        return 0
     polarion_id, test_ids = _resolve_test_ids(kw)
     for test_id in test_ids:
         if test_id not in TEST_HANDLERS:


### PR DESCRIPTION

Adding version check to run NFS Stats via prometheus from 9.2 or 20.2.2 version.. 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
