### PR TITLE
iscsi: run FIO sequentially with lighter time-based workload

### DIFF
--- a/tests/iscsi/workflows/initiator.py
+++ b/tests/iscsi/workflows/initiator.py
@@ -1,5 +1,4 @@
 from ceph.iscsi.initiator import ISCSIInitiator
-from ceph.parallel import parallel
 from tests.iscsi.workflows.iscsi_utils import fetch_tcmu_devices, format_iscsiadm_output
 from utility.log import Log
 from utility.utils import run_fio
@@ -45,23 +44,30 @@ class Initiator(ISCSIInitiator):
         self.node.exec_command(cmd="dnf install -y fio", sudo=True)
         targets = fetch_tcmu_devices(self.node)
         results = []
-        io_args = {"size": "100%"}
-        with parallel() as p:
-            for serial, target in targets.items():
-                LOG.info(f"Starting FIO for Disk UUID {serial} and {target}....")
-                _io_args = {}
-                _io_args.update(
-                    {
-                        "test_name": f"test-{target['mapper_path'].replace('/', '_')}",
-                        "device_name": target["mapper_path"],
-                        "client_node": self.node,
-                        "long_running": True,
-                    }
-                )
-                _io_args = {**io_args, **_io_args}
-                p.spawn(run_fio, **_io_args)
-            for op in p:
-                results.append(op)
+        io_args = {
+            "cmd_timeout": 300,
+            "io_type": "randrw",
+            "iodepth": "2",
+            "direct": "1",
+            "run_time": 60,
+        }
+
+        for serial, target in targets.items():
+            LOG.info(f"Starting FIO for Disk UUID {serial} and {target}....")
+            _io_args = {}
+            _io_args.update(
+                {
+                    "test_name": f"test-{target['mapper_path'].replace('/', '_')}",
+                    "device_name": target["mapper_path"],
+                    "client_node": self.node,
+                    "long_running": True,
+                }
+            )
+            _io_args = {**io_args, **_io_args}
+            result = run_fio(**_io_args)
+            results.append(result)
+            LOG.info(f"Completed FIO for {target['mapper_path']}")
+
         LOG.info("Completed all IO executions.....")
         return results
 


### PR DESCRIPTION
# Description

**Source of test case:** Regression test fix (iSCSI sanity failure on IBM Cloud CI)

The iSCSI sanity test (`suites/tentacle/iscsi/iscsi_sanity.yaml`) fails intermittently on IBM Cloud because `start_fio()` previously ran 5 parallel full-disk FIO writes (`--rw write --iodepth 8`, `size=100%`) on network-attached storage. Under I/O contention, operations could exceed the default 3600s timeout (`fio failed to execute within 3600 seconds`), even though iSCSI setup and the Ceph cluster were healthy.

This change updates `tests/iscsi/workflows/initiator.py` to improve CI reliability on IBM Cloud:

- Run FIO **sequentially** (one disk at a time) instead of in parallel
- Use a lighter FIO profile: `--rw randrw`, `--iodepth 2`, `--direct=1`
- Use time-based FIO (`run_time: 60`) instead of filling the full disk (`size=100%`)
- Set `cmd_timeout: 300` seconds per disk

This is a **test reliability / CI infrastructure** fix, not a Ceph product code change.

## Summary

- Run iSCSI FIO sequentially in `Initiator.start_fio()` to reduce I/O contention on IBM Cloud
- Change FIO workload from heavy sequential write/full-disk IO to lighter time-based `randrw`
- Use `iodepth=2`, `direct=1`, and `run_time=60`
- Add `cmd_timeout: 300` per FIO operation
- Remove unused `parallel` import from `initiator.py`

## Problem

- **Suite:** `suites/tentacle/iscsi/iscsi_sanity.yaml`
- **Failure:** Parallel FIO on 5 x 1GB iSCSI disks times out on IBM Cloud (timeout after 3600s)
- **Root cause:** Slower network block storage + parallel / heavy FIO contention in CI, not iSCSI/Ceph functional failure

## Solution

| Before                                         | After                                                                        |
|-------------------------------|------------------------------------------------|
| 5 parallel FIO jobs                     | Sequential FIO (one disk at a time)                      |
| --rw write --iodepth 8              | --rw randrw --iodepth 2 --direct=1                     |
| size=100% (fill full disk)           | run_time=60 (time-based)                                   |
| Default 3600s timeout             | 300s per disk (cmd_timeout)                               |
| Flaky on IBM Cloud sanity        | More predictable runtime (~5 min for 5 disks)   |

## Files changed

- `tests/iscsi/workflows/initiator.py`

## Test plan

- [x] Run `suites/tentacle/iscsi/iscsi_sanity.yaml` on IBM Cloud (`ibmc`) using branch `iscsi-fix`
- [x] Confirm logs show sequential `Starting FIO` / `Completed FIO` per disk
- [x] Confirm FIO uses `randrw`, `iodepth 2`, `direct 1`, `runtime 60`
- [x] Confirm no `failed to execute within` timeout errors

## Validation evidence

Tested 3 times on IBM 9.1; all passed:

- https://149.81.216.83/job/tentacle-test-executor/2374/
- https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-324/iscsi/2372/logs/
- https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-324/iscsi/2371/logs/