### PR TITLE
Fix multisite Vault: single server, shared transit keys, auto-unseal after restarts.

### DIFF
--- a/cli/vault/server.py
+++ b/cli/vault/server.py
@@ -38,6 +38,86 @@ RestartSec=10
 WantedBy=multi-user.target
 """
 
+AUTO_UNSEAL_SCRIPT = """#!/bin/bash
+# Auto-unseal Vault when sealed (e.g. after container restart).
+# Deployed by cephci install_vault.py.
+
+VAULT_ADDR="{{ vault_url }}"
+KEYS_FILE="/vault/unseal-keys.json"
+
+if [ ! -f "$KEYS_FILE" ]; then
+    echo "No unseal keys file found at $KEYS_FILE"
+    exit 1
+fi
+
+THRESHOLD=$(jq -r '.threshold' "$KEYS_FILE")
+KEYS=$(jq -r '.keys[]' "$KEYS_FILE")
+
+wait_for_api() {
+    for i in $(seq 1 60); do
+        if curl -sf "$VAULT_ADDR/v1/sys/health" -o /dev/null 2>/dev/null; then
+            return 0
+        fi
+        # 501 = not initialized, 503 = sealed — both mean API is up
+        CODE=$(curl -sf -o /dev/null -w '%{http_code}' "$VAULT_ADDR/v1/sys/health" 2>/dev/null)
+        if [ "$CODE" = "501" ] || [ "$CODE" = "503" ]; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "Vault API not reachable after 120s"
+    return 1
+}
+
+wait_for_api || exit 1
+
+SEALED=$(curl -sf "$VAULT_ADDR/v1/sys/seal-status" 2>/dev/null | jq -r '.sealed')
+
+if [ "$SEALED" != "true" ]; then
+    echo "Vault is already unsealed"
+    exit 0
+fi
+
+echo "Vault is sealed, unsealing..."
+COUNT=0
+for KEY in $KEYS; do
+    curl -sf -X POST "$VAULT_ADDR/v1/sys/unseal" \
+        -d "{\\"key\\": \\"$KEY\\"}" > /dev/null 2>&1
+    COUNT=$((COUNT + 1))
+    if [ "$COUNT" -ge "$THRESHOLD" ]; then
+        break
+    fi
+done
+
+SEALED=$(curl -sf "$VAULT_ADDR/v1/sys/seal-status" 2>/dev/null | jq -r '.sealed')
+if [ "$SEALED" = "false" ]; then
+    echo "Vault successfully unsealed"
+else
+    echo "Failed to unseal Vault"
+    exit 1
+fi
+"""
+
+AUTO_UNSEAL_SYSTEMD = """[Unit]
+Description=Auto-unseal Vault after container start
+After={{ container_name }}.service
+Requires={{ container_name }}.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sleep 5
+ExecStart=/bin/bash /vault/auto-unseal.sh
+Restart=on-failure
+RestartSec=15
+StartLimitIntervalSec=300
+StartLimitBurst=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+"""
+
 
 class Server(object):
     """Vault server container lifecycle management.
@@ -129,6 +209,42 @@ class Server(object):
         container_name = kw_copy.pop("container-name", "vault-server")
         cmd = f"systemctl is-active {container_name}"
         return self.parent.execute_as_sudo(cmd=cmd, check_ec=False)
+
+    def enable_auto_unseal(self, **kw):
+        """Deploy an auto-unseal systemd service that unseals Vault on restart.
+
+        Args:
+            kw(dict): Key/value pairs for auto-unseal.
+                Supported keys:
+                    unseal-keys(list): Base64 unseal key shares
+                    threshold(int): Number of keys needed to unseal
+                    vault-url(str): Vault server URL
+                    container-name(str): Container name (default: vault-server)
+        """
+        import json
+
+        kw_copy = deepcopy(kw)
+        unseal_keys = kw_copy.pop("unseal-keys", [])
+        threshold = kw_copy.pop("threshold", 3)
+        vault_url = kw_copy.pop("vault-url", "")
+        container_name = kw_copy.pop("container-name", "vault-server")
+
+        keys_data = json.dumps({"keys": unseal_keys, "threshold": threshold})
+        self._write_file("/vault/unseal-keys.json", keys_data)
+        self.parent.execute_as_sudo(cmd="chmod 600 /vault/unseal-keys.json")
+
+        script = Template(AUTO_UNSEAL_SCRIPT).render(vault_url=vault_url)
+        self._write_file("/vault/auto-unseal.sh", script)
+        self.parent.execute_as_sudo(cmd="chmod 700 /vault/auto-unseal.sh")
+
+        unit = Template(AUTO_UNSEAL_SYSTEMD).render(container_name=container_name)
+        self._write_file("/etc/systemd/system/vault-auto-unseal.service", unit)
+
+        self.parent.execute_as_sudo(cmd="systemctl daemon-reload")
+        self.parent.execute_as_sudo(cmd="systemctl enable vault-auto-unseal")
+        self.parent.execute_as_sudo(
+            cmd="systemctl start vault-auto-unseal", check_ec=False
+        )
 
     def _write_file(self, file_name, content):
         """Write content to a remote file on the node."""

--- a/tests/misc_env/install_vault.py
+++ b/tests/misc_env/install_vault.py
@@ -40,6 +40,8 @@ import json
 import time
 from typing import Dict, Tuple
 
+import requests
+
 from ceph.ceph import Ceph, CephNode
 from cli.vault.vault import Vault
 from utility.log import Log
@@ -90,6 +92,11 @@ def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
     """
     Deploy containerized Vault infrastructure.
 
+    In multisite setups, the Vault server is deployed only on the first
+    cluster (primary).  Subsequent clusters (secondary, archive) reuse
+    the primary's Vault server — their vault-agents point to it over
+    the network so that all sites share the same transit encryption keys.
+
     Args:
         ceph_cluster: The cluster participating in the test
         config: Configuration passed to the test
@@ -107,11 +114,25 @@ def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
         LOG.info("CONTAINERIZED VAULT DEPLOYMENT")
         LOG.info("=" * 70)
 
+        test_data = kwargs.get("test_data", {})
         vault_config = config.get("vault", {})
 
-        LOG.info("Deploying Vault server container on client node...")
-        vault_url, credentials = _deploy_vault_server(ceph_cluster, vault_config)
-        LOG.info(f"Vault server deployed at {vault_url}")
+        existing_vault = test_data.get("vault")
+        if existing_vault:
+            vault_url = existing_vault["vault_url"]
+            credentials = existing_vault["credentials"]
+            LOG.info(
+                f"Reusing primary Vault server at {vault_url} "
+                "(skipping server deployment for this cluster)"
+            )
+        else:
+            LOG.info("Deploying Vault server container on client node...")
+            vault_url, credentials = _deploy_vault_server(ceph_cluster, vault_config)
+            LOG.info(f"Vault server deployed at {vault_url}")
+            test_data["vault"] = {
+                "vault_url": vault_url,
+                "credentials": credentials,
+            }
 
         LOG.info("Deploying Vault agents on RGW nodes...")
         _deploy_vault_agents(ceph_cluster, vault_url, credentials)
@@ -126,7 +147,6 @@ def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
         LOG.info("=" * 70)
         LOG.info(f"Vault Server: {vault_url}")
         LOG.info(f"Transit Key: {credentials.get('key_name', 'testKey01')}")
-        LOG.info("Credentials: /vault/credentials.json on client node")
         LOG.info("=" * 70)
 
         return 0
@@ -162,11 +182,61 @@ def _deploy_vault_server(cluster: Ceph, config: Dict) -> Tuple[str, Dict]:
     )
 
     LOG.info("Waiting for Vault to be ready...")
-    time.sleep(10)
+    _wait_for_vault(vault, node)
 
     credentials = _initialize_vault(vault, config)
 
+    LOG.info("Enabling auto-unseal for Vault server...")
+    vault.server.enable_auto_unseal(
+        **{
+            "unseal-keys": credentials["unseal_keys"],
+            "threshold": 3,
+            "vault-url": vault_url,
+            "container-name": config.get("container-name", "vault-server"),
+        }
+    )
+    LOG.info("Auto-unseal enabled")
+
     return vault_url, credentials
+
+
+def _wait_for_vault(vault: Vault, node: CephNode, timeout: int = 120) -> None:
+    """Wait for Vault container to be running and API to be reachable."""
+    out, _ = node.exec_command(
+        sudo=True, cmd="systemctl is-active vault-server", check_ec=False
+    )
+    if "active" not in out.strip():
+        LOG.error(f"vault-server systemd unit is not active: {out.strip()}")
+        out, _ = node.exec_command(
+            sudo=True,
+            cmd="journalctl -u vault-server --no-pager -n 30",
+            check_ec=False,
+        )
+        LOG.error(f"vault-server journal:\n{out}")
+        raise RuntimeError("vault-server systemd unit failed to start")
+
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            resp = requests.get(
+                f"{vault.vault_url}/v1/sys/health",
+                timeout=5,
+            )
+            LOG.info(f"Vault is reachable (HTTP {resp.status_code})")
+            return
+        except Exception as e:
+            last_err = e
+            LOG.debug(f"Vault not ready yet: {e}")
+            time.sleep(5)
+
+    out, _ = node.exec_command(
+        sudo=True, cmd="podman ps -a --filter name=vault-server", check_ec=False
+    )
+    LOG.error(f"Container status: {out}")
+    raise RuntimeError(
+        f"Vault not reachable at {vault.vault_url} after {timeout}s: {last_err}"
+    )
 
 
 def _initialize_vault(vault: Vault, config: Dict) -> Dict:


### PR DESCRIPTION


**Fix multisite encryption failure:** In multisite setups (primary + secondary + archive), install_vault.py was deploying a separate Vault server on each cluster. Each got independently initialized transit keys, so objects encrypted on the primary could not be decrypted on other sites ("Failed to retrieve the actual key"). 

Now only the primary cluster deploys the Vault server; secondary/archive clusters deploy vault-agents pointing to the primary's Vault over the network via test_data shared state.

**Add auto-unseal:** New systemd service (vault-auto-unseal.service) automatically unseals the Vault server after container restarts using stored Shamir key shares.

**Add request timeouts**: Vault REST API calls now have a configurable timeout (default 30s) to prevent indefinite hangs.
Add wait-for-ready: Proper health-check loop before Vault initialization instead of a fixed sleep(10).

TFA failed logs before fix - https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-9/upgrade/20.2.1-324/rgw/72/logs/Tier_1_rgw_upgrade_ssl_archive_81GA_to_9x_latest/

After the fix, clean passed logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JMV8KY
