### PR TITLE
Ensure correct Ceph cluster version is reported

### DIFF
--- a/run.py
+++ b/run.py
@@ -1340,37 +1340,59 @@ def collect_recipe(ceph_cluster):
     Returns:
         None
     """
-    version_datails = {}
+    version_details = {}
     installer_node = ceph_cluster.get_ceph_objects("installer")
     client_node = ceph_cluster.get_ceph_objects("client")
-    out, rc = installer_node[0].exec_command(
-        sudo=True, cmd="podman --version | awk {'print $3'}", check_ec=False
-    )
 
-    output = out.rstrip()
-    if output:
-        log.info(f"Podman Version {output}")
-        version_datails["PODMAN"] = output
+    if installer_node:
+        # podman version
+        out, _ = installer_node[0].exec_command(
+            sudo=True, cmd="podman --version | awk {'print $3'}", check_ec=False
+        )
 
-    out, _ = installer_node[0].exec_command(
-        sudo=True, cmd="docker --version | awk {'print $3'}", check_ec=False
-    )
-    output = out.rstrip()
-    if output:
-        log.info(f"Docker Version {output}")
-        version_datails["DOCKER"] = output
+        output = out.rstrip()
+        if output:
+            log.info(f"Podman Version {output}")
+            version_details["PODMAN"] = output
 
+        # docker version
+        out, _ = installer_node[0].exec_command(
+            sudo=True, cmd="docker --version | awk {'print $3'}", check_ec=False
+        )
+        output = out.rstrip()
+        if output:
+            log.info(f"Docker Version {output}")
+            version_details["DOCKER"] = output
+
+        # cephadm version
+        out, _ = installer_node[0].exec_command(
+            sudo=True, cmd="cephadm version", check_ec=False
+        )
+        output = out.rstrip()
+        if output:
+            log.info(f"cephadm Version: {output}")
     if client_node:
+        # client rpm version
         out, _ = client_node[0].exec_command(
             sudo=True, cmd="ceph --version | awk '{print $3}'", check_ec=False
         )
         output = out.rstrip()
-        log.info(f"ceph Version {output}")
-        version_datails["CEPH"] = output
+        if output:
+            log.info(f"ceph client rpm Version: {output}")
 
-    version_detail = open("version_info.json", "w+")
-    json.dump(version_datails, version_detail)
-    version_detail.close()
+        # ceph cluster version
+        out, _ = client_node[0].exec_command(
+            sudo=True, cmd="ceph version", check_ec=False
+        )
+        output = out.rstrip()
+        if output:
+            match = re.search(r"ceph version (\S+)", output)
+            short_version = match.group(1) if match else output
+            log.info(f"Ceph cluster Version: {output}")
+            version_details["CEPH"] = short_version
+
+    with open("version_info.json", "w") as version_detail:
+        json.dump(version_details, version_detail)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It was observed that the framework executes a command to fetch the ceph version which returns the version of ceph client package rpm instead of actual ceph cluster version.

This becomes misleading when partial upgrade has been performed or if cephadm packages have been upgraded, Cluster has been upgraded but ceph-common packages are yet to be updated.

Also relevant for scenarios where a new version ceph rpm has been used with an older version ceph image.


Ceph client rpm version - 
```
[root@ceph-hakumar-j7lsr8-node6 ~]# ceph --version
ceph version 19.2.1-379.el9cp (728d37748c729c9965aadf4a4ff92042f686e53e) squid (stable)
```

Ceph cluster version -
```
[root@ceph-hakumar-j7lsr8-node6 ~]# ceph version
ceph version 19.2.1-382.el9cp (06098182bd9694578526de4918ba881cd2bd87cf) squid (stable)
```

Cephadm version -
```
[root@ceph-hakumar-j7lsr8-node1-installer ~]# cephadm version
cephadm version 19.2.1-382.el9cp (06098182bd9694578526de4918ba881cd2bd87cf) squid (stable)

[root@ceph-hakumar-j7lsr8-node1-installer ~]# cephadm shell -- ceph version
rpInferring fsid a1c58696-854e-11f1-96f7-fa163e5f8851
mInferring config /var/lib/ceph/a1c58696-854e-11f1-96f7-fa163e5f8851/mon.ceph-hakumar-j7lsr8-node1-installer/config
 Using ceph image with id '35d6127026ae' and tag 'v8.1-21530' created on 2026-07-23 02:17:07 +0000 UTC
cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9@sha256:03b0124bff263481c52a730ea5ed2b9ef9a168dfc7cbf20ca74ecfce9238b9f3
ceph version 19.2.1-382.el9cp (06098182bd9694578526de4918ba881cd2bd87cf) squid (stable)
```

Code changes also include logging of cephadm package version.


Output from run log - 
```
2026-07-29 06:57:08,885 - cephci - ceph:2004 - INFO - Execute podman --version | awk {'print $3'} on ceph-hakumar-kkqcr1-node1-installer [10.0.65.61]
2026-07-29 06:57:09,889 - cephci - ceph:2039 - INFO - Execution of podman --version | awk {'print $3'} took 1.003951 seconds on ceph-hakumar-kkqcr1-node1-installer by user root [10.0.65.61]
2026-07-29 06:57:09,890 - cephci - run:1355 - INFO - Podman Version 5.8.2
2026-07-29 06:57:09,891 - cephci - ceph:2004 - INFO - Execute docker --version | awk {'print $3'} on ceph-hakumar-kkqcr1-node1-installer [10.0.65.61]
2026-07-29 06:57:10,896 - cephci - ceph:2039 - INFO - Execution of docker --version | awk {'print $3'} took 1.003919 seconds on ceph-hakumar-kkqcr1-node1-installer by user root [10.0.65.61]
2026-07-29 06:57:10,898 - cephci - ceph:2004 - INFO - Execute cephadm version on ceph-hakumar-kkqcr1-node1-installer [10.0.65.61]
2026-07-29 06:57:11,903 - cephci - ceph:2039 - INFO - Execution of cephadm version took 1.004305 seconds on ceph-hakumar-kkqcr1-node1-installer by user root [10.0.65.61]
2026-07-29 06:57:11,903 - cephci - run:1373 - INFO - cephadm Version: cephadm version 20.2.2-133.el10cp (c4b9f29ae0cdf064ad17d7dcf2939fcfed2b3f99) tentacle (stable)
2026-07-29 06:57:11,905 - cephci - ceph:2004 - INFO - Execute ceph --version | awk '{print $3}' on ceph-hakumar-kkqcr1-node6 [10.0.65.4]
2026-07-29 06:57:12,909 - cephci - ceph:2039 - INFO - Execution of ceph --version | awk '{print $3}' took 1.003723 seconds on ceph-hakumar-kkqcr1-node6 by user root [10.0.65.4]
2026-07-29 06:57:12,910 - cephci - run:1381 - INFO - ceph client rpm Version: 20.2.2-133.el10cp
2026-07-29 06:57:12,912 - cephci - ceph:2004 - INFO - Execute ceph version on ceph-hakumar-kkqcr1-node6 [10.0.65.4]
2026-07-29 06:57:13,916 - cephci - ceph:2039 - INFO - Execution of ceph version took 1.00376 seconds on ceph-hakumar-kkqcr1-node6 by user root [10.0.65.4]
2026-07-29 06:57:13,917 - cephci - run:1390 - INFO - Ceph cluster Version: ceph version 20.2.2-133.el10cp (c4b9f29ae0cdf064ad17d7dcf2939fcfed2b3f99) tentacle (stable - RelWithDebInfo) release 9.9.2.0
2026-07-29 06:57:13,919 - cephci - run:1326 - INFO - ceph_clusters_file rerun/None-KKQCR1
2026-07-29 06:57:13,919 - cephci - run:1164 - INFO - Test <module 'rados_prep' from '/home/hakumar/forked-repo-main/cephci/tests/rados/rados_prep.py'> passed
```
Pass log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KKQCR1/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
