### PR TITLE
[RBD] Added 9.2 key based migration enhancement test cases

### DIFF
--- a/ceph/rbd/workflows/cluster_operations.py
+++ b/ceph/rbd/workflows/cluster_operations.py
@@ -1,3 +1,4 @@
+import json
 import re
 import time
 from importlib import import_module
@@ -196,3 +197,164 @@ def operation(obj, test, **kw):
     rc = method(**kw)
     if (type(rc) is bool and rc is False) or (type(rc) is int and rc == 1):
         raise Exception(f"method {test} failed")
+
+
+def validate_cluster_health_and_daemons(client, cluster_label, allow_warn=True):
+    """Validate that a Ceph cluster is usable and core daemons are running.
+
+    Checks:
+    1. ``ceph health`` is ``HEALTH_OK``, or ``HEALTH_WARN`` when *allow_warn*
+       is True. ``HEALTH_ERR`` always fails.
+    2. ``ceph -s`` status is captured in the logs for triage.
+    3. All ``mon``, ``mgr``, and ``osd`` daemons are in running state.
+
+    Args:
+        client: CephNode client to run commands on.
+        cluster_label: Human-readable label (e.g. ``source``, ``destination``)
+            used in log messages.
+        allow_warn: When True (default), ``HEALTH_WARN`` does not fail the
+            check; status is still logged via ``ceph -s``.
+
+    Returns:
+        0 if cluster health is acceptable with all daemons running.
+        1 if any check fails.
+    """
+    try:
+        # Always capture cluster status for logs (OK or WARN)
+        status, _ = client.exec_command(cmd="ceph -s", sudo=True, check_ec=False)
+        log.info(f"{cluster_label} cluster ceph -s output:\n{status}")
+
+        health, _ = client.exec_command(cmd="ceph health", sudo=True)
+        health = health.strip()
+        # ``ceph health`` may append detail text, e.g.
+        # ``HEALTH_WARN 1 failed cephadm daemon(s)``
+        health_status = health.split(None, 1)[0] if health else ""
+
+        if health_status == "HEALTH_ERR" or (
+            health_status == "HEALTH_WARN" and not allow_warn
+        ):
+            log.error(f"{cluster_label} cluster is not healthy: {health}")
+            client.exec_command(cmd="ceph health detail", sudo=True, check_ec=False)
+            return 1
+
+        if health_status not in ("HEALTH_OK", "HEALTH_WARN"):
+            log.error(
+                f"{cluster_label} cluster returned unexpected health status: {health}"
+            )
+            client.exec_command(cmd="ceph health detail", sudo=True, check_ec=False)
+            return 1
+
+        if health_status == "HEALTH_WARN":
+            log.info(
+                f"{cluster_label} cluster health is HEALTH_WARN; continuing test "
+                f"(ceph -s captured above): {health}"
+            )
+            client.exec_command(cmd="ceph health detail", sudo=True, check_ec=False)
+        else:
+            log.info(f"{cluster_label} cluster health: {health}")
+
+        for daemon_type in ("mon", "mgr", "osd"):
+            out, _ = client.exec_command(
+                cmd=f"ceph orch ps --daemon-type {daemon_type} --format json",
+                sudo=True,
+            )
+            daemons = json.loads(out)
+            if not daemons:
+                log.error(f"{cluster_label} cluster has no {daemon_type} daemons")
+                return 1
+
+            failed = [
+                d
+                for d in daemons
+                if d.get("status_desc") != "running" and d.get("status") != 1
+            ]
+            if failed:
+                log.error(
+                    f"{cluster_label} cluster has non-running {daemon_type} "
+                    f"daemons: {failed}"
+                )
+                return 1
+
+            log.info(
+                f"{cluster_label} cluster: {len(daemons)} {daemon_type} "
+                f"daemon(s) running"
+            )
+
+    except Exception as err:
+        log.error(
+            f"Failed to validate {cluster_label} cluster health and daemons: {err}"
+        )
+        return 1
+
+    return 0
+
+
+def get_ceph_major_version(config):
+    """Extract the major Ceph version number from the rhbuild config key.
+
+    Useful for code paths that branch on the major release (e.g. >= 3 for
+    EC pool init, >= 9 for native import features).
+
+    Args:
+        config (dict): Test configuration dict containing an optional
+            ``rhbuild`` key (e.g. ``"9.2"`` or ``"8.0"``).
+
+    Returns:
+        int: Major Ceph version integer. Defaults to 9 when rhbuild is absent.
+    """
+    rhbuild = str(config.get("rhbuild", "9"))
+    match = re.search(r"\d+", rhbuild)
+    return int(match.group(0)) if match else 9
+
+
+def validate_min_ceph_version(config, min_major, min_minor, *clients):
+    """Validate that all supplied cluster clients meet a minimum Ceph version.
+
+    Logs the live ``ceph -v`` output for every client and then checks the
+    ``rhbuild`` config key against the requested minimum.  When ``rhbuild``
+    is absent the check is skipped (returns 0) so CI can still run against
+    dev builds where the build string is unavailable.
+
+    Args:
+        config (dict): Test configuration dict containing an optional
+            ``rhbuild`` key (e.g. ``"9.2"``).
+        min_major (int): Minimum required major version (e.g. 9).
+        min_minor (int): Minimum required minor version (e.g. 2).
+        *clients: One or more ``(label, CephNode)`` tuples, e.g.
+            ``("source", src_client), ("destination", dst_client)``.
+
+    Returns:
+        int: 0 if the version requirement is met or rhbuild is unavailable,
+             1 if the deployed version is below the minimum.
+
+    Example::
+
+        rc = validate_min_ceph_version(
+            config, 9, 2,
+            ("source", source_client),
+            ("destination", destination_client),
+        )
+        if rc:
+            return 1
+    """
+    from ceph.rbd.utils import exec_cmd
+
+    for label, client in clients:
+        ceph_ver = exec_cmd(node=client, cmd="ceph -v", output=True)
+        log.info(f"{label} cluster ceph version: {ceph_ver}")
+
+    rhbuild = str(config.get("rhbuild", ""))
+    match = re.search(r"(\d+)(?:\.(\d+))?", rhbuild)
+    if not match:
+        log.info("rhbuild is unavailable; skipping minimum version check")
+        return 0
+
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    if (major, minor) < (min_major, min_minor):
+        log.error(
+            f"This test requires Ceph/RHCS {min_major}.{min_minor} or later, "
+            f"found rhbuild={rhbuild}"
+        )
+        return 1
+    return 0

--- a/ceph/rbd/workflows/migration.py
+++ b/ceph/rbd/workflows/migration.py
@@ -1,7 +1,9 @@
+import copy
 import json
+import re
 import tempfile
 
-from ceph.rbd.utils import random_string
+from ceph.rbd.utils import exec_cmd, random_string
 from ceph.rbd.workflows.rbd import create_single_pool_and_images
 from cli.rbd.rbd import Rbd
 from utility.log import Log
@@ -178,3 +180,766 @@ def run_prepare_execute_commit(rbd, pool, image, **kw):
         return 1
     else:
         log.info("Migration committed successfully")
+
+
+def _build_mon_host_from_dump(mon_dump):
+    """Build a formatted mon_host string from a JSON mon dump.
+
+    Parses the structured output of ``ceph mon dump --format json``
+    and returns a space-separated string of messenger v2/v1 endpoints
+    suitable for use in a native source spec ``mon_host`` field.
+
+    Args:
+        mon_dump: Parsed JSON dict from ``ceph mon dump --format json``.
+
+    Returns:
+        str: Space-separated string of monitor endpoints.
+
+    Raises:
+        ValueError: If no usable endpoints can be extracted.
+    """
+    mons = sorted(mon_dump.get("mons", []), key=lambda mon: mon.get("rank", 0))
+    endpoints = []
+
+    for mon in mons:
+        addrvec = mon.get("public_addrs", {}).get("addrvec", [])
+        endpoint_parts = []
+        for addr in addrvec:
+            addr_type = addr.get("type")
+            addr_value = addr.get("addr")
+            if not addr_type or not addr_value:
+                continue
+            if "/" not in addr_value and addr.get("nonce") is not None:
+                addr_value = f"{addr_value}/{addr['nonce']}"
+            endpoint_parts.append(f"{addr_type}:{addr_value}")
+
+        if endpoint_parts:
+            endpoints.append(f"[{','.join(endpoint_parts)}]")
+        elif mon.get("public_addr"):
+            endpoints.append(mon["public_addr"])
+        elif mon.get("addr"):
+            endpoints.append(mon["addr"])
+
+    if not endpoints:
+        raise ValueError(f"Unable to build mon_host from mon dump: {mon_dump}")
+    return " ".join(endpoints)
+
+
+def get_source_mon_host(client):
+    """Extract the formatted mon_host string from a Ceph cluster.
+
+    Attempts JSON-formatted ``ceph mon dump`` first; falls back to
+    plain-text parsing if JSON parsing fails.
+
+    Args:
+        client: Source cluster CephNode client.
+
+    Returns:
+        str: Space-separated mon_host string for use in native source specs.
+
+    Raises:
+        ValueError: If mon_host cannot be determined from either method.
+    """
+    out = exec_cmd(node=client, cmd="ceph mon dump --format json", output=True)
+    try:
+        return _build_mon_host_from_dump(json.loads(out))
+    except Exception as error:
+        log.info(
+            "JSON mon dump parsing failed, using plain mon dump fallback: %s", error
+        )
+
+    out = exec_cmd(node=client, cmd="ceph mon dump", output=True)
+    endpoints = re.findall(r"\[v\d:[^\]]+\]", out)
+    if endpoints:
+        return " ".join(endpoints)
+    raise ValueError(f"Unable to parse mon_host from mon dump output: {out}")
+
+
+def create_source_cephx_client(client, pool, client_name):
+    """Create a read-only CephX client on the source cluster for migration.
+
+    The created client has:
+      - ``mon 'profile rbd'``
+      - ``mgr 'profile rbd pool=<pool>'``
+      - ``osd 'profile rbd-read-only pool=<pool>'``
+
+    Args:
+        client: Source cluster CephNode client.
+        pool: Source pool name to grant read-only access to.
+        client_name: CephX client name (e.g. ``client.rbd-migration``).
+
+    Returns:
+        tuple: ``(entity, key)`` where *entity* is the normalized client
+        entity string and *key* is the base64-encoded CephX key.
+    """
+    entity = (
+        client_name if client_name.startswith("client.") else f"client.{client_name}"
+    )
+
+    exec_cmd(
+        node=client,
+        cmd=(
+            f"ceph auth get-or-create {entity} "
+            f"mon 'profile rbd' "
+            f"mgr 'profile rbd pool={pool}' "
+            f"osd 'profile rbd-read-only pool={pool}'"
+        ),
+    )
+    log.info(f"Created CephX entity {entity} with read-only access to pool {pool}")
+    exec_cmd(node=client, cmd=f"ceph auth get {entity}")
+
+    key = exec_cmd(
+        node=client,
+        cmd=f"ceph auth get-key {entity}",
+        output=True,
+    ).strip()
+
+    return entity, key
+
+
+def write_native_source_spec(client, spec_path, spec):
+    """Write an arbitrary native source-spec JSON file on *client*.
+
+    Redacts ``key`` values in logs when the value does not use ``config://``.
+
+    Args:
+        client: CephNode where the spec file is written.
+        spec_path: Absolute path for the JSON file.
+        spec: Source-spec dictionary (must include ``type``).
+
+    Returns:
+        dict: The spec that was written.
+    """
+    spec_file = client.remote_file(sudo=True, file_name=spec_path, file_mode="w")
+    spec_file.write(json.dumps(spec, indent=4))
+    spec_file.flush()
+    spec_file.close()
+    exec_cmd(node=client, cmd=f"chmod 600 {spec_path}")
+
+    logged = copy.deepcopy(spec)
+    key_val = logged.get("key")
+    if isinstance(key_val, str) and key_val and not key_val.startswith("config://"):
+        logged["key"] = "<redacted>"
+    log.info(f"Wrote native source spec to {spec_path}: {logged}")
+    return spec
+
+
+def prepare_native_source_spec_with_key(
+    client, spec_path, mon_host, client_name, key, pool_name, image_name, snap_name
+):
+    """Create a native source spec JSON file using mon_host and inline key.
+
+    Unlike ``prepare_migration_source_spec`` which uses ``cluster_name``,
+    this function uses ``mon_host`` + ``key`` fields so that the destination
+    client does not need source ``ceph.conf`` or keyring files.
+
+    Args:
+        client: Destination CephNode client where the spec file is written.
+        spec_path: Absolute path on the destination node for the JSON file.
+        mon_host: Source cluster mon_host string.
+        client_name: CephX client entity (e.g. ``client.rbd-migration``).
+        key: Base64-encoded CephX key.
+        pool_name: Source pool name.
+        image_name: Source image name.
+        snap_name: Source snapshot name.
+
+    Returns:
+        dict: The native source spec dictionary that was written.
+    """
+    spec = {
+        "type": "native",
+        "mon_host": mon_host,
+        "client_name": client_name,
+        "key": key,
+        "pool_name": pool_name,
+        "image_name": image_name,
+        "snap_name": snap_name,
+    }
+    return write_native_source_spec(client, spec_path, spec)
+
+
+def attempt_migration_prepare_import(client, source_spec_path, dest_spec, timeout=300):
+    """Run ``rbd migration prepare --import-only`` and capture pass/fail + output.
+
+    Uses ``check_ec=False`` so negative cases can assert on failure without
+    raising. Default *timeout* is shorter than a long-running migration so
+    unreachable-mon cases fail within a bounded window.
+
+    Args:
+        client: Destination CephNode client.
+        source_spec_path: Path to source-spec JSON on the destination node.
+        dest_spec: Destination image spec ``pool/image``.
+        timeout: Command timeout in seconds.
+
+    Returns:
+        tuple: ``(failed, combined_output)`` where *failed* is True when the
+        command exit status is non-zero, and *combined_output* is stdout+stderr
+        (or the exception text) for error matching.
+    """
+    cmd = (
+        f"rbd migration prepare --import-only "
+        f"--source-spec-path {source_spec_path} {dest_spec}"
+    )
+    try:
+        out, err = client.exec_command(
+            sudo=True, cmd=cmd, check_ec=False, timeout=timeout
+        )
+        combined = f"{out or ''}{err or ''}"
+        exit_status = getattr(client, "exit_status", 0)
+        failed = int(exit_status) != 0
+    except Exception as error:
+        combined = str(error)
+        failed = True
+
+    log.info(
+        f"migration prepare --import-only for {dest_spec}: "
+        f"failed={failed}, output={combined[:500]}"
+    )
+    return failed, combined
+
+
+def verify_no_stale_migration_target(client, pool, image):
+    """Verify failed prepare left no target image or migration metadata.
+
+    Args:
+        client: Destination CephNode client.
+        pool: Destination pool name.
+        image: Target image name that must not remain after failure.
+
+    Returns:
+        0 if no stale target/migration state remains, 1 otherwise.
+    """
+    target_spec = f"{pool}/{image}"
+    listed = exec_cmd(node=client, cmd=f"rbd ls {pool}", output=True, check_ec=False)
+    listed = (listed or "").split()
+    if image in listed:
+        status_out = exec_cmd(
+            node=client,
+            cmd=f"rbd status {target_spec} --format json",
+            output=True,
+            check_ec=False,
+        )
+        log.error(
+            f"Stale target image {target_spec} present after failed prepare; "
+            f"status={status_out}"
+        )
+        # Best-effort cleanup so subsequent negative cases stay isolated
+        exec_cmd(
+            node=client,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=client,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        return 1
+
+    log.info(f"No stale target image {target_spec} after failed prepare")
+    return 0
+
+
+def create_insufficient_caps_cephx_client(client, client_name):
+    """Create a CephX client without OSD read access (for negative auth tests).
+
+    Grants only ``mon 'allow r'`` so native import prepare should fail when
+    opening the source pool/image.
+
+    Args:
+        client: Source cluster CephNode client.
+        client_name: CephX client name (e.g. ``client.rbd-migration-limited``).
+
+    Returns:
+        tuple: ``(entity, key)``.
+    """
+    entity = (
+        client_name if client_name.startswith("client.") else f"client.{client_name}"
+    )
+    exec_cmd(
+        node=client,
+        cmd=f"ceph auth get-or-create {entity} mon 'allow r'",
+    )
+    key = exec_cmd(
+        node=client,
+        cmd=f"ceph auth get-key {entity}",
+        output=True,
+    ).strip()
+    log.info(f"Created insufficient-caps CephX entity {entity}")
+    return entity, key
+
+
+def store_source_key_in_config_key(client, config_key_path, key, workdir):
+    """Store a source CephX key in the destination MON config-key store.
+
+    Writes the key to a temporary file and loads it with
+    ``ceph config-key set <path> -i <file>`` to avoid shell quoting issues.
+
+    Args:
+        client: Destination CephNode client.
+        config_key_path: MON config-key path (e.g. ``rbd/native/source_client_key``).
+        key: Base64-encoded CephX key value.
+        workdir: Temporary directory on the destination node for the key file.
+
+    Returns:
+        None
+    """
+    key_file = f"{workdir}/source_client.key"
+    remote = client.remote_file(sudo=True, file_name=key_file, file_mode="w")
+    remote.write(key)
+    remote.flush()
+    remote.close()
+    exec_cmd(node=client, cmd=f"chmod 600 {key_file}")
+    exec_cmd(
+        node=client,
+        cmd=f"ceph config-key set {config_key_path} -i {key_file}",
+    )
+    exec_cmd(node=client, cmd=f"rm -f {key_file}", check_ec=False)
+    log.info(f"Stored source client key at config-key path {config_key_path}")
+
+
+def verify_config_key(client, config_key_path, expected_key):
+    """Verify a MON config-key value matches the expected source client key.
+
+    Args:
+        client: Destination CephNode client.
+        config_key_path: MON config-key path to read.
+        expected_key: Expected base64-encoded CephX key.
+
+    Returns:
+        0 if the stored key matches *expected_key*, 1 otherwise.
+    """
+    stored = exec_cmd(
+        node=client,
+        cmd=f"ceph config-key get {config_key_path}",
+        output=True,
+    ).strip()
+    if stored != expected_key.strip():
+        log.error(
+            f"config-key mismatch at {config_key_path}: "
+            f"expected length {len(expected_key.strip())}, "
+            f"got length {len(stored)}"
+        )
+        return 1
+    log.info(f"Verified config-key {config_key_path} matches source client key")
+    return 0
+
+
+def remove_config_key(client, config_key_path):
+    """Remove a key from the MON config-key store.
+
+    Args:
+        client: Destination CephNode client.
+        config_key_path: MON config-key path to remove.
+    """
+    exec_cmd(
+        node=client,
+        cmd=f"ceph config-key rm {config_key_path}",
+        check_ec=False,
+    )
+    log.info(f"Removed config-key path {config_key_path}")
+
+
+def prepare_native_source_spec_with_config_key(
+    client,
+    spec_path,
+    mon_host,
+    client_name,
+    config_key_path,
+    pool_name,
+    image_name,
+    snap_name,
+):
+    """Create a native source spec JSON using mon_host and config:// key ref.
+
+    The ``key`` field is set to ``config://<config_key_path>`` so librbd
+    resolves the CephX secret from the destination MON config-key store
+    instead of embedding the key inline in the source-spec file.
+
+    Args:
+        client: Destination CephNode client where the spec file is written.
+        spec_path: Absolute path on the destination node for the JSON file.
+        mon_host: Source cluster mon_host string.
+        client_name: CephX client entity (e.g. ``client.rbd-migration``).
+        config_key_path: MON config-key path holding the source client key.
+        pool_name: Source pool name.
+        image_name: Source image name.
+        snap_name: Source snapshot name.
+
+    Returns:
+        dict: The native source spec dictionary that was written.
+    """
+    key_ref = f"config://{config_key_path}"
+    spec = {
+        "type": "native",
+        "mon_host": mon_host,
+        "client_name": client_name,
+        "key": key_ref,
+        "pool_name": pool_name,
+        "image_name": image_name,
+        "snap_name": snap_name,
+    }
+
+    spec_file = client.remote_file(sudo=True, file_name=spec_path, file_mode="w")
+    spec_file.write(json.dumps(spec, indent=4))
+    spec_file.flush()
+    spec_file.close()
+    exec_cmd(node=client, cmd=f"chmod 600 {spec_path}")
+
+    log.info(f"Created native source spec with config:// key reference: {spec}")
+    return spec
+
+
+def verify_key_not_logged(client, key, workdir, test_start):
+    """Verify that a CephX inline key was not leaked to logs on a node.
+
+    Scans ``/var/log/ceph``, ``/var/log/messages``, and ``journalctl``
+    since *test_start* for the raw key string.
+
+    Args:
+        client: CephNode to scan for key leakage.
+        key: The base64-encoded CephX key to search for.
+        workdir: Temporary directory for the pattern file.
+        test_start: ISO/datetime string for journalctl ``--since``.
+
+    Returns:
+        0 if the key was not found in any logs.
+        1 if the key was found (security leak).
+    """
+    pattern_path = f"{workdir}/inline-key-pattern"
+    pattern_file = client.remote_file(sudo=True, file_name=pattern_path, file_mode="w")
+    pattern_file.write(key)
+    pattern_file.flush()
+    pattern_file.close()
+    exec_cmd(node=client, cmd=f"chmod 600 {pattern_path}", check_ec=False)
+
+    cmd = (
+        'sh -c "'
+        f"grep -R -F -l -f {pattern_path} /var/log/ceph /var/log/messages "
+        "2>/dev/null || true; "
+        f"journalctl --since '{test_start}' --no-pager 2>/dev/null "
+        f"| grep -F -q -f {pattern_path} && echo journalctl || true"
+        '"'
+    )
+    matches = exec_cmd(node=client, cmd=cmd, output=True, check_ec=False)
+    exec_cmd(node=client, cmd=f"rm -f {pattern_path}", check_ec=False)
+    if matches and matches.strip():
+        log.error(f"Inline source key was found in log locations: {matches}")
+        return 1
+
+    log.info("Verified inline key not present in destination logs")
+    return 0
+
+
+def resolve_gateway_like_client(destination_cluster, client_a, config=None):
+    """Resolve a destination-side node to act as the gateway-like Client-B.
+
+    Preference order:
+      1. Explicit ``gateway_like_node`` hostname from *config*
+      2. First node with role ``rbd-mirror`` that is not *client_a*
+      3. First non-client node on the destination cluster
+
+    Args:
+        destination_cluster: Destination Ceph cluster object.
+        client_a: Destination Client-A node used for migration prepare.
+        config: Optional test config dict.
+
+    Returns:
+        CephNode: Gateway-like Client-B node.
+
+    Raises:
+        ValueError: If no suitable Client-B node can be resolved.
+    """
+    config = config or {}
+    gateway_hostname = config.get("gateway_like_node")
+    if gateway_hostname:
+        for node in destination_cluster.get_nodes():
+            if node.hostname == gateway_hostname or getattr(
+                node, "shortname", None
+            ) == (gateway_hostname):
+                log.info(f"Using configured gateway-like Client-B: {node.hostname}")
+                return node
+        raise ValueError(
+            f"Configured gateway_like_node '{gateway_hostname}' not found "
+            f"on destination cluster"
+        )
+
+    try:
+        mirror_nodes = destination_cluster.get_nodes(role="rbd-mirror")
+    except Exception:
+        mirror_nodes = []
+    for node in mirror_nodes:
+        if node.hostname != client_a.hostname:
+            log.info(f"Using rbd-mirror node as gateway-like Client-B: {node.hostname}")
+            return node
+
+    for node in destination_cluster.get_nodes():
+        if node.hostname == client_a.hostname:
+            continue
+        if "client" in node.role:
+            continue
+        log.info(f"Using non-client node as gateway-like Client-B: {node.hostname}")
+        return node
+
+    raise ValueError(
+        "Unable to resolve a gateway-like Client-B node on the destination cluster"
+    )
+
+
+def prepare_gateway_like_client(client_a, client_b, packages=None):
+    """Prepare Client-B with destination-only ceph.conf and keyring.
+
+    Installs required packages, copies destination cluster configuration from
+    *client_a*, and removes any accidental source-cluster config files so the
+    node behaves like an NVMe-oF gateway host that only knows the destination.
+
+    Args:
+        client_a: Destination Client-A node that already has dest conf/keyring.
+        client_b: Gateway-like Client-B node to prepare.
+        packages: Optional package list. Defaults to ``ceph-common``, ``fio``,
+            and ``rbd-nbd``.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from ceph.rbd.utils import copy_file
+
+    packages = packages or ["ceph-common", "fio", "rbd-nbd"]
+    try:
+        for pkg in packages:
+            exec_cmd(
+                node=client_b,
+                cmd=f"yum install -y --nogpgcheck {pkg}",
+                long_running=True,
+                check_ec=False,
+            )
+
+        exec_cmd(node=client_b, cmd="mkdir -p /etc/ceph && chmod 755 /etc/ceph")
+
+        # Remove any pre-existing source-style multi-cluster configs
+        exec_cmd(
+            node=client_b,
+            cmd=(
+                "rm -f /etc/ceph/cluster*.conf /etc/ceph/cluster*.keyring "
+                "/etc/ceph/*source* /etc/ceph/ceph.client.rbd-migration.keyring"
+            ),
+            check_ec=False,
+        )
+
+        for path in (
+            "/etc/ceph/ceph.conf",
+            "/etc/ceph/ceph.client.admin.keyring",
+        ):
+            copy_file(file_name=path, src=client_a, dest=client_b)
+
+        exec_cmd(node=client_b, cmd="chmod 644 /etc/ceph/ceph.conf", check_ec=False)
+        exec_cmd(
+            node=client_b,
+            cmd="chmod 600 /etc/ceph/ceph.client.admin.keyring",
+            check_ec=False,
+        )
+
+        dest_fsid = exec_cmd(node=client_a, cmd="ceph fsid", output=True).strip()
+        client_b_fsid = exec_cmd(node=client_b, cmd="ceph fsid", output=True).strip()
+        if dest_fsid != client_b_fsid:
+            log.error(
+                f"Client-B fsid {client_b_fsid} does not match destination "
+                f"fsid {dest_fsid}"
+            )
+            return 1
+
+        log.info(
+            f"Prepared gateway-like Client-B {client_b.hostname} with "
+            f"destination-only configuration (fsid {client_b_fsid})"
+        )
+        return 0
+    except Exception as error:
+        log.error(f"Failed to prepare gateway-like Client-B: {error}")
+        return 1
+
+
+def assert_no_source_cluster_config(client_b, source_fsid, source_mon_host=None):
+    """Assert Client-B has no local source cluster configuration.
+
+    Checks that:
+      - Client-B ``ceph fsid`` is not the source FSID
+      - No source-style multi-cluster conf/keyring files exist under ``/etc/ceph``
+      - Optional: source monitor endpoints are absent from local ceph.conf
+
+    Args:
+        client_b: Gateway-like Client-B node.
+        source_fsid: Source cluster FSID that must not be local.
+        source_mon_host: Optional mon_host string; endpoints must not appear
+            in Client-B ``ceph.conf``.
+
+    Returns:
+        0 if Client-B has destination-only config, 1 otherwise.
+    """
+    client_b_fsid = exec_cmd(node=client_b, cmd="ceph fsid", output=True).strip()
+    if client_b_fsid == source_fsid:
+        log.error(
+            f"Client-B unexpectedly resolves to source fsid {source_fsid}; "
+            f"source cluster config may be present"
+        )
+        return 1
+
+    listing = exec_cmd(
+        node=client_b,
+        cmd="ls -1 /etc/ceph/ 2>/dev/null || true",
+        output=True,
+        check_ec=False,
+    )
+    forbidden = (
+        "cluster2.conf",
+        "cluster2.client.admin.keyring",
+        "ceph.client.rbd-migration.keyring",
+    )
+    for name in forbidden:
+        if name in (listing or "").split():
+            log.error(f"Forbidden source-related file present on Client-B: {name}")
+            return 1
+
+    if "source" in (listing or "").lower():
+        log.error(f"Source-named config files present on Client-B: {listing}")
+        return 1
+
+    # Ensure Client-B does not carry a local copy of the source-spec used on Client-A
+    stale_specs = exec_cmd(
+        node=client_b,
+        cmd=(
+            "ls /tmp/rbd-native-import-gateway-like-test/*source*.json "
+            "/tmp/*native*source*.json 2>/dev/null || true"
+        ),
+        output=True,
+        check_ec=False,
+    )
+    if stale_specs and stale_specs.strip():
+        log.error(f"Source-spec files unexpectedly present on Client-B: {stale_specs}")
+        return 1
+
+    if source_mon_host:
+        preview = (
+            source_mon_host
+            if len(source_mon_host) <= 80
+            else (source_mon_host[:80] + "...")
+        )
+        log.info(
+            "Source mon_host was supplied for context; Client-B local config "
+            "checks rely on fsid and /etc/ceph contents (mon endpoints may "
+            f"overlap in shared lab networks): {preview}"
+        )
+
+    log.info(
+        f"Verified Client-B {client_b.hostname} has no local source cluster "
+        f"configuration (local fsid {client_b_fsid})"
+    )
+    return 0
+
+
+def simulate_librbd_consumer_restart(client, image_spec):
+    """Simulate a gateway-like librbd consumer restart via NBD map/unmap.
+
+    Maps the target image with ``rbd device map -t nbd``, then unmaps it so
+    subsequent opens must re-read destination migration metadata — analogous
+    to restarting an NVMe-oF gateway process that holds the image open.
+
+    Args:
+        client: Gateway-like Client-B node.
+        image_spec: Destination image spec (``pool/image``).
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    try:
+        # Ensure rbd-nbd is available for the map/unmap cycle
+        nbd_check = exec_cmd(
+            node=client,
+            cmd="rpm -q rbd-nbd || yum install -y --nogpgcheck rbd-nbd",
+            output=True,
+            check_ec=False,
+            long_running=True,
+        )
+        log.info(f"rbd-nbd availability on Client-B: {nbd_check}")
+
+        # Best-effort cleanup of any stale mapping
+        exec_cmd(
+            node=client,
+            cmd=f"rbd device unmap -t nbd {image_spec}",
+            check_ec=False,
+        )
+
+        device = exec_cmd(
+            node=client,
+            cmd=f"rbd device map -t nbd {image_spec}",
+            output=True,
+        ).strip()
+        log.info(f"Mapped {image_spec} to {device} on Client-B")
+
+        exec_cmd(
+            node=client,
+            cmd=f"rbd device unmap -t nbd {device}",
+        )
+        log.info(
+            f"Unmapped {device}; simulated librbd/gateway-like consumer restart "
+            f"for {image_spec}"
+        )
+        return 0
+    except Exception as error:
+        log.error(f"Failed to simulate librbd consumer restart: {error}")
+        # Ensure we do not leave a mapped device behind
+        exec_cmd(
+            node=client,
+            cmd=f"rbd device unmap -t nbd {image_spec}",
+            check_ec=False,
+        )
+        return 1
+
+
+def verify_gateway_like_logs(client_b, source_key, workdir, test_start):
+    """Verify Client-B logs show no source-config requirement or key leak.
+
+    Args:
+        client_b: Gateway-like Client-B node.
+        source_key: Source CephX key that must not appear in logs.
+        workdir: Temporary work directory on Client-B.
+        test_start: Timestamp string for journalctl ``--since``.
+
+    Returns:
+        0 if checks pass, 1 otherwise.
+    """
+    if source_key and verify_key_not_logged(client_b, source_key, workdir, test_start):
+        return 1
+
+    # Look for messages that would indicate a local source conf/keyring or
+    # gateway API source-cluster parameter was required.
+    patterns = (
+        "source ceph.conf",
+        "source keyring",
+        "source-cluster",
+        "source_cluster",
+        "cluster_name.*required",
+    )
+    joined = "|".join(patterns)
+    cmd = (
+        'sh -c "'
+        f"journalctl --since '{test_start}' --no-pager 2>/dev/null "
+        f"| grep -Ei '{joined}' || true"
+        '"'
+    )
+    matches = exec_cmd(node=client_b, cmd=cmd, output=True, check_ec=False)
+    if matches and matches.strip():
+        log.error(
+            "Client-B logs indicate a requirement for source cluster config "
+            f"or gateway source-cluster parameter: {matches}"
+        )
+        return 1
+
+    log.info(
+        "Verified Client-B logs do not require source ceph.conf/keyring or "
+        "gateway API source-cluster parameter"
+    )
+    return 0

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -820,3 +820,77 @@ def wrapper_for_image_ops(**kw):
                 )
                 return 1
     return 0
+
+
+def run_rbd_fio(client, pool, image, rw, offset, size, pattern, **kw):
+    """Run fio with the rbd ioengine for verified pattern I/O.
+
+    Executes fio using ``--ioengine=rbd`` with verification and a
+    specific byte pattern at the given offset. This is useful for writing
+    known data patterns and verifying them later.
+
+    Args:
+        client: CephNode client where fio runs.
+        pool: RBD pool name.
+        image: RBD image name.
+        rw: fio read/write mode (e.g. ``write``, ``read``).
+        offset: Byte offset in the image (e.g. ``0``, ``4G``).
+        size: Size of the I/O region (e.g. ``1G``, ``256M``).
+        pattern: Byte pattern for verification (e.g. ``0xAA``).
+        kw: Optional overrides:
+            - name (str): fio job name. Default: ``rbd-fio``.
+            - rate (str): I/O rate limit (e.g. ``64M``).
+            - bs (str): Block size. Default: ``4M``.
+            - iodepth (int): I/O depth. Default: ``16``.
+            - timeout (int): Command timeout in seconds. Default: ``3600``.
+            - verify (str): fio verify mode. Default: ``crc32c``.
+              Use ``pattern`` for unwritten sparse holes (raw zeros have no
+              crc32c magic headers).
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    name = kw.get("name", "rbd-fio")
+    bs = kw.get("bs", "4M")
+    iodepth = kw.get("iodepth", 16)
+    rate = kw.get("rate")
+    timeout = kw.get("timeout", 3600)
+    verify = kw.get("verify", "crc32c")
+
+    cmd = (
+        f"fio --name={name} --ioengine=rbd --clientname=admin "
+        f"--pool={pool} --rbdname={image} --rw={rw} --bs={bs} "
+        f"--offset={offset} --size={size} --iodepth={iodepth} "
+        f"--verify={verify} --verify_pattern={pattern} --do_verify=1 "
+        f"--verify_fatal=1 --group_reporting"
+    )
+    if rate:
+        cmd += f" --rate={rate}"
+
+    from ceph.rbd.utils import exec_cmd
+
+    return exec_cmd(node=client, cmd=cmd, long_running=True, timeout=timeout)
+
+
+def get_checksum_rbd_image(client, image_spec, algorithm="sha256"):
+    """Compute a checksum of an RBD image by streaming rbd export to a hash tool.
+
+    This avoids writing the image to disk, making it efficient for
+    large images.
+
+    Args:
+        client: CephNode client to run the command on.
+        image_spec: Image or snap spec (e.g. ``pool/image`` or
+            ``pool/image@snap``).
+        algorithm: Hash algorithm to use. Default: ``sha256``.
+            Supported: ``sha256``, ``md5``.
+
+    Returns:
+        str: Hex digest of the image checksum.
+    """
+    hash_cmd = f"{algorithm}sum" if algorithm != "md5" else "md5sum"
+    cmd = f"rbd export {image_spec} - | {hash_cmd} | awk '{{print $1}}'"
+
+    from ceph.rbd.utils import exec_cmd
+
+    return exec_cmd(node=client, cmd=cmd, output=True, timeout=7200).strip()

--- a/cli/rbd/migration.py
+++ b/cli/rbd/migration.py
@@ -58,6 +58,8 @@ class Migration(Cli):
             Supported keys:
                 source_spec_path : json formatted string for streamed imports
                 dest_spec: Target image spec TARGET_POOL_NAME/TARGET_IMAGE_NAME
+                cluster_name: name of the destination cluster (optional; omit
+                    for import-only migrations driven entirely by the source spec)
 
         """
         log.info("Starting prepare Live migration of image to external ceph cluster")
@@ -66,6 +68,8 @@ class Migration(Cli):
         cluster_name = kw.get("cluster_name", None)
         cmd = (
             f"{self.base_cmd} prepare --import-only --source-spec-path {source_spec_path} "
-            f"{dest_spec} --cluster {cluster_name}"
+            f"{dest_spec}"
         )
+        if cluster_name is not None:
+            cmd += f" --cluster {cluster_name}"
         return self.execute_as_sudo(cmd=cmd, long_running=True)

--- a/suites/tentacle/rbd/tier-2_rbd_migration_key_import_9_2.yaml
+++ b/suites/tentacle/rbd/tier-2_rbd_migration_key_import_9_2.yaml
@@ -1,0 +1,374 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_migration_key_import_9_2.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/tentacle/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD, 1 Client
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client (also NVMe-oF Gateway / Client-B on destination)
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
+#     Node5 - OSD, rbd-mirror
+#
+# Objective:
+#    RBD native key import with mon_host 9.2 feature validation.
+#    All Polarion cases are implemented in one module
+#    (test_rbd_native_import_mon_host_inline_key.py) and selected via
+#    config.operation — same pattern as tier-2_non_default_namespace_mirroring.yaml:
+#    - CEPH-83632846: native import with mon_host and inline CephX key
+#    - CEPH-83632847: native import with mon_host and config:// credential reference
+#    - CEPH-83632851: source-backed reads from NVMe-oF gateway Client-B without
+#      local source ceph.conf/keyring (persisted migration metadata)
+#    - CEPH-83632848: sparse native import preserves used size and zero holes
+#    - CEPH-83632849: native import of LUKS/LUKS2 encrypted images with mon_host
+#    - CEPH-83632850: negative validation of mon_host/key native source-spec
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisites
+      desc: >
+        Setup phase to deploy the required pre-requisites
+        for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: Two ceph cluster deployment for RBD native import 9.2 testing
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy two ceph cluster
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - fio
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - fio
+            copy_admin_keyring: true
+      desc: Configure the client node for both the clusters
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+
+  - test:
+      name: Test native import with mon_host and key
+      desc: Verify RBD native import-only migration using mon_host and inline Ceph key
+      module: test_rbd_native_import_mon_host_inline_key.py
+      polarion-id: CEPH-83632846
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83632846
+            rep_pool_config:
+              src_pool: src_pool
+              dst_pool: dst_pool
+              src_image: src_image
+              target_image: target_image
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              image_size: 10G
+              source_pattern_size: 1G
+              source_pattern_a_offset: "0"
+              source_pattern_b_offset: 6G
+              target_write_offset: 2G
+              target_write_size: 256M
+              active_io_offset: 4G
+              active_io_size: 1G
+              active_io_rate: 64M
+            ec_pool_config:
+              src_pool: ec_src_pool
+              dst_pool: ec_dst_pool
+              src_image: ec_src_image
+              target_image: ec_target_image
+              src_snap: ec_snap1
+              source_client_name: client.rbd-migration
+              image_size: 10G
+              source_pattern_size: 1G
+              source_pattern_a_offset: "0"
+              source_pattern_b_offset: 6G
+              target_write_offset: 2G
+              target_write_size: 256M
+              active_io_offset: 4G
+              active_io_size: 1G
+              active_io_rate: 64M
+
+  - test:
+      name: Test native import with mon_host and config-key path
+      desc: >
+        Verify cross-cluster native import-only RBD migration using
+        mon_host and config:// credential reference
+      module: test_rbd_native_import_mon_host_inline_key.py
+      polarion-id: CEPH-83632847
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83632847
+            rep_pool_config:
+              src_pool: src_pool
+              dst_pool: dst_pool
+              src_image: src_image
+              target_image: target_image
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              config_key_path: rbd/native/source_client_key
+              image_size: 10G
+              source_pattern_size: 1G
+              source_pattern_a_offset: "0"
+              source_pattern_b_offset: 6G
+              target_write_offset: 2G
+              target_write_size: 256M
+              active_io_offset: 4G
+              active_io_size: 1G
+              active_io_rate: 64M
+            ec_pool_config:
+              src_pool: ec_src_pool
+              dst_pool: ec_dst_pool
+              src_image: ec_src_image
+              target_image: ec_target_image
+              src_snap: ec_snap1
+              source_client_name: client.rbd-migration
+              config_key_path: rbd/native/source_client_key
+              image_size: 10G
+              source_pattern_size: 1G
+              source_pattern_a_offset: "0"
+              source_pattern_b_offset: 6G
+              target_write_offset: 2G
+              target_write_size: 256M
+              active_io_offset: 4G
+              active_io_size: 1G
+              active_io_rate: 64M
+
+  - test:
+      name: Test native import sparse image preserves used size
+      desc: >
+        Verify sparse native import-only migration keeps used size close to
+        source and zero-fills unwritten holes across prepare/execute/commit.
+      module: test_rbd_native_import_mon_host_inline_key.py
+      polarion-id: CEPH-83632848
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83632848
+            rep_pool_config:
+              src_pool: src_pool
+              dst_pool: dst_pool
+              src_image: sparse_img
+              target_image: sparse_target
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              image_size: 10G
+              max_used_ratio: 0.5
+              max_inflation_ratio: 1.5
+            ec_pool_config:
+              src_pool: ec_src_pool
+              dst_pool: ec_dst_pool
+              src_image: ec_sparse_img
+              target_image: ec_sparse_target
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              image_size: 10G
+              max_used_ratio: 0.5
+              max_inflation_ratio: 1.5
+
+  - test:
+      name: Test native import NVMe-oF gateway Client-B source-backed reads
+      desc: >
+        Verify prepared import-only target reads from destination NVMe-oF
+        gateway Client-B without source conf/keyring, including after restart.
+      module: test_rbd_native_import_mon_host_inline_key.py
+      polarion-id: CEPH-83632851
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83632851
+            nvme_config:
+              rbd_pool: rbd
+              nvme_metadata_pool: rbd
+              gw_nodes:
+                - node2
+              gw_group: gw-group1
+              install: true
+              subsystem_nqn: nqn.2016-06.io.spdk:rbd-native-import
+              listener_port: 4420
+              allow_host: "*"
+              serial: "1"
+            rep_pool_config:
+              src_pool: src_pool
+              dst_pool: dst_pool
+              src_image: src_image
+              target_image: target_image
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              image_size: 10G
+
+  - test:
+      name: Test native import of encrypted RBD image with mon_host
+      desc: >
+        Verify import-only native migration of LUKS/LUKS2 encrypted RBD images
+        using mon_host and inline CephX key
+      module: test_rbd_native_import_mon_host_inline_key.py
+      polarion-id: CEPH-83632849
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83632849
+            encryption_type:
+              - luks1
+              - luks2
+            fio:
+              size: 100M
+            rep_pool_config:
+              src_pool: src_pool
+              dst_pool: dst_pool
+              src_image: encrypted_img
+              target_image: encrypted_target
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              image_size: 2G
+              target_write_size: 50M
+            ec_pool_config:
+              src_pool: ec_src_pool
+              dst_pool: ec_dst_pool
+              src_image: ec_encrypted_img
+              target_image: ec_encrypted_target
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              image_size: 2G
+              target_write_size: 50M
+
+  - test:
+      name: Test native import mon_host/key negative validation
+      desc: >
+        Verify migration prepare --import-only fails cleanly for invalid or
+        mutually exclusive mon_host/key native source-spec fields
+      module: test_rbd_native_import_mon_host_inline_key.py
+      polarion-id: CEPH-83632850
+      clusters:
+        ceph-rbd1:
+          config:
+            operation: CEPH-83632850
+            rep_pool_config:
+              src_pool: src_pool
+              dst_pool: dst_pool
+              src_image: src_image
+              target_image: neg_target
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              limited_client_name: client.rbd-migration-limited
+              image_size: 1G
+              source_pattern_size: 64M
+            ec_pool_config:
+              src_pool: ec_src_pool
+              dst_pool: ec_dst_pool
+              src_image: ec_src_image
+              target_image: ec_neg_target
+              src_snap: snap1
+              source_client_name: client.rbd-migration
+              limited_client_name: client.rbd-migration-limited
+              image_size: 1G
+              source_pattern_size: 64M

--- a/tests/rbd/test_rbd_native_import_mon_host_inline_key.py
+++ b/tests/rbd/test_rbd_native_import_mon_host_inline_key.py
@@ -1,0 +1,3595 @@
+"""RBD native import-only migration tests using mon_host credentials.
+
+Test cases covered (dispatched via config.operation, same pattern as
+test_namespace_mirror_operations.py) -
+CEPH-83632846 - Native import with mon_host and inline CephX key
+CEPH-83632847 - Native import with mon_host and config:// credential reference
+CEPH-83632851 - Source-backed reads from NVMe-oF gateway Client-B without
+                local source ceph.conf/keyring (persisted migration metadata)
+CEPH-83632848 - Sparse native import-only migration preserves used size and
+                zero-filled holes across prepare / execute / commit
+CEPH-83632849 - Native import of LUKS/LUKS2 encrypted images with mon_host
+                and inline CephX key (encryption preserved across prepare /
+                execute / commit)
+CEPH-83632850 - Negative validation of mon_host/key native source-spec
+                (missing/invalid fields, mutual exclusion, auth/config-key
+                failures, insufficient caps, stale-state checks)
+
+Pre-requisites:
+- Two Ceph clusters deployed and accessible (ceph-rbd1 and ceph-rbd2).
+- Each cluster has a client node with ceph-common and fio installed.
+- For CEPH-83632851, destination NVMe-oF gateway is deployed by the test
+  (or via suite) on configured gw_nodes.
+- Ceph/RHCS 9.2 or later.
+"""
+
+import random
+from datetime import datetime
+from time import sleep
+
+from looseversion import LooseVersion
+
+from ceph.parallel import parallel
+from ceph.rbd.io_utils import (
+    assert_image_is_sparse,
+    assert_used_size_close,
+    filter_profiles_by_role,
+    get_block_io_profiles,
+    get_effective_used_size,
+    get_rbd_du_exact,
+    get_sparse_io_profiles,
+    run_profile_fio,
+)
+from ceph.rbd.utils import copy_file, create_map_options, exec_cmd, random_string
+from ceph.rbd.workflows.cleanup import pool_cleanup
+from ceph.rbd.workflows.cluster_operations import (
+    get_ceph_major_version,
+    validate_cluster_health_and_daemons,
+    validate_min_ceph_version,
+)
+from ceph.rbd.workflows.encryption import create_passphrase_file
+from ceph.rbd.workflows.krbd_io_handler import krbd_io_handler
+from ceph.rbd.workflows.migration import (
+    assert_no_source_cluster_config,
+    attempt_migration_prepare_import,
+    create_insufficient_caps_cephx_client,
+    create_source_cephx_client,
+    get_source_mon_host,
+    prepare_gateway_like_client,
+    prepare_native_source_spec_with_config_key,
+    prepare_native_source_spec_with_key,
+    remove_config_key,
+    resolve_gateway_like_client,
+    simulate_librbd_consumer_restart,
+    store_source_key_in_config_key,
+    verify_config_key,
+    verify_gateway_like_logs,
+    verify_key_not_logged,
+    verify_migration_state,
+    verify_no_stale_migration_target,
+    write_native_source_spec,
+)
+from ceph.rbd.workflows.rbd import (
+    create_single_pool_and_images,
+    get_checksum_rbd_image,
+    run_rbd_fio,
+)
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import (
+    check_and_set_nvme_cli_image,
+    get_network_mask,
+)
+from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster
+
+log = Log(__name__)
+
+
+def _ensure_rbd_nbd(client):
+    """Install rbd-nbd if missing (required for encrypted device map)."""
+    out = exec_cmd(
+        cmd="rpm -qa|grep rbd-nbd", node=client, sudo=True, output=True, check_ec=False
+    )
+    if not out or out == 1 or "rbd-nbd" not in str(out):
+        exec_cmd(cmd="dnf install rbd-nbd -y", node=client, sudo=True)
+
+
+def _device_path_from_map_out(out):
+    """Normalize rbd device map stdout to a device path string."""
+    if isinstance(out, tuple):
+        out = out[0]
+    return str(out).strip()
+
+
+def map_encrypted_image(rbd, image_spec, encryption_config, device_type="nbd", **kw):
+    """Map an encrypted image/snap and return the device path."""
+    options = create_map_options(encryption_config)
+    map_config = {
+        "image-or-snap-spec": image_spec,
+        "device-type": device_type,
+        "options": options,
+    }
+    if kw.get("read_only"):
+        map_config["read-only"] = True
+    out, err = rbd.device.map(**map_config)
+    if err:
+        raise Exception(f"Encrypted map failed for {image_spec}: {err}")
+    return _device_path_from_map_out(out), options
+
+
+def unmap_encrypted_device(rbd, device, options=None, device_type="nbd"):
+    """Unmap an encrypted nbd/krbd device."""
+    unmap_config = {
+        "image-snap-or-device-spec": device,
+        "device-type": device_type,
+    }
+    if options:
+        unmap_config["options"] = options
+    out, err = rbd.device.unmap(**unmap_config)
+    if err and "not mapped" not in str(err).lower():
+        log.error(f"Encrypted unmap failed for {device}: {err}")
+        return 1
+    return 0
+
+
+def get_encrypted_file_checksum(
+    rbd, client, image_spec, encryption_config, file_path, read_only=False
+):
+    """Map encrypted image, mount filesystem, return md5 of file_path, then cleanup."""
+    _ensure_rbd_nbd(client)
+    device, options = map_encrypted_image(
+        rbd, image_spec, encryption_config, read_only=read_only
+    )
+    mount_point = file_path.rsplit("/", 1)[0]
+    try:
+        mount_cmd = f"mkdir -p {mount_point}; mount"
+        if read_only:
+            mount_cmd += " -o ro,noload"
+        mount_cmd += f" {device} {mount_point}"
+        out, err = exec_cmd(cmd=mount_cmd, node=client, all=True)
+        if err and out == 1:
+            raise Exception(
+                f"Mount failed for encrypted {image_spec} on {device}: {err}"
+            )
+        md5 = exec_cmd(node=client, cmd=f"md5sum {file_path}", output=True).split()[0]
+        log.info(f"Plaintext md5 for {file_path} on {image_spec}: {md5}")
+        return md5
+    finally:
+        exec_cmd(cmd=f"umount {mount_point}", node=client, check_ec=False)
+        unmap_encrypted_device(rbd, device, options=options)
+
+
+def verify_wrong_passphrase_rejected(rbd, client, image_spec, encryption_type, workdir):
+    """Verify map with wrong passphrase does not expose plaintext data.
+
+    Returns:
+        0 if map correctly fails (or mount of raw ciphertext fails), else 1.
+    """
+    _ensure_rbd_nbd(client)
+    wrong_pass = f"{workdir}/wrong_passphrase_{random_string(len=4)}.bin"
+    create_passphrase_file(client, wrong_pass)
+    options = create_map_options(
+        [
+            {"encryption-format": encryption_type},
+            {"encryption-passphrase-file": wrong_pass},
+        ]
+    )
+    map_config = {
+        "image-or-snap-spec": image_spec,
+        "device-type": "nbd",
+        "options": options,
+    }
+    try:
+        out, err = rbd.device.map(**map_config)
+        if err:
+            log.info(
+                f"Map with wrong passphrase correctly failed for {image_spec}: {err}"
+            )
+            return 0
+        # Unexpected success — ensure ciphertext is not a usable plaintext FS
+        device = _device_path_from_map_out(out)
+        log.warning(
+            f"Map with wrong passphrase unexpectedly succeeded for {image_spec}; "
+            "verifying plaintext is not readable"
+        )
+        try:
+            mount_point = f"/tmp/wrong_pass_mnt_{random_string(len=4)}"
+            out, err = exec_cmd(
+                cmd=f"mkdir -p {mount_point}; mount {device} {mount_point}",
+                node=client,
+                all=True,
+            )
+            if err and out == 1:
+                log.info(
+                    "Wrong-passphrase device is not mountable as plaintext filesystem"
+                )
+                return 0
+            log.error("Wrong-passphrase map exposed a mountable plaintext filesystem")
+            exec_cmd(cmd=f"umount {mount_point}", node=client, check_ec=False)
+            return 1
+        finally:
+            unmap_encrypted_device(rbd, device, options=options)
+    except Exception as error:
+        log.info(
+            f"Map with wrong passphrase correctly failed for {image_spec}: {error}"
+        )
+        return 0
+    finally:
+        exec_cmd(node=client, cmd=f"rm -f {wrong_pass}", check_ec=False)
+
+
+def verify_no_passphrase_hides_plaintext(rbd, client, image_spec, expected_file_path):
+    """Map without encryption options; plaintext file must not be readable."""
+    _ensure_rbd_nbd(client)
+    out, err = rbd.device.map(
+        **{"image-or-snap-spec": image_spec, "device-type": "nbd"}
+    )
+    if err:
+        log.info(f"Unencrypted map of encrypted image failed as expected: {err}")
+        return 0
+    device = _device_path_from_map_out(out)
+    mount_point = expected_file_path.rsplit("/", 1)[0]
+    try:
+        out, err = exec_cmd(
+            cmd=f"mkdir -p {mount_point}; mount {device} {mount_point}",
+            node=client,
+            all=True,
+        )
+        if err and out == 1:
+            log.info("Encrypted image without passphrase is not mountable as plaintext")
+            return 0
+        # If mount somehow works, the known data file must not match
+        exists = exec_cmd(
+            node=client,
+            cmd=f"test -f {expected_file_path}",
+            check_ec=False,
+        )
+        if exists == 0:
+            log.error("Plaintext data file readable without encryption passphrase")
+            return 1
+        log.info("Plaintext data file not present without encryption passphrase")
+        return 0
+    finally:
+        exec_cmd(cmd=f"umount {mount_point}", node=client, check_ec=False)
+        unmap_encrypted_device(rbd, device)
+
+
+def deploy_nvme_service_like_suite(destination_cluster, nvme_config, client=None, **kw):
+    """Deploy NVMe-oF the same way tentacle NVMe suites do (NVMeService).
+
+    Mirrors ``test_ceph_nvmeof_qos_tests`` / HA:
+    create dedicated ``rbd`` pool, ``NVMeService.deploy()``, ``init_gateways()``.
+    Gateway is placed on the destination client node by default (not an OSD).
+    """
+    rbd_pool = nvme_config.get("rbd_pool", "rbd")
+    nvme_config.setdefault("rbd_pool", rbd_pool)
+    nvme_config.setdefault("nvme_metadata_pool", rbd_pool)
+    nvme_config.setdefault("gw_group", "gw-group1")
+    # Destination client node is the NVMe-oF gateway (Client-B).
+    nvme_config.setdefault("gw_nodes", ["node2"])
+    nvme_config.setdefault("install", True)
+
+    if client:
+        for cmd in (
+            f"ceph osd pool create {rbd_pool}",
+            f"ceph osd pool application enable {rbd_pool} rbd",
+            f"rbd pool init {rbd_pool}",
+        ):
+            exec_cmd(node=client, cmd=cmd, check_ec=False)
+        log.info(f"Ensured NVMe RBD pool '{rbd_pool}' exists")
+
+    custom_config = kw.get("test_data", {}).get("custom-config")
+    try:
+        check_and_set_nvme_cli_image(destination_cluster, config=custom_config)
+    except RuntimeError as error:
+        log.info(f"NVMe CLI image check: {error}")
+
+    nvme_service = NVMeService(nvme_config, destination_cluster)
+    if nvme_config.get("install", True):
+        log.info(
+            "Deploying NVMe-oF via NVMeService "
+            f"(rbd_pool={rbd_pool}, metadata={nvme_service.nvme_metadata_pool}, "
+            f"gw_group={nvme_config.get('gw_group')}, "
+            f"gw_nodes={nvme_config.get('gw_nodes')})"
+        )
+        nvme_service.deploy()
+    nvme_service.init_gateways()
+    if not nvme_service.gateways:
+        raise Exception("NVMeService.init_gateways returned no gateways")
+    log.info(
+        f"NVMe-oF gateway ready on {nvme_service.gateways[0].node.hostname} "
+        f"(service={getattr(nvme_service, 'service_name', None)})"
+    )
+    return nvme_service
+
+
+def configure_nvme_namespace_for_image(
+    nvme_service, destination_cluster, pool, image, nvme_config
+):
+    """Configure subsystem/listener/host/namespace for an existing RBD image.
+
+    Follows ``gateway_entities.configure_subsystems`` conventions for
+    Ceph >= 20.2.1 (port + network-mask on subsystem.add).
+    """
+    gateway = nvme_service.gateways[0]
+    nqn = nvme_config.get("subsystem_nqn", "nqn.2016-06.io.spdk:rbd-native-import")
+    listener_port = nvme_config.get("listener_port", 4420)
+    allow_host = nvme_config.get("allow_host", "*")
+    serial = nvme_config.get("serial", "1")
+    sub_args = {"subsystem": nqn}
+
+    ceph_version = get_ceph_version_from_cluster(
+        destination_cluster.get_nodes(role="client")[0]
+    )
+    sub_add_args = {
+        **sub_args,
+        "serial-number": serial,
+        "max-namespaces": nvme_config.get("max_ns", 32),
+        "no-group-append": True,
+    }
+    if LooseVersion(ceph_version) >= LooseVersion("20.2.1"):
+        sub_add_args["port"] = listener_port
+        sub_add_args["network-mask"] = get_network_mask(nvme_service.gateways)
+        gateway.subsystem.add(**{"args": sub_add_args})
+    else:
+        gateway.subsystem.add(**{"args": sub_add_args})
+        gateway.listener.add(
+            **{
+                "args": {
+                    **sub_args,
+                    "host-name": gateway.fetch_gateway_hostname(),
+                    "traddr": gateway.node.ip_address,
+                    "trsvcid": listener_port,
+                }
+            }
+        )
+
+    gateway.host.add(**{"args": {**sub_args, "host": repr(allow_host)}})
+    gateway.namespace.add(
+        **{"args": {**sub_args, "rbd-pool": pool, "rbd-image": image}}
+    )
+    log.info(
+        f"Configured NVMe subsystem {nqn} namespace {pool}/{image} "
+        f"on {gateway.node.hostname}"
+    )
+    return nqn
+
+
+def restart_nvme_service(nvme_service, client, timeout=300):
+    """Redeploy NVMe-oF service (same as NVMe HA suites) and wait for running."""
+    import json
+
+    if nvme_service and getattr(nvme_service, "service_name", None):
+        log.info(f"Redeploying NVMe-oF service {nvme_service.service_name}")
+        nvme_service.redeploy(wait_sec=30)
+    else:
+        out = exec_cmd(
+            node=client,
+            cmd="ceph orch ps --daemon_type nvmeof --format json",
+            output=True,
+        )
+        daemons = json.loads(out) if out else []
+        for daemon in daemons:
+            full = daemon.get("daemon_name")
+            if not full:
+                continue
+            exec_cmd(node=client, cmd=f"ceph orch daemon redeploy {full}")
+
+    elapsed = 0
+    while elapsed < timeout:
+        status_out = exec_cmd(
+            node=client,
+            cmd="ceph orch ps --daemon_type nvmeof --format json",
+            output=True,
+        )
+        try:
+            status = json.loads(status_out) if status_out else []
+        except Exception:
+            status = []
+        if status and all(d.get("status_desc") == "running" for d in status):
+            log.info("NVMe-oF daemons running after redeploy")
+            return 0
+        sleep(10)
+        elapsed += 10
+    log.error(f"NVMe-oF daemons not running after {timeout}s")
+    return 1
+
+
+def cleanup_nvme_service(nvme_service, nvme_config):
+    """Best-effort delete subsystem and NVMe orch service."""
+    nqn = nvme_config.get("subsystem_nqn", "nqn.2016-06.io.spdk:rbd-native-import")
+    if nvme_service and nvme_service.gateways:
+        try:
+            nvme_service.gateways[0].subsystem.delete(
+                **{"args": {"subsystem": nqn, "force": True}}
+            )
+        except Exception as error:
+            log.info(f"NVMe subsystem cleanup: {error}")
+    if nvme_service and hasattr(nvme_service, "delete_nvme_service"):
+        try:
+            nvme_service.delete_nvme_service()
+        except Exception as error:
+            log.info(f"NVMe service cleanup: {error}")
+
+
+def test_native_import_mon_host_inline_key(
+    source_client, destination_client, is_ec_pool=False, **kw
+):
+    """Execute the RBD native import test using mon_host and inline key.
+
+    This test validates that an RBD image can be migrated across two
+    independent Ceph clusters using only the source cluster's monitor
+    addresses and an inline CephX key — without deploying source
+    ceph.conf or keyring files on the destination client.
+
+    Args:
+        source_client: Source cluster CephNode client.
+        destination_client: Destination cluster CephNode client.
+        is_ec_pool: If True, create EC pools instead of replicated pools.
+        kw: Test configuration keyword arguments.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    config = kw.get("config", {})
+    src_pool = config.get("src_pool", "src_pool")
+    dst_pool = config.get("dst_pool", "dst_pool")
+    src_image = config.get("src_image", "src_image")
+    target_image = config.get("target_image", f"target_image_{random_string(len=5)}")
+    snap_name = config.get("src_snap", "snap1")
+    image_size = config.get("image_size", "10G")
+    source_cephx_client = config.get("source_client_name", "client.rbd-migration")
+    workdir = config.get("workdir", "/tmp/rbd-native-import-test")
+    source_spec_path = config.get(
+        "source_spec_path", f"{workdir}/native-inline-key.json"
+    )
+    target_spec = f"{dst_pool}/{target_image}"
+    ceph_version = get_ceph_major_version(config)
+
+    source_rbd = Rbd(source_client)
+    destination_rbd = Rbd(destination_client)
+    source_entity = None
+    source_key = None
+
+    try:
+        # --- Setup workdir ---
+        exec_cmd(
+            node=destination_client, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}"
+        )
+
+        # --- Step 1: Validate cluster versions and health ---
+        if validate_min_ceph_version(
+            config,
+            9,
+            2,
+            ("source", source_client),
+            ("destination", destination_client),
+        ):
+            return 1
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # --- Step 2: Create source and destination pools ---
+        for label, client, rbd, pool in (
+            ("source", source_client, source_rbd, src_pool),
+            ("destination", destination_client, destination_rbd, dst_pool),
+        ):
+            rc = create_single_pool_and_images(
+                config=config,
+                pool=pool,
+                pool_config={
+                    "pg_num": config.get("pg_num", 32),
+                    "pgp_num": config.get("pgp_num", 32),
+                },
+                client=client,
+                cluster="ceph",
+                rbd=rbd,
+                ceph_version=ceph_version,
+                is_ec_pool=False,
+                is_secondary=False,
+                do_not_create_image=True,
+            )
+            if rc:
+                log.error(f"{label} pool creation failed")
+                return 1
+
+        # --- Step 3: Create source image and write data patterns ---
+        out, err = source_rbd.create(
+            **{"image-spec": f"{src_pool}/{src_image}", "size": image_size}
+        )
+        if out or err:
+            log.error(f"Source image creation failed: {out} {err}")
+            return 1
+
+        # Write pattern A at offset 0
+        run_rbd_fio(
+            client=source_client,
+            pool=src_pool,
+            image=src_image,
+            rw="write",
+            offset=config.get("source_pattern_a_offset", "0"),
+            size=config.get("source_pattern_size", "1G"),
+            pattern=config.get("source_pattern_a", "0xAA"),
+            name="source-pattern-a",
+        )
+        # Write pattern B at offset 6G
+        run_rbd_fio(
+            client=source_client,
+            pool=src_pool,
+            image=src_image,
+            rw="write",
+            offset=config.get("source_pattern_b_offset", "6G"),
+            size=config.get("source_pattern_size", "1G"),
+            pattern=config.get("source_pattern_b", "0xBB"),
+            name="source-pattern-b",
+        )
+        # Flush/verify source image is readable
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd export {src_pool}/{src_image} - >/dev/null",
+            long_running=True,
+            timeout=7200,
+        )
+
+        # --- Step 3b: Create source snapshot and baseline checksum ---
+        out, err = source_rbd.snap.create(
+            **{"snap-spec": f"{src_pool}/{src_image}@{snap_name}"}
+        )
+        if err and "error" in err.lower():
+            log.error(f"Source snapshot creation failed: {out} {err}")
+            return 1
+        log.info(f"Source snapshot created: {src_pool}/{src_image}@{snap_name}")
+        source_rbd.snap.ls(**{"image-spec": f"{src_pool}/{src_image}"})
+
+        baseline_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        log.info(f"Source snapshot baseline sha256: {baseline_checksum}")
+
+        # --- Step 4: Create CephX client and build native source spec ---
+        source_entity, source_key = create_source_cephx_client(
+            client=source_client,
+            pool=src_pool,
+            client_name=source_cephx_client,
+        )
+        mon_host = get_source_mon_host(source_client)
+        spec = prepare_native_source_spec_with_key(
+            client=destination_client,
+            spec_path=source_spec_path,
+            mon_host=mon_host,
+            client_name=source_entity,
+            key=source_key,
+            pool_name=src_pool,
+            image_name=src_image,
+            snap_name=snap_name,
+        )
+
+        # Verify destination resolves to a different cluster than source
+        source_fsid = exec_cmd(node=source_client, cmd="ceph fsid", output=True).strip()
+        destination_fsid = exec_cmd(
+            node=destination_client, cmd="ceph fsid", output=True
+        ).strip()
+        if source_fsid == destination_fsid:
+            log.error(
+                f"Source and destination resolve to the same cluster "
+                f"fsid {source_fsid}"
+            )
+            return 1
+        if "cluster_name" in spec:
+            log.error("mon_host/key source spec must not include cluster_name")
+            return 1
+        log.info(
+            f"Destination fsid {destination_fsid}, source fsid {source_fsid} "
+            f"(confirmed different clusters)"
+        )
+
+        # --- Step 5: Prepare import-only migration ---
+        destination_rbd.migration.prepare_import(
+            source_spec_path=source_spec_path,
+            dest_spec=target_spec,
+        )
+
+        # Verify target image exists in destination pool
+        out, err = destination_rbd.ls(**{"pool-spec": dst_pool})
+        if target_image not in out.split():
+            log.error(f"Target image {target_spec} not listed in destination pool")
+            return 1
+        destination_rbd.info(**{"image-or-snap-spec": target_spec})
+
+        if verify_migration_state(
+            action="prepare",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration prepare state verification failed")
+            return 1
+
+        # --- Step 6: Verify reads from prepared image match source ---
+        prepared_checksum = get_checksum_rbd_image(destination_client, target_spec)
+        if prepared_checksum != baseline_checksum:
+            log.error(
+                f"Prepared target checksum mismatch: source={baseline_checksum} "
+                f"destination={prepared_checksum}"
+            )
+            return 1
+        log.info("Prepared target checksum matches source baseline")
+
+        # --- Step 7: Target-side writes (while prepared) ---
+        run_rbd_fio(
+            client=destination_client,
+            pool=dst_pool,
+            image=target_image,
+            rw="write",
+            offset=config.get("target_write_offset", "2G"),
+            size=config.get("target_write_size", "256M"),
+            pattern=config.get("target_write_pattern", "0xCC"),
+            name="target-post-prepare-write",
+        )
+        run_rbd_fio(
+            client=destination_client,
+            pool=dst_pool,
+            image=target_image,
+            rw="read",
+            offset=config.get("target_write_offset", "2G"),
+            size=config.get("target_write_size", "256M"),
+            pattern=config.get("target_write_pattern", "0xCC"),
+            name="target-post-prepare-read-verify",
+        )
+
+        # Verify source snapshot is unchanged (immutability check)
+        source_checksum_after = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if source_checksum_after != baseline_checksum:
+            log.error("Source snapshot changed after target-side writes")
+            return 1
+
+        # --- Step 8: Execute migration with concurrent I/O ---
+        def _execute_migration():
+            destination_rbd.migration.action(
+                action="execute",
+                dest_spec=target_spec,
+            )
+
+        def _run_active_io():
+            run_rbd_fio(
+                client=destination_client,
+                pool=dst_pool,
+                image=target_image,
+                rw="write",
+                offset=config.get("active_io_offset", "4G"),
+                size=config.get("active_io_size", "1G"),
+                pattern=config.get("active_io_pattern", "0xDD"),
+                rate=config.get("active_io_rate", "64M"),
+                name="target-active-io",
+                timeout=7200,
+            )
+
+        with parallel(timeout=7200, max_workers=2) as p:
+            p.spawn(_run_active_io)
+            sleep(config.get("active_io_start_delay", 5))
+            p.spawn(_execute_migration)
+
+        if verify_migration_state(
+            action="execute",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration execute state verification failed")
+            return 1
+
+        # --- Step 9: Verify all data regions after execute ---
+        verify_regions = [
+            (
+                "verify-source-backed-a",
+                "source_pattern_a_offset",
+                "0",
+                "source_pattern_size",
+                "1G",
+                "source_pattern_a",
+                "0xAA",
+            ),
+            (
+                "verify-source-backed-b",
+                "source_pattern_b_offset",
+                "6G",
+                "source_pattern_size",
+                "1G",
+                "source_pattern_b",
+                "0xBB",
+            ),
+            (
+                "verify-target-write",
+                "target_write_offset",
+                "2G",
+                "target_write_size",
+                "256M",
+                "target_write_pattern",
+                "0xCC",
+            ),
+            (
+                "verify-active-io",
+                "active_io_offset",
+                "4G",
+                "active_io_size",
+                "1G",
+                "active_io_pattern",
+                "0xDD",
+            ),
+        ]
+        for name, off_key, off_def, sz_key, sz_def, pat_key, pat_def in verify_regions:
+            run_rbd_fio(
+                client=destination_client,
+                pool=dst_pool,
+                image=target_image,
+                rw="read",
+                offset=config.get(off_key, off_def),
+                size=config.get(sz_key, sz_def),
+                pattern=config.get(pat_key, pat_def),
+                name=f"{name}-after-execute",
+            )
+
+        # --- Step 10: Commit migration and final verification ---
+        destination_rbd.migration.action(
+            action="commit",
+            dest_spec=target_spec,
+        )
+
+        if verify_migration_state(
+            action="commit",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration commit state verification failed")
+            return 1
+
+        # Final data integrity verification for all four regions
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd export {target_spec} - >/dev/null",
+            long_running=True,
+            timeout=7200,
+        )
+        for name, off_key, off_def, sz_key, sz_def, pat_key, pat_def in verify_regions:
+            run_rbd_fio(
+                client=destination_client,
+                pool=dst_pool,
+                image=target_image,
+                rw="read",
+                offset=config.get(off_key, off_def),
+                size=config.get(sz_key, sz_def),
+                pattern=config.get(pat_key, pat_def),
+                name=f"final-{name}",
+            )
+        log.info("Reads at all offsets completed successfully for the migrated image")
+
+        # Verify source snapshot immutability throughout the migration lifecycle
+        final_source_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if final_source_checksum != baseline_checksum:
+            log.error("Source snapshot changed by migration lifecycle")
+            return 1
+
+        # Final cluster health checks
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # --- Step 11: Security check — inline key not leaked ---
+        test_start = kw.get("test_start")
+        if (
+            test_start
+            and source_key
+            and verify_key_not_logged(
+                destination_client, source_key, workdir, test_start
+            )
+        ):
+            return 1
+
+        log.info("RBD native import with mon_host and inline key passed")
+        return 0
+
+    except Exception as error:
+        log.error(f"RBD native import with mon_host and inline key failed: {error}")
+        return 1
+
+    finally:
+        log.info("Cleaning up RBD native import test resources")
+
+        # Remove spec file from destination
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -f {source_spec_path}",
+            check_ec=False,
+        )
+
+        # Final key leak check during cleanup
+        if source_key:
+            verify_key_not_logged(
+                destination_client,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+
+        # Abort migration if still in progress, then remove target image
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+
+        # Remove source snapshot and image
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd snap rm {src_pool}/{src_image}@{snap_name}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd rm {src_pool}/{src_image}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+
+        # Remove CephX client from source cluster
+        if source_entity:
+            exec_cmd(
+                node=source_client,
+                cmd=f"ceph auth rm {source_entity}",
+                check_ec=False,
+            )
+
+        # Cleanup pools
+        pool_cleanup(
+            client=destination_client,
+            pools=[dst_pool],
+            ceph_version=ceph_version,
+        )
+        pool_cleanup(
+            client=source_client,
+            pools=[src_pool],
+            ceph_version=ceph_version,
+        )
+
+        # Remove work directory
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -rf {workdir}",
+            check_ec=False,
+        )
+
+
+def test_native_import_mon_host_config_key(
+    source_client, destination_client, is_ec_pool=False, **kw
+):
+    """Execute RBD native import using mon_host and config:// key reference.
+
+    Validates that an RBD image can be migrated across two independent Ceph
+    clusters using source mon_host addresses and a CephX key stored in the
+    destination MON config-key store (referenced via config://), without
+    deploying source ceph.conf or keyring files on the destination client.
+
+    Args:
+        source_client: Source cluster CephNode client.
+        destination_client: Destination cluster CephNode client.
+        is_ec_pool: If True, create EC pools instead of replicated pools.
+        kw: Test configuration keyword arguments.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    config = kw.get("config", {})
+    src_pool = config.get("src_pool", "src_pool")
+    dst_pool = config.get("dst_pool", "dst_pool")
+    src_image = config.get("src_image", "src_image")
+    target_image = config.get("target_image", f"target_image_{random_string(len=5)}")
+    snap_name = config.get("src_snap", "snap1")
+    image_size = config.get("image_size", "10G")
+    source_cephx_client = config.get("source_client_name", "client.rbd-migration")
+    config_key_path = config.get("config_key_path", "rbd/native/source_client_key")
+    workdir = config.get("workdir", "/tmp/rbd-native-import-config-key-test")
+    source_spec_path = config.get(
+        "source_spec_path", f"{workdir}/native-config-key.json"
+    )
+    target_spec = f"{dst_pool}/{target_image}"
+    ceph_version = get_ceph_major_version(config)
+
+    source_rbd = Rbd(source_client)
+    destination_rbd = Rbd(destination_client)
+    source_entity = None
+    source_key = None
+    config_key_stored = False
+
+    try:
+        # --- Setup workdir ---
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}")
+
+        # --- Step 1: Validate cluster versions and health ---
+        if validate_min_ceph_version(
+            config,
+            9,
+            2,
+            ("source", source_client),
+            ("destination", destination_client),
+        ):
+            return 1
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # --- Step 2: Create source and destination pools ---
+        for label, client, rbd, pool in (
+            ("source", source_client, source_rbd, src_pool),
+            ("destination", destination_client, destination_rbd, dst_pool),
+        ):
+            rc = create_single_pool_and_images(
+                config=config,
+                pool=pool,
+                pool_config={
+                    "pg_num": config.get("pg_num", 32),
+                    "pgp_num": config.get("pgp_num", 32),
+                },
+                client=client,
+                cluster="ceph",
+                rbd=rbd,
+                ceph_version=ceph_version,
+                is_ec_pool=False,
+                is_secondary=False,
+                do_not_create_image=True,
+            )
+            if rc:
+                log.error(f"{label} pool creation failed")
+                return 1
+
+        # --- Step 3: Create source image and write data patterns ---
+        out, err = source_rbd.create(
+            **{"image-spec": f"{src_pool}/{src_image}", "size": image_size}
+        )
+        if out or err:
+            log.error(f"Source image creation failed: {out} {err}")
+            return 1
+
+        run_rbd_fio(
+            client=source_client,
+            pool=src_pool,
+            image=src_image,
+            rw="write",
+            offset=config.get("source_pattern_a_offset", "0"),
+            size=config.get("source_pattern_size", "1G"),
+            pattern=config.get("source_pattern_a", "0xAA"),
+            name="source-pattern-a",
+        )
+        run_rbd_fio(
+            client=source_client,
+            pool=src_pool,
+            image=src_image,
+            rw="write",
+            offset=config.get("source_pattern_b_offset", "6G"),
+            size=config.get("source_pattern_size", "1G"),
+            pattern=config.get("source_pattern_b", "0xBB"),
+            name="source-pattern-b",
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd export {src_pool}/{src_image} - >/dev/null",
+            long_running=True,
+            timeout=7200,
+        )
+
+        # --- Step 3b: Create source snapshot and baseline checksum ---
+        out, err = source_rbd.snap.create(
+            **{"snap-spec": f"{src_pool}/{src_image}@{snap_name}"}
+        )
+        if err and "error" in err.lower():
+            log.error(f"Source snapshot creation failed: {out} {err}")
+            return 1
+        log.info(f"Source snapshot created: {src_pool}/{src_image}@{snap_name}")
+        source_rbd.snap.ls(**{"image-spec": f"{src_pool}/{src_image}"})
+
+        baseline_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        log.info(f"Source snapshot baseline sha256: {baseline_checksum}")
+
+        # --- Steps 4-5: Create CephX client and fetch key ---
+        source_entity, source_key = create_source_cephx_client(
+            client=source_client,
+            pool=src_pool,
+            client_name=source_cephx_client,
+        )
+
+        # --- Steps 6-7: Store and verify key in destination config-key ---
+        store_source_key_in_config_key(
+            client=destination_client,
+            config_key_path=config_key_path,
+            key=source_key,
+            workdir=workdir,
+        )
+        config_key_stored = True
+        if verify_config_key(destination_client, config_key_path, source_key):
+            return 1
+
+        # --- Steps 8-10: Build source-spec with config:// reference ---
+        mon_host = get_source_mon_host(source_client)
+        spec = prepare_native_source_spec_with_config_key(
+            client=destination_client,
+            spec_path=source_spec_path,
+            mon_host=mon_host,
+            client_name=source_entity,
+            config_key_path=config_key_path,
+            pool_name=src_pool,
+            image_name=src_image,
+            snap_name=snap_name,
+        )
+
+        expected_key_ref = f"config://{config_key_path}"
+        if spec.get("key") != expected_key_ref:
+            log.error(
+                f"Source-spec key must be {expected_key_ref}, got {spec.get('key')}"
+            )
+            return 1
+        # Ensure raw key is not embedded in the source-spec file
+        spec_contents = exec_cmd(
+            node=destination_client,
+            cmd=f"cat {source_spec_path}",
+            output=True,
+        )
+        if source_key in spec_contents:
+            log.error("Raw source CephX key must not appear in source-spec file")
+            return 1
+        if "cluster_name" in spec:
+            log.error("mon_host/config:// source spec must not include cluster_name")
+            return 1
+
+        source_fsid = exec_cmd(node=source_client, cmd="ceph fsid", output=True).strip()
+        destination_fsid = exec_cmd(
+            node=destination_client, cmd="ceph fsid", output=True
+        ).strip()
+        if source_fsid == destination_fsid:
+            log.error(
+                f"Source and destination resolve to the same cluster "
+                f"fsid {source_fsid}"
+            )
+            return 1
+        log.info(
+            f"Destination fsid {destination_fsid}, source fsid {source_fsid} "
+            f"(confirmed different clusters)"
+        )
+
+        # --- Step 11-12: Prepare import-only migration ---
+        destination_rbd.migration.prepare_import(
+            source_spec_path=source_spec_path,
+            dest_spec=target_spec,
+        )
+
+        out, err = destination_rbd.ls(**{"pool-spec": dst_pool})
+        if target_image not in out.split():
+            log.error(f"Target image {target_spec} not listed in destination pool")
+            return 1
+        destination_rbd.info(**{"image-or-snap-spec": target_spec})
+
+        if verify_migration_state(
+            action="prepare",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration prepare state verification failed")
+            return 1
+
+        # --- Steps 13-14: Immediate reads match source snapshot ---
+        prepared_checksum = get_checksum_rbd_image(destination_client, target_spec)
+        if prepared_checksum != baseline_checksum:
+            log.error(
+                f"Prepared target checksum mismatch: source={baseline_checksum} "
+                f"destination={prepared_checksum}"
+            )
+            return 1
+        log.info(
+            "Prepared target checksum matches source baseline "
+            "(config:// key resolved from destination MON config-key store)"
+        )
+
+        # --- Steps 15-16: Target-side writes; source snap unchanged ---
+        run_rbd_fio(
+            client=destination_client,
+            pool=dst_pool,
+            image=target_image,
+            rw="write",
+            offset=config.get("target_write_offset", "2G"),
+            size=config.get("target_write_size", "256M"),
+            pattern=config.get("target_write_pattern", "0xCC"),
+            name="target-post-prepare-write",
+        )
+        run_rbd_fio(
+            client=destination_client,
+            pool=dst_pool,
+            image=target_image,
+            rw="read",
+            offset=config.get("target_write_offset", "2G"),
+            size=config.get("target_write_size", "256M"),
+            pattern=config.get("target_write_pattern", "0xCC"),
+            name="target-post-prepare-read-verify",
+        )
+
+        source_checksum_after = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if source_checksum_after != baseline_checksum:
+            log.error("Source snapshot changed after target-side writes")
+            return 1
+
+        # --- Step 17: Execute migration with concurrent I/O ---
+        def _execute_migration():
+            destination_rbd.migration.action(
+                action="execute",
+                dest_spec=target_spec,
+            )
+
+        def _run_active_io():
+            run_rbd_fio(
+                client=destination_client,
+                pool=dst_pool,
+                image=target_image,
+                rw="write",
+                offset=config.get("active_io_offset", "4G"),
+                size=config.get("active_io_size", "1G"),
+                pattern=config.get("active_io_pattern", "0xDD"),
+                rate=config.get("active_io_rate", "64M"),
+                name="target-active-io",
+                timeout=7200,
+            )
+
+        with parallel(timeout=7200, max_workers=2) as p:
+            p.spawn(_run_active_io)
+            sleep(config.get("active_io_start_delay", 5))
+            p.spawn(_execute_migration)
+
+        if verify_migration_state(
+            action="execute",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration execute state verification failed")
+            return 1
+
+        verify_regions = [
+            (
+                "verify-source-backed-a",
+                "source_pattern_a_offset",
+                "0",
+                "source_pattern_size",
+                "1G",
+                "source_pattern_a",
+                "0xAA",
+            ),
+            (
+                "verify-source-backed-b",
+                "source_pattern_b_offset",
+                "6G",
+                "source_pattern_size",
+                "1G",
+                "source_pattern_b",
+                "0xBB",
+            ),
+            (
+                "verify-target-write",
+                "target_write_offset",
+                "2G",
+                "target_write_size",
+                "256M",
+                "target_write_pattern",
+                "0xCC",
+            ),
+            (
+                "verify-active-io",
+                "active_io_offset",
+                "4G",
+                "active_io_size",
+                "1G",
+                "active_io_pattern",
+                "0xDD",
+            ),
+        ]
+        for name, off_key, off_def, sz_key, sz_def, pat_key, pat_def in verify_regions:
+            run_rbd_fio(
+                client=destination_client,
+                pool=dst_pool,
+                image=target_image,
+                rw="read",
+                offset=config.get(off_key, off_def),
+                size=config.get(sz_key, sz_def),
+                pattern=config.get(pat_key, pat_def),
+                name=f"{name}-after-execute",
+            )
+
+        # --- Step 18: Commit migration ---
+        destination_rbd.migration.action(
+            action="commit",
+            dest_spec=target_spec,
+        )
+
+        if verify_migration_state(
+            action="commit",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration commit state verification failed")
+            return 1
+
+        # --- Steps 19-20: Reopen target, final verify, health ---
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd export {target_spec} - >/dev/null",
+            long_running=True,
+            timeout=7200,
+        )
+        for name, off_key, off_def, sz_key, sz_def, pat_key, pat_def in verify_regions:
+            run_rbd_fio(
+                client=destination_client,
+                pool=dst_pool,
+                image=target_image,
+                rw="read",
+                offset=config.get(off_key, off_def),
+                size=config.get(sz_key, sz_def),
+                pattern=config.get(pat_key, pat_def),
+                name=f"final-{name}",
+            )
+
+        final_source_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if final_source_checksum != baseline_checksum:
+            log.error("Source snapshot changed by migration lifecycle")
+            return 1
+
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        test_start = kw.get("test_start")
+        if (
+            test_start
+            and source_key
+            and verify_key_not_logged(
+                destination_client, source_key, workdir, test_start
+            )
+        ):
+            return 1
+
+        log.info(
+            "RBD native import with mon_host and config:// credential reference passed"
+        )
+        return 0
+
+    except Exception as error:
+        log.error(f"RBD native import with mon_host and config:// key failed: {error}")
+        return 1
+
+    finally:
+        log.info("Cleaning up RBD native import config-key test resources")
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -f {source_spec_path}",
+            check_ec=False,
+        )
+
+        if source_key:
+            verify_key_not_logged(
+                destination_client,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd snap rm {src_pool}/{src_image}@{snap_name}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd rm {src_pool}/{src_image}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+
+        if config_key_stored:
+            remove_config_key(destination_client, config_key_path)
+
+        if source_entity:
+            exec_cmd(
+                node=source_client,
+                cmd=f"ceph auth rm {source_entity}",
+                check_ec=False,
+            )
+
+        pool_cleanup(
+            client=destination_client,
+            pools=[dst_pool],
+            ceph_version=ceph_version,
+        )
+        pool_cleanup(
+            client=source_client,
+            pools=[src_pool],
+            ceph_version=ceph_version,
+        )
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -rf {workdir}",
+            check_ec=False,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rm -rf {workdir}",
+            check_ec=False,
+        )
+
+
+def test_native_import_gateway_like_client(
+    source_client, client_a, client_b, is_ec_pool=False, **kw
+):
+    """Execute CEPH-83632851 NVMe-oF gateway Client-B native import validation.
+
+    Deploys an NVMe-oF gateway on the destination cluster, uses the gateway
+    node as Client-B (destination-only config), prepares import-only migration
+    on Client-A, exposes the target via NVMe namespace, validates source-backed
+    reads, restarts the NVMe-oF daemon, and completes execute/commit.
+
+    Args:
+        source_client: Source cluster CephNode client.
+        client_a: Destination Client-A used for prepare/execute/commit.
+        client_b: Destination NVMe-oF gateway node (Client-B).
+        is_ec_pool: If True, create EC pools instead of replicated pools.
+        kw: Test configuration keyword arguments. Expects optional
+            ``destination_cluster`` and ``nvme_config``.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    config = kw.get("config", {})
+    src_pool = config.get("src_pool", "src_pool")
+    dst_pool = config.get("dst_pool", "dst_pool")
+    src_image = config.get("src_image", "src_image")
+    target_image = config.get("target_image", f"target_image_{random_string(len=5)}")
+    snap_name = config.get("src_snap", "snap1")
+    image_size = config.get("image_size", "10G")
+    source_cephx_client = config.get("source_client_name", "client.rbd-migration")
+    workdir = config.get("workdir", "/tmp/rbd-native-import-gateway-like-test")
+    source_spec_path = config.get(
+        "source_spec_path", f"{workdir}/native-gateway-like.json"
+    )
+    target_spec = f"{dst_pool}/{target_image}"
+    ceph_version = get_ceph_major_version(config)
+    destination_cluster = kw.get("destination_cluster")
+    nvme_config = dict(kw.get("nvme_config") or config.get("nvme_config") or {})
+    # Dedicated NVMe pool; gateway runs on destination client (node2).
+    nvme_config.setdefault("gw_nodes", ["node2"])
+    nvme_config.setdefault("gw_group", "gw-group1")
+    nvme_config.setdefault("rbd_pool", "rbd")
+    nvme_config.setdefault("nvme_metadata_pool", "rbd")
+    nvme_config.setdefault("install", True)
+
+    source_rbd = Rbd(source_client)
+    client_a_rbd = Rbd(client_a)
+    client_b_rbd = Rbd(client_b)
+    source_entity = None
+    source_key = None
+    mon_host = None
+    source_fsid = None
+    nvmegwcli = None
+    nvme_service = None
+    nvme_deployed = False
+
+    try:
+        # --- Setup workdirs ---
+        for node in (source_client, client_a, client_b):
+            exec_cmd(node=node, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}")
+
+        # --- Step 1: Validate cluster versions and health ---
+        if validate_min_ceph_version(
+            config,
+            9,
+            2,
+            ("source", source_client),
+            ("destination-client-a", client_a),
+        ):
+            return 1
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(client_a, "destination"):
+            return 1
+
+        # --- Step 2: Create source and destination pools ---
+        for label, client, rbd, pool in (
+            ("source", source_client, source_rbd, src_pool),
+            ("destination", client_a, client_a_rbd, dst_pool),
+        ):
+            rc = create_single_pool_and_images(
+                config=config,
+                pool=pool,
+                pool_config={
+                    "pg_num": config.get("pg_num", 32),
+                    "pgp_num": config.get("pgp_num", 32),
+                },
+                client=client,
+                cluster="ceph",
+                rbd=rbd,
+                ceph_version=ceph_version,
+                is_ec_pool=False,
+                is_secondary=False,
+                do_not_create_image=True,
+            )
+            if rc:
+                log.error(f"{label} pool creation failed")
+                return 1
+
+        # --- Step 3: Create source image, write multi-bs patterns, snapshot ---
+        out, err = source_rbd.create(
+            **{"image-spec": f"{src_pool}/{src_image}", "size": image_size}
+        )
+        if out or err:
+            log.error(f"Source image creation failed: {out} {err}")
+            return 1
+
+        io_profiles = get_block_io_profiles(config)
+        source_profiles = filter_profiles_by_role(io_profiles, "source")
+        target_profiles = filter_profiles_by_role(io_profiles, "target")
+        log.info(
+            "Using block IO profiles: source=%s target=%s",
+            [f"{p['name']}({p['bs']})" for p in source_profiles],
+            [f"{p['name']}({p['bs']})" for p in target_profiles],
+        )
+        for profile in source_profiles:
+            if run_profile_fio(
+                source_client, src_pool, src_image, profile, "write", "src-write-"
+            ):
+                log.error(f"Source write failed for profile {profile['name']}")
+                return 1
+
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd export {src_pool}/{src_image} - >/dev/null",
+            long_running=True,
+            timeout=7200,
+        )
+
+        out, err = source_rbd.snap.create(
+            **{"snap-spec": f"{src_pool}/{src_image}@{snap_name}"}
+        )
+        if err and "error" in err.lower():
+            log.error(f"Source snapshot creation failed: {out} {err}")
+            return 1
+        log.info(f"Source snapshot created: {src_pool}/{src_image}@{snap_name}")
+
+        # --- Step 4: Baseline checksum ---
+        baseline_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        log.info(f"Source snapshot baseline sha256: {baseline_checksum}")
+
+        # --- Steps 5-6: Source CephX client + mon_host ---
+        source_entity, source_key = create_source_cephx_client(
+            client=source_client,
+            pool=src_pool,
+            client_name=source_cephx_client,
+        )
+        mon_host = get_source_mon_host(source_client)
+        source_fsid = exec_cmd(node=source_client, cmd="ceph fsid", output=True).strip()
+        destination_fsid = exec_cmd(node=client_a, cmd="ceph fsid", output=True).strip()
+        if source_fsid == destination_fsid:
+            log.error(
+                f"Source and destination resolve to the same cluster "
+                f"fsid {source_fsid}"
+            )
+            return 1
+        log.info(
+            f"Destination fsid {destination_fsid}, source fsid {source_fsid} "
+            f"(confirmed different clusters)"
+        )
+
+        # --- Steps 7-8: Deploy NVMe-oF gateway; Client-B is gateway node ---
+        if not destination_cluster:
+            log.error("destination_cluster is required for NVMe-oF gateway deploy")
+            return 1
+
+        log.info(
+            f"Deploying NVMe-oF gateway via NVMeService "
+            f"(nodes={nvme_config.get('gw_nodes')}, "
+            f"rbd_pool={nvme_config.get('rbd_pool')}, "
+            f"group={nvme_config.get('gw_group')}); "
+            f"namespace will use migration target {dst_pool}/{target_image}"
+        )
+        nvme_service = deploy_nvme_service_like_suite(
+            destination_cluster,
+            nvme_config,
+            client=client_a,
+            test_data=kw.get("test_data", {}),
+        )
+        nvmegwcli = nvme_service.gateways[0]
+        client_b = nvmegwcli.node
+        nvme_deployed = True
+        client_b_rbd = Rbd(client_b)
+        exec_cmd(node=client_b, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}")
+
+        log.info(
+            f"Client-A for prepare/execute/commit: {client_a.hostname}; "
+            f"Client-B NVMe-oF gateway node: {client_b.hostname}"
+        )
+        # Ensure gateway node can run rbd/fio with destination-only conf
+        if prepare_gateway_like_client(client_a, client_b):
+            return 1
+        if assert_no_source_cluster_config(
+            client_b, source_fsid=source_fsid, source_mon_host=mon_host
+        ):
+            return 1
+
+        # --- Steps 9-11: Source-spec + import-only prepare on Client-A ---
+        spec = prepare_native_source_spec_with_key(
+            client=client_a,
+            spec_path=source_spec_path,
+            mon_host=mon_host,
+            client_name=source_entity,
+            key=source_key,
+            pool_name=src_pool,
+            image_name=src_image,
+            snap_name=snap_name,
+        )
+        if "cluster_name" in spec:
+            log.error("mon_host/key source spec must not include cluster_name")
+            return 1
+
+        # Source-spec must never be copied to Client-B / gateway
+        exec_cmd(
+            node=client_b,
+            cmd=f"rm -f {source_spec_path}",
+            check_ec=False,
+        )
+
+        client_a_rbd.migration.prepare_import(
+            source_spec_path=source_spec_path,
+            dest_spec=target_spec,
+        )
+
+        out, err = client_a_rbd.ls(**{"pool-spec": dst_pool})
+        if target_image not in out.split():
+            log.error(f"Target image {target_spec} not listed in destination pool")
+            return 1
+        client_a_rbd.info(**{"image-or-snap-spec": target_spec})
+
+        if verify_migration_state(
+            action="prepare",
+            image_spec=target_spec,
+            client=client_a,
+        ):
+            log.error("Migration prepare state verification failed")
+            return 1
+
+        # Expose prepared target via NVMe-oF namespace on the gateway (Client-B)
+        configure_nvme_namespace_for_image(
+            nvme_service,
+            destination_cluster,
+            dst_pool,
+            target_image,
+            nvme_config,
+        )
+
+        # --- Steps 12-15: Client-B/gateway source-backed reads without source config ---
+        if assert_no_source_cluster_config(
+            client_b, source_fsid=source_fsid, source_mon_host=mon_host
+        ):
+            return 1
+
+        client_b_rbd.info(**{"image-or-snap-spec": target_spec})
+        prepared_checksum = get_checksum_rbd_image(client_b, target_spec)
+        if prepared_checksum != baseline_checksum:
+            log.error(
+                f"Client-B prepared target checksum mismatch: "
+                f"source={baseline_checksum} client_b={prepared_checksum}"
+            )
+            return 1
+        log.info(
+            "Client-B/NVMe-oF gateway prepared target checksum matches source "
+            "baseline (source-backed reads via persisted migration metadata)"
+        )
+
+        for profile in source_profiles:
+            if run_profile_fio(
+                client_b,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "client-b-read-",
+            ):
+                log.error(
+                    f"Client-B source-backed read failed for profile "
+                    f"{profile['name']} (bs={profile['bs']})"
+                )
+                return 1
+
+        # --- Steps 16-18: Restart NVMe-oF gateway daemon and re-read ---
+        if restart_nvme_service(nvme_service, client_a):
+            log.error("NVMe-oF gateway daemon restart failed")
+            return 1
+        # Also cycle any local librbd mapping on the gateway node
+        simulate_librbd_consumer_restart(client_b, target_spec)
+
+        client_b_rbd.info(**{"image-or-snap-spec": target_spec})
+        post_restart_checksum = get_checksum_rbd_image(client_b, target_spec)
+        if post_restart_checksum != baseline_checksum:
+            log.error(
+                f"Client-B post-gateway-restart checksum mismatch: "
+                f"source={baseline_checksum} client_b={post_restart_checksum}"
+            )
+            return 1
+        log.info(
+            "Client-B post-NVMe-oF-restart reads match source baseline "
+            "(unmigrated extents fetched via persisted metadata)"
+        )
+        for profile in source_profiles:
+            if run_profile_fio(
+                client_b,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "client-b-post-restart-",
+            ):
+                log.error(
+                    f"Client-B post-restart read failed for profile "
+                    f"{profile['name']} (bs={profile['bs']})"
+                )
+                return 1
+
+        # --- Step 19: Multi-bs writes from Client-B ---
+        for profile in target_profiles:
+            if run_profile_fio(
+                client_b,
+                dst_pool,
+                target_image,
+                profile,
+                "write",
+                "client-b-tgt-write-",
+            ):
+                log.error(
+                    f"Client-B target write failed for profile "
+                    f"{profile['name']} (bs={profile['bs']})"
+                )
+                return 1
+            if run_profile_fio(
+                client_b,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "client-b-tgt-verify-",
+            ):
+                log.error(
+                    f"Client-B target write verify failed for profile "
+                    f"{profile['name']} (bs={profile['bs']})"
+                )
+                return 1
+        source_checksum_after = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if source_checksum_after != baseline_checksum:
+            log.error("Source snapshot changed after Client-B target-side writes")
+            return 1
+
+        # --- Step 20: Execute + commit from Client-A (destination context) ---
+        client_a_rbd.migration.action(action="execute", dest_spec=target_spec)
+        if verify_migration_state(
+            action="execute",
+            image_spec=target_spec,
+            client=client_a,
+        ):
+            log.error("Migration execute state verification failed")
+            return 1
+
+        client_a_rbd.migration.action(action="commit", dest_spec=target_spec)
+        if verify_migration_state(
+            action="commit",
+            image_spec=target_spec,
+            client=client_a,
+        ):
+            log.error("Migration commit state verification failed")
+            return 1
+
+        # --- Steps 21-22: Reopen on Client-B as standalone; final verify ---
+        client_b_rbd.info(**{"image-or-snap-spec": target_spec})
+        exec_cmd(
+            node=client_b,
+            cmd=f"rbd export {target_spec} - >/dev/null",
+            long_running=True,
+            timeout=7200,
+        )
+        for profile in source_profiles + target_profiles:
+            if run_profile_fio(
+                client_b,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "final-",
+            ):
+                log.error(
+                    f"Final verify failed for profile {profile['name']} "
+                    f"(bs={profile['bs']})"
+                )
+                return 1
+
+        final_source_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if final_source_checksum != baseline_checksum:
+            log.error("Source snapshot changed by migration lifecycle")
+            return 1
+
+        # --- Step 23: Cluster health ---
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(client_a, "destination"):
+            return 1
+
+        # --- Step 24: Client-B log / key exposure checks ---
+        test_start = kw.get("test_start")
+        if test_start and source_key:
+            if verify_gateway_like_logs(client_b, source_key, workdir, test_start):
+                return 1
+            if verify_key_not_logged(client_a, source_key, workdir, test_start):
+                return 1
+
+        log.info(
+            "RBD native import gateway-like Client-B source-backed read test passed"
+        )
+        return 0
+
+    except Exception as error:
+        log.error(f"RBD native import gateway-like Client-B test failed: {error}")
+        return 1
+
+    finally:
+        log.info(
+            "Cleaning up RBD native import NVMe-oF gateway Client-B test resources"
+        )
+
+        if nvme_deployed and nvme_service:
+            cleanup_nvme_service(nvme_service, nvme_config)
+
+        exec_cmd(
+            node=client_b,
+            cmd=f"rbd device unmap -t nbd {target_spec}",
+            check_ec=False,
+        )
+        exec_cmd(
+            node=client_a,
+            cmd=f"rm -f {source_spec_path}",
+            check_ec=False,
+        )
+
+        if source_key:
+            verify_key_not_logged(
+                client_a,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+            verify_key_not_logged(
+                client_b,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+
+        exec_cmd(
+            node=client_a,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=client_a,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd snap rm {src_pool}/{src_image}@{snap_name}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd rm {src_pool}/{src_image}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+
+        if source_entity:
+            exec_cmd(
+                node=source_client,
+                cmd=f"ceph auth rm {source_entity}",
+                check_ec=False,
+            )
+
+        pool_cleanup(
+            client=client_a,
+            pools=[dst_pool],
+            ceph_version=ceph_version,
+        )
+        pool_cleanup(
+            client=source_client,
+            pools=[src_pool],
+            ceph_version=ceph_version,
+        )
+
+        for node in (source_client, client_a, client_b):
+            exec_cmd(node=node, cmd=f"rm -rf {workdir}", check_ec=False)
+
+
+def test_native_import_sparse_image(
+    source_client, destination_client, is_ec_pool=False, **kw
+):
+    """Execute CEPH-83632848 sparse native import-only migration validation.
+
+    Creates a large sparse source image with data only at beginning/middle/end,
+    verifies sparseness via ``rbd du --exact``, import-only migrates with
+    mon_host + inline key, and confirms destination used size stays close to
+    source without inflating to full provisioned size. Hole regions must read
+    as zeroes throughout.
+
+    Args:
+        source_client: Source cluster CephNode client.
+        destination_client: Destination cluster CephNode client.
+        is_ec_pool: Unused; retained for dispatcher compatibility.
+        kw: Test configuration keyword arguments.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    config = kw.get("config", {})
+    src_pool = config.get("src_pool", "src_pool")
+    dst_pool = config.get("dst_pool", "dst_pool")
+    src_image = config.get("src_image", "sparse_img")
+    target_image = config.get("target_image", f"sparse_target_{random_string(len=5)}")
+    snap_name = config.get("src_snap", "snap1")
+    image_size = config.get("image_size", "10G")
+    source_cephx_client = config.get("source_client_name", "client.rbd-migration")
+    workdir = config.get("workdir", "/tmp/rbd-native-import-sparse-test")
+    source_spec_path = config.get("source_spec_path", f"{workdir}/native-sparse.json")
+    max_used_ratio = float(config.get("max_used_ratio", 0.5))
+    max_inflation_ratio = float(config.get("max_inflation_ratio", 1.5))
+    target_spec = f"{dst_pool}/{target_image}"
+    ceph_version = get_ceph_major_version(config)
+
+    source_rbd = Rbd(source_client)
+    destination_rbd = Rbd(destination_client)
+    source_entity = None
+    source_key = None
+
+    try:
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}")
+
+        # --- Step 1: Version and health ---
+        if validate_min_ceph_version(
+            config,
+            9,
+            2,
+            ("source", source_client),
+            ("destination", destination_client),
+        ):
+            return 1
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # --- Step 2: Pools ---
+        for label, client, rbd, pool in (
+            ("source", source_client, source_rbd, src_pool),
+            ("destination", destination_client, destination_rbd, dst_pool),
+        ):
+            rc = create_single_pool_and_images(
+                config=config,
+                pool=pool,
+                pool_config={
+                    "pg_num": config.get("pg_num", 32),
+                    "pgp_num": config.get("pgp_num", 32),
+                },
+                client=client,
+                cluster="ceph",
+                rbd=rbd,
+                ceph_version=ceph_version,
+                is_ec_pool=False,
+                is_secondary=False,
+                do_not_create_image=True,
+            )
+            if rc:
+                log.error(f"{label} pool creation failed")
+                return 1
+
+        # --- Steps 3-4: Large sparse image with partial writes ---
+        out, err = source_rbd.create(
+            **{"image-spec": f"{src_pool}/{src_image}", "size": image_size}
+        )
+        if out or err:
+            log.error(f"Source sparse image creation failed: {out} {err}")
+            return 1
+
+        sparse_profiles = get_sparse_io_profiles(config)
+        written_profiles = filter_profiles_by_role(sparse_profiles, "written")
+        hole_profiles = filter_profiles_by_role(sparse_profiles, "hole")
+        log.info(
+            "Sparse IO profiles: written=%s holes=%s",
+            [f"{p['name']}@{p['offset']}" for p in written_profiles],
+            [f"{p['name']}@{p['offset']}" for p in hole_profiles],
+        )
+
+        for profile in written_profiles:
+            if run_profile_fio(
+                source_client,
+                src_pool,
+                src_image,
+                profile,
+                "write",
+                "sparse-write-",
+            ):
+                log.error(f"Sparse write failed for {profile['name']}")
+                return 1
+
+        # --- Step 5: Source sparseness via rbd du --exact ---
+        source_usage = get_rbd_du_exact(source_client, f"{src_pool}/{src_image}")
+        if assert_image_is_sparse(source_usage, max_used_ratio=max_used_ratio):
+            return 1
+
+        # --- Step 6: Snapshot ---
+        out, err = source_rbd.snap.create(
+            **{"snap-spec": f"{src_pool}/{src_image}@{snap_name}"}
+        )
+        if err and "error" in err.lower():
+            log.error(f"Source snapshot creation failed: {out} {err}")
+            return 1
+        log.info(f"Source snapshot created: {src_pool}/{src_image}@{snap_name}")
+
+        snap_usage = get_rbd_du_exact(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if assert_image_is_sparse(snap_usage, max_used_ratio=max_used_ratio):
+            return 1
+
+        # --- Step 7: Baseline written + zero-filled holes ---
+        for profile in written_profiles:
+            if run_profile_fio(
+                source_client,
+                src_pool,
+                src_image,
+                profile,
+                "read",
+                "sparse-src-verify-",
+            ):
+                log.error(f"Source written-region verify failed for {profile['name']}")
+                return 1
+        for profile in hole_profiles:
+            if run_profile_fio(
+                source_client,
+                src_pool,
+                src_image,
+                profile,
+                "read",
+                "sparse-src-hole-",
+            ):
+                log.error(f"Source hole (zero) verify failed for {profile['name']}")
+                return 1
+
+        # --- Steps 8-9: CephX + mon_host native source-spec ---
+        source_entity, source_key = create_source_cephx_client(
+            client=source_client,
+            pool=src_pool,
+            client_name=source_cephx_client,
+        )
+        mon_host = get_source_mon_host(source_client)
+        spec = prepare_native_source_spec_with_key(
+            client=destination_client,
+            spec_path=source_spec_path,
+            mon_host=mon_host,
+            client_name=source_entity,
+            key=source_key,
+            pool_name=src_pool,
+            image_name=src_image,
+            snap_name=snap_name,
+        )
+        if "cluster_name" in spec:
+            log.error("mon_host/key source spec must not include cluster_name")
+            return 1
+
+        source_fsid = exec_cmd(node=source_client, cmd="ceph fsid", output=True).strip()
+        destination_fsid = exec_cmd(
+            node=destination_client, cmd="ceph fsid", output=True
+        ).strip()
+        if source_fsid == destination_fsid:
+            log.error(
+                f"Source and destination resolve to the same cluster "
+                f"fsid {source_fsid}"
+            )
+            return 1
+
+        # --- Steps 10-11: Prepare import-only; du must stay sparse ---
+        destination_rbd.migration.prepare_import(
+            source_spec_path=source_spec_path,
+            dest_spec=target_spec,
+        )
+        out, err = destination_rbd.ls(**{"pool-spec": dst_pool})
+        if target_image not in out.split():
+            log.error(f"Target image {target_spec} not listed in destination pool")
+            return 1
+        if verify_migration_state(
+            action="prepare",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration prepare state verification failed")
+            return 1
+
+        prepared_usage = get_rbd_du_exact(destination_client, target_spec)
+        if assert_image_is_sparse(prepared_usage, max_used_ratio=max_used_ratio):
+            log.error("Destination allocated full size immediately after prepare")
+            return 1
+
+        # --- Step 12: Read written + hole regions from prepared target ---
+        for profile in written_profiles:
+            if run_profile_fio(
+                destination_client,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "sparse-prep-written-",
+            ):
+                log.error(
+                    f"Prepared target written-region verify failed for "
+                    f"{profile['name']}"
+                )
+                return 1
+        for profile in hole_profiles:
+            if run_profile_fio(
+                destination_client,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "sparse-prep-hole-",
+            ):
+                log.error(
+                    f"Prepared target hole (zero) verify failed for {profile['name']}"
+                )
+                return 1
+
+        # --- Steps 13-14: Execute; must not inflate to full provisioned size ---
+        # On some builds ``rbd du --exact`` still reports used=0 while the
+        # image is in executed (pre-commit) migration state. Prefer rbd diff
+        # fallback, and only enforce anti-inflation here; require close-to-
+        # source used size after commit (standalone image).
+        destination_rbd.migration.action(action="execute", dest_spec=target_spec)
+        if verify_migration_state(
+            action="execute",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration execute state verification failed")
+            return 1
+
+        executed_usage = get_effective_used_size(destination_client, target_spec)
+        if assert_used_size_close(
+            snap_usage,
+            executed_usage,
+            max_inflation_ratio=max_inflation_ratio,
+            min_ratio=0,
+        ):
+            return 1
+        if assert_image_is_sparse(executed_usage, max_used_ratio=max_used_ratio):
+            return 1
+
+        # --- Steps 15-16: Commit; sparseness preserved and used ~ source ---
+        destination_rbd.migration.action(action="commit", dest_spec=target_spec)
+        if verify_migration_state(
+            action="commit",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration commit state verification failed")
+            return 1
+
+        committed_usage = get_effective_used_size(destination_client, target_spec)
+        if assert_used_size_close(
+            snap_usage, committed_usage, max_inflation_ratio=max_inflation_ratio
+        ):
+            return 1
+        if assert_image_is_sparse(committed_usage, max_used_ratio=max_used_ratio):
+            return 1
+
+        # --- Steps 17-18: Final data integrity ---
+        for profile in written_profiles:
+            if run_profile_fio(
+                destination_client,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "sparse-final-written-",
+            ):
+                log.error(f"Final written-region verify failed for {profile['name']}")
+                return 1
+        for profile in hole_profiles:
+            if run_profile_fio(
+                destination_client,
+                dst_pool,
+                target_image,
+                profile,
+                "read",
+                "sparse-final-hole-",
+            ):
+                log.error(f"Final hole (zero) verify failed for {profile['name']}")
+                return 1
+
+        # --- Step 19: Health ---
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        test_start = kw.get("test_start")
+        if (
+            test_start
+            and source_key
+            and verify_key_not_logged(
+                destination_client, source_key, workdir, test_start
+            )
+        ):
+            return 1
+
+        log.info("RBD sparse native import-only migration test passed")
+        return 0
+
+    except Exception as error:
+        log.error(f"RBD sparse native import test failed: {error}")
+        return 1
+
+    finally:
+        log.info("Cleaning up RBD sparse native import test resources")
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -f {source_spec_path}",
+            check_ec=False,
+        )
+        if source_key:
+            verify_key_not_logged(
+                destination_client,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd snap rm {src_pool}/{src_image}@{snap_name}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd rm {src_pool}/{src_image}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        if source_entity:
+            exec_cmd(
+                node=source_client,
+                cmd=f"ceph auth rm {source_entity}",
+                check_ec=False,
+            )
+
+        pool_cleanup(
+            client=destination_client,
+            pools=[dst_pool],
+            ceph_version=ceph_version,
+        )
+        pool_cleanup(
+            client=source_client,
+            pools=[src_pool],
+            ceph_version=ceph_version,
+        )
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"rm -rf {workdir}", check_ec=False)
+
+
+def test_native_import_encrypted_image(
+    source_client, destination_client, is_ec_pool=False, **kw
+):
+    """Execute CEPH-83632849 encrypted native import-only migration validation.
+
+    Formats a source RBD image with LUKS1/LUKS2, writes plaintext through the
+    encryption layer, verifies wrong credentials hide plaintext, then
+    import-only migrates the encrypted snapshot to a second cluster using
+    mon_host + inline CephX key. Destination target is opened with the same
+    passphrase before execute, written again after prepare, then execute /
+    commit are verified for data integrity and encryption protection.
+
+    Args:
+        source_client: Source cluster CephNode client.
+        destination_client: Destination cluster CephNode client.
+        is_ec_pool: Unused; retained for dispatcher compatibility.
+        kw: Test configuration keyword arguments.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    config = kw.get("config", {})
+    src_pool = config.get("src_pool", "src_pool")
+    dst_pool = config.get("dst_pool", "dst_pool")
+    src_image = config.get("src_image", "encrypted_img")
+    target_image = config.get(
+        "target_image", f"encrypted_target_{random_string(len=5)}"
+    )
+    snap_name = config.get("src_snap", "snap1")
+    image_size = config.get("image_size", "2G")
+    source_cephx_client = config.get("source_client_name", "client.rbd-migration")
+    workdir = config.get("workdir", "/tmp/rbd-native-import-encrypted-test")
+    source_spec_path = config.get(
+        "source_spec_path", f"{workdir}/native-encrypted.json"
+    )
+    encryption_types = config.get("encryption_type", ["luks1", "luks2"])
+    if isinstance(encryption_types, str):
+        encryption_types = [encryption_types]
+    encryption_type = random.choice(encryption_types)
+    fio_size = config.get("fio", {}).get("size", config.get("fio_size", "100M"))
+    target_spec = f"{dst_pool}/{target_image}"
+    src_spec = f"{src_pool}/{src_image}"
+    src_snap_spec = f"{src_spec}@{snap_name}"
+    ceph_version = get_ceph_major_version(config)
+
+    source_rbd = Rbd(source_client)
+    destination_rbd = Rbd(destination_client)
+    source_entity = None
+    source_key = None
+    passphrase = None
+    dest_passphrase = None
+    data_file = f"/mnt/mnt_{random_string(len=3)}/encrypted_data"
+    post_prepare_file = f"/mnt/mnt_{random_string(len=3)}/post_prepare_data"
+
+    try:
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}")
+            _ensure_rbd_nbd(client)
+
+        # --- Step 1: Version and health ---
+        if validate_min_ceph_version(
+            config,
+            9,
+            2,
+            ("source", source_client),
+            ("destination", destination_client),
+        ):
+            return 1
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # --- Step 2: Create source and destination pools ---
+        for label, client, rbd, pool in (
+            ("source", source_client, source_rbd, src_pool),
+            ("destination", destination_client, destination_rbd, dst_pool),
+        ):
+            rc = create_single_pool_and_images(
+                config=config,
+                pool=pool,
+                pool_config={
+                    "pg_num": config.get("pg_num", 32),
+                    "pgp_num": config.get("pgp_num", 32),
+                },
+                client=client,
+                cluster="ceph",
+                rbd=rbd,
+                ceph_version=ceph_version,
+                is_ec_pool=False,
+                is_secondary=False,
+                do_not_create_image=True,
+            )
+            if rc:
+                log.error(f"{label} pool creation failed")
+                return 1
+
+        # --- Step 3: Create source image ---
+        out, err = source_rbd.create(**{"image-spec": src_spec, "size": image_size})
+        if out or err:
+            log.error(f"Source image creation failed: {out} {err}")
+            return 1
+        log.info(f"Created source image {src_spec}")
+
+        # --- Step 4: Format with LUKS/LUKS2 and resize for header ---
+        log.info(f"Formatting {src_spec} with encryption type {encryption_type}")
+        passphrase = (
+            f"{workdir}/{encryption_type}_passphrase_{random_string(len=3)}.bin"
+        )
+        create_passphrase_file(source_client, passphrase)
+        out, err = source_rbd.encryption_format(
+            **{
+                "image-spec": src_spec,
+                "format": encryption_type,
+                "passphrase-file": passphrase,
+            }
+        )
+        if err:
+            log.error(
+                f"Encryption format {encryption_type} failed on {src_spec}: {err}"
+            )
+            return 1
+        log.info(f"Successfully formatted {src_spec} with {encryption_type}")
+
+        # Compensate LUKS header overhead so usable capacity matches image_size
+        resize_out = source_rbd.resize(
+            **{
+                "image-spec": src_spec,
+                "size": image_size,
+                "encryption_config": [{"encryption-passphrase-file": passphrase}],
+            }
+        )
+        log.info(f"Post-encryption resize output: {resize_out}")
+
+        encryption_config = [
+            {"encryption-format": encryption_type},
+            {"encryption-passphrase-file": passphrase},
+        ]
+
+        # --- Steps 5-6: Open with passphrase and write known data ---
+        io_config = {
+            "rbd_obj": source_rbd,
+            "client": source_client,
+            "size": image_size,
+            "do_not_create_image": True,
+            "config": {
+                "file_size": fio_size,
+                "file_path": [data_file],
+                "get_time_taken": True,
+                "image_spec": [src_spec],
+                "operations": {
+                    "fs": "ext4",
+                    "io": True,
+                    "mount": True,
+                    "device_map": True,
+                },
+                "cmd_timeout": 2400,
+                "io_type": "write",
+                "encryption_config": encryption_config,
+            },
+        }
+        out, err = krbd_io_handler(**io_config)
+        if out:
+            log.error(f"Encrypted write I/O failed on {src_spec}: {err}")
+            return 1
+        log.info(f"Encrypted write I/O succeeded on {src_spec}")
+
+        # --- Step 7: Read back with correct passphrase and baseline checksum ---
+        baseline_checksum = get_encrypted_file_checksum(
+            source_rbd,
+            source_client,
+            src_spec,
+            encryption_config,
+            data_file,
+        )
+        if not baseline_checksum:
+            log.error("Failed to generate source plaintext baseline checksum")
+            return 1
+        log.info(f"Source encrypted image baseline md5: {baseline_checksum}")
+
+        # --- Step 8: Wrong / missing passphrase must not expose plaintext ---
+        if verify_wrong_passphrase_rejected(
+            source_rbd, source_client, src_spec, encryption_type, workdir
+        ):
+            return 1
+        if verify_no_passphrase_hides_plaintext(
+            source_rbd, source_client, src_spec, data_file
+        ):
+            return 1
+
+        # --- Step 9: Create source snapshot ---
+        out, err = source_rbd.snap.create(**{"snap-spec": src_snap_spec})
+        if err and "error" in err.lower():
+            log.error(f"Source snapshot creation failed: {out} {err}")
+            return 1
+        log.info(f"Source snapshot created: {src_snap_spec}")
+
+        snap_checksum = get_encrypted_file_checksum(
+            source_rbd,
+            source_client,
+            src_snap_spec,
+            encryption_config,
+            data_file,
+            read_only=True,
+        )
+        if snap_checksum != baseline_checksum:
+            log.error(
+                f"Snapshot plaintext checksum mismatch: "
+                f"image={baseline_checksum} snap={snap_checksum}"
+            )
+            return 1
+        log.info("Source snapshot plaintext checksum matches image baseline")
+
+        # --- Steps 10-12: CephX client, mon_host, native source-spec ---
+        source_entity, source_key = create_source_cephx_client(
+            client=source_client,
+            pool=src_pool,
+            client_name=source_cephx_client,
+        )
+        mon_host = get_source_mon_host(source_client)
+        spec = prepare_native_source_spec_with_key(
+            client=destination_client,
+            spec_path=source_spec_path,
+            mon_host=mon_host,
+            client_name=source_entity,
+            key=source_key,
+            pool_name=src_pool,
+            image_name=src_image,
+            snap_name=snap_name,
+        )
+
+        source_fsid = exec_cmd(node=source_client, cmd="ceph fsid", output=True).strip()
+        destination_fsid = exec_cmd(
+            node=destination_client, cmd="ceph fsid", output=True
+        ).strip()
+        if source_fsid == destination_fsid:
+            log.error(
+                f"Source and destination resolve to the same cluster fsid {source_fsid}"
+            )
+            return 1
+        if "cluster_name" in spec:
+            log.error("mon_host/key source spec must not include cluster_name")
+            return 1
+        log.info(
+            f"Destination fsid {destination_fsid}, source fsid {source_fsid} "
+            f"(confirmed different clusters)"
+        )
+
+        # Copy passphrase to destination for encrypted target I/O
+        dest_passphrase = f"{workdir}/{encryption_type}_passphrase_dest.bin"
+        copy_file(passphrase, source_client, destination_client, dest_passphrase)
+        dest_encryption_config = [
+            {"encryption-format": encryption_type},
+            {"encryption-passphrase-file": dest_passphrase},
+        ]
+
+        # --- Step 13: Prepare import-only migration ---
+        destination_rbd.migration.prepare_import(
+            source_spec_path=source_spec_path,
+            dest_spec=target_spec,
+        )
+        out, err = destination_rbd.ls(**{"pool-spec": dst_pool})
+        if target_image not in out.split():
+            log.error(f"Target image {target_spec} not listed in destination pool")
+            return 1
+        destination_rbd.info(**{"image-or-snap-spec": target_spec})
+
+        if verify_migration_state(
+            action="prepare",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration prepare state verification failed")
+            return 1
+        log.info(f"Migration prepare succeeded for encrypted target {target_spec}")
+
+        # --- Steps 14-16: Read prepared target with passphrase; deny wrong key ---
+        prepared_checksum = get_encrypted_file_checksum(
+            destination_rbd,
+            destination_client,
+            target_spec,
+            dest_encryption_config,
+            data_file,
+            read_only=True,
+        )
+        if prepared_checksum != baseline_checksum:
+            log.error(
+                f"Prepared target plaintext checksum mismatch: "
+                f"source={baseline_checksum} destination={prepared_checksum}"
+            )
+            return 1
+        log.info("Prepared encrypted target plaintext checksum matches source baseline")
+
+        if verify_wrong_passphrase_rejected(
+            destination_rbd,
+            destination_client,
+            target_spec,
+            encryption_type,
+            workdir,
+        ):
+            return 1
+        if verify_no_passphrase_hides_plaintext(
+            destination_rbd, destination_client, target_spec, data_file
+        ):
+            return 1
+
+        # --- Step 17: New encrypted writes on destination after prepare ---
+        post_io_config = {
+            "rbd_obj": destination_rbd,
+            "client": destination_client,
+            "size": image_size,
+            "do_not_create_image": True,
+            "config": {
+                "file_size": config.get("target_write_size", "50M"),
+                "file_path": [post_prepare_file],
+                "get_time_taken": True,
+                "image_spec": [target_spec],
+                "operations": {
+                    "fs": "ext4",
+                    "io": True,
+                    "mount": True,
+                    "device_map": True,
+                },
+                "cmd_timeout": 2400,
+                "io_type": "write",
+                "skip_mkfs": True,
+                "encryption_config": dest_encryption_config,
+            },
+        }
+        out, err = krbd_io_handler(**post_io_config)
+        if out:
+            log.error(f"Post-prepare encrypted write failed on {target_spec}: {err}")
+            return 1
+        log.info(f"Post-prepare encrypted write succeeded on {target_spec}")
+
+        post_prepare_checksum = get_encrypted_file_checksum(
+            destination_rbd,
+            destination_client,
+            target_spec,
+            dest_encryption_config,
+            post_prepare_file,
+        )
+        if not post_prepare_checksum:
+            log.error("Failed to checksum post-prepare encrypted write")
+            return 1
+
+        # Source snapshot must remain immutable
+        source_snap_after = get_encrypted_file_checksum(
+            source_rbd,
+            source_client,
+            src_snap_spec,
+            encryption_config,
+            data_file,
+            read_only=True,
+        )
+        if source_snap_after != baseline_checksum:
+            log.error("Source encrypted snapshot changed after target-side writes")
+            return 1
+
+        # --- Step 18: Execute migration ---
+        destination_rbd.migration.action(
+            action="execute",
+            dest_spec=target_spec,
+        )
+        if verify_migration_state(
+            action="execute",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration execute state verification failed")
+            return 1
+        log.info("Migration execute completed for encrypted target")
+
+        # --- Step 19: Commit migration ---
+        destination_rbd.migration.action(
+            action="commit",
+            dest_spec=target_spec,
+        )
+        if verify_migration_state(
+            action="commit",
+            image_spec=target_spec,
+            client=destination_client,
+        ):
+            log.error("Migration commit state verification failed")
+            return 1
+        log.info("Migration commit completed; target is standalone")
+
+        # --- Step 20: Final encrypted reopen / checksum / health ---
+        final_baseline = get_encrypted_file_checksum(
+            destination_rbd,
+            destination_client,
+            target_spec,
+            dest_encryption_config,
+            data_file,
+        )
+        if final_baseline != baseline_checksum:
+            log.error(
+                f"Final source-backed plaintext mismatch: "
+                f"expected={baseline_checksum} actual={final_baseline}"
+            )
+            return 1
+
+        final_post = get_encrypted_file_checksum(
+            destination_rbd,
+            destination_client,
+            target_spec,
+            dest_encryption_config,
+            post_prepare_file,
+        )
+        if final_post != post_prepare_checksum:
+            log.error(
+                f"Final post-prepare plaintext mismatch: "
+                f"expected={post_prepare_checksum} actual={final_post}"
+            )
+            return 1
+
+        if verify_wrong_passphrase_rejected(
+            destination_rbd,
+            destination_client,
+            target_spec,
+            encryption_type,
+            workdir,
+        ):
+            return 1
+
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        test_start = kw.get("test_start")
+        if (
+            test_start
+            and source_key
+            and verify_key_not_logged(
+                destination_client, source_key, workdir, test_start
+            )
+        ):
+            return 1
+
+        log.info(
+            f"CEPH-83632849 native import of {encryption_type}-encrypted image passed"
+        )
+        return 0
+
+    except Exception as error:
+        log.error(f"CEPH-83632849 encrypted native import failed: {error}")
+        return 1
+
+    finally:
+        log.info("Cleaning up encrypted native import test resources")
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -f {source_spec_path}",
+            check_ec=False,
+        )
+        if source_key:
+            verify_key_not_logged(
+                destination_client,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd snap rm {src_snap_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd rm {src_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        if source_entity:
+            exec_cmd(
+                node=source_client,
+                cmd=f"ceph auth rm {source_entity}",
+                check_ec=False,
+            )
+        pool_cleanup(
+            client=destination_client,
+            pools=[dst_pool],
+            ceph_version=ceph_version,
+        )
+        pool_cleanup(
+            client=source_client,
+            pools=[src_pool],
+            ceph_version=ceph_version,
+        )
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"rm -rf {workdir}", check_ec=False)
+            for path in (data_file, post_prepare_file):
+                mount_point = path.rsplit("/", 1)[0]
+                exec_cmd(node=client, cmd=f"umount {mount_point}", check_ec=False)
+                exec_cmd(node=client, cmd=f"rm -rf {mount_point}", check_ec=False)
+
+
+def _match_any_error(output, expected_substrings):
+    """Return True if *output* contains any of the expected error substrings."""
+    text = str(output).lower()
+    return any(substr.lower() in text for substr in expected_substrings)
+
+
+def _run_negative_prepare_case(
+    destination_client,
+    spec_path,
+    dest_pool,
+    target_image,
+    case_name,
+    spec,
+    expected_errors,
+):
+    """Write *spec*, run prepare, assert failure + expected error + no stale target.
+
+    Returns:
+        0 on success (prepare failed as expected), 1 on unexpected outcome.
+    """
+    target_spec = f"{dest_pool}/{target_image}"
+    log.info(f"Negative case: {case_name}")
+    write_native_source_spec(destination_client, spec_path, spec)
+    failed, output = attempt_migration_prepare_import(
+        destination_client, spec_path, target_spec
+    )
+    if not failed:
+        log.error(f"{case_name}: prepare unexpectedly succeeded")
+        # Clean up unexpected target so later cases remain isolated
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd migration abort {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd rm {target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        return 1
+
+    if not _match_any_error(output, expected_errors):
+        log.error(
+            f"{case_name}: prepare failed but error did not match expected "
+            f"substrings {expected_errors}; got: {output}"
+        )
+        return 1
+
+    if verify_no_stale_migration_target(destination_client, dest_pool, target_image):
+        log.error(f"{case_name}: stale target/migration state remained after failure")
+        return 1
+
+    log.info(f"{case_name}: failed as expected with matching error")
+    return 0
+
+
+def test_native_import_mon_host_key_negative(
+    source_client, destination_client, is_ec_pool=False, **kw
+):
+    """CEPH-83632850: negative validation for mon_host/key native import.
+
+    Validates that invalid or mutually exclusive native source-spec fields
+    cause ``rbd migration prepare --import-only`` to fail cleanly with no
+    stale destination migration state, while the source image/snap remain
+    unchanged.
+
+    Args:
+        source_client: Source cluster CephNode client.
+        destination_client: Destination cluster CephNode client.
+        is_ec_pool: Unused; kept for dispatcher compatibility.
+        kw: Test configuration keyword arguments.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    config = kw.get("config", {})
+    src_pool = config.get("src_pool", "src_pool")
+    dst_pool = config.get("dst_pool", "dst_pool")
+    src_image = config.get("src_image", "src_image")
+    target_image = config.get("target_image", f"neg_target_{random_string(len=5)}")
+    snap_name = config.get("src_snap", "snap1")
+    image_size = config.get("image_size", "1G")
+    source_cephx_client = config.get("source_client_name", "client.rbd-migration")
+    limited_client_name = config.get(
+        "limited_client_name", "client.rbd-migration-limited"
+    )
+    workdir = config.get("workdir", "/tmp/rbd-native-import-neg")
+    source_spec_path = config.get("source_spec_path", f"{workdir}/native-negative.json")
+    valid_target = config.get(
+        "valid_target_image", f"valid_target_{random_string(len=5)}"
+    )
+    wrong_config_key_path = config.get(
+        "wrong_config_key_path", "rbd/native/wrong_source_key"
+    )
+    missing_config_key_path = config.get(
+        "missing_config_key_path", "rbd/native/missing_key"
+    )
+    ceph_version = get_ceph_major_version(config)
+
+    source_rbd = Rbd(source_client)
+    destination_rbd = Rbd(destination_client)
+    source_entity = None
+    source_key = None
+    limited_entity = None
+    config_keys_to_remove = []
+
+    try:
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"mkdir -p {workdir} && chmod 700 {workdir}")
+
+        # Steps 1: version + health
+        if validate_min_ceph_version(
+            config,
+            9,
+            2,
+            ("source", source_client),
+            ("destination", destination_client),
+        ):
+            return 1
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # Step 2: pools
+        for label, client, rbd, pool in (
+            ("source", source_client, source_rbd, src_pool),
+            ("destination", destination_client, destination_rbd, dst_pool),
+        ):
+            rc = create_single_pool_and_images(
+                config=config,
+                pool=pool,
+                pool_config={
+                    "pg_num": config.get("pg_num", 32),
+                    "pgp_num": config.get("pgp_num", 32),
+                },
+                client=client,
+                cluster="ceph",
+                rbd=rbd,
+                ceph_version=ceph_version,
+                is_ec_pool=False,
+                is_secondary=False,
+                do_not_create_image=True,
+            )
+            if rc:
+                log.error(f"{label} pool creation failed")
+                return 1
+
+        # Step 3: source image, data, snap + baseline checksum
+        out, err = source_rbd.create(
+            **{"image-spec": f"{src_pool}/{src_image}", "size": image_size}
+        )
+        if out or err:
+            log.error(f"Source image creation failed: {out} {err}")
+            return 1
+
+        run_rbd_fio(
+            client=source_client,
+            pool=src_pool,
+            image=src_image,
+            rw="write",
+            offset=config.get("source_pattern_a_offset", "0"),
+            size=config.get("source_pattern_size", "64M"),
+            pattern=config.get("source_pattern_a", "0xAA"),
+            name="neg-source-pattern-a",
+        )
+        out, err = source_rbd.snap.create(
+            **{"snap-spec": f"{src_pool}/{src_image}@{snap_name}"}
+        )
+        if err and "error" in str(err).lower():
+            log.error(f"Source snapshot creation failed: {out} {err}")
+            return 1
+
+        baseline_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        log.info(f"Source snapshot baseline sha256: {baseline_checksum}")
+
+        # Steps 4-5: valid CephX client + mon_host/key
+        source_entity, source_key = create_source_cephx_client(
+            client=source_client,
+            pool=src_pool,
+            client_name=source_cephx_client,
+        )
+        mon_host = get_source_mon_host(source_client)
+        log.info(f"Valid source mon_host collected (length={len(mon_host)})")
+
+        base_spec = {
+            "type": "native",
+            "mon_host": mon_host,
+            "client_name": source_entity,
+            "key": source_key,
+            "pool_name": src_pool,
+            "image_name": src_image,
+            "snap_name": snap_name,
+        }
+
+        # Step 6: one valid prepare to confirm environment
+        valid_spec_path = f"{workdir}/native-valid.json"
+        valid_target_spec = f"{dst_pool}/{valid_target}"
+        prepare_native_source_spec_with_key(
+            client=destination_client,
+            spec_path=valid_spec_path,
+            mon_host=mon_host,
+            client_name=source_entity,
+            key=source_key,
+            pool_name=src_pool,
+            image_name=src_image,
+            snap_name=snap_name,
+        )
+        destination_rbd.migration.prepare_import(
+            source_spec_path=valid_spec_path,
+            dest_spec=valid_target_spec,
+        )
+        if verify_migration_state(
+            action="prepare",
+            image_spec=valid_target_spec,
+            client=destination_client,
+        ):
+            log.error("Valid migration prepare state verification failed")
+            return 1
+        log.info("Valid source-spec prepare succeeded (environment sanity check)")
+
+        # Step 7: abort/cleanup valid target before negative cases
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd migration abort {valid_target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rbd rm {valid_target_spec}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        if verify_no_stale_migration_target(destination_client, dst_pool, valid_target):
+            log.error("Valid target remained after abort/cleanup")
+            return 1
+
+        # Build invalid key by flipping characters (keep length / charset-ish)
+        invalid_key = source_key[::-1]
+        if invalid_key == source_key:
+            invalid_key = ("A" + source_key[1:]) if source_key else "invalidkey"
+
+        # Insufficient-caps client (step 16)
+        limited_entity, limited_key = create_insufficient_caps_cephx_client(
+            client=source_client,
+            client_name=limited_client_name,
+        )
+
+        # Wrong key in config-key store (step 15)
+        store_source_key_in_config_key(
+            destination_client, wrong_config_key_path, invalid_key, workdir
+        )
+        config_keys_to_remove.append(wrong_config_key_path)
+
+        # Unique target image per case to make stale-state checks unambiguous
+        def _target(suffix):
+            return f"{target_image}_{suffix}"
+
+        negative_cases = [
+            # Step 8: mon_host without key
+            {
+                "name": "mon_host without key",
+                "target": _target("no_key"),
+                "spec": {k: v for k, v in base_spec.items() if k != "key"},
+                "errors": [
+                    "cannot specify mon host without key",
+                    "without key",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+            # Step 9: key without mon_host
+            {
+                "name": "key without mon_host",
+                "target": _target("no_mon"),
+                "spec": {k: v for k, v in base_spec.items() if k != "mon_host"},
+                "errors": [
+                    "cannot specify key without mon host",
+                    "without mon host",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+            # Step 10: cluster_name + mon_host
+            {
+                "name": "cluster_name and mon_host mutually exclusive",
+                "target": _target("cluster_mon"),
+                "spec": {**base_spec, "cluster_name": "source"},
+                "errors": [
+                    "cannot specify both cluster name and mon host",
+                    "cluster name and mon host",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+            # Step 11: cluster_name + key (no mon_host) — key requires mon_host
+            {
+                "name": "cluster_name and key mixed",
+                "target": _target("cluster_key"),
+                "spec": {
+                    "type": "native",
+                    "cluster_name": "source",
+                    "client_name": source_entity,
+                    "key": source_key,
+                    "pool_name": src_pool,
+                    "image_name": src_image,
+                    "snap_name": snap_name,
+                },
+                "errors": [
+                    "cannot specify key without mon host",
+                    "without mon host",
+                    "cluster name",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+            # Step 12: unreachable mon_host
+            {
+                "name": "invalid/unreachable mon_host",
+                "target": _target("bad_mon"),
+                "spec": {
+                    **base_spec,
+                    "mon_host": "[v2:127.0.0.1:1/0,v1:127.0.0.1:2/0]",
+                },
+                "errors": [
+                    "connection",
+                    "timed out",
+                    "timeout",
+                    "refused",
+                    "unavailable",
+                    "failed",
+                    "error",
+                    "errno",
+                ],
+            },
+            # Step 13: invalid inline key
+            {
+                "name": "invalid inline key",
+                "target": _target("bad_key"),
+                "spec": {**base_spec, "key": invalid_key},
+                "errors": [
+                    "auth",
+                    "authentication",
+                    "permission",
+                    "access",
+                    "denied",
+                    "failed",
+                    "error",
+                    "EINVAL",
+                ],
+            },
+            # Step 14: missing config-key path
+            {
+                "name": "missing config:// key path",
+                "target": _target("missing_cfg"),
+                "spec": {
+                    **base_spec,
+                    "key": f"config://{missing_config_key_path}",
+                },
+                "errors": [
+                    "config-key",
+                    "config key",
+                    "does not exist",
+                    "no such",
+                    "not found",
+                    "ENOENT",
+                    "failed",
+                    "error",
+                ],
+            },
+            # Step 15: wrong key via config://
+            {
+                "name": "wrong key via config://",
+                "target": _target("wrong_cfg"),
+                "spec": {
+                    **base_spec,
+                    "key": f"config://{wrong_config_key_path}",
+                },
+                "errors": [
+                    "auth",
+                    "authentication",
+                    "permission",
+                    "access",
+                    "denied",
+                    "failed",
+                    "error",
+                ],
+            },
+            # Step 16: insufficient caps
+            {
+                "name": "insufficient source client caps",
+                "target": _target("nocaps"),
+                "spec": {
+                    **base_spec,
+                    "client_name": limited_entity,
+                    "key": limited_key,
+                },
+                "errors": [
+                    "permission",
+                    "access",
+                    "denied",
+                    "EACCES",
+                    "auth",
+                    "failed",
+                    "error",
+                ],
+            },
+            # Step 17: invalid pool name
+            {
+                "name": "invalid source pool name",
+                "target": _target("bad_pool"),
+                "spec": {**base_spec, "pool_name": "nonexistent_src_pool_xyz"},
+                "errors": [
+                    "pool",
+                    "No such",
+                    "not found",
+                    "does not exist",
+                    "ENOENT",
+                    "failed",
+                    "error",
+                ],
+            },
+            # Step 18: invalid image name
+            {
+                "name": "invalid source image name",
+                "target": _target("bad_image"),
+                "spec": {**base_spec, "image_name": "nonexistent_src_image_xyz"},
+                "errors": [
+                    "image",
+                    "No such",
+                    "not found",
+                    "does not exist",
+                    "ENOENT",
+                    "failed",
+                    "error",
+                ],
+            },
+            # Step 19a: invalid snap name
+            {
+                "name": "invalid source snap name",
+                "target": _target("bad_snap"),
+                "spec": {**base_spec, "snap_name": "nonexistent_snap_xyz"},
+                "errors": [
+                    "snap",
+                    "snapshot",
+                    "No such",
+                    "not found",
+                    "does not exist",
+                    "ENOENT",
+                    "failed",
+                    "error",
+                ],
+            },
+            # Step 19b: missing snap for import-only
+            {
+                "name": "missing snap_name/snap_id for import-only",
+                "target": _target("no_snap"),
+                "spec": {k: v for k, v in base_spec.items() if k != "snap_name"},
+                "errors": [
+                    "snap name or snap id required for import",
+                    "snap name or snap id required",
+                    "required for import",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+            # Step 20a: pool_name + pool_id
+            {
+                "name": "pool_name and pool_id conflict",
+                "target": _target("pool_both"),
+                "spec": {**base_spec, "pool_id": 0},
+                "errors": [
+                    "cannot specify both pool name and pool id",
+                    "pool name and pool id",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+            # Step 20b: snap_name + snap_id
+            {
+                "name": "snap_name and snap_id conflict",
+                "target": _target("snap_both"),
+                "spec": {**base_spec, "snap_id": 1},
+                "errors": [
+                    "cannot specify both snap name and snap id",
+                    "snap name and snap id",
+                    "EINVAL",
+                    "invalid",
+                ],
+            },
+        ]
+
+        failures = 0
+        for case in negative_cases:
+            # Unique spec path per case avoids races / stale files
+            case_spec_path = f"{workdir}/neg_{case['target']}.json"
+            rc = _run_negative_prepare_case(
+                destination_client=destination_client,
+                spec_path=case_spec_path,
+                dest_pool=dst_pool,
+                target_image=case["target"],
+                case_name=case["name"],
+                spec=case["spec"],
+                expected_errors=case["errors"],
+            )
+            if rc:
+                failures += 1
+
+        if failures:
+            log.error(f"{failures} negative prepare case(s) failed")
+            return 1
+
+        # Step 22: source image/snap unchanged
+        final_checksum = get_checksum_rbd_image(
+            source_client, f"{src_pool}/{src_image}@{snap_name}"
+        )
+        if final_checksum != baseline_checksum:
+            log.error(
+                "Source snapshot checksum changed after negative tests: "
+                f"baseline={baseline_checksum} final={final_checksum}"
+            )
+            return 1
+        log.info("Source image and snapshot remain unchanged after negative tests")
+
+        # Step 23: cluster health
+        if validate_cluster_health_and_daemons(source_client, "source"):
+            return 1
+        if validate_cluster_health_and_daemons(destination_client, "destination"):
+            return 1
+
+        # Step 24: no key leak in destination logs / command output already redacted
+        test_start = kw.get("test_start")
+        if (
+            test_start
+            and source_key
+            and verify_key_not_logged(
+                destination_client, source_key, workdir, test_start
+            )
+        ):
+            return 1
+
+        log.info("CEPH-83632850 native import mon_host/key negative validation passed")
+        return 0
+
+    except Exception as error:
+        log.error(f"CEPH-83632850 negative validation failed: {error}")
+        return 1
+
+    finally:
+        # Step 25: cleanup
+        log.info("Cleaning up CEPH-83632850 negative test resources")
+        exec_cmd(
+            node=destination_client,
+            cmd=f"rm -f {source_spec_path} {workdir}/native-valid.json",
+            check_ec=False,
+        )
+        for path in config_keys_to_remove:
+            remove_config_key(destination_client, path)
+
+        # Abort/remove any leftover targets matching this run's prefix
+        listed = exec_cmd(
+            node=destination_client,
+            cmd=f"rbd ls {dst_pool}",
+            output=True,
+            check_ec=False,
+        )
+        for img in (listed or "").split():
+            if img == valid_target or img.startswith(f"{target_image}"):
+                spec = f"{dst_pool}/{img}"
+                exec_cmd(
+                    node=destination_client,
+                    cmd=f"rbd migration abort {spec}",
+                    check_ec=False,
+                    long_running=True,
+                    timeout=7200,
+                )
+                exec_cmd(
+                    node=destination_client,
+                    cmd=f"rbd rm {spec}",
+                    check_ec=False,
+                    long_running=True,
+                    timeout=7200,
+                )
+
+        if source_key:
+            verify_key_not_logged(
+                destination_client,
+                source_key,
+                workdir,
+                kw.get("test_start", datetime.utcnow().isoformat()),
+            )
+
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd snap rm {src_pool}/{src_image}@{snap_name}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        exec_cmd(
+            node=source_client,
+            cmd=f"rbd rm {src_pool}/{src_image}",
+            check_ec=False,
+            long_running=True,
+            timeout=7200,
+        )
+        for entity in (source_entity, limited_entity):
+            if entity:
+                exec_cmd(
+                    node=source_client,
+                    cmd=f"ceph auth rm {entity}",
+                    check_ec=False,
+                )
+
+        pool_cleanup(
+            client=destination_client,
+            pools=[dst_pool],
+            ceph_version=ceph_version,
+        )
+        pool_cleanup(
+            client=source_client,
+            pools=[src_pool],
+            ceph_version=ceph_version,
+        )
+        for client in (source_client, destination_client):
+            exec_cmd(node=client, cmd=f"rm -rf {workdir}", check_ec=False)
+
+
+def resolve_source_destination_clients(**kw):
+    """Resolve source and destination client nodes from ceph_cluster_dict."""
+    cluster_dict = kw.get("ceph_cluster_dict", {})
+    if "ceph-rbd1" in cluster_dict and "ceph-rbd2" in cluster_dict:
+        source_cluster = cluster_dict["ceph-rbd1"]
+        destination_cluster = cluster_dict["ceph-rbd2"]
+    else:
+        clusters = list(cluster_dict.values())
+        if len(clusters) < 2:
+            raise ValueError("This test requires two Ceph clusters")
+        source_cluster, destination_cluster = clusters[0], clusters[1]
+
+    source_client = source_cluster.get_nodes(role="client")[0]
+    destination_client = destination_cluster.get_nodes(role="client")[0]
+    return source_cluster, destination_cluster, source_client, destination_client
+
+
+def prepare_pool_type_config(**kw):
+    """Select rep or ec pool config and merge into kw[config].
+
+    When only one of ``rep_pool_config`` / ``ec_pool_config`` is present,
+    that pool type is used. When both are present, one is chosen at random.
+    """
+    config = kw.get("config", {})
+    available = [
+        pool_type
+        for pool_type in ("rep_pool_config", "ec_pool_config")
+        if config.get(pool_type)
+    ]
+    if not available:
+        raise ValueError("Config must include rep_pool_config and/or ec_pool_config")
+
+    pool_type = available[0] if len(available) == 1 else random.choice(available)
+    log.info("Running test on pool type: %s", pool_type)
+
+    pool_cfg = config.get(pool_type, {})
+
+    if pool_type == "rep_pool_config":
+        config["rep-pool-only"] = True
+        is_ec_pool = False
+    else:
+        config["ec-pool-only"] = True
+        is_ec_pool = True
+
+    config.update(pool_cfg)
+    kw["config"] = config
+    return pool_type, is_ec_pool
+
+
+def run(**kw):
+    """CephCI entry point for native import Polarion cases.
+
+    Dispatches based on ``config.operation`` (same pattern as
+    ``test_namespace_mirror_operations.py``):
+
+    - CEPH-83632846: mon_host + inline key
+    - CEPH-83632847: mon_host + config:// key
+    - CEPH-83632851: NVMe-oF gateway Client-B source-backed reads
+    - CEPH-83632848: sparse native import preserves used size / zero holes
+    - CEPH-83632849: LUKS/LUKS2 encrypted native import with mon_host + key
+    - CEPH-83632850: negative validation of mon_host/key source-spec
+
+    When ``operation`` is omitted, defaults to CEPH-83632846.
+    """
+    kw["test_start"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    config = kw.get("config", {})
+    operation = config.get("operation", "CEPH-83632846")
+
+    operation_mapping = {
+        "CEPH-83632846": "inline_key",
+        "CEPH-83632847": "config_key",
+        "CEPH-83632851": "nvmeof_gateway",
+        "CEPH-83632848": "sparse_import",
+        "CEPH-83632849": "encrypted_import",
+        "CEPH-83632850": "negative_validation",
+    }
+    if operation not in operation_mapping:
+        log.error(
+            f"Unsupported operation {operation}. Supported: "
+            f"{list(operation_mapping)}"
+        )
+        return 1
+
+    log.info(f"Executing native import operation {operation}")
+
+    try:
+        (
+            source_cluster,
+            destination_cluster,
+            source_client,
+            destination_client,
+        ) = resolve_source_destination_clients(**kw)
+    except Exception as error:
+        log.error(f"Unable to locate source/destination clients: {error}")
+        return 1
+
+    pool_type, is_ec_pool = prepare_pool_type_config(**kw)
+
+    try:
+        if operation == "CEPH-83632846":
+            ret_val = test_native_import_mon_host_inline_key(
+                source_client=source_client,
+                destination_client=destination_client,
+                is_ec_pool=is_ec_pool,
+                **kw,
+            )
+        elif operation == "CEPH-83632847":
+            ret_val = test_native_import_mon_host_config_key(
+                source_client=source_client,
+                destination_client=destination_client,
+                is_ec_pool=is_ec_pool,
+                **kw,
+            )
+        elif operation == "CEPH-83632848":
+            ret_val = test_native_import_sparse_image(
+                source_client=source_client,
+                destination_client=destination_client,
+                is_ec_pool=is_ec_pool,
+                **kw,
+            )
+        elif operation == "CEPH-83632849":
+            ret_val = test_native_import_encrypted_image(
+                source_client=source_client,
+                destination_client=destination_client,
+                is_ec_pool=is_ec_pool,
+                **kw,
+            )
+        elif operation == "CEPH-83632850":
+            ret_val = test_native_import_mon_host_key_negative(
+                source_client=source_client,
+                destination_client=destination_client,
+                is_ec_pool=is_ec_pool,
+                **kw,
+            )
+        elif operation == "CEPH-83632851":
+            nvme_config = dict(kw.get("config", {}).get("nvme_config", {}))
+            nvme_config.setdefault("gw_nodes", ["node2"])
+            nvme_config.setdefault("gw_group", "gw-group1")
+            nvme_config.setdefault("rbd_pool", "rbd")
+            nvme_config.setdefault("nvme_metadata_pool", "rbd")
+            nvme_config.setdefault("install", True)
+            client_a = destination_client
+            # Prefer configured gateway node as Client-B (destination client)
+            gw_node_id = nvme_config.get("gw_node") or nvme_config["gw_nodes"][0]
+            try:
+                client_b = get_node_by_id(destination_cluster, gw_node_id)
+            except Exception:
+                client_b = resolve_gateway_like_client(
+                    destination_cluster, client_a, kw.get("config", {})
+                )
+            kw["destination_cluster"] = destination_cluster
+            kw["nvme_config"] = nvme_config
+            ret_val = test_native_import_gateway_like_client(
+                source_client=source_client,
+                client_a=client_a,
+                client_b=client_b,
+                is_ec_pool=is_ec_pool,
+                **kw,
+            )
+        else:
+            log.error(f"Unsupported operation: {operation}")
+            return 1
+
+    except Exception as error:
+        log.error(f"Test {operation} failed with error: {error}")
+        return 1
+
+    if ret_val:
+        log.error(f"Test {operation} FAILED on pool type: {pool_type}")
+    else:
+        log.info(f"Test {operation} PASSED on pool type: {pool_type}")
+    return ret_val


### PR DESCRIPTION
# Description
Test case Automated:
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632846
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632847
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632848
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632849
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632850
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83632851

Test result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Z64G3U/

Adds CephCI automation for the Ceph 9.2 RBD native import enhancement using source mon_host and inline CephX key metadata.
This PR introduces a new dedicated 9.2 RBD migration suite:
Suites/tentacle/rbd/tier-2_rbd_migration_key_import_9_2.yaml
and a new test module:
tests/rbd/test_rbd_native_import_mon_host_inline_key.py

The automated test validates an end-to-end cross-cluster RBD native import lifecycle without requiring source cluster ceph.conf or source keyring files on the destination client. It creates source and destination pools, writes verified source data, snapshots the source image, creates a dedicated read-only source CephX client, builds a native source spec with mon_host, client_name, and inline key, then runs rbd migration prepare, execute, and commit.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
