### PR TITLE
CephFS 9.2 - Adding Subvolume Quarantine Functional Tests

### DIFF
--- a/suites/tentacle/cephfs/tier-1_cephfs_subvolume_quarantine.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_subvolume_quarantine.yaml
@@ -1,0 +1,158 @@
+---
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier-1_cephfs_subvolume_quarantine
+# Conf file : conf/tentacle/cephfs/tier-2_cephfs_7-node-cluster.yaml
+# Feature   : CephFS Subvolume Quarantine (MR !1929 / tracker 73007)
+# Polarion  : CEPH-83632677 (Sanity) | CEPH-83632678 (Functional) | CEPH-83632679 (Negative)
+# Structure : 3 suite blocks — each module runs all scenarios as subtests
+#===============================================================================================
+tests:
+  # ---------------------------------------------------------------------------
+  # Cluster setup
+  # ---------------------------------------------------------------------------
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisites"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow with CephFS volume and MDS.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573740
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:
+                verbose: true
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure CephFS client 1 (admin CLI)"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client 1"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure CephFS client 2 (fuse I/O)"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client 2"
+
+  # ---------------------------------------------------------------------------
+  # 1. Sanity (Acceptance) — all scenarios as subtests
+  # ---------------------------------------------------------------------------
+  -
+    test:
+      abort-on-fail: false
+      name: "qtn_sanity"
+      desc: "CephFS subvolume quarantine — Sanity/Acceptance (A1–A3 + lifecycle/isolation/mds/e2e)"
+      module: cephfs_subvol_quarantine.test_subvolume_quarantine_sanity.py
+      polarion-id: CEPH-83632677
+      config:
+        fs_name: cephfs
+
+  # ---------------------------------------------------------------------------
+  # 2. Functional — all scenarios as subtests
+  # ---------------------------------------------------------------------------
+  -
+    test:
+      abort-on-fail: false
+      name: "qtn_functional"
+      desc: "CephFS subvolume quarantine — Functional F-01..F-18"
+      module: cephfs_subvol_quarantine.test_subvolume_quarantine_functional.py
+      polarion-id: CEPH-83632678
+      config:
+        fs_name: cephfs
+
+  # ---------------------------------------------------------------------------
+  # 3. Negative — all scenarios as subtests
+  # ---------------------------------------------------------------------------
+  -
+    test:
+      abort-on-fail: false
+      name: "qtn_negative"
+      desc: "CephFS subvolume quarantine — Negative N-01..N-04"
+      module: cephfs_subvol_quarantine.test_subvolume_quarantine_negative.py
+      polarion-id: CEPH-83632679
+      config:
+        fs_name: cephfs

--- a/tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_functional.py
+++ b/tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_functional.py
@@ -1,0 +1,1128 @@
+"""
+CephFS Subvolume Quarantine — Functional workflows.
+
+Polarion: CEPH-83632678
+Suite block: Functional
+
+Subtests F-01 .. F-18 map to the Functional test plan.
+No workarounds for regressions against the MGR contract:
+  - getpath blocked while quarantined
+  - ls enabled (names only, no quarantine indication)
+  - info: non-quarantined full payload with quarantine="disabled";
+         quarantined minimal payload with quarantine="enabled"
+F-18 (encrypted) is N/A until GKLM/fscrypt lab is available.
+"""
+
+import json
+import re
+import shlex
+import time
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from tests.cephfs.lib.cephfs_subvol_quarantine_utils import SubvolQuarantineUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+BASELINE_FILE = "testfile.txt"
+
+
+def _cfg(config, key, default):
+    return config.get(key, default)
+
+
+def _prepare(ceph_cluster, config):
+    fs_util = FsUtils(ceph_cluster)
+    qtn = SubvolQuarantineUtils(ceph_cluster)
+    clients = ceph_cluster.get_ceph_objects("client")
+    if len(clients) < 2:
+        log.error("Need at least 2 client nodes; found %d", len(clients))
+        return None
+
+    build = config.get("build", config.get("rhbuild"))
+    fs_util.prepare_clients(clients[:2], build)
+    fs_util.auth_list(clients[:2])
+
+    admin = clients[0]
+    fuse = clients[1]
+    if not qtn.feature_available(admin):
+        log.error("Subvolume quarantine CLI not available — mark NA")
+        return None
+
+    return qtn, fs_util, admin, fuse, config.get("fs_name", "cephfs")
+
+
+def _umount_all(qtn, client, mounts):
+    for mnt in mounts:
+        qtn.umount_fuse(client, mnt)
+
+
+def _del_clients(qtn, admin, names):
+    for name in names:
+        qtn.delete_client(admin, name)
+
+
+def _rm_sv(qtn, admin, vol, sub, group=None):
+    qtn.cleanup_subvolume(admin, vol, sub, group_name=group)
+
+
+def _rm_group(fs_util, admin, vol, group):
+    try:
+        fs_util.remove_subvolumegroup(
+            admin, vol, group, force=True, validate=False, check_ec=False
+        )
+    except Exception as exc:
+        log.warning("remove_subvolumegroup %s: %s", group, exc)
+
+
+def _mount_root(fuse_client, mount_point, vol_name):
+    """Mount FS root with default/admin client keyring on the fuse node."""
+    fuse_client.exec_command(sudo=True, cmd=f"mkdir -p {mount_point}")
+    rc = fuse_client.exec_command(
+        sudo=True,
+        cmd=f"ceph-fuse {mount_point} --client_fs {vol_name}",
+        long_running=True,
+    )
+    if rc:
+        raise CommandFailed(f"root fuse mount failed: {rc}")
+
+
+def _snap_schedule_status_entries(admin, path):
+    out, err = admin.exec_command(
+        sudo=True, cmd=f"ceph fs snap-schedule status {path}", check_ec=False
+    )
+    if admin.node.exit_status:
+        log.error("snap-schedule status failed: %s %s", out, err)
+        return []
+    entries = []
+    for chunk in re.split(r"\n===\n", out.strip()):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            entries.append(json.loads(chunk))
+        except json.JSONDecodeError:
+            log.warning("skip non-JSON schedule status chunk: %s", chunk[:120])
+    return entries
+
+
+def _max_created_count(entries):
+    if not entries:
+        return 0
+    return max(int(e.get("created_count") or 0) for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# F-01 .. F-18
+# ---------------------------------------------------------------------------
+
+
+def f01_group_quarantine(qtn, fs_util, admin, fuse, vol, config):
+    """F-01 Quarantine under subvolume group — enable + info state."""
+    group = _cfg(config, "group", "qtn-group")
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    try:
+        fs_util.create_subvolumegroup(admin, vol, group)
+        if qtn.setup_subvolume(admin, vol, sub, group_name=group):
+            return 1
+        result = qtn.quarantine_enable(admin, vol, sub, group_name=group)
+        log.info("enable result: %s", result)
+        if qtn.assert_info_quarantined(admin, vol, sub, group_name=group):
+            return 1
+        log.info("f01_group_quarantine PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _rm_sv(qtn, admin, vol, sub, group)
+        _rm_group(fs_util, admin, vol, group)
+
+
+def f02_clear_quarantine(qtn, fs_util, admin, fuse, vol, config):
+    """F-02 Clear quarantine flag under group — disable + info cleared + mount OK."""
+    group = _cfg(config, "group", "qtn-group")
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f02-normal"
+    mount = "/mnt/qtn-f02"
+    try:
+        fs_util.create_subvolumegroup(admin, vol, group)
+        if qtn.setup_subvolume(admin, vol, sub, group_name=group):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub, group_name=group)
+        qtn.quarantine_enable(admin, vol, sub, group_name=group)
+
+        result = qtn.quarantine_disable(admin, vol, sub, group_name=group)
+        log.info("disable result: %s", result)
+        if qtn.assert_info_not_quarantined(admin, vol, sub, group_name=group):
+            return 1
+
+        qtn.create_rw_client(admin, vol, root, client)
+        qtn.mount_fuse(fuse, mount, data, client, vol)
+        if qtn.assert_write_ok(fuse, mount, "after-disable.txt"):
+            return 1
+
+        log.info("f02_clear_quarantine PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub, group)
+        _rm_group(fs_util, admin, vol, group)
+
+
+def f03_reject_mount_without_q(qtn, fs_util, admin, fuse, vol, config):
+    """F-03 Reject mount without q — Permission denied (13)."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f03-normal"
+    mount = "/mnt/qtn-f03"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.create_rw_client(admin, vol, root, client)
+        qtn.quarantine_enable(admin, vol, sub)
+        if qtn.assert_fuse_mount_fails(fuse, mount, data, client, vol):
+            return 1
+        log.info("f03_reject_mount_without_q PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f04_mount_with_rwq(qtn, fs_util, admin, fuse, vol, config):
+    """F-04 Mount with rwq — R/W on quarantined SV succeeds."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f04-recovery"
+    mount = "/mnt/qtn-f04"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.quarantine_enable(admin, vol, sub)
+        qtn.create_rwq_client(admin, vol, root, client)
+        qtn.mount_fuse(fuse, mount, data, client, vol)
+        if qtn.assert_write_ok(fuse, mount, "recovery.txt"):
+            return 1
+        if qtn.assert_read_ok(fuse, mount, "recovery.txt"):
+            return 1
+        log.info("f04_mount_with_rwq PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f05_allow_star_denied(qtn, fs_util, admin, fuse, vol, config):
+    """F-05 allow * does not grant quarantine access."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f05-star"
+    mount = "/mnt/qtn-f05"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        _, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.quarantine_enable(admin, vol, sub)
+        qtn.create_star_client(admin, client)
+        if qtn.assert_fuse_mount_fails(fuse, mount, data, client, vol):
+            return 1
+        log.info("f05_allow_star_denied PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f06_isolation_same_group(qtn, fs_util, admin, fuse, vol, config):
+    """F-06 Isolation within same group — only SUB_A blocked."""
+    group = _cfg(config, "group", "qtn-group")
+    sub_a = _cfg(config, "sub_a", "qtn-sv-a")
+    sub_b = _cfg(config, "sub_b", "qtn-sv-b")
+    client_a, client_b = "qtn-f06-a", "qtn-f06-b"
+    mount_a, mount_b = "/mnt/qtn-f06-a", "/mnt/qtn-f06-b"
+    try:
+        fs_util.create_subvolumegroup(admin, vol, group)
+        if qtn.setup_subvolume(admin, vol, sub_a, group_name=group):
+            return 1
+        if qtn.setup_subvolume(admin, vol, sub_b, group_name=group):
+            return 1
+        root_a, data_a = qtn.get_subvolume_paths(admin, vol, sub_a, group_name=group)
+        root_b, data_b = qtn.get_subvolume_paths(admin, vol, sub_b, group_name=group)
+
+        qtn.create_rw_client(admin, vol, root_a, client_a)
+        qtn.create_rw_client(admin, vol, root_b, client_b)
+        qtn.mount_fuse(fuse, mount_b, data_b, client_b, vol)
+        if qtn.write_baseline_file(fuse, mount_b, "test.txt", "b-ok"):
+            return 1
+
+        qtn.quarantine_enable(admin, vol, sub_a, group_name=group)
+        if qtn.assert_fuse_mount_fails(fuse, mount_a, data_a, client_a, vol):
+            return 1
+        if qtn.assert_content_equals(fuse, mount_b, "test.txt", "b-ok"):
+            return 1
+        if qtn.assert_write_ok(fuse, mount_b, "new.txt"):
+            return 1
+
+        log.info("f06_isolation_same_group PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount_a, mount_b])
+        _del_clients(qtn, admin, [client_a, client_b])
+        _rm_sv(qtn, admin, vol, sub_a, group)
+        _rm_sv(qtn, admin, vol, sub_b, group)
+        _rm_group(fs_util, admin, vol, group)
+
+
+def f07_info_shows_quarantine(qtn, fs_util, admin, fuse, vol, config):
+    """
+    F-07 Info shows quarantine status (minimal payload); volume info remains valid.
+
+    Quarantined SV info: name / group / quarantine status only (no path/size).
+    """
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        if qtn.assert_info_not_quarantined(admin, vol, sub):
+            return 1
+
+        qtn.quarantine_enable(admin, vol, sub)
+
+        if qtn.assert_info_quarantined(admin, vol, sub):
+            return 1
+
+        out, err = admin.exec_command(
+            sudo=True, cmd=f"ceph fs volume info {vol} -f json", check_ec=False
+        )
+        if admin.node.exit_status:
+            log.error("volume info failed: %s %s", out, err)
+            return 1
+        vinfo = json.loads(out)
+        if "pools" not in vinfo:
+            log.error("volume info missing pools: %s", vinfo)
+            return 1
+        log.info("volume info OK (volume itself not quarantined)")
+
+        log.info("f07_info_shows_quarantine PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f08_snapshot_ops_under_quarantine(qtn, fs_util, admin, fuse, vol, config):
+    """F-08 Snapshot create/clone blocked while quarantined; pre-snap exists."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        admin.exec_command(
+            sudo=True, cmd=f"ceph fs subvolume snapshot create {vol} {sub} snap1"
+        )
+        qtn.quarantine_enable(admin, vol, sub)
+
+        rc = 0
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume snapshot create {vol} {sub} snap2",
+            "snapshot create while quarantined",
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume snapshot clone {vol} {sub} snap1 clone-from-snap1",
+            "snapshot clone while quarantined",
+        )
+        if rc:
+            return 1
+
+        qtn.quarantine_disable(admin, vol, sub)
+        snaps, _ = admin.exec_command(
+            sudo=True, cmd=f"ceph fs subvolume snapshot ls {vol} {sub}"
+        )
+        if "snap1" not in snaps:
+            log.error("pre-quarantine snap1 missing after disable: %s", snaps)
+            return 1
+
+        log.info("f08_snapshot_ops_under_quarantine PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        admin.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume snapshot rm {vol} {sub} snap1 --force",
+            check_ec=False,
+        )
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f09_clone_blocked(qtn, fs_util, admin, fuse, vol, config):
+    """F-09 Clone blocked while source quarantined."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    clone = f"{sub}-clone"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        admin.exec_command(
+            sudo=True, cmd=f"ceph fs subvolume snapshot create {vol} {sub} snap1"
+        )
+        qtn.quarantine_enable(admin, vol, sub)
+        if qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume snapshot clone {vol} {sub} snap1 {clone}",
+            "clone while quarantined",
+        ):
+            return 1
+        log.info("f09_clone_blocked PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        admin.exec_command(
+            sudo=True,
+            cmd=f"ceph fs clone cancel {vol} {clone}",
+            check_ec=False,
+        )
+        _rm_sv(qtn, admin, vol, clone)
+        admin.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume snapshot rm {vol} {sub} snap1 --force",
+            check_ec=False,
+        )
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f10_snap_schedule(qtn, fs_util, admin, fuse, vol, config):
+    """
+    F-10 Snap-schedule under quarantine.
+
+    Schedule on subvolume root path; created_count must not increase while
+    quarantined; after disable, schedule creates again.
+    """
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    wait_sec = int(_cfg(config, "snap_schedule_wait_sec", 75))
+    sched_path = None
+    try:
+        admin.exec_command(
+            sudo=True,
+            cmd="ceph config set mgr mgr/snap_schedule/allow_m_granularity true",
+            check_ec=False,
+        )
+        admin.exec_command(
+            sudo=True, cmd="ceph mgr module enable snap_schedule", check_ec=False
+        )
+
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, _data = qtn.get_subvolume_paths(admin, vol, sub)
+        sched_path = root if root.endswith("/") else root + "/"
+
+        admin.exec_command(
+            sudo=True, cmd=f"ceph fs snap-schedule add {sched_path} 1m", check_ec=False
+        )
+        # EEXIST is fine if schedule already present from a prior attempt
+        entries = _snap_schedule_status_entries(admin, sched_path)
+        if not entries:
+            log.error(
+                "snap-schedule not active on %s — cannot validate F-10", sched_path
+            )
+            return 1
+
+        log.info("Wait for at least one scheduled snap before quarantine")
+        time.sleep(wait_sec)
+        before = _max_created_count(_snap_schedule_status_entries(admin, sched_path))
+        log.info("created_count before quarantine window: %s", before)
+
+        qtn.quarantine_enable(admin, vol, sub)
+        time.sleep(wait_sec)
+        during = _max_created_count(_snap_schedule_status_entries(admin, sched_path))
+        log.info("created_count during quarantine: %s", during)
+        if during > before:
+            log.error(
+                "F-10 FAILED: snap-schedule created new snaps while quarantined "
+                "(%s → %s)",
+                before,
+                during,
+            )
+            return 1
+
+        qtn.quarantine_disable(admin, vol, sub)
+        time.sleep(wait_sec)
+        after = _max_created_count(_snap_schedule_status_entries(admin, sched_path))
+        log.info("created_count after disable: %s", after)
+        if after <= during:
+            log.error(
+                "F-10 FAILED: snap-schedule did not resume after disable " "(%s → %s)",
+                during,
+                after,
+            )
+            return 1
+
+        log.info("f10_snap_schedule PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f11_subdir_mount_blocked(qtn, fs_util, admin, fuse, vol, config):
+    """F-11 Mount subdir under quarantined SV also blocked."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f11-normal"
+    mount = "/mnt/qtn-f11"
+    mount_sub = "/mnt/qtn-f11-subdir"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.create_rw_client(admin, vol, root, client)
+        qtn.mount_fuse(fuse, mount, data, client, vol)
+        fuse.exec_command(sudo=True, cmd=f"mkdir -p {mount}/subdir")
+        fuse.exec_command(
+            sudo=True, cmd=f"bash -c 'echo x > {mount}/subdir/f.txt'", check_ec=True
+        )
+        qtn.umount_fuse(fuse, mount)
+
+        qtn.quarantine_enable(admin, vol, sub)
+        if qtn.assert_fuse_mount_fails(fuse, mount_sub, f"{data}/subdir", client, vol):
+            return 1
+
+        log.info("f11_subdir_mount_blocked PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount, mount_sub])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f12_root_mount_vs_quarantined(qtn, fs_util, admin, fuse, vol, config):
+    """F-12 Root mount OK; access into quarantined SV tree blocked."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    sub_b = _cfg(config, "sub_b", "qtn-sv-b")
+    mount_root = "/mnt/qtn-f12-root"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        if qtn.setup_subvolume(admin, vol, sub_b):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        _root_b, data_b = qtn.get_subvolume_paths(admin, vol, sub_b)
+
+        _mount_root(fuse, mount_root, vol)
+        # write a marker via admin path before quarantine
+        fuse.exec_command(
+            sudo=True,
+            cmd=f"bash -c 'echo pre > {mount_root}{data}/marker.txt'",
+            check_ec=False,
+        )
+
+        qtn.quarantine_enable(admin, vol, sub)
+
+        log.info("Parent listing may show name but access must fail")
+        out, err = fuse.exec_command(
+            sudo=True,
+            cmd=f"ls {mount_root}{root}",
+            check_ec=False,
+        )
+        if fuse.node.exit_status == 0:
+            log.error("expected Permission denied on quarantined SV path ls: %s", out)
+            return 1
+        log.info("ls quarantined path blocked as expected: %s %s", out, err)
+
+        _, _ = fuse.exec_command(
+            sudo=True, cmd=f"cat {mount_root}{data}/marker.txt", check_ec=False
+        )
+        if fuse.node.exit_status == 0:
+            log.error("expected EACCES reading quarantined path via root mount")
+            return 1
+
+        # sibling still accessible via root mount
+        fuse.exec_command(
+            sudo=True,
+            cmd=f"bash -c 'echo sib > {mount_root}{data_b}/ok.txt'",
+            check_ec=True,
+        )
+
+        log.info("f12_root_mount_vs_quarantined PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount_root])
+        _rm_sv(qtn, admin, vol, sub)
+        _rm_sv(qtn, admin, vol, sub_b)
+
+
+def _resolve_active_mgr_node(admin, ceph_cluster):
+    """
+    Return (mgr_node, daemon_name) for the *active* MGR.
+
+    cephadm logs must be run on the host where that MGR runs — not on a client.
+    """
+    dump_out, _ = admin.exec_command(
+        sudo=True, cmd="ceph mgr dump -f json", check_ec=False
+    )
+    active_name = ""
+    try:
+        active_name = json.loads(dump_out).get("active_name", "") or ""
+    except json.JSONDecodeError:
+        log.warning("could not parse ceph mgr dump: %s", dump_out)
+    log.info("Active MGR name from mgr dump: %s", active_name)
+
+    orch_out, _ = admin.exec_command(
+        sudo=True, cmd="ceph orch ps --daemon_type mgr -f json", check_ec=False
+    )
+    try:
+        mgrs = json.loads(orch_out) if orch_out else []
+    except json.JSONDecodeError:
+        mgrs = []
+
+    daemon_name = None
+    hostname = None
+    for mgr in mgrs:
+        did = str(mgr.get("daemon_id", ""))
+        dname = str(mgr.get("daemon_name", "") or "")
+        if not dname and did:
+            dname = f"mgr.{did}"
+        status = str(mgr.get("status_desc", "") or mgr.get("status", "")).lower()
+        matches_active = bool(
+            active_name
+            and (
+                active_name == did
+                or active_name in did
+                or active_name in dname
+                or did in active_name
+            )
+        )
+        if matches_active or (not active_name and "running" in status):
+            daemon_name = dname if dname.startswith("mgr.") else f"mgr.{dname}"
+            hostname = mgr.get("hostname")
+            if matches_active:
+                break
+
+    if not daemon_name and active_name:
+        daemon_name = (
+            active_name if active_name.startswith("mgr.") else f"mgr.{active_name}"
+        )
+
+    log.info("Resolved MGR daemon_name=%s hostname=%s", daemon_name, hostname)
+
+    mgr_node = None
+    nodes = list(ceph_cluster.get_nodes())
+    if hostname:
+        for node in nodes:
+            if (
+                node.hostname == hostname
+                or hostname in node.hostname
+                or node.hostname in str(hostname)
+            ):
+                mgr_node = node
+                break
+
+    if not mgr_node and active_name:
+        for node in nodes:
+            if node.hostname and node.hostname in active_name:
+                mgr_node = node
+                break
+
+    if not mgr_node:
+        for role in ("mgr", "installer", "_admin"):
+            role_nodes = ceph_cluster.get_nodes(role=role)
+            if role_nodes:
+                mgr_node = role_nodes[0]
+                log.warning(
+                    "Falling back to first node with role=%s: %s",
+                    role,
+                    mgr_node.hostname,
+                )
+                break
+
+    return mgr_node, daemon_name
+
+
+def f13_logs_set_unset(qtn, fs_util, admin, fuse, vol, config):
+    """F-13 Active MGR logs contain quarantine enable/disable entries."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+
+        qtn.quarantine_enable(admin, vol, sub)
+        qtn.quarantine_disable(admin, vol, sub)
+
+        mgr_node, daemon_name = _resolve_active_mgr_node(admin, qtn.ceph_cluster)
+        if not mgr_node or not daemon_name:
+            log.error(
+                "F-13 FAILED: could not resolve active MGR node/daemon "
+                "(node=%s daemon=%s)",
+                getattr(mgr_node, "hostname", None),
+                daemon_name,
+            )
+            return 1
+
+        log.info(
+            "Collecting cephadm logs for %s on active MGR host %s",
+            daemon_name,
+            mgr_node.hostname,
+        )
+        # Run on the MGR/installer host — not the client
+        mgr_node.exec_command(
+            sudo=True,
+            cmd=(
+                f"cephadm logs --name {shlex.quote(daemon_name)} "
+                f"> {shlex.quote('/tmp/qtn-f13-mgr.log')}"
+            ),
+            check_ec=False,
+        )
+        logs, err = mgr_node.exec_command(
+            sudo=True,
+            cmd="tail -n 800 /tmp/qtn-f13-mgr.log",
+            check_ec=False,
+        )
+        if not logs:
+            log.warning("empty mgr log output: %s", err)
+
+        hits = [
+            line for line in (logs or "").splitlines() if "quarantine" in line.lower()
+        ]
+        log.info(
+            "mgr %s on %s quarantine log hits: %d",
+            daemon_name,
+            mgr_node.hostname,
+            len(hits),
+        )
+        for line in hits[:30]:
+            log.info("MGRLOG: %s", line)
+
+        enable_hit = any(
+            "quarantine_enable" in line.lower() or "quarantine enable" in line.lower()
+            for line in hits
+        )
+        disable_hit = any(
+            "quarantine_disable" in line.lower() or "quarantine disable" in line.lower()
+            for line in hits
+        )
+        if not hits:
+            log.error(
+                "F-13 FAILED: no quarantine entries in active MGR (%s) logs on %s",
+                daemon_name,
+                mgr_node.hostname,
+            )
+            return 1
+        if not enable_hit or not disable_hit:
+            log.error(
+                "F-13 FAILED: need both enable and disable log lines "
+                "(enable_hit=%s disable_hit=%s)",
+                enable_hit,
+                disable_hit,
+            )
+            return 1
+
+        log.info("f13_logs_set_unset PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f14_mgr_ops_matrix(qtn, fs_util, admin, fuse, vol, config):
+    """
+    F-14 MGR ops matrix while quarantined (updated Dev contract).
+
+    Blocked on quarantined SV: resize, rm, snapshot create/clone/ls, getpath,
+    earmark set/get
+    Allowed: subvolume ls (names only), info (minimal quarantine status);
+    earmark set/get on non-quarantined sibling SV
+    """
+    sub_a = _cfg(config, "sub_a", "qtn-sv-a")
+    sub_b = _cfg(config, "sub_b", "qtn-sv-b")
+    try:
+        if qtn.setup_subvolume(admin, vol, sub_a):
+            return 1
+        if qtn.setup_subvolume(admin, vol, sub_b):
+            return 1
+        admin.exec_command(
+            sudo=True, cmd=f"ceph fs subvolume snapshot create {vol} {sub_a} snap1"
+        )
+        qtn.quarantine_enable(admin, vol, sub_a)
+
+        rc = 0
+        log.info("--- Expect FAIL (structural + getpath) ---")
+        rc |= qtn.assert_mgr_op_fails(
+            admin, f"ceph fs subvolume resize {vol} {sub_a} 10485760", "resize"
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin, f"ceph fs subvolume rm {vol} {sub_a}", "rm"
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume snapshot create {vol} {sub_a} snap-blocked",
+            "snapshot create",
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume snapshot clone {vol} {sub_a} snap1 clone-x",
+            "snapshot clone",
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin, f"ceph fs subvolume getpath {vol} {sub_a}", "getpath"
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume snapshot ls {vol} {sub_a}",
+            "snapshot ls",
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume earmark set {vol} {sub_a} --earmark nfs",
+            "earmark set",
+        )
+        rc |= qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume earmark get {vol} {sub_a}",
+            "earmark get",
+        )
+
+        log.info("--- Expect SUCCEED (ls / minimal info) ---")
+        if qtn.assert_subvolume_ls_complete(admin, vol, [sub_a, sub_b]):
+            log.error("F-14 FAILED: subvolume ls must list names while quarantined")
+            rc = 1
+        if qtn.assert_info_quarantined(admin, vol, sub_a):
+            rc = 1
+        # sibling remains fully visible via info
+        if qtn.assert_info_not_quarantined(admin, vol, sub_b):
+            rc = 1
+
+        log.info("--- Earmark on non-quarantined sibling (working CLI) ---")
+        rc |= qtn.assert_mgr_op_succeeds(
+            admin,
+            f"ceph fs subvolume earmark set {vol} {sub_b} --earmark nfs",
+            "earmark set on sibling",
+        )
+        rc |= qtn.assert_mgr_op_succeeds(
+            admin,
+            f"ceph fs subvolume earmark set {vol} {sub_b} --earmark smb",
+            "earmark update on sibling",
+        )
+        info_b = qtn.get_subvolume_info_json(admin, vol, sub_b)
+        if not info_b or info_b.get("earmark") != "smb":
+            log.error(
+                "F-14 FAILED: sibling info earmark expected smb, got %s",
+                info_b.get("earmark") if info_b else None,
+            )
+            rc = 1
+        rc |= qtn.assert_mgr_op_succeeds(
+            admin,
+            f"ceph fs subvolume earmark get {vol} {sub_b}",
+            "earmark get on sibling",
+        )
+
+        if rc:
+            return 1
+        log.info("f14_mgr_ops_matrix PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        qtn.quarantine_disable(admin, vol, sub_a)
+        admin.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume snapshot rm {vol} {sub_a} snap1 --force",
+            check_ec=False,
+        )
+        _rm_sv(qtn, admin, vol, "clone-x")
+        _rm_sv(qtn, admin, vol, sub_a)
+        _rm_sv(qtn, admin, vol, sub_b)
+
+
+def f15_symlink_into_quarantined(qtn, fs_util, admin, fuse, vol, config):
+    """F-15 Symlink into quarantined path also returns EACCES."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f15-normal"
+    mount_root = "/mnt/qtn-f15-root"
+    mount_sv = "/mnt/qtn-f15-sv"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.create_rw_client(admin, vol, root, client)
+
+        _mount_root(fuse, mount_root, vol)
+        qtn.mount_fuse(fuse, mount_sv, data, client, vol)
+        if qtn.write_baseline_file(fuse, mount_sv, "orig.txt", "data"):
+            return 1
+        fuse.exec_command(
+            sudo=True,
+            cmd=(
+                f"ln -sfn {mount_root}{data}/orig.txt " f"{mount_root}/outside-link.txt"
+            ),
+        )
+
+        qtn.quarantine_enable(admin, vol, sub)
+
+        _, _ = fuse.exec_command(
+            sudo=True, cmd=f"cat {mount_root}/outside-link.txt", check_ec=False
+        )
+        if fuse.node.exit_status == 0:
+            log.error("expected EACCES via symlink into quarantined tree")
+            return 1
+        log.info("symlink access blocked as expected")
+
+        if qtn.assert_read_blocked(fuse, mount_sv, "orig.txt"):
+            return 1
+
+        log.info("f15_symlink_into_quarantined PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [mount_sv, mount_root])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f16_multiple_quarantined(qtn, fs_util, admin, fuse, vol, config):
+    """F-16 Multiple SVs quarantined — normal blocked; rwq/rwQ recovery OK."""
+    sub_a = _cfg(config, "sub_a", "qtn-sv-a")
+    sub_b = _cfg(config, "sub_b", "qtn-sv-b")
+    ca, cb = "qtn-f16-a", "qtn-f16-b"
+    ra, rb = "qtn-f16-rec-a", "qtn-f16-rec-b"
+    rq = "qtn-f16-recQ"
+    ma, mb = "/mnt/qtn-f16-a", "/mnt/qtn-f16-b"
+    mra, mrb = "/mnt/qtn-f16-rec-a", "/mnt/qtn-f16-rec-b"
+    mqa, mqb = "/mnt/qtn-f16-recQ-a", "/mnt/qtn-f16-recQ-b"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub_a):
+            return 1
+        if qtn.setup_subvolume(admin, vol, sub_b):
+            return 1
+        root_a, data_a = qtn.get_subvolume_paths(admin, vol, sub_a)
+        root_b, data_b = qtn.get_subvolume_paths(admin, vol, sub_b)
+        qtn.create_rw_client(admin, vol, root_a, ca)
+        qtn.create_rw_client(admin, vol, root_b, cb)
+
+        qtn.mount_fuse(fuse, ma, data_a, ca, vol)
+        qtn.mount_fuse(fuse, mb, data_b, cb, vol)
+        qtn.write_baseline_file(fuse, ma, BASELINE_FILE, "data-a")
+        qtn.write_baseline_file(fuse, mb, BASELINE_FILE, "data-b")
+        qtn.umount_fuse(fuse, ma)
+        qtn.umount_fuse(fuse, mb)
+
+        qtn.quarantine_enable(admin, vol, sub_a)
+        qtn.quarantine_enable(admin, vol, sub_b)
+
+        if qtn.assert_fuse_mount_fails(fuse, ma, data_a, ca, vol):
+            return 1
+        if qtn.assert_fuse_mount_fails(fuse, mb, data_b, cb, vol):
+            return 1
+
+        qtn.create_rwq_client(admin, vol, root_a, ra)
+        qtn.create_rwq_client(admin, vol, root_b, rb)
+        qtn.mount_fuse(fuse, mra, data_a, ra, vol)
+        qtn.mount_fuse(fuse, mrb, data_b, rb, vol)
+        if qtn.assert_content_equals(fuse, mra, BASELINE_FILE, "data-a"):
+            return 1
+        if qtn.assert_content_equals(fuse, mrb, BASELINE_FILE, "data-b"):
+            return 1
+        qtn.umount_fuse(fuse, mra)
+        qtn.umount_fuse(fuse, mrb)
+
+        qtn.create_rwQ_client(admin, vol, rq)
+        qtn.mount_fuse(fuse, mqa, data_a, rq, vol)
+        qtn.mount_fuse(fuse, mqb, data_b, rq, vol)
+        if qtn.assert_read_ok(fuse, mqa, BASELINE_FILE):
+            return 1
+        if qtn.assert_read_ok(fuse, mqb, BASELINE_FILE):
+            return 1
+
+        log.info("f16_multiple_quarantined PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount_all(qtn, fuse, [ma, mb, mra, mrb, mqa, mqb])
+        _del_clients(qtn, admin, [ca, cb, ra, rb, rq])
+        _rm_sv(qtn, admin, vol, sub_a)
+        _rm_sv(qtn, admin, vol, sub_b)
+
+
+def f17_quarantine_during_heavy_io(qtn, fs_util, admin, fuse, vol, config):
+    """F-17 Quarantine during heavy IO — enable succeeds; new IO blocked."""
+    sub = _cfg(config, "sub_a", "qtn-sv-a")
+    client = "qtn-f17-normal"
+    mount = "/mnt/qtn-f17"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.delete_client(admin, client)
+        qtn.create_rw_client(admin, vol, root, client)
+        qtn.mount_fuse(fuse, mount, data, client, vol)
+
+        log.info("Start background dd IO")
+        fuse.exec_command(
+            sudo=True,
+            cmd=(
+                f"bash -c 'dd if=/dev/zero of={mount}/big.img bs=1M count=512 "
+                f"oflag=direct >/tmp/qtn-f17-dd.out 2>&1 &'"
+            ),
+            check_ec=False,
+        )
+        time.sleep(2)
+
+        result = qtn.quarantine_enable(admin, vol, sub)
+        log.info("enable during IO: %s", result)
+
+        time.sleep(3)
+        if qtn.assert_write_blocked(fuse, mount, "after.txt"):
+            return 1
+        # read of big.img may fail with EACCES
+        _, _ = fuse.exec_command(
+            sudo=True, cmd=f"cat {mount}/big.img >/dev/null", check_ec=False
+        )
+        if fuse.node.exit_status == 0:
+            log.error("expected post-quarantine read of big.img to fail")
+            return 1
+        log.info("post-quarantine IO blocked as expected")
+
+        log.info("f17_quarantine_during_heavy_io PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        fuse.exec_command(
+            sudo=True, cmd="pkill -f 'dd if=/dev/zero' || true", check_ec=False
+        )
+        _umount_all(qtn, fuse, [mount])
+        _del_clients(qtn, admin, [client])
+        _rm_sv(qtn, admin, vol, sub)
+
+
+def f18_encrypted_na(qtn, fs_util, admin, fuse, vol, config):
+    """F-18 Encrypted subvolume + quarantine — N/A pending GKLM/fscrypt lab."""
+    log.info(
+        "F-18 N/A: encrypted subvolume quarantine requires GKLM/fscrypt lab setup. "
+        "Skipping until environment is available."
+    )
+    return 0
+
+
+SUBTESTS = {
+    "f01_group_quarantine": f01_group_quarantine,
+    "f02_clear_quarantine": f02_clear_quarantine,
+    "f03_reject_mount_without_q": f03_reject_mount_without_q,
+    "f04_mount_with_rwq": f04_mount_with_rwq,
+    "f05_allow_star_denied": f05_allow_star_denied,
+    "f06_isolation_same_group": f06_isolation_same_group,
+    "f07_info_shows_quarantine": f07_info_shows_quarantine,
+    "f08_snapshot_ops_under_quarantine": f08_snapshot_ops_under_quarantine,
+    "f09_clone_blocked": f09_clone_blocked,
+    "f10_snap_schedule": f10_snap_schedule,
+    "f11_subdir_mount_blocked": f11_subdir_mount_blocked,
+    "f12_root_mount_vs_quarantined": f12_root_mount_vs_quarantined,
+    "f13_logs_set_unset": f13_logs_set_unset,
+    "f14_mgr_ops_matrix": f14_mgr_ops_matrix,
+    "f15_symlink_into_quarantined": f15_symlink_into_quarantined,
+    "f16_multiple_quarantined": f16_multiple_quarantined,
+    "f17_quarantine_during_heavy_io": f17_quarantine_during_heavy_io,
+    "f18_encrypted_na": f18_encrypted_na,
+}
+
+
+def run(ceph_cluster, **kw):
+    """Run Functional subtests for CephFS subvolume quarantine."""
+    config = kw.get("config") or {}
+    log.info("=" * 80)
+    log.info("TEST TYPE : Functional")
+    log.info("MODULE    : test_subvolume_quarantine_functional.py")
+    log.info("POLARION  : CEPH-83632678")
+    log.info("=" * 80)
+
+    prepared = _prepare(ceph_cluster, config)
+    if prepared is None:
+        return 1
+    qtn, fs_util, admin, fuse, vol = prepared
+
+    requested = config.get("subtests")
+    test_list = requested if requested else list(SUBTESTS.keys())
+
+    failed = []
+    for name in test_list:
+        if name not in SUBTESTS:
+            log.error(
+                "Unknown Functional subtest '%s'; known: %s", name, list(SUBTESTS)
+            )
+            failed.append(name)
+            continue
+
+        log.info("")
+        log.info("=" * 80)
+        log.info("SUBTEST START : [Functional] %s", name)
+        log.info("DESC          : %s", (SUBTESTS[name].__doc__ or "").strip())
+        log.info("=" * 80)
+
+        try:
+            rc = SUBTESTS[name](qtn, fs_util, admin, fuse, vol, config)
+        except Exception:
+            log.error("SUBTEST EXCEPTION : [Functional] %s", name)
+            log.error(traceback.format_exc())
+            rc = 1
+
+        if rc:
+            log.error("SUBTEST FAILED  : [Functional] %s", name)
+            failed.append(name)
+        else:
+            log.info("SUBTEST PASSED  : [Functional] %s", name)
+        log.info("-" * 80)
+
+    log.info("=" * 80)
+    if failed:
+        log.error(
+            "Functional summary: %d/%d FAILED → %s",
+            len(failed),
+            len(test_list),
+            failed,
+        )
+        log.info("=" * 80)
+        return 1
+
+    log.info("Functional summary: ALL %d subtest(s) PASSED", len(test_list))
+    log.info("=" * 80)
+    return 0

--- a/tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_negative.py
+++ b/tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_negative.py
@@ -1,0 +1,376 @@
+"""
+CephFS Subvolume Quarantine — Negative workflows.
+
+Polarion: CEPH-83632679
+Suite block: Negative
+
+N-01 Non-existent / clear when not set
+N-02 rw / r (no q) denied on quarantined SV
+N-03 Quarantine on live mounted SV — enable OK; new IO blocked
+N-04 rwq write semantics (authorization, not write-lock) — plan v1 outdated
+"""
+
+import time
+import traceback
+
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from tests.cephfs.lib.cephfs_subvol_quarantine_utils import SubvolQuarantineUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def _prepare(ceph_cluster, config):
+    fs_util = FsUtils(ceph_cluster)
+    qtn = SubvolQuarantineUtils(ceph_cluster)
+    clients = ceph_cluster.get_ceph_objects("client")
+    if len(clients) < 2:
+        log.error("Need at least 2 client nodes; found %d", len(clients))
+        return None
+
+    build = config.get("build", config.get("rhbuild"))
+    fs_util.prepare_clients(clients[:2], build)
+    fs_util.auth_list(clients[:2])
+
+    admin = clients[0]
+    fuse = clients[1]
+    if not qtn.feature_available(admin):
+        log.error("Subvolume quarantine CLI not available — mark NA")
+        return None
+
+    return qtn, admin, fuse, config.get("fs_name", "cephfs")
+
+
+def _umount(qtn, client, mounts):
+    for mnt in mounts:
+        qtn.umount_fuse(client, mnt)
+
+
+def _del_clients(qtn, admin, names):
+    for name in names:
+        qtn.delete_client(admin, name)
+
+
+def _failed_quarantine_result(result) -> bool:
+    """True if enable/disable clearly failed (non-zero / status failed)."""
+    if not isinstance(result, dict):
+        return True
+    status = str(result.get("status", "")).lower()
+    rc = result.get("return_code", 0)
+    if status == "failed":
+        return True
+    try:
+        if int(rc) != 0:
+            return True
+    except (TypeError, ValueError):
+        if rc not in (0, None, "0"):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# N-01 .. N-04
+# ---------------------------------------------------------------------------
+
+
+def n01_nonexistent_and_clear_unset(qtn, admin, fuse, vol, config):
+    """
+    N-01 Part A: enable on missing SV fails.
+    Part B: disable when not set — idempotent success (lab) is acceptable.
+    Also: disable on missing SV fails.
+    """
+    sub = config.get("subvol", "qtn-neg-sv")
+    missing = config.get("missing_subvol", "does-not-exist")
+    try:
+        log.info("Part A: enable on non-existent subvolume")
+        result = qtn._quarantine_cmd(
+            admin, "enable", vol, missing, expect_success=False
+        )
+        log.info("enable missing result: %s", result)
+        if not _failed_quarantine_result(result):
+            log.error("N-01 FAILED: enable on missing SV should fail")
+            return 1
+        err = str(result.get("error", "")) + str(result.get("raw", ""))
+        if (
+            "no such" not in err.lower()
+            and "enoent" not in err.lower()
+            and result.get("return_code") not in (-2, 2, "-2", "2")
+        ):
+            log.warning(
+                "enable missing failed but error text unclear: %s (still scoring PASS)",
+                result,
+            )
+        log.info("enable on missing SV failed as expected")
+
+        log.info("Part B: disable when quarantine was never set")
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        if qtn.assert_info_not_quarantined(admin, vol, sub):
+            return 1
+
+        result = qtn._quarantine_cmd(admin, "disable", vol, sub, expect_success=False)
+        # Lab: idempotent success (return_code 0). Also accept clear failure.
+        log.info("disable when not set result: %s", result)
+        if _failed_quarantine_result(result):
+            log.info(
+                "disable when not quarantined failed with clear error (acceptable)"
+            )
+        else:
+            log.info(
+                "disable when not quarantined succeeded idempotently "
+                "(observed/acceptable per N-01)"
+            )
+
+        # second disable also ok if idempotent
+        result2 = qtn._quarantine_cmd(admin, "disable", vol, sub, expect_success=False)
+        log.info("second disable when not set: %s", result2)
+
+        log.info("Part B: disable on missing name")
+        result = qtn._quarantine_cmd(
+            admin, "disable", vol, missing, expect_success=False
+        )
+        log.info("disable missing result: %s", result)
+        if not _failed_quarantine_result(result):
+            log.error("N-01 FAILED: disable on missing SV should fail")
+            return 1
+
+        log.info("n01_nonexistent_and_clear_unset PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        qtn.cleanup_subvolume(admin, vol, sub)
+
+
+def n02_rw_without_q_denied(qtn, admin, fuse, vol, config):
+    """
+    N-02 Mount with rw / r (no q) on quarantined SV must fail.
+
+    Note: mds 'allow rwx ...' is rejected by this build (EINVAL parse);
+    use rw + r as the “without q” matrix.
+    """
+    sub = config.get("subvol", "qtn-neg-sv")
+    client_rw = "qtn-neg-rw"
+    client_r = "qtn-neg-r"
+    mount_rw = "/mnt/qtn-n2-rw"
+    mount_r = "/mnt/qtn-n2-r"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.create_rw_client(admin, vol, root, client_rw)
+        qtn.create_r_client(admin, vol, root, client_r)
+
+        qtn.quarantine_enable(admin, vol, sub)
+
+        if qtn.assert_fuse_mount_fails(fuse, mount_rw, data, client_rw, vol):
+            return 1
+        if qtn.assert_fuse_mount_fails(fuse, mount_r, data, client_r, vol):
+            return 1
+
+        log.info("n02_rw_without_q_denied PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount(qtn, fuse, [mount_rw, mount_r])
+        _del_clients(qtn, admin, [client_rw, client_r])
+        qtn.cleanup_subvolume(admin, vol, sub)
+
+
+def n03_quarantine_live_mount(qtn, admin, fuse, vol, config):
+    """
+    N-03 Quarantine while fuse mount + IO active.
+
+    Enable must succeed; new IO blocked. In-flight dd need not stop cleanly.
+    """
+    sub = config.get("subvol", "qtn-neg-sv")
+    client = "qtn-neg-live"
+    mount = "/mnt/qtn-n3-live"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.create_rw_client(admin, vol, root, client)
+        qtn.mount_fuse(fuse, mount, data, client, vol)
+
+        if qtn.write_baseline_file(fuse, mount, "testfile.txt", "baseline"):
+            return 1
+        if qtn.assert_read_ok(fuse, mount, "testfile.txt"):
+            return 1
+
+        log.info("Start background dd (in-flight IO)")
+        fuse.exec_command(
+            sudo=True,
+            cmd=(
+                f"bash -c 'dd if=/dev/zero of={mount}/big.img bs=1M count=512 "
+                f"oflag=direct >/tmp/qtn-n3-dd.out 2>&1 &'"
+            ),
+            check_ec=False,
+        )
+        time.sleep(2)
+
+        result = qtn.quarantine_enable(admin, vol, sub)
+        log.info("enable on live mount: %s", result)
+        if result.get("status") not in (None, "successful"):
+            log.error("N-03 FAILED: enable on live SV did not succeed: %s", result)
+            return 1
+
+        time.sleep(2)
+        # Do not require dd to exit cleanly
+        fuse.exec_command(
+            sudo=True, cmd="pkill -f 'dd if=/dev/zero' || true", check_ec=False
+        )
+
+        log.info("New IO must be blocked")
+        if qtn.assert_read_blocked(fuse, mount, "testfile.txt"):
+            return 1
+        if qtn.assert_write_blocked(fuse, mount, "after-q.txt"):
+            return 1
+
+        log.info("n03_quarantine_live_mount PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        fuse.exec_command(
+            sudo=True, cmd="pkill -f 'dd if=/dev/zero' || true", check_ec=False
+        )
+        _umount(qtn, fuse, [mount])
+        _del_clients(qtn, admin, [client])
+        qtn.cleanup_subvolume(admin, vol, sub)
+
+
+def n04_rwq_write_semantics(qtn, admin, fuse, vol, config):
+    """
+    N-04 Correct rwq semantics (authorization, not write restriction).
+
+    - Not quarantined: rwq mount + write OK
+    - Quarantined: rwq mount + write OK
+    - Quarantined: normal rw mount denied
+    """
+    sub = config.get("subvol", "qtn-neg-sv")
+    client_rwq = "qtn-neg-rwq"
+    client_rw = "qtn-neg-rw2"
+    mount_rwq = "/mnt/qtn-n4-rwq"
+    mount_rw = "/mnt/qtn-n4-rw"
+    try:
+        if qtn.setup_subvolume(admin, vol, sub):
+            return 1
+        root, data = qtn.get_subvolume_paths(admin, vol, sub)
+        qtn.create_rwq_client(admin, vol, root, client_rwq)
+
+        log.info("Part A: rwq when NOT quarantined — write allowed")
+        qtn._quarantine_cmd(admin, "disable", vol, sub, expect_success=False)
+        qtn.mount_fuse(fuse, mount_rwq, data, client_rwq, vol)
+        fuse.exec_command(
+            sudo=True,
+            cmd=f"bash -c 'echo before-q > {mount_rwq}/write-before.txt'",
+            check_ec=True,
+        )
+        if qtn.assert_content_equals(fuse, mount_rwq, "write-before.txt", "before-q"):
+            return 1
+
+        log.info("Part B: rwq when quarantined — write still allowed (recovery)")
+        qtn.quarantine_enable(admin, vol, sub)
+        qtn.umount_fuse(fuse, mount_rwq)
+        qtn.mount_fuse(fuse, mount_rwq, data, client_rwq, vol)
+        fuse.exec_command(
+            sudo=True,
+            cmd=f"bash -c 'echo after-q > {mount_rwq}/write-after.txt'",
+            check_ec=True,
+        )
+        if qtn.assert_content_equals(fuse, mount_rwq, "write-after.txt", "after-q"):
+            return 1
+        if qtn.assert_content_equals(fuse, mount_rwq, "write-before.txt", "before-q"):
+            return 1
+
+        log.info("Control: normal rw still blocked while quarantined")
+        qtn.create_rw_client(admin, vol, root, client_rw)
+        if qtn.assert_fuse_mount_fails(fuse, mount_rw, data, client_rw, vol):
+            return 1
+
+        log.info(
+            "N-04 note: IBM plan 'writes blocked with q' is outdated; "
+            "rwq = authorization (full rw)"
+        )
+        log.info("n04_rwq_write_semantics PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        _umount(qtn, fuse, [mount_rwq, mount_rw])
+        _del_clients(qtn, admin, [client_rwq, client_rw])
+        qtn.cleanup_subvolume(admin, vol, sub)
+
+
+SUBTESTS = {
+    "n01_nonexistent_and_clear_unset": n01_nonexistent_and_clear_unset,
+    "n02_rw_without_q_denied": n02_rw_without_q_denied,
+    "n03_quarantine_live_mount": n03_quarantine_live_mount,
+    "n04_rwq_write_semantics": n04_rwq_write_semantics,
+}
+
+
+def run(ceph_cluster, **kw):
+    """Run Negative subtests for CephFS subvolume quarantine."""
+    config = kw.get("config") or {}
+    log.info("=" * 80)
+    log.info("TEST TYPE : Negative")
+    log.info("MODULE    : test_subvolume_quarantine_negative.py")
+    log.info("POLARION  : CEPH-83632679")
+    log.info("=" * 80)
+
+    prepared = _prepare(ceph_cluster, config)
+    if prepared is None:
+        return 1
+    qtn, admin, fuse, vol = prepared
+
+    requested = config.get("subtests")
+    test_list = requested if requested else list(SUBTESTS.keys())
+
+    failed = []
+    for name in test_list:
+        if name not in SUBTESTS:
+            log.error("Unknown Negative subtest '%s'; known: %s", name, list(SUBTESTS))
+            failed.append(name)
+            continue
+
+        log.info("")
+        log.info("=" * 80)
+        log.info("SUBTEST START : [Negative] %s", name)
+        log.info("DESC          : %s", (SUBTESTS[name].__doc__ or "").strip())
+        log.info("=" * 80)
+
+        try:
+            rc = SUBTESTS[name](qtn, admin, fuse, vol, config)
+        except Exception:
+            log.error("SUBTEST EXCEPTION : [Negative] %s", name)
+            log.error(traceback.format_exc())
+            rc = 1
+
+        if rc:
+            log.error("SUBTEST FAILED  : [Negative] %s", name)
+            failed.append(name)
+        else:
+            log.info("SUBTEST PASSED  : [Negative] %s", name)
+        log.info("-" * 80)
+
+    log.info("=" * 80)
+    if failed:
+        log.error(
+            "Negative summary: %d/%d FAILED → %s",
+            len(failed),
+            len(test_list),
+            failed,
+        )
+        log.info("=" * 80)
+        return 1
+
+    log.info("Negative summary: ALL %d subtest(s) PASSED", len(test_list))
+    log.info("=" * 80)
+    return 0

--- a/tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_sanity.py
+++ b/tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_sanity.py
@@ -1,0 +1,588 @@
+"""
+CephFS Subvolume Quarantine — Sanity (Acceptance) workflows.
+
+Polarion: CEPH-83632677
+Suite block: Sanity
+
+Acceptance TCs (primary):
+  acceptance1_quarantine_flag   — enable succeeds; full info (quarantine=disabled) then minimal (enabled)
+  acceptance2_blocks_normal     — normal (no q) mount/I/O blocked
+  acceptance3_rwq_recovery      — rwq recovery client retains access; normal stays blocked
+
+Additional Sanity coverage (prior lab phases, no workarounds):
+  prereq_feature_health
+  lifecycle_disable_restore     — disable restores full access; baseline intact
+  isolation_sibling             — sibling subvolume unaffected
+  mds_asok                      — ceph tell mds.<id> quarantine enable|disable
+  e2e_incident_workflow         — full incident checklist
+"""
+
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from tests.cephfs.lib.cephfs_subvol_quarantine_utils import SubvolQuarantineUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+BASELINE_A = "baseline-tenant-a"
+BASELINE_B = "baseline-tenant-b"
+BASELINE_FILE = "testfile.txt"
+
+
+class LabContext:
+    """Shared tenant lab layout for Sanity subtests."""
+
+    def __init__(self, qtn, admin, fuse_client, vol_name, config):
+        self.qtn = qtn
+        self.admin = admin
+        self.fuse = fuse_client
+        self.vol = vol_name
+        self.sub_a = config.get("subvol_a", "qtn-tenant-a")
+        self.sub_b = config.get("subvol_b", "qtn-tenant-b")
+        self.mount_a = config.get("mount_a", "/mnt/qtn-normal")
+        self.mount_b = config.get("mount_b", "/mnt/qtn-tenant-b")
+        self.mount_recovery = config.get("mount_recovery", "/mnt/qtn-recovery")
+        self.client_a = config.get("client_a", "qtn-normal")
+        self.client_b = config.get("client_b", "qtn-tenant-b")
+        self.client_recovery = config.get("client_recovery", "qtn-recovery")
+        self.root_a = self.data_a = None
+        self.root_b = self.data_b = None
+        self._with_b = False
+        self._with_recovery = False
+        self._mounted_a = False
+
+    def create_subvolume_a(self):
+        log.info("Create subvolume %s", self.sub_a)
+        if self.qtn.setup_subvolume(self.admin, self.vol, self.sub_a):
+            raise CommandFailed(f"failed to create {self.sub_a}")
+        self.root_a, self.data_a = self.qtn.get_subvolume_paths(
+            self.admin, self.vol, self.sub_a
+        )
+        log.info("DATA=%s ROOT=%s", self.data_a, self.root_a)
+
+    def setup(
+        self,
+        with_b=False,
+        with_recovery=False,
+        mount_a=True,
+        write_baseline=True,
+    ):
+        self._with_b = with_b
+        self._with_recovery = with_recovery
+        self.create_subvolume_a()
+
+        self.qtn.create_rw_client(self.admin, self.vol, self.root_a, self.client_a)
+        if mount_a:
+            self.qtn.mount_fuse(
+                self.fuse, self.mount_a, self.data_a, self.client_a, self.vol
+            )
+            self._mounted_a = True
+            if write_baseline and self.qtn.write_baseline_file(
+                self.fuse, self.mount_a, BASELINE_FILE, BASELINE_A
+            ):
+                raise CommandFailed("failed to write baseline on tenant-a")
+
+        if with_b:
+            log.info("Create sibling subvolume %s", self.sub_b)
+            if self.qtn.setup_subvolume(self.admin, self.vol, self.sub_b):
+                raise CommandFailed(f"failed to create {self.sub_b}")
+            self.root_b, self.data_b = self.qtn.get_subvolume_paths(
+                self.admin, self.vol, self.sub_b
+            )
+            self.qtn.create_rw_client(self.admin, self.vol, self.root_b, self.client_b)
+            self.qtn.mount_fuse(
+                self.fuse, self.mount_b, self.data_b, self.client_b, self.vol
+            )
+            if self.qtn.write_baseline_file(
+                self.fuse, self.mount_b, BASELINE_FILE, BASELINE_B
+            ):
+                raise CommandFailed("failed to write baseline on tenant-b")
+
+        if with_recovery:
+            self.qtn.create_rwq_client(
+                self.admin, self.vol, self.root_a, self.client_recovery
+            )
+
+        log.info("Lab setup complete")
+
+    def cleanup(self):
+        log.info("Lab cleanup starting")
+        for mnt in (self.mount_recovery, self.mount_a, self.mount_b):
+            self.qtn.umount_fuse(self.fuse, mnt)
+        for cname in (self.client_a, self.client_b, self.client_recovery):
+            self.qtn.delete_client(self.admin, cname)
+        self.qtn.cleanup_subvolume(self.admin, self.vol, self.sub_a)
+        if self._with_b:
+            self.qtn.cleanup_subvolume(self.admin, self.vol, self.sub_b)
+        log.info("Lab cleanup done")
+
+
+def _prepare(ceph_cluster, config):
+    fs_util = FsUtils(ceph_cluster)
+    qtn = SubvolQuarantineUtils(ceph_cluster)
+    clients = ceph_cluster.get_ceph_objects("client")
+    if len(clients) < 2:
+        log.error("Need at least 2 client nodes; found %d", len(clients))
+        return None
+
+    build = config.get("build", config.get("rhbuild"))
+    fs_util.prepare_clients(clients[:2], build)
+    fs_util.auth_list(clients[:2])
+
+    admin = clients[0]
+    fuse_client = clients[1]
+    vol_name = config.get("fs_name", "cephfs")
+    return qtn, admin, fuse_client, vol_name
+
+
+# ---------------------------------------------------------------------------
+# Subtests
+# ---------------------------------------------------------------------------
+
+
+def subtest_prereq_feature_health(qtn, admin, fuse_client, vol_name, config):
+    """Confirm feature CLI, HEALTH_OK, volume present, volumes module on."""
+    out, _ = admin.exec_command(sudo=True, cmd="ceph versions", check_ec=False)
+    log.info("ceph versions:\n%s", out)
+
+    if not qtn.feature_available(admin):
+        log.error("quarantine enable/disable CLI not present")
+        return 1
+    log.info("quarantine CLI present")
+
+    health, _ = admin.exec_command(sudo=True, cmd="ceph health")
+    health = health.strip()
+    log.info("ceph health: %s", health)
+    if "HEALTH_OK" not in health:
+        log.error("cluster not HEALTH_OK: %s", health)
+        return 1
+
+    vols, _ = admin.exec_command(sudo=True, cmd="ceph fs volume ls")
+    if vol_name not in vols:
+        log.error("volume %s not in fs volume ls: %s", vol_name, vols)
+        return 1
+
+    mods, _ = admin.exec_command(sudo=True, cmd="ceph mgr module ls")
+    if "volumes" not in mods:
+        log.error("volumes module not listed")
+        return 1
+
+    log.info("prereq_feature_health PASSED")
+    return 0
+
+
+def subtest_acceptance1_quarantine_flag(qtn, admin, fuse_client, vol_name, config):
+    """
+    Acceptance 1 — Quarantine flag can be set on a subvolume.
+
+    Expected before enable:
+      - full subvolume info (path, size, pools, etc.)
+      - quarantine field is "disabled" (string), not enabled
+    After enable:
+      - subvolume ls still lists the subvolume (names only, no quarantine field)
+      - subvolume getpath is blocked while quarantined
+      - subvolume info is minimal with quarantine "enabled"
+    After disable:
+      - full info restored with quarantine "disabled"
+    """
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        lab.create_subvolume_a()
+
+        log.info("Confirm subvolume exists and is not quarantined")
+        if qtn.assert_subvolume_ls_complete(admin, vol_name, [lab.sub_a]):
+            return 1
+        if qtn.assert_info_not_quarantined(admin, vol_name, lab.sub_a):
+            return 1
+
+        log.info("Set quarantine: enable %s", lab.sub_a)
+        result = qtn.quarantine_enable(admin, vol_name, lab.sub_a)
+        log.info("enable result: %s", result)
+        if result.get("status") != "successful" and result.get("return_code", 0) != 0:
+            log.error("enable did not return success: %s", result)
+            return 1
+
+        log.info("Re-check: subvolume ls must still list %s (names only)", lab.sub_a)
+        if qtn.assert_subvolume_ls_complete(admin, vol_name, [lab.sub_a]):
+            return 1
+
+        log.info("Re-check: getpath must be blocked while quarantined")
+        if qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume getpath {vol_name} {lab.sub_a}",
+            "getpath while quarantined",
+        ):
+            return 1
+
+        log.info("Re-check: subvolume info minimal quarantine status")
+        if qtn.assert_info_quarantined(admin, vol_name, lab.sub_a):
+            return 1
+
+        log.info("Cleanup: quarantine disable")
+        qtn.quarantine_disable(admin, vol_name, lab.sub_a)
+        if qtn.assert_info_not_quarantined(admin, vol_name, lab.sub_a):
+            log.error("info still looks quarantined after disable")
+            return 1
+
+        log.info("acceptance1_quarantine_flag PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+def subtest_acceptance2_blocks_normal(qtn, admin, fuse_client, vol_name, config):
+    """
+    Acceptance 2 — Quarantined subvolume blocks standard mount (no q).
+
+    Covers:
+      A) Live mount then enable → read/write EACCES
+      B) Fresh mount after enable → Permission denied (mount fails)
+    """
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        # --- Sequence A: mount first, then quarantine ---
+        lab.setup(mount_a=True, write_baseline=True)
+
+        log.info("A: baseline I/O before quarantine")
+        if qtn.assert_read_ok(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+
+        log.info("A: enable quarantine")
+        qtn.quarantine_enable(admin, vol_name, lab.sub_a)
+
+        log.info("A: retry I/O on live normal mount — expect EACCES")
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+        if qtn.assert_write_blocked(fuse_client, lab.mount_a, "newfile.txt"):
+            return 1
+
+        # --- Sequence B: remount after quarantine must fail ---
+        log.info("B: umount and retry normal fuse mount — expect Permission denied")
+        qtn.umount_fuse(fuse_client, lab.mount_a)
+        lab._mounted_a = False
+        if qtn.assert_fuse_mount_fails(
+            fuse_client, lab.mount_a, lab.data_a, lab.client_a, vol_name
+        ):
+            return 1
+
+        qtn.quarantine_disable(admin, vol_name, lab.sub_a)
+
+        log.info("acceptance2_blocks_normal PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+def subtest_acceptance3_rwq_recovery(qtn, admin, fuse_client, vol_name, config):
+    """
+    Acceptance 3 — Quarantined subvolume accessible with rwq.
+
+    Recovery mount succeeds with R/W; normal client remains blocked.
+    """
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        lab.setup(with_recovery=True, mount_a=True, write_baseline=True)
+
+        log.info("Enable quarantine")
+        qtn.quarantine_enable(admin, vol_name, lab.sub_a)
+
+        log.info("Normal client still blocked")
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+        if qtn.assert_write_blocked(fuse_client, lab.mount_a, "blocked.txt"):
+            return 1
+
+        log.info("Mount recovery client with rwq")
+        qtn.mount_fuse(
+            fuse_client,
+            lab.mount_recovery,
+            lab.data_a,
+            lab.client_recovery,
+            vol_name,
+        )
+
+        log.info("Recovery client can read baseline and write")
+        if qtn.assert_content_equals(
+            fuse_client, lab.mount_recovery, BASELINE_FILE, BASELINE_A
+        ):
+            return 1
+        if qtn.assert_write_ok(fuse_client, lab.mount_recovery, "recovery.txt"):
+            return 1
+
+        log.info("Confirm normal client remains blocked after recovery I/O")
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+
+        qtn.umount_fuse(fuse_client, lab.mount_recovery)
+        qtn.quarantine_disable(admin, vol_name, lab.sub_a)
+
+        log.info("After disable: normal client sees recovery write")
+        if qtn.assert_read_ok(fuse_client, lab.mount_a, "recovery.txt"):
+            return 1
+
+        log.info("acceptance3_rwq_recovery PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+def subtest_lifecycle_disable_restore(qtn, admin, fuse_client, vol_name, config):
+    """Contain and release: blocked while enabled; full rw after disable; data intact."""
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        lab.setup()
+
+        if qtn.assert_read_ok(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+
+        qtn.quarantine_enable(admin, vol_name, lab.sub_a)
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+        if qtn.assert_write_blocked(fuse_client, lab.mount_a, "newfile.txt"):
+            return 1
+
+        qtn.quarantine_disable(admin, vol_name, lab.sub_a)
+        if qtn.assert_content_equals(
+            fuse_client, lab.mount_a, BASELINE_FILE, BASELINE_A
+        ):
+            return 1
+        if qtn.assert_write_ok(fuse_client, lab.mount_a, "after-disable.txt"):
+            return 1
+
+        log.info("lifecycle_disable_restore PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+def subtest_isolation_sibling(qtn, admin, fuse_client, vol_name, config):
+    """Quarantine tenant-a; sibling tenant-b stays fully accessible."""
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        lab.setup(with_b=True)
+
+        qtn.quarantine_enable(admin, vol_name, lab.sub_a)
+
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+        if qtn.assert_content_equals(
+            fuse_client, lab.mount_b, BASELINE_FILE, BASELINE_B
+        ):
+            return 1
+        if qtn.assert_write_ok(fuse_client, lab.mount_b, "still-ok.txt"):
+            return 1
+
+        # ls must still list both (names only; no quarantine indication)
+        if qtn.assert_subvolume_ls_complete(admin, vol_name, [lab.sub_a, lab.sub_b]):
+            return 1
+
+        qtn.quarantine_disable(admin, vol_name, lab.sub_a)
+        log.info("isolation_sibling PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+def subtest_mds_asok(qtn, admin, fuse_client, vol_name, config):
+    """MDS admin socket quarantine enable/disable (A-01)."""
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        lab.setup()
+
+        mds = qtn.get_active_mds_name(admin, vol_name)
+        log.info("Active MDS: %s", mds)
+
+        result = qtn.mds_quarantine(admin, mds, "enable", lab.root_a)
+        log.info("mds enable result: %s", result)
+        if result.get("status") not in (None, "successful"):
+            log.error("unexpected mds enable status: %s", result)
+            return 1
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+
+        result = qtn.mds_quarantine(admin, mds, "disable", lab.root_a)
+        log.info("mds disable result: %s", result)
+        if qtn.assert_content_equals(
+            fuse_client, lab.mount_a, BASELINE_FILE, BASELINE_A
+        ):
+            return 1
+
+        log.info("mds_asok PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+def subtest_e2e_incident_workflow(qtn, admin, fuse_client, vol_name, config):
+    """
+    End-to-end incident workflow:
+      baseline → enable → EACCES → sibling OK → info quarantined →
+      rwq recovery OK → disable → restored
+    """
+    lab = LabContext(qtn, admin, fuse_client, vol_name, config)
+    try:
+        lab.setup(with_b=True, with_recovery=True)
+
+        log.info("E2E-1: baseline I/O OK")
+        if qtn.assert_read_ok(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+        if qtn.assert_write_ok(fuse_client, lab.mount_a, "e2e-baseline.txt"):
+            return 1
+
+        log.info("E2E-2: quarantine enable")
+        qtn.quarantine_enable(admin, vol_name, lab.sub_a)
+
+        log.info("E2E-3: normal client EACCES")
+        if qtn.assert_read_blocked(fuse_client, lab.mount_a, BASELINE_FILE):
+            return 1
+
+        log.info("E2E-4: sibling still OK")
+        if qtn.assert_read_ok(fuse_client, lab.mount_b, BASELINE_FILE):
+            return 1
+
+        log.info("E2E-5: subvolume info shows minimal quarantined status")
+        if qtn.assert_info_quarantined(admin, vol_name, lab.sub_a):
+            return 1
+
+        log.info("E2E-5b: subvolume ls still lists names (no quarantine fields)")
+        if qtn.assert_subvolume_ls_complete(admin, vol_name, [lab.sub_a, lab.sub_b]):
+            return 1
+
+        log.info("E2E-5c: getpath blocked while quarantined")
+        if qtn.assert_mgr_op_fails(
+            admin,
+            f"ceph fs subvolume getpath {vol_name} {lab.sub_a}",
+            "e2e getpath",
+        ):
+            return 1
+
+        log.info("E2E-6: rwq recovery R/W")
+        qtn.mount_fuse(
+            fuse_client,
+            lab.mount_recovery,
+            lab.data_a,
+            lab.client_recovery,
+            vol_name,
+        )
+        if qtn.assert_read_ok(fuse_client, lab.mount_recovery, BASELINE_FILE):
+            return 1
+        if qtn.assert_write_ok(fuse_client, lab.mount_recovery, "e2e-recovered.txt"):
+            return 1
+        qtn.umount_fuse(fuse_client, lab.mount_recovery)
+
+        log.info("E2E-7: quarantine disable")
+        qtn.quarantine_disable(admin, vol_name, lab.sub_a)
+
+        log.info("E2E-8: normal client restored")
+        if qtn.assert_content_equals(
+            fuse_client, lab.mount_a, BASELINE_FILE, BASELINE_A
+        ):
+            return 1
+        if qtn.assert_read_ok(fuse_client, lab.mount_a, "e2e-recovered.txt"):
+            return 1
+
+        log.info("e2e_incident_workflow PASSED")
+        return 0
+    except Exception:
+        qtn.log_exception()
+        return 1
+    finally:
+        lab.cleanup()
+
+
+SUBTESTS = {
+    "prereq_feature_health": subtest_prereq_feature_health,
+    "acceptance1_quarantine_flag": subtest_acceptance1_quarantine_flag,
+    "acceptance2_blocks_normal": subtest_acceptance2_blocks_normal,
+    "acceptance3_rwq_recovery": subtest_acceptance3_rwq_recovery,
+    "lifecycle_disable_restore": subtest_lifecycle_disable_restore,
+    "isolation_sibling": subtest_isolation_sibling,
+    "mds_asok": subtest_mds_asok,
+    "e2e_incident_workflow": subtest_e2e_incident_workflow,
+}
+
+
+def run(ceph_cluster, **kw):
+    """
+    Run Sanity / Acceptance subtests for CephFS subvolume quarantine.
+
+    Optional config:
+      subtests: list of names (default: all)
+      fs_name, subvol_a/b, mount_*, client_*
+    """
+    config = kw.get("config") or {}
+    log.info("=" * 80)
+    log.info("TEST TYPE : Sanity (Acceptance)")
+    log.info("MODULE    : test_subvolume_quarantine_sanity.py")
+    log.info("POLARION  : CEPH-83632677")
+    log.info("=" * 80)
+
+    prepared = _prepare(ceph_cluster, config)
+    if prepared is None:
+        return 1
+    qtn, admin, fuse_client, vol_name = prepared
+
+    requested = config.get("subtests")
+    test_list = requested if requested else list(SUBTESTS.keys())
+
+    failed = []
+    for name in test_list:
+        if name not in SUBTESTS:
+            log.error("Unknown Sanity subtest '%s'; known: %s", name, list(SUBTESTS))
+            failed.append(name)
+            continue
+
+        log.info("")
+        log.info("=" * 80)
+        log.info("SUBTEST START : [Sanity] %s", name)
+        log.info("DESC          : %s", (SUBTESTS[name].__doc__ or "").strip())
+        log.info("=" * 80)
+
+        try:
+            rc = SUBTESTS[name](qtn, admin, fuse_client, vol_name, config)
+        except Exception:
+            log.error("SUBTEST EXCEPTION : [Sanity] %s", name)
+            log.error(traceback.format_exc())
+            rc = 1
+
+        if rc:
+            log.error("SUBTEST FAILED  : [Sanity] %s", name)
+            failed.append(name)
+        else:
+            log.info("SUBTEST PASSED  : [Sanity] %s", name)
+        log.info("-" * 80)
+
+    log.info("=" * 80)
+    if failed:
+        log.error(
+            "Sanity summary: %d/%d FAILED → %s",
+            len(failed),
+            len(test_list),
+            failed,
+        )
+        log.info("=" * 80)
+        return 1
+
+    log.info("Sanity summary: ALL %d subtest(s) PASSED", len(test_list))
+    log.info("=" * 80)
+    return 0

--- a/tests/cephfs/lib/cephfs_subvol_quarantine_utils.py
+++ b/tests/cephfs/lib/cephfs_subvol_quarantine_utils.py
@@ -1,0 +1,810 @@
+"""
+CephFS Subvolume Quarantine utility module.
+
+Wraps MGR quarantine CLI, subvolume path discovery, client caps (rw / rwq),
+fuse mount helpers, and common pass/fail assertions for cephci workflows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import traceback
+from typing import List, Optional, Tuple
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+_QUARANTINE_KEYS = ("quarantine", "quarantined", "is_quarantined")
+_QUARANTINE_ENABLED = frozenset({"1", "true", "yes", "on", "enabled", "quarantined"})
+_QUARANTINE_DISABLED = frozenset(
+    {"0", "false", "no", "off", "disabled", "not_quarantined", "unset"}
+)
+
+
+def _parse_quarantine_flag(value) -> Optional[bool]:
+    """Return True/False for quarantine state, or None if value is unrecognized."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    text = str(value).strip().lower()
+    if text in _QUARANTINE_ENABLED:
+        return True
+    if text in _QUARANTINE_DISABLED:
+        return False
+    return None
+
+
+def _quarantine_flag_from_info(info: dict) -> Tuple[Optional[bool], Optional[str]]:
+    """Return (is_quarantined, matched_key) from subvolume info JSON."""
+    for key in _QUARANTINE_KEYS:
+        if key not in info:
+            continue
+        parsed = _parse_quarantine_flag(info[key])
+        if parsed is not None:
+            return parsed, key
+        log.warning(
+            "unrecognized quarantine value for info.%s: %r",
+            key,
+            info[key],
+        )
+    return None, None
+
+
+def _is_fuse_mount_denied_output(text: str) -> bool:
+    """True when ceph-fuse output indicates EACCES / quarantine block."""
+    err = (text or "").lower()
+    return (
+        "permission denied" in err
+        or "eacces" in err
+        or "(13)" in err
+        or "error: 13" in err
+    )
+
+
+class SubvolQuarantineUtils:
+    """Helpers for subvolume quarantine cephci tests."""
+
+    def __init__(self, ceph_cluster):
+        self.ceph_cluster = ceph_cluster
+        self.fs_util = FsUtils(ceph_cluster)
+
+    def feature_available(self, client) -> bool:
+        """Return True if quarantine subcommand exists in this build.
+
+        Bare ``ceph fs subvolume quarantine`` returns EINVAL with usage hints
+        listing enable/disable; do not rely on exit code alone.
+        """
+        out, err = client.exec_command(
+            sudo=True,
+            cmd="ceph fs subvolume quarantine",
+            check_ec=False,
+        )
+        text = f"{out}\n{err}".lower()
+        return "quarantine enable" in text and "quarantine disable" in text
+
+    def _quarantine_cmd(
+        self,
+        client,
+        operation: str,
+        vol_name: str,
+        subvol_name: str,
+        group_name: Optional[str] = None,
+        expect_success: bool = True,
+    ) -> dict:
+        cmd = f"ceph fs subvolume quarantine {operation} {vol_name} {subvol_name}"
+        if group_name:
+            cmd += f" --group_name {group_name}"
+        cmd += " --format json"
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        rc = client.node.exit_status
+        parsed = None
+        try:
+            parsed = json.loads(out) if out else None
+        except json.JSONDecodeError:
+            parsed = None
+
+        if rc and not expect_success:
+            if isinstance(parsed, dict):
+                parsed.setdefault("return_code", rc)
+                parsed.setdefault("raw", out or err)
+                return parsed
+            return {"return_code": rc, "raw": out or err, "err": err}
+        if rc:
+            raise CommandFailed(
+                f"quarantine {operation} failed: rc={rc} out={out} err={err}"
+            )
+        if isinstance(parsed, dict):
+            return parsed
+        log.warning("quarantine response is not JSON: %s", out)
+        return {"return_code": 0, "raw": out}
+
+    def quarantine_enable(
+        self, client, vol_name: str, subvol_name: str, group_name: Optional[str] = None
+    ) -> dict:
+        result = self._quarantine_cmd(
+            client, "enable", vol_name, subvol_name, group_name=group_name
+        )
+        if result.get("status") not in (None, "successful"):
+            raise CommandFailed(f"quarantine enable unexpected status: {result}")
+        return result
+
+    def quarantine_disable(
+        self, client, vol_name: str, subvol_name: str, group_name: Optional[str] = None
+    ) -> dict:
+        result = self._quarantine_cmd(
+            client, "disable", vol_name, subvol_name, group_name=group_name
+        )
+        if result.get("status") not in (None, "successful"):
+            raise CommandFailed(f"quarantine disable unexpected status: {result}")
+        return result
+
+    def get_subvolume_paths(
+        self, client, vol_name: str, subvol_name: str, group_name: Optional[str] = None
+    ) -> Tuple[str, str]:
+        """Return (subvolume_root_path, data_path)."""
+        cmd = f"ceph fs subvolume getpath {vol_name} {subvol_name}"
+        if group_name:
+            cmd += f" --group_name {group_name}"
+        out, _ = client.exec_command(sudo=True, cmd=cmd)
+        data_path = out.strip()
+        root_path = os.path.dirname(data_path)
+        return root_path, data_path
+
+    def list_subvolume_entries(
+        self, client, vol_name: str, group_name: Optional[str] = None
+    ) -> List[dict]:
+        cmd = f"ceph fs subvolume ls {vol_name} --format json"
+        if group_name:
+            cmd += f" --group_name {group_name}"
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        if client.node.exit_status:
+            log.error("subvolume ls failed: out=%s err=%s", out, err)
+            return []
+        try:
+            entries = json.loads(out)
+        except json.JSONDecodeError:
+            log.error("subvolume ls returned non-JSON: %s", out)
+            return []
+        if not isinstance(entries, list):
+            log.error("subvolume ls unexpected type: %s", type(entries))
+            return []
+        return entries
+
+    def list_subvolume_names(
+        self, client, vol_name: str, group_name: Optional[str] = None
+    ) -> List[str]:
+        return [
+            e["name"]
+            for e in self.list_subvolume_entries(client, vol_name, group_name)
+            if "name" in e
+        ]
+
+    def assert_subvolume_ls_complete(
+        self, client, vol_name: str, expected_names: List[str]
+    ) -> int:
+        """
+        Return 0 if all expected names appear in ls.
+
+        Dev contract: ls remains enabled while quarantined and returns names only
+        (no quarantine indication on entries).
+        """
+        entries = self.list_subvolume_entries(client, vol_name)
+        found = {e["name"] for e in entries if "name" in e}
+        missing = [n for n in expected_names if n not in found]
+        if missing:
+            log.error(
+                "subvolume ls incomplete for vol %s; missing: %s; found: %s",
+                vol_name,
+                missing,
+                sorted(found),
+            )
+            return 1
+        for entry in entries:
+            bad_keys = [k for k in entry if "quarantine" in k.lower()]
+            if bad_keys:
+                log.error(
+                    "subvolume ls must not include quarantine indication; "
+                    "entry=%s bad_keys=%s",
+                    entry,
+                    bad_keys,
+                )
+                return 1
+        log.info("subvolume ls OK (names only, includes expected): %s", expected_names)
+        return 0
+
+    def get_subvolume_info_json(
+        self, client, vol_name: str, subvol_name: str, group_name: Optional[str] = None
+    ) -> Optional[dict]:
+        """Return parsed subvolume info JSON, or None on failure."""
+        cmd = f"ceph fs subvolume info {vol_name} {subvol_name} -f json"
+        if group_name:
+            cmd += f" --group_name {group_name}"
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        if client.node.exit_status:
+            log.error(
+                "subvolume info failed for %s: rc=%s out=%s err=%s",
+                subvol_name,
+                client.node.exit_status,
+                out,
+                err,
+            )
+            return None
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            log.error("subvolume info non-JSON: %s", out)
+            return None
+
+    def assert_info_not_quarantined(
+        self,
+        client,
+        vol_name: str,
+        subvol_name: str,
+        group_name: Optional[str] = None,
+    ) -> int:
+        """
+        Return 0 if info succeeds and the subvolume is not quarantined.
+
+        Non-quarantined SVs return full info (path, size, pools, etc.) and
+        ``quarantine`` is the string ``"disabled"`` (or the field is absent).
+        Do not use bare ``bool()`` on the field — ``bool("disabled")`` is True.
+        """
+        info = self.get_subvolume_info_json(
+            client, vol_name, subvol_name, group_name=group_name
+        )
+        if info is None:
+            log.error("expected subvolume info to succeed for non-quarantined SV")
+            return 1
+        flag, matched_key = _quarantine_flag_from_info(info)
+        if flag is True:
+            log.error(
+                "subvolume is quarantined but expected not quarantined: %s",
+                info,
+            )
+            return 1
+        if "path" not in info:
+            log.error(
+                "expected full subvolume info when not quarantined (missing path): %s",
+                list(info.keys()),
+            )
+            return 1
+        if flag is False:
+            log.info(
+                "subvolume info OK (not quarantined; full info; %s=%r)",
+                matched_key,
+                info.get(matched_key),
+            )
+        elif matched_key:
+            log.info(
+                "subvolume info OK (not quarantined; unrecognized %s=%r)",
+                matched_key,
+                info.get(matched_key),
+            )
+        else:
+            log.info(
+                "subvolume info OK (not quarantined; full info; no quarantine field)"
+            )
+        return 0
+
+    def assert_info_quarantined(
+        self,
+        client,
+        vol_name: str,
+        subvol_name: str,
+        group_name: Optional[str] = None,
+    ) -> int:
+        """
+        Dev contract: info succeeds for quarantined SVs with *minimal* payload:
+        name, group, and ``quarantine`` = ``"enabled"`` — not path/size/etc.
+
+        Contrast with non-quarantined info where ``quarantine`` = ``"disabled"``
+        and full metadata (path, bytes_*, data_pool, ...) is present.
+        """
+        info = self.get_subvolume_info_json(
+            client, vol_name, subvol_name, group_name=group_name
+        )
+        if info is None:
+            log.error(
+                "FAILED: subvolume info must succeed while quarantined with "
+                "minimal quarantine status (got error instead)"
+            )
+            return 1
+
+        flag, matched_key = _quarantine_flag_from_info(info)
+        if matched_key is None:
+            log.error(
+                "FAILED: quarantined info missing quarantine status field; keys=%s",
+                list(info.keys()),
+            )
+            return 1
+        if flag is not True:
+            log.error(
+                "FAILED: info.%s is not enabled after quarantine enable: %r (%s)",
+                matched_key,
+                info.get(matched_key),
+                info,
+            )
+            return 1
+
+        if "name" in info and info["name"] != subvol_name:
+            log.error(
+                "FAILED: info.name mismatch: expected %s got %s",
+                subvol_name,
+                info.get("name"),
+            )
+            return 1
+
+        if group_name is not None and "group" in info and info["group"] != group_name:
+            log.error(
+                "FAILED: info.group mismatch: expected %s got %s",
+                group_name,
+                info.get("group"),
+            )
+            return 1
+
+        # Full-detail fields must not appear on quarantined minimal info
+        forbidden = (
+            "path",
+            "bytes_used",
+            "bytes_quota",
+            "bytes_pcent",
+            "data_pool",
+            "mon_addrs",
+            "features",
+        )
+        present_forbidden = [k for k in forbidden if k in info]
+        if present_forbidden:
+            log.error(
+                "FAILED: quarantined info must be minimal (no size/path/etc); "
+                "unexpected keys=%s full=%s",
+                present_forbidden,
+                info,
+            )
+            return 1
+
+        log.info(
+            "quarantined info OK (minimal; status via '%s'): %s",
+            matched_key,
+            info,
+        )
+        return 0
+
+    def get_quarantine_from_info(
+        self, client, vol_name: str, subvol_name: str, group_name: Optional[str] = None
+    ) -> Optional[bool]:
+        info = self.get_subvolume_info_json(
+            client, vol_name, subvol_name, group_name=group_name
+        )
+        if not info:
+            return None
+        flag, _ = _quarantine_flag_from_info(info)
+        if flag is not None:
+            return flag
+        log.info("subvolume info has no quarantine flag; keys=%s", list(info.keys()))
+        return None
+
+    def get_active_mds_name(self, client, vol_name: str) -> str:
+        active = self.fs_util.get_active_mdss(client, vol_name)
+        if not active:
+            raise CommandFailed(f"no active MDS found for {vol_name}")
+        return active[0]
+
+    def mds_quarantine(
+        self,
+        client,
+        mds_name: str,
+        operation: str,
+        subvol_root: str,
+        expect_success: bool = True,
+    ) -> dict:
+        """MDS admin-socket path: ceph tell mds.<name> quarantine enable|disable <root>."""
+        cmd = f"ceph tell mds.{mds_name} quarantine {operation} {subvol_root}"
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        rc = client.node.exit_status
+        if rc and not expect_success:
+            return {"return_code": rc, "raw": out or err}
+        if rc:
+            raise CommandFailed(
+                f"mds quarantine {operation} failed: rc={rc} out={out} err={err}"
+            )
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            log.warning("mds quarantine response is not JSON: %s", out)
+            return {"return_code": 0, "raw": out}
+
+    def assert_content_equals(
+        self, client, mount_point: str, file_name: str, expected: str
+    ) -> int:
+        try:
+            out, _ = client.exec_command(
+                sudo=True, cmd=f"cat {mount_point}/{file_name}", check_ec=True
+            )
+        except CommandFailed as exc:
+            log.error("read failed while expecting content match: %s", exc)
+            return 1
+        actual = out.strip()
+        if actual != expected:
+            log.error(
+                "content mismatch for %s: expected '%s', got '%s'",
+                file_name,
+                expected,
+                actual,
+            )
+            return 1
+        return 0
+
+    def create_rw_client(
+        self,
+        client,
+        vol_name: str,
+        subvol_root: str,
+        client_name: str,
+    ) -> None:
+        self.fs_util.create_ceph_client(
+            client,
+            client_name,
+            mon_caps="allow r",
+            osd_caps=f"allow rw tag cephfs data={vol_name}",
+            mds_caps=f"allow rw fsname={vol_name} path={subvol_root}",
+        )
+
+    def create_r_client(
+        self,
+        client,
+        vol_name: str,
+        subvol_root: str,
+        client_name: str,
+    ) -> None:
+        """Read-only MDS caps (no q) — must not open a quarantined SV."""
+        self.fs_util.create_ceph_client(
+            client,
+            client_name,
+            mon_caps="allow r",
+            osd_caps=f"allow rw tag cephfs data={vol_name}",
+            mds_caps=f"allow r fsname={vol_name} path={subvol_root}",
+        )
+
+    def create_rwq_client(
+        self,
+        client,
+        vol_name: str,
+        subvol_root: str,
+        client_name: str,
+    ) -> None:
+        self.fs_util.create_ceph_client(
+            client,
+            client_name,
+            mon_caps="allow r",
+            osd_caps=f"allow rw tag cephfs data={vol_name}",
+            mds_caps=f"allow rwq fsname={vol_name} path={subvol_root}",
+        )
+
+    def create_rwQ_client(
+        self,
+        client,
+        vol_name: str,
+        client_name: str,
+    ) -> None:
+        """Recovery client authorized for all quarantined paths (capital Q)."""
+        self.fs_util.create_ceph_client(
+            client,
+            client_name,
+            mon_caps="allow r",
+            osd_caps=f"allow rw tag cephfs data={vol_name}",
+            mds_caps=f"allow rwQ fsname={vol_name}",
+        )
+
+    def create_star_client(self, client, client_name: str) -> None:
+        """Client with allow * — must NOT grant quarantine access."""
+        self.fs_util.create_ceph_client(
+            client,
+            client_name,
+            mon_caps="allow *",
+            osd_caps="allow *",
+            mds_caps="allow *",
+        )
+
+    def assert_mgr_op_succeeds(self, client, cmd: str, label: str) -> int:
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        rc = client.node.exit_status
+        if rc != 0:
+            log.error(
+                "expected %s to succeed but failed: rc=%s out=%s err=%s cmd=%s",
+                label,
+                rc,
+                out,
+                err,
+                cmd,
+            )
+            return 1
+        log.info("%s succeeded as expected", label)
+        return 0
+
+    def delete_client(self, client, client_name: str) -> None:
+        client.exec_command(
+            sudo=True,
+            cmd=f"ceph auth del client.{client_name}",
+            check_ec=False,
+        )
+
+    def mount_fuse(
+        self,
+        client,
+        mount_point: str,
+        data_path: str,
+        client_name: str,
+        vol_name: str = "cephfs",
+    ) -> None:
+        # fuse_mount iterates fuse_clients; pass a single-client list
+        self.fs_util.fuse_mount(
+            [client],
+            mount_point,
+            new_client_hostname=client_name,
+            extra_params=f" -r {data_path} --client_fs {vol_name}",
+        )
+
+    def assert_fuse_mount_fails(
+        self,
+        client,
+        mount_point: str,
+        data_path: str,
+        client_name: str,
+        vol_name: str = "cephfs",
+    ) -> int:
+        """
+        Acceptance 2B: remount after quarantine must fail with EACCES.
+
+        Do not call FsUtils.fuse_mount here: it is wrapped in @retry and, on
+        failure, raises only ``Ceph Fuse Command failed with error: 1`` without
+        the ceph-fuse stderr that contains ``(13) Permission denied``.
+        """
+        client.exec_command(
+            sudo=True, cmd=f"mkdir -p {shlex.quote(mount_point)}", check_ec=False
+        )
+        client.exec_command(
+            sudo=True,
+            cmd=(
+                f"ceph auth get client.{client_name} "
+                f"-o /etc/ceph/ceph.client.{client_name}.keyring"
+            ),
+            check_ec=False,
+        )
+        fuse_cmd = (
+            f"ceph-fuse -n client.{client_name} {shlex.quote(mount_point)} "
+            f"-r {shlex.quote(data_path)} --client_fs {vol_name}"
+        )
+        # Do not pass long_running=True: cephci returns exit code only (int),
+        # not (stdout, stderr). ceph-fuse fails fast on EACCES (~1s).
+        out, err = client.exec_command(sudo=True, cmd=fuse_cmd, check_ec=False)
+        rc = client.node.exit_status
+        combined = f"{out}\n{err}"
+
+        if rc == 0:
+            log.error(
+                "fuse mount succeeded for client.%s but expected Permission denied",
+                client_name,
+            )
+            self.umount_fuse(client, mount_point)
+            return 1
+
+        if _is_fuse_mount_denied_output(combined):
+            log.info(
+                "fuse mount blocked as expected for client.%s (rc=%s): %s",
+                client_name,
+                rc,
+                (err or out).strip(),
+            )
+            return 0
+
+        log.error(
+            "unexpected fuse mount failure for client.%s (rc=%s): out=%s err=%s",
+            client_name,
+            rc,
+            out,
+            err,
+        )
+        return 1
+
+    def umount_fuse(self, client, mount_point: str) -> None:
+        client.exec_command(
+            sudo=True,
+            cmd=f"fusermount -u {mount_point}",
+            check_ec=False,
+        )
+
+    def assert_read_blocked(self, client, mount_point: str, file_name: str) -> int:
+        try:
+            client.exec_command(
+                sudo=True, cmd=f"cat {mount_point}/{file_name}", check_ec=True
+            )
+            log.error("read succeeded but expected EACCES on %s", file_name)
+            return 1
+        except CommandFailed as exc:
+            err = str(exc).lower()
+            if "permission denied" in err or "eacces" in err:
+                log.info("read blocked as expected: %s", exc)
+                return 0
+            log.error("unexpected read error: %s", exc)
+            return 1
+
+    def assert_write_blocked(self, client, mount_point: str, file_name: str) -> int:
+        try:
+            client.exec_command(
+                sudo=True,
+                cmd=f"bash -c 'echo blocked-test > {mount_point}/{file_name}'",
+                check_ec=True,
+            )
+            log.error("write succeeded but expected EACCES on %s", file_name)
+            return 1
+        except CommandFailed as exc:
+            err = str(exc).lower()
+            if "permission denied" in err or "eacces" in err:
+                log.info("write blocked as expected: %s", exc)
+                return 0
+            log.error("unexpected write error: %s", exc)
+            return 1
+
+    def assert_read_ok(self, client, mount_point: str, file_name: str) -> int:
+        try:
+            client.exec_command(
+                sudo=True, cmd=f"cat {mount_point}/{file_name}", check_ec=True
+            )
+            return 0
+        except CommandFailed as exc:
+            log.error("read failed unexpectedly: %s", exc)
+            return 1
+
+    def assert_write_ok(self, client, mount_point: str, file_name: str) -> int:
+        try:
+            client.exec_command(
+                sudo=True,
+                cmd=f"bash -c 'echo write-ok > {mount_point}/{file_name}'",
+                check_ec=True,
+            )
+            return 0
+        except CommandFailed as exc:
+            log.error("write failed unexpectedly: %s", exc)
+            return 1
+
+    def write_baseline_file(
+        self, client, mount_point: str, file_name: str, content: str
+    ) -> int:
+        file_path = f"{mount_point}/{file_name}"
+        try:
+            client.exec_command(
+                sudo=True,
+                cmd=(f"printf %s {shlex.quote(content)} > {shlex.quote(file_path)}"),
+                check_ec=True,
+            )
+            return 0
+        except CommandFailed as exc:
+            log.error("baseline write failed: %s", exc)
+            return 1
+
+    def setup_subvolume(
+        self,
+        client,
+        vol_name: str,
+        subvol_name: str,
+        group_name: Optional[str] = None,
+        mode: str = "777",
+    ) -> int:
+        kwargs = {"mode": mode}
+        if group_name:
+            kwargs["group_name"] = group_name
+        try:
+            self.fs_util.create_subvolume(client, vol_name, subvol_name, **kwargs)
+            return 0
+        except CommandFailed as exc:
+            log.error("create_subvolume failed: %s", exc)
+            return 1
+
+    @staticmethod
+    def subvolume_root_path(subvol_name: str, group_name: Optional[str] = None) -> str:
+        """CephFS subvolume root path (parent of the UUID data dir)."""
+        if group_name:
+            return f"/volumes/{group_name}/{subvol_name}"
+        return f"/volumes/_nogroup/{subvol_name}"
+
+    def _remove_snap_schedule(self, client, sched_path: str) -> None:
+        path = sched_path if sched_path.endswith("/") else f"{sched_path}/"
+        client.exec_command(
+            sudo=True,
+            cmd=f"ceph fs snap-schedule remove {path}",
+            check_ec=False,
+        )
+
+    def _remove_all_subvolume_snapshots(
+        self,
+        client,
+        vol_name: str,
+        subvol_name: str,
+        group_name: Optional[str] = None,
+    ) -> None:
+        cmd = f"ceph fs subvolume snapshot ls {vol_name} {subvol_name} --format json"
+        if group_name:
+            cmd += f" --group_name {group_name}"
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        if client.node.exit_status:
+            log.warning(
+                "snapshot ls during cleanup failed for %s: %s %s",
+                subvol_name,
+                out,
+                err,
+            )
+            return
+        try:
+            snaps = json.loads(out)
+        except json.JSONDecodeError:
+            log.warning("snapshot ls during cleanup returned non-JSON: %s", out)
+            return
+        if not isinstance(snaps, list):
+            return
+        for entry in snaps:
+            snap_name = entry.get("name")
+            if not snap_name:
+                continue
+            rm_cmd = (
+                f"ceph fs subvolume snapshot rm {vol_name} {subvol_name} "
+                f"{snap_name} --force"
+            )
+            if group_name:
+                rm_cmd += f" --group_name {group_name}"
+            client.exec_command(sudo=True, cmd=rm_cmd, check_ec=False)
+
+    def cleanup_subvolume(
+        self,
+        client,
+        vol_name: str,
+        subvol_name: str,
+        group_name: Optional[str] = None,
+    ) -> None:
+        try:
+            self.quarantine_disable(
+                client, vol_name, subvol_name, group_name=group_name
+            )
+        except CommandFailed:
+            pass
+
+        sched_path = self.subvolume_root_path(subvol_name, group_name=group_name)
+        self._remove_snap_schedule(client, sched_path)
+        self._remove_all_subvolume_snapshots(
+            client, vol_name, subvol_name, group_name=group_name
+        )
+
+        self.fs_util.remove_subvolume(
+            client,
+            vol_name,
+            subvol_name,
+            group_name=group_name,
+            force=True,
+            check_ec=False,
+            validate=False,
+        )
+
+    def assert_mgr_op_fails(self, client, cmd: str, label: str) -> int:
+        out, err = client.exec_command(sudo=True, cmd=cmd, check_ec=False)
+        rc = client.node.exit_status
+        if rc == 0:
+            log.error(
+                "expected %s to fail but command succeeded: %s (out=%s)",
+                label,
+                cmd,
+                out,
+            )
+            return 1
+        log.info("%s blocked as expected (rc=%s err=%s)", label, rc, err)
+        return 0
+
+    def log_exception(self) -> None:
+        log.info(traceback.format_exc())


### PR DESCRIPTION
# Description

- Add tier-1 cephci coverage for CephFS subvolume quarantine (tracker 73007 / MR !1929) as three suite blocks: Sanity (`CEPH-83632677`), Functional (`CEPH-83632678`), and Negative (`CEPH-83632679`).
- Each block runs scenarios as logged subtests under one module, with shared helpers for quarantine CLI, fuse mounts, `rw`/`rwq`/`rwQ`/`allow *` caps, MDS tell, and MGR assert helpers.

Coverage
**Sanity / Acceptance**
- Prereq feature/health, A1 flag + ls/info/getpath contract, A2 normal client block (live I/O + remount deny), A3 `rwq` recovery, lifecycle disable/restore, sibling isolation, MDS admin-socket quarantine, e2e incident workflow.

**Functional (F-01..F-18)**
- Group quarantine enable/disable, mount deny without `q`, `rwq` access, `allow *` deny, same-group isolation, info/volume info, snap/clone blocked, snap-schedule behavior, subdir/root-mount access, active-MGR `cephadm` logs, MGR ops matrix, symlink deny, multi-SV + `rwQ`, quarantine during heavy I/O; F-18 encrypted marked N/A (GKLM pending).

**Negative (N-01..N-04)**
- Missing SV enable/disable errors; idempotent disable when unset; `rw`/`r` deny; live mount + quarantine with new I/O blocked; `rwq` write semantics (authorization, full rw) vs normal `rw` deny.

Files
- `suites/tentacle/cephfs/tier-1_cephfs_subvolume_quarantine.yaml`
- `tests/cephfs/lib/cephfs_subvol_quarantine_utils.py`
- `tests/cephfs/cephfs_subvol_quarantine/test_subvolume_quarantine_{sanity,functional,negative}.py`
- `tests/cephfs/cephfs_subvol_quarantine/README.md`
- Conf: existing `conf/tentacle/cephfs/tier-2_cephfs_7-node-cluster.yaml`

Test plan
- [x] Deploy feature build with `ceph fs subvolume quarantine enable|disable`
- [x] Run suite:
  `run.py --global-conf conf/tentacle/cephfs/tier-2_cephfs_7-node-cluster.yaml --suite suites/tentacle/cephfs/tier-1_cephfs_subvolume_quarantine.yaml ...`
- [x] Confirm subtest logging (`SUBTEST START/PASSED/FAILED`) for Sanity, Functional, Negative
- [x] Verify MGR contract asserts: getpath fail; ls names complete; info minimal when quarantined
- [x] Spot-check F-13 logs collected from **active MGR host** via `cephadm logs`
- [x] Confirm F-18 reports N/A (encrypted/GKLM)

Logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-611GW4/ 


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
