### PR TITLE
Adding automation for cross namespace copy feature for rhel initiators

### DIFF
--- a/ceph/nvmeof/initiators/linux/nvme_cli.py
+++ b/ceph/nvmeof/initiators/linux/nvme_cli.py
@@ -132,6 +132,74 @@ class NVMeCLI(Cli):
 
         return namespace_list if nsid_device_pair else devices
 
+    def id_ctrl(self, device, **kwargs):
+        """Identify controller.
+
+        Example::
+
+            kwargs:
+                output-format: json             # output format
+                human-readable: True            # human readable (-H)
+        """
+        return self.execute(
+            cmd=f"nvme id-ctrl {device} {config_dict_to_string(kwargs)}",
+            sudo=True,
+        )
+
+    def id_ns(self, device, **kwargs):
+        """Identify namespace.
+
+        Example::
+
+            kwargs:
+                namespace-id: 1                   # NSID
+                output-format: json             # output format
+                human-readable: True            # human readable (-H)
+        """
+        return self.execute(
+            cmd=f"nvme id-ns {device} {config_dict_to_string(kwargs)}",
+            sudo=True,
+        )
+
+    def copy(self, device, **kwargs):
+        """Execute NVMe Copy (CNC) command.
+
+        Destination is ``device``. Source ranges use ``slbs``, ``blocks``,
+        ``snsids`` (comma-separated for multi-range). Use ``format=2`` for
+        cross-namespace copy descriptors.
+
+        Example::
+
+            kwargs:
+                sdlba: 1000
+                slbs: 5000                      # or "5000,9000"
+                blocks: 1255                    # or "99,199"
+                snsids: 1                       # or "1,1"
+                format: 2
+        """
+        check_ec = kwargs.pop("check_ec", True)
+        return self.execute(
+            cmd=f"nvme copy {device} {config_dict_to_string(kwargs)}",
+            sudo=True,
+            check_ec=check_ec,
+        )
+
+    def read(self, device, **kwargs):
+        """Read logical blocks from an NVMe namespace.
+
+        Example::
+
+            kwargs:
+                start-block: 1000
+                block-count: 99                 # 0-based count (NLB - 1)
+                data-size: 51200
+                data: /tmp/region.bin
+        """
+        return self.execute(
+            cmd=f"nvme read {device} {config_dict_to_string(kwargs)}",
+            sudo=True,
+        )
+
     def disconnect(self, **kwargs):
         """Disconnect controller connected to the subsystem.
 

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_xcopy_rhel.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_xcopy_rhel.yaml
@@ -1,0 +1,229 @@
+# Ceph NVMe-oF XCOPY/CNC RHEL functional tests (P0)
+# Cross-NS copy verify, large-scale integrity, dual-GW ANA (RHEL)
+# cluster configuration file: conf/tentacle/nvmeof/ceph_nvmeof_2GW_1Client.yaml
+# inventory: conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml
+---
+tests:
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                allow-overwrite: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node6
+        copy_admin_keyring: true
+        install_packages:
+          - ceph-common
+      desc: Setup RHEL NVMe-oF initiator client
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+
+  # RHEL Cross-Namespace Copy with Data Verification
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node4
+          - node5
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: gw_group1
+        install: true
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        operation: cross_ns_copy_verify
+        enable_cnc_logging: true
+        cnc_config:
+          host_behav_support_cnc: true
+          chunk_nlb: 512
+          max_inflight: 8
+          rate_limit_bytes: 400000000
+        cleanup:
+          - subsystems
+          - initiators
+          - disconnect_all
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              - count: 2
+                size: 10G
+                ns_create_image: true
+            listeners:
+              - node4
+              - node5
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node6
+      desc: >
+        RHEL CNC same-NS, multi-range, cross-NS and large chunked
+        copies with data verification
+      destroy-cluster: false
+      module: test_nvmeof_xcopy_cnc_rhel.py
+      name: RHEL cross-namespace CNC copy with verification
+
+  # Large-Scale Data Integrity over Ceph NVMe-oF Namespaces
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node4
+          - node5
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: gw_group1
+        install: true
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        operation: full_volume_integrity
+        io_size: 5G
+        fio_bs: 1M
+        fio_iodepth: 32
+        stress_loop: true
+        stress_count: 50
+        cnc_config:
+          host_behav_support_cnc: true
+          chunk_nlb: 512
+          max_inflight: 8
+          rate_limit_bytes: 400000000
+        cleanup:
+          - subsystems
+          - initiators
+          - disconnect_all
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              - count: 2
+                size: 20G
+                ns_create_image: true
+            listeners:
+              - node4
+              - node5
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node6
+      desc: >
+        fio crc32c fill, CNC copy entire region, fio verify on destination
+      destroy-cluster: false
+      module: test_nvmeof_xcopy_cnc_rhel.py
+      name: large-scale CNC data integrity
+
+  # Dual-Gateway ANA with CNC (RHEL)
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node4
+          - node5
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: gw_group1
+        install: true
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        operation: ana_cnc
+        failover_mid_copy: true
+        large_blocks: 50000
+        cnc_config:
+          host_behav_support_cnc: true
+          chunk_nlb: 512
+          max_inflight: 8
+          rate_limit_bytes: 400000000
+        fault-injection-methods:
+          - tool: systemctl
+            nodes:
+              - node5
+        cleanup:
+          - subsystems
+          - initiators
+          - disconnect_all
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              - count: 2
+                size: 10G
+                ns_create_image: true
+            listeners:
+              - node4
+              - node5
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node6
+      desc: >
+        RHEL CNC via Active ANA path and mid-copy gateway failover
+        without silent data corruption
+      destroy-cluster: false
+      module: test_nvmeof_xcopy_cnc_rhel.py
+      name: dual-gateway ANA CNC normal and failover

--- a/tests/nvmeof/test_nvmeof_xcopy_cnc_rhel.py
+++ b/tests/nvmeof/test_nvmeof_xcopy_cnc_rhel.py
@@ -1,0 +1,93 @@
+"""
+RHEL initiator CNC / XCOPY tests for Ceph NVMe-oF.
+
+Config-driven operations:
+  - cross_ns_copy_verify
+  - ana_cnc
+  - full_volume_integrity
+  - perf_cnc_vs_host_rw
+  - cnc_soak
+"""
+
+from ceph.ceph import Ceph
+from tests.nvmeof.workflows.cnc import OPERATIONS
+from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Execute a RHEL CNC/XCOPY operation against Ceph NVMe-oF.
+
+    Example::
+
+        config:
+            gw_nodes: [node5, node6]
+            rbd_pool: rbd
+            install: true
+            operation: cross_ns_copy_verify
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode1
+                bdevs: [{count: 2, size: 10G, ns_create_image: true}]
+                listeners: [node5, node6]
+                listener_port: 4420
+                allow_host: "*"
+            initiators:
+              - nqn: connect-all
+                listener_port: 4420
+                node: node10
+            cleanup: [pool, gateway, initiators, subsystems]
+    """
+    config = kwargs["config"]
+    operation = config.get("operation")
+    if operation not in OPERATIONS:
+        raise ValueError(
+            f"Unknown or missing operation={operation}. "
+            f"Supported: {list(OPERATIONS)}"
+        )
+
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+
+        if config.get("install"):
+            nvme_service.deploy()
+
+        nvme_service.init_gateways()
+
+        if config.get("cleanup-only"):
+            teardown(nvme_service, rbd_obj)
+            return 0
+
+        if config.get("subsystems"):
+            configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        clients = prepare_io_execution(
+            config.get("initiators", []),
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        if not clients:
+            raise Exception("No NVMe initiators connected")
+
+        initiator = clients[0]
+        LOG.info(f"Running CNC operation '{operation}' on {initiator.node.hostname}")
+        OPERATIONS[operation](initiator, nvme_service.gateways, config)
+        return 0
+    except Exception as err:
+        LOG.error(err)
+    finally:
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)
+
+    return 1

--- a/tests/nvmeof/workflows/cnc.py
+++ b/tests/nvmeof/workflows/cnc.py
@@ -1,0 +1,966 @@
+"""CNC / XCOPY helpers for RHEL NVMe-oF initiator tests."""
+
+import json
+import re
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+from utility.log import Log
+from utility.utils import run_fio
+
+LOG = Log(__name__)
+
+DEFAULT_LBA_SIZE = 512
+# 4 MiB at 512-byte LBA
+BLOCKS_4MIB = 8192
+
+
+def _to_comma_list(value):
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(v) for v in value)
+    return str(value)
+
+
+def _blocks_to_nlb(block_count):
+    """Convert an actual block count to nvme-cli 0-based NLB (--blocks).
+
+    nvme-cli documents --blocks as zeroes-based values (same as NVMe NLB).
+    """
+    count = int(block_count)
+    if count < 1:
+        raise ValueError(f"block count must be >= 1, got {count}")
+    return count - 1
+
+
+def get_ns_devices(initiator):
+    """Return list of {Namespace, NSID} for Ceph SPDK drives."""
+    devices = initiator.list_spdk_drives(nsid_device_pair=True)
+    if not devices or len(devices) < 2:
+        raise Exception(f"CNC tests require at least 2 namespaces, found: {devices}")
+    LOG.info(f"CNC namespace devices: {devices}")
+    return devices
+
+
+def get_lba_size(initiator, device):
+    """Return namespace LBA size in bytes from id-ns (fallback 512)."""
+    try:
+        out, _ = initiator.id_ns(device, **{"output-format": "json"})
+        data = json.loads(out)
+        lbads = None
+        lbafs = data.get("lbafs")
+        if lbafs:
+            flbas = data.get("flbas", 0) & 0xF
+            if flbas < len(lbafs):
+                lbads = lbafs[flbas].get("ds")
+            if lbads is None:
+                lbads = lbafs[0].get("ds")
+        if lbads is None:
+            lbads = data.get("lbads")
+        if lbads is not None:
+            return 1 << int(lbads)
+    except Exception as err:
+        LOG.warning(f"Unable to parse LBA size from id-ns: {err}")
+    return DEFAULT_LBA_SIZE
+
+
+def assert_copy_capabilities(initiator, devices):
+    """Verify controller Copy support and namespace CNC advertisement.
+
+    Returns:
+        dict: {device: {"mcl": int, "mcd": int, "cfs": int, "lba_size": int}}
+    """
+    caps = {}
+    for entry in devices:
+        device = entry["Namespace"]
+        ctrl_out, _ = initiator.id_ctrl(device, **{"human-readable": True})
+        if "Copy" not in ctrl_out and "0x19" not in ctrl_out:
+            # JSON path fallback
+            ctrl_json, _ = initiator.id_ctrl(device, **{"output-format": "json"})
+            oncs = json.loads(ctrl_json).get("oncs", 0)
+            if not (int(oncs) & 0x100):
+                raise Exception(f"Controller {device} does not advertise Copy support")
+
+        ns_out, _ = initiator.id_ns(device, **{"human-readable": True})
+        ns_json, _ = initiator.id_ns(device, **{"output-format": "json"})
+        ns_data = json.loads(ns_json)
+
+        mcl = ns_data.get("mcl")
+        mcd = ns_data.get("mcd")
+        cfs = None
+        # NVMe copy format support may appear as 'cfs' in newer identify
+        if "cfs" in ns_data:
+            cfs = ns_data["cfs"]
+        elif re.search(r"cfs\s*[:=]\s*(\d+)", ns_out, re.I):
+            cfs = int(re.search(r"cfs\s*[:=]\s*(\d+)", ns_out, re.I).group(1))
+
+        if mcl is None:
+            match = re.search(r"mcl\s*[:=]\s*(\d+)", ns_out, re.I)
+            mcl = int(match.group(1)) if match else None
+        if mcd is None:
+            match = re.search(r"mcd\s*[:=]\s*(\d+)", ns_out, re.I)
+            mcd = int(match.group(1)) if match else None
+
+        lba_size = get_lba_size(initiator, device)
+        LOG.info(
+            f"NS {device} (NSID={entry['NSID']}): mcl={mcl} mcd={mcd} "
+            f"cfs={cfs} lba_size={lba_size}"
+        )
+        # cfs bit for format 2 is typically value including 2, or bitfield
+        if cfs is not None and int(cfs) not in (2, 3, 6, 7) and not (int(cfs) & 0x2):
+            LOG.warning(
+                f"Unexpected cfs={cfs} on {device}; continuing if copy succeeds"
+            )
+
+        caps[device] = {
+            "nsid": entry["NSID"],
+            "mcl": int(mcl) if mcl is not None else 65535,
+            "mcd": int(mcd) if mcd is not None else 128,
+            "cfs": cfs,
+            "lba_size": lba_size,
+        }
+    return caps
+
+
+def apply_cnc_config(gateways, cnc_config=None, enable_logging=True):
+    """Apply CNC RPC config (and optional logging) on all gateways."""
+    cfg = {
+        "host_behav_support_cnc": True,
+        "chunk_nlb": 512,
+        "max_inflight": 8,
+        "rate_limit_bytes": 400000000,
+    }
+    if cnc_config:
+        cfg.update(cnc_config)
+    for gw in gateways:
+        LOG.info(f"Applying CNC config on {gw.node.hostname}: {cfg}")
+        if enable_logging:
+            try:
+                gw.cnc_enable_logging()
+            except Exception as err:
+                LOG.warning(f"CNC logging enable failed on {gw.node.hostname}: {err}")
+        gw.cnc_set_config(**cfg)
+
+
+def write_verified_pattern(
+    node,
+    device,
+    size="100M",
+    offset=None,
+    verify="crc32c",
+    bs=None,
+    io_type="write",
+    lba_size=DEFAULT_LBA_SIZE,
+    iodepth=8,
+):
+    """Write (or read-verify) a fio pattern on a device."""
+    # Offset LBA writes must use LBA-sized blocks so size maps 1:1 to NLB counts.
+    # Bulk fills use a larger block size for acceptable runtime.
+    if bs is None:
+        bs = lba_size if offset is not None else "1M"
+    fio_args = {
+        "device_name": device,
+        "client_node": node,
+        "io_type": io_type,
+        "size": size,
+        "bs": bs,
+        "direct": 1,
+        "iodepth": iodepth,
+        "verify": verify,
+        "verify_fatal": 1,
+        "long_running": True,
+        "cmd_timeout": "notimeout",
+        "test_name": f"cnc-{io_type}-{device.replace('/', '_')}",
+    }
+    if offset is not None:
+        # run_fio does not expose offset; inject via custom fio invocation
+        offset_bytes = offset if isinstance(offset, int) else offset
+        cmd = (
+            f"fio --name={fio_args['test_name']} --ioengine=libaio "
+            f"--filename={device} --rw={io_type} --bs={bs} --size={size} "
+            f"--offset={offset_bytes} --direct=1 --verify={verify} "
+            f"--verify_fatal=1 --iodepth={iodepth} --group_reporting"
+        )
+        LOG.info(f"Running offset fio: {cmd}")
+        return node.exec_command(cmd=cmd, sudo=True, long_running=True, timeout=3600)
+    return run_fio(**fio_args)
+
+
+def nvme_copy_format2(
+    initiator,
+    dest_device,
+    sdlba,
+    slbs,
+    blocks,
+    snsids,
+    check_ec=True,
+    mcl=None,
+):
+    """Execute ``nvme copy --format=2``.
+
+    ``blocks`` is the actual number of logical blocks to copy per range.
+    Values are converted to 0-based NLBs for nvme-cli ``--blocks``.
+    ``mcl`` from id-ns is treated as a 0-based max NLB per range.
+    """
+    slbs_list = (
+        [int(x) for x in str(slbs).split(",")]
+        if not isinstance(slbs, (list, tuple))
+        else [int(x) for x in slbs]
+    )
+    blocks_list = (
+        [int(x) for x in str(blocks).split(",")]
+        if not isinstance(blocks, (list, tuple))
+        else [int(x) for x in blocks]
+    )
+    nlbs_list = [_blocks_to_nlb(b) for b in blocks_list]
+    if mcl is not None:
+        for count, nlb in zip(blocks_list, nlbs_list):
+            if nlb > int(mcl):
+                raise ValueError(
+                    f"Copy range length {count} (NLB={nlb}) exceeds mcl={mcl}"
+                )
+
+    kwargs = {
+        "sdlba": sdlba,
+        "slbs": _to_comma_list(slbs_list),
+        "blocks": _to_comma_list(nlbs_list),
+        "snsids": _to_comma_list(snsids),
+        "format": 2,
+        "check_ec": check_ec,
+    }
+    LOG.info(
+        f"nvme copy {dest_device} sdlba={sdlba} slbs={slbs_list} "
+        f"blocks(count)={blocks_list} blocks(nlb)={nlbs_list} snsids={snsids}"
+    )
+    start = time.time()
+    out = initiator.copy(dest_device, **kwargs)
+    elapsed = time.time() - start
+    LOG.info(f"nvme copy completed in {elapsed:.2f}s")
+    return out, elapsed
+
+
+def verify_copied_regions(
+    node,
+    src_device,
+    dst_device,
+    src_slba,
+    dst_slba,
+    blocks,
+    lba_size=DEFAULT_LBA_SIZE,
+):
+    """Compare source and destination LBA regions via dd + cmp."""
+    suffix = uuid.uuid4().hex
+    src_file = f"/tmp/cnc_src_{suffix}.bin"
+    dst_file = f"/tmp/cnc_dst_{suffix}.bin"
+    try:
+        node.exec_command(
+            cmd=(
+                f"dd if={src_device} of={src_file} bs={lba_size} "
+                f"skip={src_slba} count={blocks} status=none"
+            ),
+            sudo=True,
+        )
+        node.exec_command(
+            cmd=(
+                f"dd if={dst_device} of={dst_file} bs={lba_size} "
+                f"skip={dst_slba} count={blocks} status=none"
+            ),
+            sudo=True,
+        )
+        node.exec_command(cmd=f"cmp {src_file} {dst_file}", sudo=True)
+        LOG.info(
+            f"Verified {blocks} blocks: {src_device}@{src_slba} == "
+            f"{dst_device}@{dst_slba}"
+        )
+    finally:
+        node.exec_command(cmd=f"rm -f {src_file} {dst_file}", sudo=True)
+
+
+def copy_within_mcl(
+    initiator,
+    dest_device,
+    src_nsid,
+    src_slba,
+    dest_slba,
+    total_blocks,
+    mcl,
+    check_ec=True,
+):
+    """Issue one or more format-2 copies to cover total_blocks within mcl."""
+    remaining = int(total_blocks)
+    src_off = int(src_slba)
+    dst_off = int(dest_slba)
+    # mcl from id-ns is 0-based max NLB → max actual blocks per range is mcl+1
+    max_chunk = (int(mcl) + 1) if mcl is not None else remaining
+    total_elapsed = 0.0
+    while remaining > 0:
+        chunk = min(remaining, max_chunk)
+        _, elapsed = nvme_copy_format2(
+            initiator,
+            dest_device,
+            sdlba=dst_off,
+            slbs=src_off,
+            blocks=chunk,
+            snsids=src_nsid,
+            check_ec=check_ec,
+            mcl=mcl,
+        )
+        total_elapsed += elapsed
+        remaining -= chunk
+        src_off += chunk
+        dst_off += chunk
+    return total_elapsed
+
+
+def host_rw_baseline(node, src_device, dst_device, size_bytes, bs=DEFAULT_LBA_SIZE):
+    """Sequential host read from source and write to destination (no CNC)."""
+    tmp = f"/tmp/cnc_host_rw_{int(time.time())}.bin"
+    start = time.time()
+    try:
+        node.exec_command(
+            cmd=f"dd if={src_device} of={tmp} bs={bs} count={size_bytes // bs} status=none",
+            sudo=True,
+            long_running=True,
+            timeout=7200,
+        )
+        node.exec_command(
+            cmd=f"dd if={tmp} of={dst_device} bs={bs} count={size_bytes // bs} status=none "
+            f"conv=fsync",
+            sudo=True,
+            long_running=True,
+            timeout=7200,
+        )
+    finally:
+        node.exec_command(cmd=f"rm -f {tmp}", sudo=True)
+    return time.time() - start
+
+
+def run_cnc_loop(
+    initiator,
+    dest_device,
+    src_nsid,
+    count=500,
+    blocks=BLOCKS_4MIB,
+    src_base_slba=0,
+    dest_base_slba=0,
+    mcl=None,
+):
+    """Run sequential CNC copies (default 500 x 4MiB)."""
+    start = time.time()
+    for i in range(count):
+        src_slba = src_base_slba + (i * blocks)
+        dst_slba = dest_base_slba + (i * blocks)
+        nvme_copy_format2(
+            initiator,
+            dest_device,
+            sdlba=dst_slba,
+            slbs=src_slba,
+            blocks=blocks,
+            snsids=src_nsid,
+            mcl=mcl,
+        )
+    elapsed = time.time() - start
+    LOG.info(f"CNC loop {count}x{blocks} blocks finished in {elapsed:.2f}s")
+    return elapsed
+
+
+def sample_gateway_resources(gateways):
+    """Sample CPU and RSS for nvmeof processes on each gateway."""
+    samples = []
+    for gw in gateways:
+        try:
+            out, _ = gw.node.exec_command(
+                cmd=(
+                    "ps -eo pid,pcpu,rss,comm,args | "
+                    "grep -E 'nvmf|spdk|nvmeof' | grep -v grep || true"
+                ),
+                sudo=True,
+            )
+            samples.append(
+                {
+                    "host": gw.node.hostname,
+                    "timestamp": time.time(),
+                    "ps": out.strip(),
+                }
+            )
+            LOG.info(f"GW resource sample [{gw.node.hostname}]:\n{out}")
+        except Exception as err:
+            LOG.warning(f"Resource sample failed on {gw.node.hostname}: {err}")
+    return samples
+
+
+def find_gateway_by_ip(gateways, ip):
+    for gw in gateways:
+        if gw.node.ip_address == ip:
+            return gw
+    return None
+
+
+def ana_active_path_copy(
+    initiator,
+    gateways,
+    src_device,
+    dest_device,
+    src_nsid,
+    dest_nsid,
+    caps,
+    blocks=1255,
+    src_slba=5000,
+    dest_slba=1000,
+):
+    """Document Active ANA path and run a cross-NS copy; verify data."""
+    paths = initiator.fetch_anastate(dest_device)
+    LOG.info(f"ANA paths for dest {dest_device}: {paths}")
+    if not paths.get("optimized"):
+        raise Exception(f"No optimized ANA path for {dest_device}")
+
+    active_ip = paths["optimized"][0]
+    active_gw = find_gateway_by_ip(gateways, active_ip)
+    LOG.info(
+        f"Active ANA gateway for NSID {dest_nsid}: "
+        f"{active_gw.node.hostname if active_gw else active_ip}"
+    )
+
+    lba_size = caps[src_device]["lba_size"]
+    write_verified_pattern(
+        initiator.node,
+        src_device,
+        size=blocks * lba_size,
+        offset=src_slba * lba_size,
+    )
+    nvme_copy_format2(
+        initiator,
+        dest_device,
+        sdlba=dest_slba,
+        slbs=src_slba,
+        blocks=blocks,
+        snsids=src_nsid,
+        mcl=caps[src_device]["mcl"],
+    )
+    verify_copied_regions(
+        initiator.node,
+        src_device,
+        dest_device,
+        src_slba,
+        dest_slba,
+        blocks,
+        lba_size=lba_size,
+    )
+    return paths
+
+
+def ana_failover_during_copy(
+    initiator,
+    gateways,
+    dest_device,
+    src_nsid,
+    src_device,
+    caps,
+    fault_nodes=None,
+    large_blocks=50000,
+):
+    """Start a large CNC, stop Active GW mid-copy, verify no silent corruption.
+
+    Accepts clean failure or successful retry; fails only on data mismatch when
+    the copy reports success.
+    """
+    paths = initiator.fetch_anastate(dest_device)
+    if not paths.get("optimized"):
+        raise Exception(f"No optimized ANA path for {dest_device}")
+    active_ip = paths["optimized"][0]
+    active_gw = find_gateway_by_ip(gateways, active_ip)
+    if active_gw is None:
+        raise Exception(f"Could not map active ANA IP {active_ip} to a gateway")
+
+    # Prefer fault_nodes from suite config if they match active
+    target_gw = active_gw
+    if fault_nodes:
+        for gw in gateways:
+            if gw.node.id in fault_nodes or gw.node.hostname in fault_nodes:
+                # still failover the currently active path
+                pass
+
+    lba_size = caps[src_device]["lba_size"]
+    mcl = caps[src_device]["mcl"]
+    blocks = min(int(large_blocks), int(mcl) + 1)
+    src_slba = 2000
+    dest_slba = 5000
+
+    write_verified_pattern(
+        initiator.node,
+        src_device,
+        size=blocks * lba_size,
+        offset=src_slba * lba_size,
+    )
+
+    copy_error = None
+    copy_ok = False
+
+    def _do_copy():
+        return nvme_copy_format2(
+            initiator,
+            dest_device,
+            sdlba=dest_slba,
+            slbs=src_slba,
+            blocks=blocks,
+            snsids=src_nsid,
+            check_ec=True,
+            mcl=mcl,
+        )
+
+    LOG.info(f"Stopping Active gateway {target_gw.node.hostname} mid-copy")
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_do_copy)
+        time.sleep(1)
+        target_gw.systemctl.stop(target_gw.system_unit_id)
+        try:
+            result, _elapsed = future.result(timeout=600)
+            copy_ok = True
+            LOG.info(f"Copy finished successfully after failover: {result}")
+        except Exception as err:
+            copy_error = err
+            LOG.warning(f"Copy failed or timed out during failover (acceptable): {err}")
+
+    # Restore gateway
+    LOG.info(f"Restoring gateway {target_gw.node.hostname}")
+    target_gw.systemctl.start(target_gw.system_unit_id)
+    time.sleep(30)
+
+    if copy_ok:
+        try:
+            verify_copied_regions(
+                initiator.node,
+                src_device,
+                dest_device,
+                src_slba,
+                dest_slba,
+                blocks,
+                lba_size=lba_size,
+            )
+        except Exception as err:
+            raise Exception(
+                f"Silent corruption after mid-copy failover: {err}"
+            ) from err
+    else:
+        LOG.info(
+            f"Failover mid-copy resulted in clean failure "
+            f"(no success to verify): {copy_error}"
+        )
+
+
+def run_cross_ns_copy_verify(initiator, gateways, config=None):
+    """Same-NS, multi-range, cross-NS, and large chunked copies."""
+    config = config or {}
+    devices = get_ns_devices(initiator)
+    caps = assert_copy_capabilities(initiator, devices)
+    apply_cnc_config(
+        gateways,
+        cnc_config=config.get("cnc_config"),
+        enable_logging=config.get("enable_cnc_logging", True),
+    )
+
+    src = devices[0]
+    dst = devices[1]
+    src_dev, src_nsid = src["Namespace"], src["NSID"]
+    dst_dev, dst_nsid = dst["Namespace"], dst["NSID"]
+    lba_size = caps[src_dev]["lba_size"]
+    mcl = caps[src_dev]["mcl"]
+    node = initiator.node
+
+    # --- same-NS single-range ---
+    same_blocks = int(config.get("same_ns_blocks", 1255))
+    src_slba = int(config.get("src_slba", 5000))
+    dst_slba = int(config.get("dst_slba", 1000))
+    write_verified_pattern(
+        node, src_dev, size=same_blocks * lba_size, offset=src_slba * lba_size
+    )
+    # Destination is same namespace device for same-NS copy
+    nvme_copy_format2(
+        initiator,
+        src_dev,
+        sdlba=dst_slba,
+        slbs=src_slba,
+        blocks=same_blocks,
+        snsids=src_nsid,
+        mcl=mcl,
+    )
+    verify_copied_regions(
+        node, src_dev, src_dev, src_slba, dst_slba, same_blocks, lba_size=lba_size
+    )
+    LOG.info("Same-NS single-range copy verified")
+
+    # --- multi-range same-NS ---
+    r1_slba, r1_blocks = 5000, 99
+    r2_slba, r2_blocks = 9000, 199
+    multi_dst = 1000
+    write_verified_pattern(
+        node, src_dev, size=r1_blocks * lba_size, offset=r1_slba * lba_size
+    )
+    write_verified_pattern(
+        node, src_dev, size=r2_blocks * lba_size, offset=r2_slba * lba_size
+    )
+    nvme_copy_format2(
+        initiator,
+        src_dev,
+        sdlba=multi_dst,
+        slbs=[r1_slba, r2_slba],
+        blocks=[r1_blocks, r2_blocks],
+        snsids=[src_nsid, src_nsid],
+        mcl=mcl,
+    )
+    verify_copied_regions(
+        node, src_dev, src_dev, r1_slba, multi_dst, r1_blocks, lba_size=lba_size
+    )
+    verify_copied_regions(
+        node,
+        src_dev,
+        src_dev,
+        r2_slba,
+        multi_dst + r1_blocks,
+        r2_blocks,
+        lba_size=lba_size,
+    )
+    LOG.info("Multi-range same-NS copy verified")
+
+    # --- cross-NS ---
+    cross_blocks = int(config.get("cross_ns_blocks", 1255))
+    cross_src_slba = int(config.get("cross_src_slba", 0))
+    cross_dst_slba = int(config.get("cross_dst_slba", 0))
+    write_verified_pattern(
+        node, src_dev, size=cross_blocks * lba_size, offset=cross_src_slba * lba_size
+    )
+    nvme_copy_format2(
+        initiator,
+        dst_dev,
+        sdlba=cross_dst_slba,
+        slbs=cross_src_slba,
+        blocks=cross_blocks,
+        snsids=src_nsid,
+        mcl=mcl,
+    )
+    verify_copied_regions(
+        node,
+        src_dev,
+        dst_dev,
+        cross_src_slba,
+        cross_dst_slba,
+        cross_blocks,
+        lba_size=lba_size,
+    )
+    LOG.info(f"Cross-NS copy NSID{src_nsid}->NSID{dst_nsid} verified")
+
+    # --- large copy within mcl (chunking) ---
+    large_blocks = min(int(config.get("large_blocks", 50000)), mcl + 1)
+    large_src = int(config.get("large_src_slba", 2000))
+    large_dst = int(config.get("large_dst_slba", 5000))
+    # Ensure chunk_nlb is set for chunking exercise
+    apply_cnc_config(
+        gateways,
+        cnc_config={**(config.get("cnc_config") or {}), "chunk_nlb": 512},
+        enable_logging=True,
+    )
+    write_verified_pattern(
+        node, src_dev, size=large_blocks * lba_size, offset=large_src * lba_size
+    )
+    elapsed = copy_within_mcl(
+        initiator,
+        dst_dev,
+        src_nsid,
+        large_src,
+        large_dst,
+        large_blocks,
+        mcl,
+    )
+    verify_copied_regions(
+        node, src_dev, dst_dev, large_src, large_dst, large_blocks, lba_size=lba_size
+    )
+    sample_gateway_resources(gateways)
+    for gw in gateways:
+        try:
+            logs = gw.cnc_get_container_logs(lines=100)
+            if "cnc" in logs.lower() or "chunk" in logs.lower():
+                LOG.info(f"CNC/chunk references found in {gw.node.hostname} logs")
+            else:
+                LOG.warning(
+                    f"No obvious CNC/chunk log lines on {gw.node.hostname} "
+                    "(build may use different log tags)"
+                )
+        except Exception as err:
+            LOG.warning(f"Could not fetch CNC logs: {err}")
+    LOG.info(f"Large chunked copy verified in {elapsed:.2f}s")
+
+
+def run_full_volume_integrity(initiator, gateways, config=None):
+    """Fio verify fill → CNC copy → fio verify on destination."""
+    config = config or {}
+    devices = get_ns_devices(initiator)
+    caps = assert_copy_capabilities(initiator, devices)
+    apply_cnc_config(gateways, cnc_config=config.get("cnc_config"))
+
+    src = devices[0]
+    dst = devices[1]
+    src_dev, src_nsid = src["Namespace"], src["NSID"]
+    dst_dev = dst["Namespace"]
+    mcl = caps[src_dev]["mcl"]
+    lba_size = caps[src_dev]["lba_size"]
+    io_size = config.get("io_size", "5G")
+    iodepth = int(config.get("fio_iodepth", 32))
+    fio_bs = config.get("fio_bs", "1M")
+
+    LOG.info(
+        f"Filling {src_dev} with {io_size} "
+        f"(bs={fio_bs}, verify=crc32c, iodepth={iodepth})"
+    )
+    write_verified_pattern(
+        initiator.node,
+        src_dev,
+        size=io_size,
+        verify="crc32c",
+        bs=fio_bs,
+        iodepth=iodepth,
+    )
+
+    # Convert io_size to blocks for CNC
+    size_bytes = _parse_size(io_size)
+    total_blocks = size_bytes // lba_size
+    start = time.time()
+    copy_within_mcl(initiator, dst_dev, src_nsid, 0, 0, total_blocks, mcl)
+    elapsed = time.time() - start
+    LOG.info(f"Full-volume CNC copy of {io_size} took {elapsed:.2f}s")
+
+    write_verified_pattern(
+        initiator.node,
+        dst_dev,
+        size=io_size,
+        verify="crc32c",
+        bs=fio_bs,
+        io_type="read",
+        iodepth=iodepth,
+    )
+    LOG.info("Destination fio read-verify passed")
+
+    if config.get("stress_loop"):
+        run_cnc_loop(
+            initiator,
+            dst_dev,
+            src_nsid,
+            count=int(config.get("stress_count", 500)),
+            blocks=int(config.get("stress_blocks", BLOCKS_4MIB)),
+            mcl=mcl,
+        )
+
+
+def run_perf_cnc_vs_host_rw(initiator, gateways, config=None):
+    """Time 500x4MB CNC vs host read/write baseline."""
+    config = config or {}
+    devices = get_ns_devices(initiator)
+    caps = assert_copy_capabilities(initiator, devices)
+    apply_cnc_config(gateways, cnc_config=config.get("cnc_config"))
+
+    src = devices[0]
+    dst = devices[1]
+    src_dev, src_nsid = src["Namespace"], src["NSID"]
+    dst_dev = dst["Namespace"]
+    mcl = caps[src_dev]["mcl"]
+    lba_size = caps[src_dev]["lba_size"]
+    count = int(config.get("copy_count", 500))
+    blocks = int(config.get("copy_blocks", BLOCKS_4MIB))
+    total_bytes = count * blocks * lba_size
+
+    write_verified_pattern(initiator.node, src_dev, size=total_bytes, verify="crc32c")
+
+    t1 = run_cnc_loop(initiator, dst_dev, src_nsid, count=count, blocks=blocks, mcl=mcl)
+    verify_copied_regions(
+        initiator.node,
+        src_dev,
+        dst_dev,
+        0,
+        0,
+        min(blocks, 1024),
+        lba_size=lba_size,
+    )
+
+    # Baseline on a cleared destination region — use second half if space, else overwrite
+    t2 = host_rw_baseline(
+        initiator.node, src_dev, dst_dev, size_bytes=total_bytes, bs=lba_size
+    )
+    verify_copied_regions(
+        initiator.node,
+        src_dev,
+        dst_dev,
+        0,
+        0,
+        min(blocks, 1024),
+        lba_size=lba_size,
+    )
+
+    speedup = t2 / t1 if t1 > 0 else 0
+    LOG.info(
+        f"Perf CNC vs host R/W: T1(cnc)={t1:.2f}s T2(host)={t2:.2f}s "
+        f"speedup={speedup:.2f}x size={total_bytes} bytes"
+    )
+    min_speedup = config.get("min_speedup")
+    if min_speedup is not None and speedup < float(min_speedup):
+        raise Exception(f"CNC speedup {speedup:.2f}x below min_speedup={min_speedup}")
+    return {"t1": t1, "t2": t2, "speedup": speedup}
+
+
+def run_ana_cnc(initiator, gateways, config=None):
+    """Active-path copy, secondary path observation, mid-copy failover."""
+    config = config or {}
+    devices = get_ns_devices(initiator)
+    caps = assert_copy_capabilities(initiator, devices)
+    apply_cnc_config(gateways, cnc_config=config.get("cnc_config"))
+
+    src = devices[0]
+    dst = devices[1]
+    src_dev, src_nsid = src["Namespace"], src["NSID"]
+    dst_dev, dst_nsid = dst["Namespace"], dst["NSID"]
+
+    paths = ana_active_path_copy(
+        initiator, gateways, src_dev, dst_dev, src_nsid, dst_nsid, caps
+    )
+
+    # Document secondary / inaccessible path presence (connect-all keeps multipath)
+    if paths.get("inaccessible"):
+        LOG.info(f"Secondary/inaccessible ANA paths: {paths['inaccessible']}")
+    else:
+        LOG.info("No inaccessible ANA paths reported (both may be optimized per NS)")
+
+    # Re-run copy (still via multipath; Active path should service dest NS)
+    ana_active_path_copy(
+        initiator,
+        gateways,
+        src_dev,
+        dst_dev,
+        src_nsid,
+        dst_nsid,
+        caps,
+        src_slba=6000,
+        dest_slba=2000,
+    )
+
+    if config.get("failover_mid_copy", True):
+        fault_nodes = []
+        for method in config.get("fault-injection-methods", []):
+            nodes = method.get("nodes", [])
+            if isinstance(nodes, str):
+                nodes = [nodes]
+            fault_nodes.extend(nodes)
+        ana_failover_during_copy(
+            initiator,
+            gateways,
+            dst_dev,
+            src_nsid,
+            src_dev,
+            caps,
+            fault_nodes=fault_nodes,
+            large_blocks=int(config.get("large_blocks", 50000)),
+        )
+
+
+def run_cnc_soak(initiator, gateways, config=None):
+    """Sustained CNC soak: continuous CNC loops with resource sampling."""
+    config = config or {}
+    devices = get_ns_devices(initiator)
+    caps = assert_copy_capabilities(initiator, devices)
+    apply_cnc_config(
+        gateways,
+        cnc_config=config.get(
+            "cnc_config",
+            {
+                "host_behav_support_cnc": True,
+                "rate_limit_bytes": 400000000,
+                "max_inflight": 8,
+                "chunk_nlb": 512,
+            },
+        ),
+    )
+
+    src = devices[0]
+    dst = devices[1]
+    src_dev, src_nsid = src["Namespace"], src["NSID"]
+    dst_dev = dst["Namespace"]
+    mcl = caps[src_dev]["mcl"]
+    lba_size = caps[src_dev]["lba_size"]
+    duration_min = int(config.get("duration_min", 30))
+    sample_interval = int(config.get("sample_interval_sec", 300))
+    spot_minutes = config.get("spot_check_minutes", [15, 30, 60])
+    blocks = min(int(config.get("copy_blocks", BLOCKS_4MIB)), mcl + 1)
+    loop_count = int(config.get("loop_copies", 50))
+
+    # Prepare source pattern large enough for one loop
+    prep_size = loop_count * blocks * lba_size
+    write_verified_pattern(initiator.node, src_dev, size=prep_size, verify="crc32c")
+
+    end_time = time.time() + (duration_min * 60)
+    next_sample = time.time()
+    spot_done = set()
+    start = time.time()
+    iteration = 0
+
+    while time.time() < end_time:
+        iteration += 1
+        LOG.info(f"Soak iteration {iteration}")
+        run_cnc_loop(
+            initiator,
+            dst_dev,
+            src_nsid,
+            count=loop_count,
+            blocks=blocks,
+            mcl=mcl,
+        )
+        now = time.time()
+        if now >= next_sample:
+            sample_gateway_resources(gateways)
+            next_sample = now + sample_interval
+
+        elapsed_min = (now - start) / 60
+        for mark in spot_minutes:
+            if mark <= duration_min and mark not in spot_done and elapsed_min >= mark:
+                LOG.info(f"Soak spot-check at {mark} minutes")
+                verify_copied_regions(
+                    initiator.node,
+                    src_dev,
+                    dst_dev,
+                    0,
+                    0,
+                    min(blocks, 1024),
+                    lba_size=lba_size,
+                )
+                spot_done.add(mark)
+
+    sample_gateway_resources(gateways)
+    verify_copied_regions(
+        initiator.node,
+        src_dev,
+        dst_dev,
+        0,
+        0,
+        min(blocks, 1024),
+        lba_size=lba_size,
+    )
+    LOG.info(f"Soak completed: {iteration} iterations over {duration_min} minutes")
+
+
+def _parse_size(size_str):
+    """Parse size strings like 10G, 100M, 2048 into bytes."""
+    if isinstance(size_str, int):
+        return size_str
+    size_str = str(size_str).strip().upper()
+    units = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+    match = re.match(r"^(\d+(?:\.\d+)?)\s*([KMGT]?)B?$", size_str)
+    if not match:
+        raise ValueError(f"Unrecognized size: {size_str}")
+    value = float(match.group(1))
+    unit = match.group(2) or "B"
+    return int(value * units[unit])
+
+
+OPERATIONS = {
+    "cross_ns_copy_verify": run_cross_ns_copy_verify,
+    "full_volume_integrity": run_full_volume_integrity,
+    "perf_cnc_vs_host_rw": run_perf_cnc_vs_host_rw,
+    "ana_cnc": run_ana_cnc,
+    "cnc_soak": run_cnc_soak,
+}

--- a/tests/nvmeof/workflows/nvme_gateway.py
+++ b/tests/nvmeof/workflows/nvme_gateway.py
@@ -75,16 +75,26 @@ class NVMeGatewayBase:
         raise NotImplementedError
 
     def get_nvme_container(self):
-        """Fetch NVMeoF GW container id."""
-        args = {"filter": "label=name=ceph-nvmeof", "quite": True}
-        return get_running_containers(self.node, **args)
+        """Fetch NVMeoF GW container id (string)."""
+        out, _ = get_running_containers(
+            self.node,
+            expr="name=nvmeof",
+            format="{{.ID}}",
+            sudo=True,
+        )
+        container_ids = [line.strip() for line in out.splitlines() if line.strip()]
+        if not container_ids:
+            raise RuntimeError(f"No NVMe-oF container found on {self.node.hostname}")
+        return container_ids[0]
 
     def get_ana_states(self, subsystem, ana_groups):
         """Fetch ANA states from NVMeoF GW container."""
         cmd = (
             f"/usr/libexec/spdk/scripts/rpc.py nvmf_subsystem_get_listeners {subsystem}"
         )
-        out, _ = exec_command_on_container(self.node, self.get_nvme_container(), cmd)
+        out, _ = exec_command_on_container(
+            self.node, self.get_nvme_container(), cmd, sudo=True
+        )
         out = loads(out)[0]["ana_states"]
 
         optimized, inaccessible = [], []
@@ -98,6 +108,53 @@ class NVMeGatewayBase:
                     inaccessible.append(ana_group_id)
 
         return optimized, inaccessible
+
+    def _rpc(self, rpc_cmd):
+        """Run an SPDK rpc.py command inside the NVMe-oF gateway container."""
+        cmd = f"/usr/libexec/spdk/scripts/rpc.py {rpc_cmd}"
+        return exec_command_on_container(
+            self.node, self.get_nvme_container(), cmd, sudo=True
+        )
+
+    def cnc_set_config(self, **params):
+        """Configure CNC via ``nvmf_cnc_set_config``.
+
+        Args:
+            host_behav_support_cnc: bool (default True)
+            rate_limit_bytes: int
+            max_inflight: int
+            chunk_nlb: int
+        """
+        support = params.get("host_behav_support_cnc", True)
+        support_flag = (
+            "--host-behav-support-cnc" if support else "--host-behav-support-cnc false"
+        )
+        parts = [f"nvmf_cnc_set_config {support_flag}"]
+        if params.get("rate_limit_bytes") is not None:
+            parts.append(f"--rate-limit-bytes {params['rate_limit_bytes']}")
+        if params.get("max_inflight") is not None:
+            parts.append(f"--max-inflight {params['max_inflight']}")
+        if params.get("chunk_nlb") is not None:
+            parts.append(f"--chunk-nlb {params['chunk_nlb']}")
+        return self._rpc(" ".join(parts))
+
+    def cnc_enable_logging(self, level="DEBUG"):
+        """Enable nvmf_cnc debug logging on the gateway.
+
+        SPDK rpc.py takes positional args: ``log_set_flag <flag>`` and
+        ``log_set_level <level>`` (not ``-i``).
+        """
+        self._rpc("log_set_flag nvmf_cnc")
+        return self._rpc(f"log_set_level {level}")
+
+    def cnc_get_container_logs(self, lines=200):
+        """Fetch recent gateway container logs for CNC diagnostics."""
+        ctr = self.get_nvme_container()
+        out, _ = self.node.exec_command(
+            cmd=f"podman logs --tail {lines} {ctr}",
+            sudo=True,
+        )
+        return out
 
 
 class NVMeGatewayV1(NVMeGatewayBase, NVMeGWCLI):


### PR DESCRIPTION
### Summary
Adds CephCI automation for RHEL-initiator NVMe-oF CNC / cross-namespace copy (XCOPY) coverage on Tentacle.

### Framework / helpers

- Extended NVMeCLI with id-ctrl, id-ns, copy, and read for CNC capability checks and format-2 copy.
- Extended NVMe-oF gateway workflows with CNC RPC helpers (nvmf_cnc_set_config, logging enable, container log fetch) and fixed get_nvme_container() to return a real container ID (with sudo) so gateway RPC calls work.
- Added tests/nvmeof/workflows/cnc.py with reusable helpers for:
- Copy capability advertisement (mcl / format 2)
- Pattern write + region verify (fio / dd+cmp)
- nvme copy --format=2 (including correct 0-based NLB conversion for --blocks)
- Multi-chunk copy within mcl
- Dual-GW ANA active-path copy and mid-copy failover integrity checks

### Test module
Added config-driven tests/nvmeof/test_nvmeof_xcopy_cnc_rhel.py with operations:

- cross_ns_copy_verify
- full_volume_integrity
- ana_cnc

### Suites
suites/tentacle/nvmeof/tier-2_nvmeof_xcopy_rhel.yaml

### Success Logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4IY0QX/ 