### PR TITLE
Apply Rook default settings on CephCI cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ result.props
 # ignore Logs
 *.log
 
+*venv*/
+
 # ignore cephci execution residues
 osd_scenarios_*node*
 version_info.json

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -16,6 +16,12 @@ from ceph.utils import (
 )
 from cephci.utils.build_info import CephTestManifest
 from utility.log import Log
+from utility.odf_defaults import (
+    APPLY_ODF_DEFAULTS_KEY,
+    apply_odf_defaults_to_bootstrap_config,
+    apply_v2_only_mon_addrs,
+    overrides_enabled,
+)
 from utility.utils import get_cephci_config
 
 from ..ceph import ResourceNotFoundError
@@ -397,6 +403,12 @@ class BootstrapMixin:
                 node=self.installer, cluster=self.cluster, specs=specs
             ).create_spec_file()
 
+        # Opt-in ODF/Rook-like defaults via --custom-config apply-odf-defaults=true
+        # Merges into args.config before INI render so mon_osd_*_ratio seeds OSDMap.
+        apply_odf_defaults_to_bootstrap_config(
+            args, overrides=self.config.get("overrides")
+        )
+
         # Bootstrap with ceph config options like ceph.conf file
         conf = args.get("config")
         if conf:
@@ -520,5 +532,14 @@ class BootstrapMixin:
             validate_spec_services(
                 self.installer, specs=specs, rhcs_version=self.cluster.rhcs_version
             )
+
+        # ODF-style v2-only monmap (requires live mon after bootstrap)
+        overrides = (self.config or {}).get("overrides") or {}
+        if overrides_enabled(overrides, APPLY_ODF_DEFAULTS_KEY):
+            logger.info(
+                "Applying v2-only mon addrs after bootstrap "
+                "(--custom-config apply-odf-defaults=true)"
+            )
+            apply_v2_only_mon_addrs(self.shell)
 
         return out, err

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -27,6 +27,11 @@ from ceph.rados import utils as osd_utils
 from tests.rados.rados_test_util import wait_for_device_rados
 from utility import utils
 from utility.log import Log
+from utility.odf_defaults import (
+    _mon_name_and_ip,
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+)
 
 log = Log(__name__)
 
@@ -7425,9 +7430,26 @@ EOF"""
         client_node.exec_command(
             cmd=f"mkdir -p {mount_path}", sudo=True, check_ec=False
         )
-        client_node.exec_command(
-            cmd=f"mount -t ceph admin@.{fs_name}=/ {mount_path}", sudo=True
-        )
+        use_msgr2 = is_msgr1_disabled(client_node)
+        mount_opts = []
+        if use_msgr2:
+            mount_opts.append("ms_mode=crc")
+            try:
+                mon_dump = self.run_ceph_command(cmd="ceph mon dump", client_exec=True)
+                mon_addrs = []
+                for mon in mon_dump.get("mons") or []:
+                    parsed = _mon_name_and_ip(mon)
+                    if parsed:
+                        # mount.ceph mon_addr uses slash-separated IP:port
+                        mon_addrs.append(format_mons_for_kernel_mount(parsed[1], True))
+                if mon_addrs:
+                    mount_opts.append("mon_addr=" + "/".join(mon_addrs))
+            except Exception as exc:  # noqa: BLE001
+                log.warning("Could not build mon_addr for msgr2 mount: %s", exc)
+        mount_cmd = f"mount -t ceph admin@.{fs_name}=/ {mount_path}"
+        if mount_opts:
+            mount_cmd += " -o " + ",".join(mount_opts)
+        client_node.exec_command(cmd=mount_cmd, sudo=True)
         log.info(f"Mounted CephFS at {mount_path}")
 
         # Return created pool names

--- a/conf/tentacle/rook/odf_rook_defaults.yaml
+++ b/conf/tentacle/rook/odf_rook_defaults.yaml
@@ -1,0 +1,30 @@
+# ODF / Rook-like Ceph defaults for standalone CephCI clusters.
+# Bootstrap --config when --custom-config apply-odf-defaults=true.
+#
+# Capacity ratios use mon_osd_*_ratio so they seed the OSDMap at cluster creation.
+# rbd_default_map_options matches ODF prefer-crc for krbd.
+# Msgr2-only monmap (v2:IP:3300 only) is applied post-deploy via
+# `ceph mon set-addrs`. Also set ms_bind_msgr1=false at bootstrap (OSD/MDS/etc.).
+# Note: mons often still bind v1 from monmap until set-addrs runs (tracker #70457).
+# SSD device class stays post-OSD (apply-odf-topology).
+
+global:
+  mon_osd_full_ratio: "0.85"
+  mon_osd_backfillfull_ratio: "0.80"
+  mon_osd_nearfull_ratio: "0.75"
+  mon_max_pg_per_osd: 1000
+  mon_target_pg_per_osd: 200
+  mon_pg_warn_max_object_skew: 0
+  mon_data_avail_warn: 15
+  bdev_flock_retry: 20
+  bluestore_prefer_deferred_size_hdd: 0
+  bluestore_slow_ops_warn_lifetime: 0
+  # ODF-like: disable msgr1 bind; monmap v2-only via post-deploy set-addrs
+  ms_bind_msgr1: "false"
+  rbd_default_map_options: "ms_mode=prefer-crc"
+
+osd:
+  osd_memory_target_cgroup_limit_ratio: "0.8"
+
+mds:
+  mds_cache_memory_limit: 3221225472

--- a/docs/odf_rook_defaults.md
+++ b/docs/odf_rook_defaults.md
@@ -1,0 +1,328 @@
+# CephCI ODF/Rook-like defaults — design document
+
+## 1. Objective
+
+Make **standalone CephCI (cephadm) clusters** able to look and behave closer to
+**OpenShift Data Foundation (ODF) / Rook** clusters, so CI can catch ODF-relevant
+regressions **without changing default CephCI behavior**.
+
+| Goal | Why |
+|------|-----|
+| Opt-in ODF-like Ceph config at bootstrap | Seed OSDMap ratios and daemon defaults the way Rook’s `rook-config-override` does |
+| Opt-in v2-only mon endpoints | Match ODF `requireMsgr2`-style monmaps (`v2:IP:3300` only) |
+| Opt-in topology/platform steps | Zones, CRUSH rules, container limits, SSD class labels |
+| Keep CephFS / RBD / SMB tests working | Kernel CephFS mounts break on v2-only clusters unless mounts use msgr2 correctly |
+| Zero impact when flags are off | Existing suites and smoke runs stay unchanged |
+
+---
+
+## 2. Solution in CephCI (architecture)
+
+### 2.1 Opt-in flags (`run.py` `--custom-config`)
+
+```bash
+--custom-config apply-odf-defaults=true    # full profile + v2-only set-addrs
+--custom-config apply-odf-topology=true    # post-OSD topology (+ light bootstrap msgr2 keys if defaults unset)
+--custom-config verify-odf-defaults=true   # assert config/osd/mon dump after deploy
+```
+
+Suite YAML keys win over profile keys when both set the same option.
+
+### 2.2 Code map
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| Profile YAML | `conf/tentacle/rook/odf_rook_defaults.yaml` | Declared ODF-like defaults |
+| Defaults helper | `utility/odf_defaults.py` | Merge into bootstrap; `set-addrs`; verify; kernel mount helpers |
+| Topology helper | `utility/odf_topology.py` | Zones, crush rules, container limits, SSD class |
+| Bootstrap | `ceph/ceph_admin/bootstrap.py` | Merge profile into `--config`; post-bootstrap `set-addrs` |
+| Deploy | `tests/ceph_installer/test_cephadm.py` | Re-apply `set-addrs` after mon steps / full deploy; run topology + verify |
+| Mon apply | `tests/cephadm/test_mon.py` | `set-addrs` after mon `apply` when defaults flag set |
+| Topology entry | `tests/ceph_installer/apply_odf_topology.py` | Standalone topology apply helper |
+| Unit tests | `unittests/utility/test_odf_*.py` | Profile merge, set-addrs, topology, mount helpers |
+
+**Design choice:** `ceph mon set-addrs` is **not** in library `ceph/ceph_admin/mon.py`.
+It runs only when `apply-odf-defaults=true`, at bootstrap / deploy / mon-apply hooks.
+
+### 2.3 Lifecycle (what runs when)
+
+```text
+run.py  -c apply-odf-defaults=true  [-c apply-odf-topology=true] [-c verify-odf-defaults=true]
+   │
+   ├─ bootstrap
+   │     ├─ merge odf_rook_defaults.yaml → args.config → cephadm bootstrap --config
+   │     └─ after success: ceph mon set-addrs <mon> '[v2:<ip>:3300/0]'   (first mon)
+   │
+   ├─ test_cephadm deploy
+   │     ├─ after each mon apply step: set-addrs again (all current mons)
+   │     ├─ after full deploy: set-addrs again
+   │     ├─ if apply-odf-topology: zones / crush_rules / container_limits / ssd_class
+   │     └─ if verify-odf-defaults: compare config dump + osd dump ratios + v2-only monmap
+   │
+   └─ later tests (CephFS/RBD/SMB/RADOS)
+         └─ kernel CephFS mounts consult: ceph config get mon ms_bind_msgr1
+              false → device :3300 + ms_mode=crc
+              true  → legacy bare IP / :6789 behavior
+```
+
+---
+
+## 3. Default configuration applied
+
+### 3.1 Full profile (`apply-odf-defaults=true`)
+
+Source: [`conf/tentacle/rook/odf_rook_defaults.yaml`](../conf/tentacle/rook/odf_rook_defaults.yaml)
+
+#### Global
+
+| Key | Value | Purpose / effect |
+|-----|-------|------------------|
+| `mon_osd_full_ratio` | `0.85` | Seeded into **OSDMap** at cluster create (ODF-like full threshold; Ceph default ~0.95) |
+| `mon_osd_backfillfull_ratio` | `0.80` | OSDMap backfill-full threshold |
+| `mon_osd_nearfull_ratio` | `0.75` | OSDMap nearfull threshold |
+| `mon_max_pg_per_osd` | `1000` | PG-per-OSD ceiling (some ODF training samples use 600; CephCI profile uses 1000) |
+| `mon_target_pg_per_osd` | `200` | Target PG density |
+| `mon_pg_warn_max_object_skew` | `0` | Soften skew warnings |
+| `mon_data_avail_warn` | `15` | Mon disk avail warn % |
+| `bdev_flock_retry` | `20` | Device flock retries |
+| `bluestore_prefer_deferred_size_hdd` | `0` | Bluestore deferred write tuning |
+| `bluestore_slow_ops_warn_lifetime` | `0` | Slow-ops warning lifetime |
+| `ms_bind_msgr1` | `false` | Daemons do not bind msgr1 (**mons often still keep v1 in monmap until set-addrs** — [tracker #70457](https://tracker.ceph.com/issues/70457)) |
+| `rbd_default_map_options` | `ms_mode=prefer-crc` | Default **krbd** map options (prefer msgr2 crc; can still fall back) |
+
+#### OSD
+
+| Key | Value | Purpose |
+|-----|-------|---------|
+| `osd_memory_target_cgroup_limit_ratio` | `0.8` | OSD memory target vs cgroup limit (ODF-like) |
+
+#### MDS
+
+| Key | Value | Purpose |
+|-----|-------|---------|
+| `mds_cache_memory_limit` | `3221225472` (~3 GiB) | MDS cache cap closer to ODF |
+
+### 3.2 Post-deploy monmap (same flag)
+
+For each mon:
+
+```bash
+ceph mon set-addrs <name> '[v2:<ip>:3300/0]'
+```
+
+**Effect:** Public monmap becomes **v2-only** (no `:6789` / `v1:`). This is the
+ODF-like “require msgr2” mon endpoint shape.
+
+### 3.3 Topology-only bootstrap (`apply-odf-topology=true` without full defaults)
+
+Injects only:
+
+```text
+global.ms_bind_msgr1 = false
+global.rbd_default_map_options = ms_mode=prefer-crc
+```
+
+Full ratios/limits from YAML are **not** applied unless `apply-odf-defaults` is also set.
+
+### 3.4 Topology post-OSD (`apply-odf-topology=true`)
+
+Default steps: `zones`, `crush_rules`, `container_limits`, `ssd_class`
+
+| Step | What is applied | Effect / caveats |
+|------|-----------------|------------------|
+| `zones` | region/zone CRUSH buckets; move first 3 hosts into `zone-a/b/c` | Skipped if fewer than 3 hosts |
+| `crush_rules` | Creates rules `odf-block`, `odf-fs-meta`, `odf-fs-data` (failure domain `zone`) | **Does not auto-rebind existing pools** to those rules |
+| `container_limits` | Orch specs: OSD 2 CPU / 5g; MON 1 CPU / 2g; MDS 2 CPU / 6g | May OOM or be ignored on small CephCI VMs (best-effort) |
+| `ssd_class` | `ceph osd crush set-device-class ssd <all osds>` | **Label only** — does not change media |
+| `msgr2` (optional step) | Re-run set-addrs + set `rbd_default_map_options` | Prefer defaults flag for this; not in default step list |
+
+---
+
+## 4. Effects of applying these defaults
+
+### 4.1 Cluster behavior
+
+| Area | Effect |
+|------|--------|
+| Capacity warnings / full handling | Nearfull/backfillfull/full trip earlier (0.75 / 0.80 / 0.85) like ODF |
+| PG planning | Higher `mon_max_pg_per_osd` / target density vs stock CephCI |
+| Messenger | New binds prefer msgr2 only; after set-addrs, **clients must use v2 (:3300)** to reach mons |
+| RBD kernel map | Gets `ms_mode=prefer-crc` from central config |
+| MDS | Larger cache limit |
+| Topology (if enabled) | Zone CRUSH + SSD labels + optional container caps |
+
+### 4.2 CephFS — the critical side effect
+
+| Client | Before ODF flags | After ODF flags (without mount fix) | After mount fix |
+|--------|------------------|--------------------------------------|-----------------|
+| **ceph-fuse** | Works | Generally still works (userspace msgr2) | Works |
+| **Kernel CephFS** | Bare `IP:/` → **:6789** | Connects to dead/missing v1 → **“no mds is up”**, corrupt mdsmap, dmesg `no match of type 1 in addrvec` | Uses **`IP:3300` + `ms_mode=crc`** → mounts succeed |
+
+Why `prefer-crc` alone is not enough for CephFS kernel:
+
+- That option is primarily for **krbd** (`rbd map`).
+- CephFS kernel mount still needs an explicit **port** and **`ms_mode=crc`** (no v1
+  fallback) when monmap is v2-only.
+- Bare `mount -t ceph IP:/` defaults to port **6789** ([mount.ceph(8)](https://docs.ceph.com/en/latest/man/8/mount.ceph/)).
+
+### 4.3 When flags are off
+
+No profile merge, no set-addrs, no topology, no mount auto-rewrite from
+`ms_bind_msgr1` (helper returns false → legacy paths). Default CephCI unchanged.
+
+---
+
+## 5. Fixes applied (CephFS / clients)
+
+### 5.1 Decision policy
+
+```text
+ceph config get mon ms_bind_msgr1
+  → false / 0 / no  ⇒ use_msgr2
+  → else            ⇒ legacy
+
+Additionally (V1 kernel_mount only):
+  mon dump is v2-only (has v2, no v1) ⇒ use_msgr2
+  (covers ODF where ms_bind_msgr1 may stay true)
+
+If caller already sets ms_mode=… (e.g. ms_mode=legacy in option matrix):
+  ⇒ do not auto-rewrite port / do not inject ms_mode=crc
+```
+
+Helpers in `utility/odf_defaults.py`:
+
+- `is_msgr1_disabled(client)`
+- `format_mons_for_kernel_mount(...)` — bare IP / list / `v2:IP:3300/0` → `IP:3300` when msgr2
+- `kernel_ms_mode_opt(...)` — append `,ms_mode=crc` if needed
+
+### 5.2 Call sites fixed
+
+| Site | Fix |
+|------|-----|
+| `tests/cephfs/cephfs_utilsV1.py` `kernel_mount` | Auto `:3300` + `ms_mode=crc`; respect explicit `ms_mode` |
+| `tests/cephfs/cephfs_utilsV1.py` `validate_fs_info` | Expect FS mon ports `:3300` when msgr1 disabled, else `:6789` |
+| `tests/cephfs/cephfs_utils.py` (V0) | Same helpers |
+| `utility/utils.py` `kernel_mount` | Same helpers (replaces hardcoded `:6789` behavior) |
+| `tests/cephfs/no_recover_session_mount.py` | Direct mount updated |
+| `tests/cephfs/BUG-1798719.py` | Direct mount updated |
+| `tests/cephfs/fs_kernel_mount_options.py` | Default/direct mounts updated; **legacy ms_mode left explicit** |
+| `tests/smb/smb_operations.py` `samba_kernel_mount` | Same policy |
+| `ceph/rados/core_workflows.py` `admin@.fs=/` | Adds `ms_mode=crc` + `mon_addr=IP:3300/...` when msgr1 disabled |
+| `tests/rados/test_bug_fixes.py` | Normalizes mon `public_addr` + `ms_mode=crc` when needed |
+
+### 5.3 What those fixes achieve
+
+- Kernel CephFS works on ODF-flagged CephCI clusters.
+- `validate_fs_info` no longer fails by comparing `:6789` expectations to `:3300` FS info.
+- Bypass mounts that skipped V1 no longer regress under msgr2-only monmaps.
+- Option-matrix tests that **intentionally** pass `ms_mode=legacy` are not silently rewritten to crc.
+
+---
+
+## 6. Configuration / behavior still left to apply (gaps)
+
+### 6.1 Ceph config often present in real ODF but not in CephCI profile
+
+| Item | Status | Notes |
+|------|--------|------|
+| Exact ODF `mon_max_pg_per_osd` (sometimes 600) | Profile uses **1000** | Align if parity with a specific ODF version is required |
+| `osd_pool_default_size` / `min_size` | **Not applied** | Common in rook-config-override examples (e.g. size 2 / min 1 for compact clusters) |
+| Full Rook operator / CSI / StorageCluster CR semantics | **N/A** | CephCI is bare cephadm, not Rook |
+| Network encryption / msgr2 secure mode | **Not applied** | Only crc/prefer-crc style options today |
+| Additional ODF ConfigMap knobs (version-specific) | **Not inventoried end-to-end** | Profile is a curated subset |
+
+### 6.2 Mon / messenger parity with ODF
+
+| Item | CephCI today | Typical ODF | Left to decide |
+|------|--------------|-------------|----------------|
+| `ms_bind_msgr1` | Set **false** via profile | Often left **true**; v2-only via monmap / requireMsgr2 | Whether to drop `ms_bind_msgr1=false` and rely only on `set-addrs` for closer ODF parity |
+| Client `ceph.conf` `mon_host` after set-addrs | Not universally rewritten | ODF clients get v2 endpoints from operator | Ensure all clients regenerate minimal conf / mon_host if mounts omit explicit mon list |
+| `ms_mode=prefer-crc` for CephFS | Not used (need **crc**) | Kernel CephFS still needs explicit mount opts | Done for known paths; hunt remaining raw mounts |
+
+### 6.3 Topology gaps
+
+| Item | Status |
+|------|--------|
+| Bind existing pools to `odf-*` crush rules | **Not automatic** — rules created only |
+| Zone layout on clusters with fewer than 3 hosts | Zones step **skipped** |
+| Container limits on small VMs | Best-effort; may fail/warn |
+| SSD class | Label only; no media validation |
+| Failure-domain / stretch / arbiter ODF topologies | **Not modeled** beyond simple 3-zone sketch |
+
+### 6.4 Test / mount follow-ups
+
+| Item | Status |
+|------|--------|
+| Migrate remaining V0 / `utility.utils.kernel_mount` callers to V1 | Recommended |
+| Grep for other `mount -t ceph` / hardcoded `:6789` | Ongoing hygiene |
+| `fs_kernel_mount_options` + `ms_mode=legacy` on v2-only clusters | Expected to fail or need skip when ODF flags on |
+| Fuse-only paths | Generally OK; still verify under verify-odf-defaults |
+| Non-CephFS clients (RGW, NVMe-oF, etc.) under v2-only monmap | **Not specifically validated** by this work |
+
+### 6.5 Operational / process
+
+| Item | Status |
+|------|--------|
+| Default smoke/BVT enabling the flags | Optional — flags are opt-in; decide per suite |
+| Document suite authors must pass `-c apply-odf-defaults=true` for ODF parity runs | Needed for adoption |
+| Compare live ODF toolbox dumps vs CephCI profile regularly | Recommended when targeting a specific ODF z-stream |
+
+---
+
+## 7. How to run and verify
+
+```bash
+# Example
+python run.py ... \
+  -c apply-odf-defaults=true \
+  -c apply-odf-topology=true \
+  -c verify-odf-defaults=true
+```
+
+Post-deploy checks:
+
+```bash
+ceph config get mon ms_bind_msgr1
+ceph config get global rbd_default_map_options
+ceph osd dump | grep -E 'full_ratio|nearfull|backfillfull'
+ceph mon dump                    # expect v2:IP:3300 only
+ceph config dump | grep -E 'mon_max_pg|mds_cache|osd_memory_target'
+```
+
+Kernel mount sanity (when msgr1 disabled):
+
+```bash
+mount -t ceph <ip>:3300:/ <mnt> -o name=admin,secretfile=...,ms_mode=crc
+# dmesg should not show persistent :6789 / type 1 addrvec errors
+```
+
+Unit tests:
+
+```bash
+python -m pytest unittests/utility/test_odf_defaults.py unittests/utility/test_odf_topology.py -q
+```
+
+---
+
+## 8. Summary table
+
+| Layer | Applied now | Effect | Still left |
+|-------|-------------|--------|------------|
+| Bootstrap Ceph config | YAML profile (ratios, PG, msgr1 off, RBD prefer-crc, OSD/MDS knobs) | ODF-like OSDMap + daemon defaults | More Rook override keys; size/min_size; version drift |
+| Monmap | `set-addrs` → v2-only | Clients must use msgr2 | Optional closer ODF parity (`ms_bind_msgr1` true + monmap only); client conf refresh |
+| Topology | Zones / rules / limits / SSD label | Partial platform shape | Pool↔rule binding; richer topologies; robust limits on small HW |
+| CephFS kernel | `:3300` + `ms_mode=crc` via helpers | Mounts work again | Remaining raw mounts; legacy option-matrix on v2-only; V0→V1 migration |
+| Default CephCI (no flags) | Nothing | Unchanged | — |
+
+---
+
+## 9. Takeaway
+
+CephCI can opt into an ODF/Rook-like cluster by merging a curated bootstrap profile,
+forcing v2-only mon addresses, and optionally applying topology steps. That combination
+disables effective msgr1 access to mons, which broke CephFS **kernel** mounts that
+defaulted to `:6789`. The fix is to decide msgr2 from `ceph config get mon ms_bind_msgr1`
+(and v2-only monmap in V1) and mount with `:3300` + `ms_mode=crc` across known call
+sites. Remaining work is fuller Rook config parity, topology depth, client `mon_host`
+hygiene, and hunting any leftover bare kernel mounts—not re-breaking default (non-flag)
+CephCI runs.

--- a/run.py
+++ b/run.py
@@ -153,6 +153,18 @@ Options:
   --skip-version-compare            Skip verification that ceph versions change post
                                     upgrade
   -c --custom-config <name>=<value> Add a custom config key/value to ceph_conf_overrides
+                                    Cephadm ODF/Rook-like profile (opt-in via -c)
+                                    apply-odf-defaults=true merges
+                                    conf/tentacle/rook/odf_rook_defaults.yaml into
+                                    bootstrap --config (OSDMap ratios, ms_bind_msgr1=false,
+                                    RBD ms_mode); v2-only mon set-addrs runs at end of
+                                    bootstrap.py, after test_cephadm deploy, and in
+                                    tests/cephadm/test_mon.py after mon apply.
+                                    apply-odf-topology=true injects msgr2 bootstrap keys
+                                    if defaults unset; after deploy applies
+                                    zone CRUSH, crush rules, container limits,
+                                    SSD device-class.
+                                    verify-odf-defaults=true checks config/osd/mon dump.
   --custom-config-file <file>       Add custom config yaml to ceph_conf_overrides
   --xunit-results                   Create xUnit result file for test suite run
                                     [default: false]

--- a/tests/ceph_installer/apply_odf_topology.py
+++ b/tests/ceph_installer/apply_odf_topology.py
@@ -1,0 +1,48 @@
+"""
+Suite-callable wrapper to apply ODF topology after deploy.
+
+Use when deploy is not via test_cephadm.py, or to re-apply topology::
+
+    - test:
+        module: apply_odf_topology.py
+        config:
+          # optional subset: zones, crush_rules, container_limits, msgr2, ssd_class
+          # steps: [zones, msgr2]
+"""
+
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+from utility.odf_defaults import APPLY_ODF_TOPOLOGY_KEY, overrides_enabled
+from utility.odf_topology import apply_odf_topology, topology_status_snapshot
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster, **kwargs):
+    config = kwargs.get("config") or {}
+    overrides = kwargs.get("test_data", {}).get("custom_config_dict") or {}
+    # Allow suite to force apply even without CLI flag
+    force = config.get("apply_odf_topology", False)
+    if not force and not overrides_enabled(overrides, APPLY_ODF_TOPOLOGY_KEY):
+        LOG.info(
+            "Skipping ODF topology (set --custom-config apply-odf-topology=true "
+            "or config.apply_odf_topology: true)"
+        )
+        return 0
+
+    # Ensure flag is seen by apply_odf_topology when forced from suite config
+    if force:
+        overrides = dict(overrides)
+        overrides[APPLY_ODF_TOPOLOGY_KEY] = True
+
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    steps = config.get("steps")
+    apply_odf_topology(
+        ceph_cluster,
+        cephadm.shell,
+        installer_node=cephadm.installer,
+        overrides=overrides,
+        steps=steps,
+    )
+    LOG.info("Topology snapshot: %s", topology_status_snapshot(cephadm.shell))
+    return 0

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -36,6 +36,14 @@ from ceph.ceph_admin.rbd_mirror import RbdMirror
 from ceph.ceph_admin.rgw import RGW
 from cli.utilities.utils import create_trusted_ca_key
 from utility.log import Log
+from utility.odf_defaults import (
+    APPLY_ODF_DEFAULTS_KEY,
+    APPLY_ODF_TOPOLOGY_KEY,
+    apply_v2_only_mon_addrs,
+    overrides_enabled,
+    verify_odf_defaults,
+)
+from utility.odf_topology import apply_odf_topology, topology_status_snapshot
 
 LOG = Log(__name__)
 
@@ -160,6 +168,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 return 1
 
         steps = config.get("steps", [])
+        overrides = config.get("overrides") or {}
         for step in steps:
             cfg = step["config"]
             command = cfg.pop("command")
@@ -167,9 +176,22 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 cephadm.shell(**cfg)
                 continue
 
-            obj = SERVICE_MAP[cfg["service"]](cluster=ceph_cluster, **config)
+            service = cfg["service"]
+            obj = SERVICE_MAP[service](cluster=ceph_cluster, **config)
             func = fetch_method(obj, command)
             func(cfg)
+
+            # After mon apply/scale in steps, re-apply v2-only monmap when requested
+            if (
+                service == "mon"
+                and command == "apply"
+                and overrides_enabled(overrides, APPLY_ODF_DEFAULTS_KEY)
+            ):
+                LOG.info(
+                    "Re-applying v2-only mon addrs after mon step "
+                    "(--custom-config apply-odf-defaults=true)"
+                )
+                apply_v2_only_mon_addrs(cephadm.shell)
 
         if config.get("verify_cluster_health"):
             cephadm.cluster.check_health(
@@ -183,6 +205,40 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         if config.get("verify_log_rotate") and not validate_log_rotate(cephadm):
             LOG.error("Log rotate validation failure")
             return 1
+
+        overrides = config.get("overrides") or {}
+        # Re-apply v2-only mon addrs after full deploy (mons may have been
+        # scaled via add_hosts / orch apply mon after bootstrap).
+        if overrides_enabled(overrides, APPLY_ODF_DEFAULTS_KEY):
+            LOG.info(
+                "Applying v2-only mon addrs after deploy "
+                "(--custom-config apply-odf-defaults=true)"
+            )
+            apply_v2_only_mon_addrs(cephadm.shell)
+
+        # Post-OSD ODF topology / platform settings (zones, limits, etc.)
+        if overrides_enabled(overrides, APPLY_ODF_TOPOLOGY_KEY):
+            LOG.info("Applying ODF topology (--custom-config apply-odf-topology=true)")
+            apply_odf_topology(
+                ceph_cluster,
+                cephadm.shell,
+                installer_node=cephadm.installer,
+                overrides=overrides,
+            )
+            LOG.info(
+                "ODF topology snapshot: %s", topology_status_snapshot(cephadm.shell)
+            )
+
+        # Optional verification when ODF defaults were requested
+        verify_odf = config.get("verify_odf_defaults") or overrides_enabled(
+            overrides, "verify-odf-defaults"
+        )
+        if overrides_enabled(overrides, APPLY_ODF_DEFAULTS_KEY) and verify_odf:
+            mismatches = verify_odf_defaults(cephadm.shell)
+            if mismatches:
+                LOG.error("ODF defaults verification mismatches: %s", mismatches)
+                return 1
+            LOG.info("ODF defaults verified via ceph config dump / osd dump / mon dump")
 
     except BaseException as be:  # noqa
         LOG.error(be, exc_info=True)

--- a/tests/cephadm/test_mon.py
+++ b/tests/cephadm/test_mon.py
@@ -2,6 +2,11 @@ from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.mon import Mon
 from utility.log import Log
+from utility.odf_defaults import (
+    APPLY_ODF_DEFAULTS_KEY,
+    apply_v2_only_mon_addrs,
+    overrides_enabled,
+)
 
 log = Log(__name__)
 
@@ -36,6 +41,22 @@ def run(ceph_cluster, **kw):
     try:
         method = fetch_method(monitor, command)
         method(config)
+        # New/replaced mons may reappear with dual v1+v2; re-apply v2-only
+        # when ODF defaults were requested via --custom-config.
+        overrides = (
+            config.get("overrides")
+            or kw.get("test_data", {}).get("custom_config_dict")
+            or {}
+        )
+        if command == "apply" and overrides_enabled(overrides, APPLY_ODF_DEFAULTS_KEY):
+            log.info(
+                "Re-applying v2-only mon addrs after mon apply "
+                "(--custom-config apply-odf-defaults=true)"
+            )
+            monitor.check_service(
+                service_name=monitor.SERVICE_NAME, timeout=300, interval=10
+            )
+            apply_v2_only_mon_addrs(monitor.shell)
     finally:
         # Get cluster state
         get_cluster_state(monitor, CLUSTER_STATE)

--- a/tests/cephfs/BUG-1798719.py
+++ b/tests/cephfs/BUG-1798719.py
@@ -4,6 +4,11 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 from utility.log import Log
+from utility.odf_defaults import (
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+    kernel_ms_mode_opt,
+)
 
 log = Log(__name__)
 
@@ -46,16 +51,18 @@ def run(ceph_cluster, **kw):
             )
             key_file.write(secret_key)
             key_file.flush()
+            use_msgr2 = is_msgr1_disabled(client)
+            mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+            ms_opt = kernel_ms_mode_opt(use_msgr2)
             op, rc = client.exec_command(
-                cmd="sudo mount -t ceph %s,%s,%s:/ "
-                "%s -o name=%s,secretfile=/etc/ceph/%s.secret"
+                cmd="sudo mount -t ceph %s:/ "
+                "%s -o name=%s,secretfile=/etc/ceph/%s.secret%s"
                 % (
-                    mon_node_ip[0],
-                    mon_node_ip[1],
-                    mon_node_ip[2],
+                    mons,
                     mounting_dir,
                     user_name,
                     user_name,
+                    ms_opt,
                 )
             )
             out, rc = client.exec_command(cmd="mount")

--- a/tests/cephfs/cephfs_utils.py
+++ b/tests/cephfs/cephfs_utils.py
@@ -6,6 +6,11 @@ import time
 
 from ceph.ceph import CommandFailed
 from utility.log import Log
+from utility.odf_defaults import (
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+    kernel_ms_mode_opt,
+)
 
 log = Log(__name__)
 
@@ -431,18 +436,20 @@ class FsUtils(object):
                     )
                     key_file.write(secret_key.rstrip("\n"))
                     key_file.flush()
+                    use_msgr2 = is_msgr1_disabled(client)
+                    mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+                    ms_opt = kernel_ms_mode_opt(use_msgr2)
                     client.exec_command(
                         sudo=True,
-                        cmd="mount -t ceph %s,%s,%s:/%s "
-                        "%s -o name=%s,secretfile=/etc/ceph/%s.secret"
+                        cmd="mount -t ceph %s:/%s "
+                        "%s -o name=%s,secretfile=/etc/ceph/%s.secret%s"
                         % (
-                            mon_node_ip[0],
-                            mon_node_ip[1],
-                            mon_node_ip[2],
+                            mons,
                             sub_dir,
                             mounting_dir,
                             new_client_hostname,
                             new_client_hostname,
+                            ms_opt,
                         ),
                     )
                     out, rc = client.exec_command(cmd="mount")

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -664,13 +664,22 @@ class FsUtils(object):
         )
         fs_info = json.loads(out)
         mon_ips = self.get_mon_node_ips()
-        if not set(fs_info["mon_addrs"]).issubset([f"{i}:6789" for i in mon_ips]):
+        # ms_bind_msgr1=false (ODF-like) → FS advertises msgr2 :3300; else legacy :6789
+        from utility.odf_defaults import is_msgr1_disabled
+
+        msgr1_disabled = is_msgr1_disabled(client)
+        port = "3300" if msgr1_disabled else "6789"
+        expected = [f"{ip}:{port}" for ip in mon_ips]
+        if not set(fs_info["mon_addrs"]).issubset(expected):
             log.error(
                 "Mon IPs are not matching with FS Info IPs.\n"
                 "Mon IPs as per the cluster config: %s\n"
-                "Mon IPs from FS Info: %s",
-                [f"{i}:6789" for i in mon_ips],
+                "Mon IPs from FS Info: %s\n"
+                "ms_bind_msgr1 disabled=%s (expected port %s)",
+                expected,
                 fs_info["mon_addrs"],
+                msgr1_disabled,
+                port,
             )
             return False
         return True
@@ -1049,8 +1058,51 @@ class FsUtils(object):
                 f"/etc/ceph/{kwargs.get('new_client_hostname', client.node.hostname)}.secret",
             )
 
+            # Bare IP mounts default to port 6789 (msgr1). When ms_bind_msgr1=false
+            # (or monmap is v2-only), use :3300 and ms_mode=crc.
+            from utility.odf_defaults import (
+                format_mons_for_kernel_mount,
+                is_msgr1_disabled,
+                kernel_ms_mode_opt,
+            )
+
+            msgr1_disabled = is_msgr1_disabled(client)
+            monmap_v2_only = False
+            try:
+                mon_dump_raw, _ = client.exec_command(
+                    sudo=True, cmd="ceph mon dump -f json"
+                )
+                md = json.loads(mon_dump_raw or "{}")
+                has_v1 = False
+                has_v2 = False
+                for mon in md.get("mons", []):
+                    addrs = mon.get("public_addrs") or {}
+                    vec = addrs.get("addrvec") if isinstance(addrs, dict) else None
+                    if vec:
+                        for addr in vec:
+                            if addr.get("type") == "v1":
+                                has_v1 = True
+                            if addr.get("type") == "v2":
+                                has_v2 = True
+                    else:
+                        public_addr = str(
+                            mon.get("public_addr") or mon.get("addr") or ""
+                        )
+                        if "v1:" in public_addr or ":6789" in public_addr:
+                            has_v1 = True
+                        if "v2:" in public_addr or ":3300" in public_addr:
+                            has_v2 = True
+                monmap_v2_only = has_v2 and not has_v1
+            except Exception as exc:  # noqa: BLE001
+                log.debug("msgr2 monmap detection failed: %s", exc)
+
+            # Caller-supplied ms_mode (e.g. legacy in option matrix) owns the policy
+            extra = kwargs.get("extra_params") or ""
+            need_msgr2 = (msgr1_disabled or monmap_v2_only) and "ms_mode=" not in extra
+            mount_mons = format_mons_for_kernel_mount(mon_node_ip, need_msgr2)
+
             kernel_cmd = (
-                f"mount -t ceph {mon_node_ip}:{kwargs.get('sub_dir', '/')} {mount_point} "
+                f"mount -t ceph {mount_mons}:{kwargs.get('sub_dir', '/')} {mount_point} "
                 f"-o name={kwargs.get('new_client_hostname', client.node.hostname)},"
                 f"secretfile=/etc/ceph/{kwargs.get('new_client_hostname', client.node.hostname)}.secret,"
                 f"noshare"
@@ -1058,6 +1110,17 @@ class FsUtils(object):
 
             if kwargs.get("extra_params"):
                 kernel_cmd += f"{kwargs.get('extra_params')}"
+
+            ms_opt = kernel_ms_mode_opt(need_msgr2, existing=extra + kernel_cmd)
+            if ms_opt:
+                kernel_cmd += ms_opt
+                log.info(
+                    "msgr2 required (ms_bind_msgr1_disabled=%s monmap_v2_only=%s): "
+                    "using mon %s and ms_mode=crc",
+                    msgr1_disabled,
+                    monmap_v2_only,
+                    mount_mons,
+                )
 
             cmd_rc = client.exec_command(sudo=True, cmd=kernel_cmd, long_running=True)
 

--- a/tests/cephfs/fs_kernel_mount_options.py
+++ b/tests/cephfs/fs_kernel_mount_options.py
@@ -7,6 +7,11 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
+from utility.odf_defaults import (
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+    kernel_ms_mode_opt,
+)
 
 log = Log(__name__)
 
@@ -81,8 +86,11 @@ def run(ceph_cluster, **kw):
             sudo=True, cmd="sed -i 's/fsid = /fsid = t1/g' /home/cephuser/ceph_dup.conf"
         )
         mon_node_ip = ",".join(mon_node_ips)
+        use_msgr2 = is_msgr1_disabled(clients[0])
+        mount_mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+        ms_opt = kernel_ms_mode_opt(use_msgr2)
         kernel_cmd = (
-            f"mount -t ceph {mon_node_ip}:/ {kernel_mounting_dir} "
+            f"mount -t ceph {mount_mons}:/ {kernel_mounting_dir} "
             f"-o conf=/home/cephuser/ceph_dup.conf"
         )
         out, rc = clients[0].exec_command(sudo=True, cmd=kernel_cmd, check_ec=False)
@@ -159,10 +167,13 @@ def run(ceph_cluster, **kw):
         out, _ = clients[0].exec_command(cmd=f"cat {secert_file}", sudo=True)
         log.info("Output : %s" % out)
         mon_node_ip = ",".join(mon_node_ips)
+        use_msgr2 = is_msgr1_disabled(clients[0])
+        mount_mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+        ms_opt = kernel_ms_mode_opt(use_msgr2)
         kernel_cmd = (
-            f"mount -t ceph {mon_node_ip}:/ {kernel_mounting_dir} "
+            f"mount -t ceph {mount_mons}:/ {kernel_mounting_dir} "
             f"-o name={clients[0].node.hostname},"
-            f"secret={out}"
+            f"secret={out}{ms_opt}"
         )
         clients[0].exec_command(sudo=True, cmd=kernel_cmd)
         fs_util.wait_until_mount_succeeds(clients[0], kernel_mounting_dir)
@@ -175,10 +186,12 @@ def run(ceph_cluster, **kw):
         # Skipping the validation because of above issue for RHEL-8
         if int(os_ver) > 8:
             log.info("mount with mon_address")
+            mon_addr = mount_mons.replace(",", "/")
             kernel_cmd = (
                 f"mount -t ceph {clients[0].node.hostname}@.cephfs=/ {kernel_mounting_dir} "
                 f"-o name={clients[0].node.hostname},"
-                f"secretfile=/etc/ceph/{clients[0].node.hostname}.secret,mon_addr={mon_node_ip.replace(',', '/')}"
+                f"secretfile=/etc/ceph/{clients[0].node.hostname}.secret,"
+                f"mon_addr={mon_addr}{ms_opt}"
             )
             clients[0].exec_command(sudo=True, cmd=kernel_cmd)
             fs_util.wait_until_mount_succeeds(clients[0], kernel_mounting_dir)

--- a/tests/cephfs/no_recover_session_mount.py
+++ b/tests/cephfs/no_recover_session_mount.py
@@ -7,6 +7,11 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
+from utility.odf_defaults import (
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+    kernel_ms_mode_opt,
+)
 
 log = Log(__name__)
 
@@ -49,6 +54,9 @@ def run(ceph_cluster, **kw):
         client2 = clients[1]
         mon_node_ip = fs_util.get_mon_node_ips()
         mon_node_ip = ",".join(mon_node_ip)
+        use_msgr2 = is_msgr1_disabled(client1)
+        mount_mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+        ms_opt = kernel_ms_mode_opt(use_msgr2)
         log.info("Collect client IDs if already exists")
         mount_dir = "/mnt/" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
@@ -71,7 +79,8 @@ def run(ceph_cluster, **kw):
         commands = [
             f"ceph fs subvolume create {fs_name} sub1",
             f"mkdir {mount_dir}",
-            f"mount -t ceph {mon_node_ip}:/ {mount_dir} -o name=admin,recover_session=no,fs={fs_name}",
+            f"mount -t ceph {mount_mons}:/ {mount_dir} "
+            f"-o name=admin,recover_session=no,fs={fs_name}{ms_opt}",
             f"ls {mount_dir}",
         ]
         output = None
@@ -139,7 +148,14 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
         client2.exec_command(sudo=True, cmd=f"mkdir {mount_dir_2}")
-        command = f"mount -t ceph {mon_node_ip}:/ {mount_dir_2} -o name=admin"
+        cleanup_mons = format_mons_for_kernel_mount(
+            mon_node_ip, is_msgr1_disabled(client2)
+        )
+        cleanup_ms = kernel_ms_mode_opt(is_msgr1_disabled(client2))
+        command = (
+            f"mount -t ceph {cleanup_mons}:/ {mount_dir_2} "
+            f"-o name=admin{cleanup_ms}"
+        )
         client2.exec_command(sudo=True, cmd=command)
         client2.exec_command(sudo=True, cmd=f"rm -rf {mount_dir_2}/*")
         client2.exec_command(sudo=True, cmd=f"umount -f {mount_dir_2}")

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -22,6 +22,11 @@ from tests.rados.rados_test_util import (
 )
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
+from utility.odf_defaults import (
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+    kernel_ms_mode_opt,
+)
 from utility.utils import method_should_succeed
 
 log = Log(__name__)
@@ -983,8 +988,12 @@ def run(ceph_cluster, **kw):
             mon_dump = rados_obj.run_ceph_command(cmd="ceph mon dump", client_exec=True)
             # Extract monitor address from rank 0 monitor
             mon_info = mon_dump["mons"][0]
-            mon_addr = mon_info["public_addr"].split("/")[0]
-            log.info(f"Monitor address: {mon_addr}")
+            use_msgr2 = is_msgr1_disabled(client_node)
+            mon_addr = format_mons_for_kernel_mount(
+                mon_info["public_addr"].split("/")[0], use_msgr2
+            )
+            ms_opt = kernel_ms_mode_opt(use_msgr2)
+            log.info(f"Monitor address: {mon_addr} (msgr2={use_msgr2})")
 
             # Step 5: Use existing admin client for mounting
             log.debug("Using admin client for mounting...")
@@ -1009,7 +1018,8 @@ def run(ceph_cluster, **kw):
                 mount_cmd = (
                     f"mount -t ceph {mon_addr}:{subvol_path} {mount_point} "
                     f"-o fs={fs_name},name={client_name},secretfile={key_file_path},"
-                    f"read_from_replica=localize,crush_location=region:east\\|zone:east-zone1,_netdev"
+                    f"read_from_replica=localize,crush_location=region:east\\|zone:east-zone1"
+                    f"{ms_opt},_netdev"
                 )
                 client_node.exec_command(sudo=True, cmd=mount_cmd, long_running=True)
             else:

--- a/tests/smb/smb_operations.py
+++ b/tests/smb/smb_operations.py
@@ -18,6 +18,11 @@ from cli.utilities.utils import (
     set_service_state,
 )
 from utility.log import Log
+from utility.odf_defaults import (
+    format_mons_for_kernel_mount,
+    is_msgr1_disabled,
+    kernel_ms_mode_opt,
+)
 
 log = Log(__name__)
 
@@ -1042,11 +1047,14 @@ def samba_kernel_mount(samba_client, mount_point, mon_node_ip, sub_dir):
         f"/etc/ceph/{samba_client.hostname}.secret",
         long_running=True,
     )
+    use_msgr2 = is_msgr1_disabled(samba_client)
+    mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+    ms_opt = kernel_ms_mode_opt(use_msgr2)
     cmd = (
-        f"mount -t ceph {mon_node_ip}:{sub_dir} {mount_point} "
+        f"mount -t ceph {mons}:{sub_dir} {mount_point} "
         f"-o name=admin,"
         f"secretfile=/etc/ceph/{samba_client.hostname}.secret,"
-        f"noshare"
+        f"noshare{ms_opt}"
     )
     cmd_rc = samba_client.exec_command(sudo=True, cmd=cmd, long_running=True)
 

--- a/unittests/utility/test_odf_defaults.py
+++ b/unittests/utility/test_odf_defaults.py
@@ -1,0 +1,353 @@
+"""Unit tests for utility.odf_defaults (ODF Rook bootstrap profile merge)."""
+
+import json
+import os
+
+import pytest
+import yaml
+
+from utility.odf_defaults import (
+    APPLY_ODF_DEFAULTS_KEY,
+    DEFAULT_ODF_PROFILE_PATH,
+    apply_odf_defaults_to_bootstrap_config,
+    apply_v2_only_mon_addrs,
+    is_truthy,
+    load_odf_defaults_profile,
+    merge_odf_into_bootstrap_config,
+    overrides_enabled,
+    verify_odf_defaults,
+)
+
+
+def test_odf_profile_file_exists_and_has_required_keys():
+    assert os.path.isfile(DEFAULT_ODF_PROFILE_PATH)
+    assert DEFAULT_ODF_PROFILE_PATH.endswith(
+        os.path.join("conf", "tentacle", "rook", "odf_rook_defaults.yaml")
+    )
+    profile = load_odf_defaults_profile()
+    assert "global" in profile
+    assert profile["global"]["mon_osd_full_ratio"] == "0.85"
+    assert profile["global"]["mon_max_pg_per_osd"] == 1000
+    assert profile["global"]["ms_bind_msgr1"] == "false"
+    assert profile["global"]["rbd_default_map_options"] == "ms_mode=prefer-crc"
+    assert profile["osd"]["osd_memory_target_cgroup_limit_ratio"] == "0.8"
+    assert profile["mds"]["mds_cache_memory_limit"] == 3221225472
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, True),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        (False, False),
+        ("false", False),
+        ("0", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_truthy(value, expected):
+    assert is_truthy(value) is expected
+
+
+def test_overrides_enabled():
+    assert overrides_enabled({APPLY_ODF_DEFAULTS_KEY: "true"}, APPLY_ODF_DEFAULTS_KEY)
+    assert not overrides_enabled({}, APPLY_ODF_DEFAULTS_KEY)
+    assert not overrides_enabled(None, APPLY_ODF_DEFAULTS_KEY)
+
+
+def test_merge_suite_keys_win():
+    odf = {
+        "global": {
+            "mon_max_pg_per_osd": 1000,
+            "public_network": "10.0.0.0/24",
+        },
+        "osd": {"osd_memory_target_cgroup_limit_ratio": 0.8},
+    }
+    suite = {"global": {"public_network": "192.168.0.0/16"}}
+    merged = merge_odf_into_bootstrap_config(suite, odf)
+    assert merged["global"]["public_network"] == "192.168.0.0/16"
+    assert merged["global"]["mon_max_pg_per_osd"] == 1000
+    assert merged["osd"]["osd_memory_target_cgroup_limit_ratio"] == 0.8
+
+
+def test_apply_odf_defaults_noop_without_flag():
+    args = {"mon-ip": "node1"}
+    apply_odf_defaults_to_bootstrap_config(args, overrides={})
+    assert "config" not in args
+
+
+def test_apply_odf_defaults_merges_when_flag_set():
+    args = {
+        "mon-ip": "node1",
+        "config": {"global": {"public_network": "10.1.0.0/24"}},
+    }
+    apply_odf_defaults_to_bootstrap_config(
+        args, overrides={APPLY_ODF_DEFAULTS_KEY: "true"}
+    )
+    assert args["config"]["global"]["public_network"] == "10.1.0.0/24"
+    assert args["config"]["global"]["mon_osd_full_ratio"] == "0.85"
+    assert args["config"]["global"]["ms_bind_msgr1"] == "false"
+    assert args["config"]["global"]["rbd_default_map_options"] == "ms_mode=prefer-crc"
+    assert args["config"]["mds"]["mds_cache_memory_limit"] == 3221225472
+
+
+def test_apply_odf_topology_alone_merges_msgr2_bootstrap_keys():
+    from utility.odf_defaults import APPLY_ODF_TOPOLOGY_KEY
+
+    args = {"mon-ip": "node1"}
+    apply_odf_defaults_to_bootstrap_config(
+        args, overrides={APPLY_ODF_TOPOLOGY_KEY: "true"}
+    )
+    assert args["config"]["global"]["ms_bind_msgr1"] == "false"
+    assert args["config"]["global"]["rbd_default_map_options"] == "ms_mode=prefer-crc"
+    # Full ODF profile knobs should not be present for topology-only
+    assert "mon_max_pg_per_osd" not in args["config"]["global"]
+
+
+def test_apply_odf_defaults_creates_config_when_absent():
+    args = {"mon-ip": "node1"}
+    apply_odf_defaults_to_bootstrap_config(
+        args, overrides={APPLY_ODF_DEFAULTS_KEY: True}
+    )
+    assert "mon_target_pg_per_osd" in args["config"]["global"]
+
+
+def test_apply_v2_only_mon_addrs():
+    calls = []
+
+    def shell_fn(args, check_status=True):
+        calls.append(list(args))
+        cmd = " ".join(args)
+        if "mon dump" in cmd and "-f" in args:
+            return (
+                json.dumps(
+                    {
+                        "mons": [
+                            {
+                                "name": "node1",
+                                "public_addrs": {
+                                    "addrvec": [
+                                        {
+                                            "type": "v2",
+                                            "addr": "10.0.64.166:3300",
+                                            "nonce": 0,
+                                        },
+                                        {
+                                            "type": "v1",
+                                            "addr": "10.0.64.166:6789",
+                                            "nonce": 0,
+                                        },
+                                    ]
+                                },
+                            },
+                            {
+                                "name": "node2",
+                                "public_addrs": {
+                                    "addrvec": [
+                                        {
+                                            "type": "v2",
+                                            "addr": "10.0.66.196:3300",
+                                            "nonce": 0,
+                                        },
+                                        {
+                                            "type": "v1",
+                                            "addr": "10.0.66.196:6789",
+                                            "nonce": 0,
+                                        },
+                                    ]
+                                },
+                            },
+                        ]
+                    }
+                ),
+                "",
+            )
+        if "mon dump" in cmd:
+            return "epoch 4\n0: v2:10.0.64.166:3300/0 mon.node1\n", ""
+        return "", ""
+
+    apply_v2_only_mon_addrs(shell_fn)
+    set_addrs = [c for c in calls if len(c) >= 4 and c[2] == "set-addrs"]
+    assert len(set_addrs) == 2
+    assert set_addrs[0] == [
+        "ceph",
+        "mon",
+        "set-addrs",
+        "node1",
+        "[v2:10.0.64.166:3300/0]",
+    ]
+    assert set_addrs[1] == [
+        "ceph",
+        "mon",
+        "set-addrs",
+        "node2",
+        "[v2:10.0.66.196:3300/0]",
+    ]
+
+
+def test_verify_odf_defaults_with_mock_shell():
+    profile = load_odf_defaults_profile()
+
+    def shell_fn(args):
+        cmd = " ".join(args)
+        if "config dump" in cmd:
+            entries = []
+            for section, opts in profile.items():
+                for name, value in opts.items():
+                    if name.startswith("mon_osd_"):
+                        continue
+                    entries.append(
+                        {"section": section, "name": name, "value": str(value)}
+                    )
+            return json.dumps(entries), ""
+        if "osd dump" in cmd:
+            return (
+                json.dumps(
+                    {
+                        "full_ratio": 0.85,
+                        "backfillfull_ratio": 0.80,
+                        "nearfull_ratio": 0.75,
+                    }
+                ),
+                "",
+            )
+        if "mon dump" in cmd:
+            return (
+                json.dumps(
+                    {
+                        "mons": [
+                            {
+                                "name": "a",
+                                "public_addrs": {
+                                    "addrvec": [
+                                        {
+                                            "type": "v2",
+                                            "addr": "10.0.0.1:3300",
+                                            "nonce": 0,
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                ),
+                "",
+            )
+        return "", ""
+
+    assert verify_odf_defaults(shell_fn, profile) == []
+
+
+def test_verify_odf_defaults_flags_v1_in_monmap():
+    profile = {
+        "global": {"rbd_default_map_options": "ms_mode=prefer-crc"},
+        "osd": {},
+        "mds": {},
+    }
+
+    def shell_fn(args):
+        cmd = " ".join(args)
+        if "config dump" in cmd:
+            return (
+                json.dumps(
+                    [
+                        {
+                            "section": "global",
+                            "name": "rbd_default_map_options",
+                            "value": "ms_mode=prefer-crc",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if "osd dump" in cmd:
+            return json.dumps({}), ""
+        if "mon dump" in cmd:
+            return (
+                json.dumps(
+                    {
+                        "mons": [
+                            {
+                                "name": "a",
+                                "public_addrs": {
+                                    "addrvec": [
+                                        {
+                                            "type": "v2",
+                                            "addr": "10.0.0.1:3300",
+                                            "nonce": 0,
+                                        },
+                                        {
+                                            "type": "v1",
+                                            "addr": "10.0.0.1:6789",
+                                            "nonce": 0,
+                                        },
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                ),
+                "",
+            )
+        return "", ""
+
+    mismatches = verify_odf_defaults(shell_fn, profile)
+    assert any("still has v1" in m for m in mismatches)
+
+
+def test_profile_yaml_roundtrip_structure():
+    with open(DEFAULT_ODF_PROFILE_PATH) as fh:
+        data = yaml.safe_load(fh)
+    assert set(data.keys()) == {"global", "osd", "mds"}
+
+
+@pytest.mark.parametrize(
+    "mons,use_msgr2,expected",
+    [
+        ("10.0.0.1,10.0.0.2", False, "10.0.0.1,10.0.0.2"),
+        ("10.0.0.1,10.0.0.2", True, "10.0.0.1:3300,10.0.0.2:3300"),
+        ("10.0.0.1:6789", True, "10.0.0.1:3300"),
+        ("10.0.0.1:3300", True, "10.0.0.1:3300"),
+        ("v2:10.0.0.1:3300/0", True, "10.0.0.1:3300"),
+        ("v1:10.0.0.1:6789/0", True, "10.0.0.1:3300"),
+        (["10.0.0.1", "10.0.0.2"], True, "10.0.0.1:3300,10.0.0.2:3300"),
+    ],
+)
+def test_format_mons_for_kernel_mount(mons, use_msgr2, expected):
+    from utility.odf_defaults import format_mons_for_kernel_mount
+
+    assert format_mons_for_kernel_mount(mons, use_msgr2) == expected
+
+
+@pytest.mark.parametrize(
+    "use_msgr2,existing,expected",
+    [
+        (True, "", ",ms_mode=crc"),
+        (True, "ms_mode=legacy", ""),
+        (True, ",ms_mode=crc", ""),
+        (False, "", ""),
+    ],
+)
+def test_kernel_ms_mode_opt(use_msgr2, existing, expected):
+    from utility.odf_defaults import kernel_ms_mode_opt
+
+    assert kernel_ms_mode_opt(use_msgr2, existing) == expected
+
+
+def test_is_msgr1_disabled():
+    from utility.odf_defaults import is_msgr1_disabled
+
+    class FakeClient:
+        def __init__(self, out):
+            self._out = out
+
+        def exec_command(self, **kwargs):
+            return self._out, 0
+
+    assert is_msgr1_disabled(FakeClient("false\n")) is True
+    assert is_msgr1_disabled(FakeClient("true\n")) is False
+    assert is_msgr1_disabled(FakeClient("0")) is True

--- a/unittests/utility/test_odf_topology.py
+++ b/unittests/utility/test_odf_topology.py
@@ -1,0 +1,94 @@
+"""Unit tests for utility.odf_topology."""
+
+from utility.odf_defaults import APPLY_ODF_TOPOLOGY_KEY
+from utility.odf_topology import (
+    _hostnames_from_cluster,
+    apply_odf_topology,
+    apply_zone_failure_domains,
+)
+
+
+class _Node:
+    def __init__(self, hostname, role="osd"):
+        self.hostname = hostname
+        self.shortname = hostname
+        self.role = role
+
+
+class _Cluster:
+    def __init__(self, nodes):
+        self._nodes = nodes
+
+    def get_nodes(self, role=None):
+        if role is None:
+            return list(self._nodes)
+        return [n for n in self._nodes if n.role == role]
+
+
+def test_hostnames_from_cluster_dedupes():
+    cluster = _Cluster(
+        [
+            _Node("h1", "osd"),
+            _Node("h1", "mon"),
+            _Node("h2", "osd"),
+            _Node("h3", "osd"),
+        ]
+    )
+    assert _hostnames_from_cluster(cluster) == ["h1", "h2", "h3"]
+
+
+def test_apply_odf_topology_noop_without_flag():
+    calls = []
+
+    def shell_fn(args, check_status=True):
+        calls.append(args)
+        return "", ""
+
+    apply_odf_topology(_Cluster([]), shell_fn, overrides={})
+    assert calls == []
+
+
+def test_apply_zone_failure_domains_skips_with_few_hosts():
+    calls = []
+
+    def shell_fn(args, check_status=True):
+        calls.append(args)
+        return "", ""
+
+    apply_zone_failure_domains(shell_fn, ["h1", "h2"])
+    assert calls == []
+
+
+def test_apply_zone_failure_domains_issues_crush_cmds():
+    calls = []
+
+    def shell_fn(args, check_status=True):
+        calls.append(list(args))
+        return "", ""
+
+    apply_zone_failure_domains(shell_fn, ["h1", "h2", "h3"])
+    flat = [" ".join(c) for c in calls]
+    assert any("add-bucket region-1 region" in x for x in flat)
+    assert any("move h1 zone=zone-a" in x for x in flat)
+    assert any("move h3 zone=zone-c" in x for x in flat)
+
+
+def test_apply_odf_topology_runs_when_flag_set():
+    calls = []
+
+    def shell_fn(args, check_status=True):
+        calls.append(list(args))
+        return "0\n1\n2", ""
+
+    cluster = _Cluster([_Node("a", "osd"), _Node("b", "osd"), _Node("c", "osd")])
+    apply_odf_topology(
+        cluster,
+        shell_fn,
+        overrides={APPLY_ODF_TOPOLOGY_KEY: "true"},
+    )
+    flat = [" ".join(c) for c in calls]
+    assert any("crush rule create-replicated odf-block" in x for x in flat)
+    assert any("set-device-class ssd" in x for x in flat)
+    # msgr2 is bootstrap --config; not in default post-OSD steps
+    assert not any("ms_bind_msgr1 false" in x for x in flat)
+    assert not any("set-addrs" in x for x in flat)  # msgr2 not in default steps

--- a/utility/odf_defaults.py
+++ b/utility/odf_defaults.py
@@ -1,0 +1,425 @@
+"""
+ODF / Rook-like Ceph defaults helpers for standalone CephCI (cephadm) clusters.
+
+Opt-in via run.py::
+
+    --custom-config apply-odf-defaults=true
+    --custom-config apply-odf-topology=true
+
+``apply-odf-defaults`` merges a shared YAML profile into bootstrap ``args.config``
+so ``cephadm bootstrap --config`` seeds the mon store and OSDMap ratios, including
+``ms_bind_msgr1=false`` and ``rbd_default_map_options``. At the end of
+``bootstrap.py`` (after bootstrap succeeds) it sets monmap to v2-only addresses via
+``ceph mon set-addrs`` (``[v2:IP:3300/0]``). Mons often ignore ``ms_bind_msgr1`` for
+bind ports and follow the monmap (tracker #70457), so both steps are required.
+
+``apply-odf-topology`` alone injects ``rbd_default_map_options`` at bootstrap.
+Post-OSD it applies CRUSH / container-limit / device-class steps.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from copy import deepcopy
+from os.path import abspath, dirname
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import yaml
+
+from utility.log import Log
+
+LOG = Log(__name__)
+
+_REPO_ROOT = dirname(dirname(abspath(__file__)))
+DEFAULT_ODF_PROFILE_PATH = os.path.join(
+    _REPO_ROOT, "conf", "tentacle", "rook", "odf_rook_defaults.yaml"
+)
+
+# CLI override keys (from --custom-config key=value)
+APPLY_ODF_DEFAULTS_KEY = "apply-odf-defaults"
+APPLY_ODF_TOPOLOGY_KEY = "apply-odf-topology"
+
+# Applied at bootstrap when apply-odf-topology is set without the full defaults profile
+MSGR2_BOOTSTRAP_CONFIG: Dict[str, Dict[str, Any]] = {
+    "global": {
+        "ms_bind_msgr1": "false",
+        "rbd_default_map_options": "ms_mode=prefer-crc",
+    }
+}
+
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_IP_PORT_RE = re.compile(r"^([^:]+):(\d+)$")
+
+
+def is_truthy(value: Any) -> bool:
+    """Return True for common truthy CLI / YAML values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in _TRUTHY
+
+
+def overrides_enabled(overrides: Optional[Dict], key: str) -> bool:
+    """Return True if *key* is present and truthy in custom-config overrides."""
+    if not overrides:
+        return False
+    return is_truthy(overrides.get(key))
+
+
+def is_msgr1_disabled(client) -> bool:
+    """
+    Return True if ``ceph config get mon ms_bind_msgr1`` is false.
+
+    Used by kernel CephFS mounts to choose msgr2 (:3300 + ms_mode=crc) vs
+    legacy (:6789 / bare IP).
+    """
+    try:
+        out, _ = client.exec_command(sudo=True, cmd="ceph config get mon ms_bind_msgr1")
+        return (out or "").strip().lower() in ("false", "0", "no")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _normalize_kernel_mon_part(part: str) -> str:
+    """Strip ``v1:``/``v2:`` and ``/nonce``; leave ``IP`` or ``IP:port``."""
+    text = str(part).strip().strip("[]")
+    if text.startswith("v2:") or text.startswith("v1:"):
+        text = text.split(":", 1)[1]
+    if "/" in text:
+        text = text.split("/", 1)[0]
+    return text
+
+
+def format_mons_for_kernel_mount(mon_node_ip, use_msgr2: bool) -> str:
+    """
+    Format mon device string for ``mount -t ceph``.
+
+    Args:
+        mon_node_ip: Comma-separated IPs, list/tuple of IPs, or single IP
+                     (optional ``:port`` already present). Also accepts
+                     mon-dump style ``v2:IP:3300/0`` strings.
+        use_msgr2: When True, ensure each mon uses port 3300.
+
+    Returns:
+        Comma-separated mon string suitable for mount device.
+    """
+    if isinstance(mon_node_ip, (list, tuple)):
+        parts = [_normalize_kernel_mon_part(x) for x in mon_node_ip if str(x).strip()]
+    else:
+        parts = [
+            _normalize_kernel_mon_part(p)
+            for p in str(mon_node_ip).replace(" ", "").split(",")
+            if p.strip()
+        ]
+    parts = [p for p in parts if p]
+    if not use_msgr2:
+        return ",".join(parts)
+    formatted = []
+    for part in parts:
+        # Bare IP → :3300; rewrite legacy :6789; keep existing :3300 / other ports
+        if part.count(":") == 0:
+            formatted.append(f"{part}:3300")
+        elif part.endswith(":6789"):
+            formatted.append(f"{part[:-5]}:3300")
+        else:
+            formatted.append(part)
+    return ",".join(formatted)
+
+
+def kernel_ms_mode_opt(use_msgr2: bool, existing: str = "") -> str:
+    """Return ``,ms_mode=crc`` when msgr2 is required and not already set."""
+    if use_msgr2 and "ms_mode=" not in (existing or ""):
+        return ",ms_mode=crc"
+    return ""
+
+
+def load_odf_defaults_profile(
+    path: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Load the ODF defaults profile YAML (section -> key -> value).
+
+    Args:
+        path: Optional absolute/relative path; defaults to conf/tentacle/rook profile.
+    """
+    profile_path = path or DEFAULT_ODF_PROFILE_PATH
+    if not os.path.isfile(profile_path):
+        raise FileNotFoundError(f"ODF defaults profile not found: {profile_path}")
+    with open(profile_path) as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"ODF defaults profile must be a mapping: {profile_path}")
+    LOG.info("Loaded ODF defaults profile from %s", profile_path)
+    return data
+
+
+def merge_odf_into_bootstrap_config(
+    suite_config: Optional[Dict[str, Dict[str, Any]]],
+    odf_profile: Dict[str, Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Deep-merge ODF profile under suite bootstrap config.
+
+    Suite section keys win on conflict (e.g. public_network from the suite).
+    """
+    merged: Dict[str, Dict[str, Any]] = deepcopy(odf_profile) if odf_profile else {}
+    suite_config = suite_config or {}
+    for section, values in suite_config.items():
+        if not isinstance(values, dict):
+            merged[section] = values
+            continue
+        section_dict = merged.setdefault(section, {})
+        if not isinstance(section_dict, dict):
+            merged[section] = deepcopy(values)
+            continue
+        section_dict.update(values)
+    return merged
+
+
+def apply_odf_defaults_to_bootstrap_config(
+    args: Dict[str, Any],
+    overrides: Optional[Dict] = None,
+    profile_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Merge ODF Rook settings into bootstrap ``args["config"]``.
+
+    - ``apply-odf-defaults=true``: full profile from YAML.
+    - ``apply-odf-topology=true`` alone: ``rbd_default_map_options`` only.
+
+    Mutates and returns *args*. No-op when neither flag is set.
+    """
+    apply_defaults = overrides_enabled(overrides, APPLY_ODF_DEFAULTS_KEY)
+    apply_topology = overrides_enabled(overrides, APPLY_ODF_TOPOLOGY_KEY)
+    if not apply_defaults and not apply_topology:
+        return args
+
+    existing = args.get("config")
+    if existing is not None and not isinstance(existing, dict):
+        LOG.warning(
+            "bootstrap args.config is not a dict (%s); skipping ODF defaults merge",
+            type(existing),
+        )
+        return args
+
+    if apply_defaults:
+        profile = load_odf_defaults_profile(profile_path)
+        args["config"] = merge_odf_into_bootstrap_config(existing, profile)
+        LOG.info(
+            "Merged ODF Rook defaults into bootstrap --config "
+            "(suite keys take precedence)"
+        )
+    else:
+        # Topology-only: still seed RBD ms_mode at bootstrap
+        args["config"] = merge_odf_into_bootstrap_config(
+            existing, MSGR2_BOOTSTRAP_CONFIG
+        )
+        LOG.info(
+            "Merged RBD ms_mode bootstrap key into --config "
+            "(apply-odf-topology without full defaults)"
+        )
+
+    LOG.debug("Bootstrap config after ODF merge: %s", args["config"])
+    return args
+
+
+def _shell(shell_fn: Callable, *cmd: str, check_status: bool = True) -> str:
+    """Run a cephadm shell command and return stdout."""
+    result = shell_fn(args=list(cmd), check_status=check_status)
+    if isinstance(result, tuple):
+        out, _err = result
+    else:
+        out = result
+    if isinstance(out, bytes):
+        out = out.decode()
+    return (out or "").strip()
+
+
+def _ip_from_addr_string(addr: str) -> Optional[str]:
+    """Extract host/IP from ``IP:port`` or ``v2:IP:port/0`` style strings."""
+    if not addr:
+        return None
+    text = addr.strip().strip("[]")
+    # v2:10.0.0.1:3300/0 or v1:10.0.0.1:6789/0
+    if text.startswith("v2:") or text.startswith("v1:"):
+        text = text.split(":", 1)[1]
+    if "/" in text:
+        text = text.split("/", 1)[0]
+    match = _IP_PORT_RE.match(text)
+    if match:
+        return match.group(1)
+    if ":" not in text:
+        return text
+    # last-resort: strip trailing :port
+    return text.rsplit(":", 1)[0]
+
+
+def _mon_name_and_ip(mon: Dict[str, Any]) -> Optional[Tuple[str, str]]:
+    """Return (mon_name, ip) from a mon dump entry, preferring v2 addr IP."""
+    name = mon.get("name")
+    if not name:
+        return None
+    addrs = mon.get("public_addrs") or {}
+    vec = addrs.get("addrvec") if isinstance(addrs, dict) else None
+    if vec:
+        for prefer in ("v2", "v1"):
+            for entry in vec:
+                if entry.get("type") == prefer:
+                    ip = _ip_from_addr_string(entry.get("addr") or "")
+                    if ip:
+                        return name, ip
+    for key in ("public_addr", "addr"):
+        ip = _ip_from_addr_string(str(mon.get(key) or ""))
+        if ip:
+            return name, ip
+    return None
+
+
+def apply_v2_only_mon_addrs(shell_fn: Callable) -> None:
+    """
+    Set each mon public addr to v2-only (ODF-style monmap).
+
+    Equivalent to::
+
+        ceph mon set-addrs <name> '[v2:<ip>:3300/0]'
+
+    Leaves ``ms_bind_msgr1`` unchanged (ODF keeps it true).
+    """
+    LOG.info("Setting monmap to v2-only addresses (ODF requireMsgr2 style)")
+    raw = _shell(shell_fn, "ceph", "mon", "dump", "-f", "json")
+    try:
+        dump = json.loads(raw or "{}")
+    except (TypeError, json.JSONDecodeError) as exc:
+        LOG.warning("Failed to parse mon dump JSON: %s", exc)
+        return
+
+    mons = dump.get("mons") or []
+    if not mons:
+        LOG.warning("No mons in mon dump; skipping set-addrs")
+        return
+
+    for mon in mons:
+        parsed = _mon_name_and_ip(mon)
+        if not parsed:
+            LOG.warning("Could not resolve name/IP for mon entry: %s", mon)
+            continue
+        name, ip = parsed
+        addrvec = f"[v2:{ip}:3300/0]"
+        LOG.info("ceph mon set-addrs %s %s", name, addrvec)
+        try:
+            _shell(shell_fn, "ceph", "mon", "set-addrs", name, addrvec)
+        except Exception as exc:  # noqa: BLE001
+            LOG.warning("mon set-addrs %s failed: %s", name, exc)
+
+    try:
+        after = _shell(shell_fn, "ceph", "mon", "dump")
+        LOG.info("mon dump after v2-only set-addrs:\n%s", after)
+    except Exception as exc:  # noqa: BLE001
+        LOG.debug("Could not re-dump monmap: %s", exc)
+
+
+def verify_odf_defaults(shell_fn, profile: Optional[Dict] = None) -> List[str]:
+    """
+    Verify ODF defaults against ``ceph config dump`` and ``ceph osd dump``.
+
+    Also checks monmap is v2-only when apply-odf-defaults path is used.
+
+    Args:
+        shell_fn: Callable that runs a ceph command list and returns (out, err)
+                  e.g. ``cephadm.shell``.
+        profile: Optional profile dict; loaded from disk if omitted.
+
+    Returns:
+        List of human-readable mismatch strings (empty if all matched).
+    """
+    profile = profile or load_odf_defaults_profile()
+    mismatches: List[str] = []
+
+    out, _ = shell_fn(args=["ceph", "config", "dump", "--format", "json"])
+    try:
+        dump = json.loads(out) if out else []
+    except (TypeError, json.JSONDecodeError):
+        dump = []
+    # config dump JSON is a list of {section, name, value, ...}
+    by_key = {}
+    if isinstance(dump, list):
+        for entry in dump:
+            section = entry.get("section") or entry.get("who") or "global"
+            name = entry.get("name") or entry.get("option")
+            if name:
+                by_key[(section, name)] = str(entry.get("value", ""))
+
+    for section, options in profile.items():
+        if not isinstance(options, dict):
+            continue
+        for name, expected in options.items():
+            if name.startswith("mon_osd_") and section == "global":
+                # Ratios verified via osd dump below
+                continue
+            actual = by_key.get((section, name))
+            if actual is None and section != "global":
+                # Some keys may appear under global in dump
+                actual = by_key.get(("global", name))
+            if actual is None:
+                mismatches.append(f"missing {section}/{name} (expected {expected})")
+                continue
+            if str(expected) != str(actual) and _normalize_num(
+                expected
+            ) != _normalize_num(actual):
+                mismatches.append(
+                    f"{section}/{name}: expected {expected}, got {actual}"
+                )
+
+    out, _ = shell_fn(args=["ceph", "osd", "dump", "--format", "json"])
+    try:
+        osd_dump = json.loads(out) if out else {}
+    except (TypeError, json.JSONDecodeError):
+        osd_dump = {}
+    ratio_map = {
+        "mon_osd_full_ratio": "full_ratio",
+        "mon_osd_backfillfull_ratio": "backfillfull_ratio",
+        "mon_osd_nearfull_ratio": "nearfull_ratio",
+    }
+    global_opts = profile.get("global", {})
+    for conf_key, dump_key in ratio_map.items():
+        if conf_key not in global_opts:
+            continue
+        expected = float(global_opts[conf_key])
+        actual = float(osd_dump.get(dump_key, -1))
+        if abs(expected - actual) > 0.011:
+            mismatches.append(f"osd dump {dump_key}: expected {expected}, got {actual}")
+
+    # ODF-style: monmap should advertise v2 only
+    out, _ = shell_fn(args=["ceph", "mon", "dump", "-f", "json"])
+    try:
+        mon_dump = json.loads(out) if out else {}
+    except (TypeError, json.JSONDecodeError):
+        mon_dump = {}
+    for mon in mon_dump.get("mons") or []:
+        name = mon.get("name", "?")
+        addrs = mon.get("public_addrs") or {}
+        vec = addrs.get("addrvec") if isinstance(addrs, dict) else None
+        if vec:
+            types = {a.get("type") for a in vec}
+            if "v1" in types:
+                mismatches.append(f"mon.{name} still has v1 in addrvec: {vec}")
+            if "v2" not in types:
+                mismatches.append(f"mon.{name} missing v2 in addrvec: {vec}")
+        else:
+            public = str(mon.get("public_addr") or mon.get("addr") or "")
+            if "v1:" in public or ":6789" in public:
+                mismatches.append(f"mon.{name} public addr still has v1: {public}")
+            if "v2:" not in public and ":3300" not in public:
+                mismatches.append(f"mon.{name} public addr not v2: {public}")
+
+    return mismatches
+
+
+def _normalize_num(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/utility/odf_topology.py
+++ b/utility/odf_topology.py
@@ -1,0 +1,284 @@
+"""
+Post-OSD ODF-like topology / platform settings for standalone CephCI.
+
+Opt-in via::
+
+    --custom-config apply-odf-topology=true
+
+Applies (when possible):
+  - Zone-based CRUSH failure domains
+  - Per-pool zone CRUSH rules (for newly named helper pools only by default)
+  - cephadm container resource limits (OSD/MON/MDS)
+  - SSD device class label on OSDs
+
+msgr2 monmap (v2-only ``set-addrs``) and ``rbd_default_map_options`` are applied
+via ``utility.odf_defaults`` (``apply-odf-defaults``). Pass topology ``steps``
+including ``msgr2`` only for an explicit post-deploy re-apply.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from utility.log import Log
+from utility.odf_defaults import (
+    APPLY_ODF_TOPOLOGY_KEY,
+    apply_v2_only_mon_addrs,
+    overrides_enabled,
+)
+
+LOG = Log(__name__)
+
+# ODF-like container caps (cephadm extra_container_args)
+OSD_CPUS = "2"
+OSD_MEMORY = "5g"
+MON_CPUS = "1"
+MON_MEMORY = "2g"
+MDS_CPUS = "2"
+MDS_MEMORY = "6g"
+
+# Default post-OSD steps (msgr2 belongs in bootstrap --config)
+DEFAULT_TOPOLOGY_STEPS = (
+    "zones",
+    "crush_rules",
+    "container_limits",
+    "ssd_class",
+)
+
+
+def _shell(shell_fn: Callable, *cmd: str, check_status: bool = True) -> str:
+    """Run a cephadm shell command and return stdout."""
+    result = shell_fn(args=list(cmd), check_status=check_status)
+    if isinstance(result, tuple):
+        out, _err = result
+    else:
+        out = result
+    if isinstance(out, bytes):
+        out = out.decode()
+    return (out or "").strip()
+
+
+def _crush(shell_fn: Callable, *parts: str) -> str:
+    """Best-effort crush command (ignores non-zero for re-entrant applies)."""
+    return _shell(shell_fn, "ceph", "osd", "crush", *parts, check_status=False)
+
+
+def _hostnames_from_cluster(ceph_cluster) -> List[str]:
+    """Return short hostnames for OSD/mon nodes suitable for CRUSH moves."""
+    names: List[str] = []
+    seen = set()
+    for role in ("osd", "mon", "manager", "installer"):
+        for node in ceph_cluster.get_nodes(role=role) or []:
+            name = getattr(node, "hostname", None) or getattr(node, "shortname", None)
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+    if not names:
+        for node in ceph_cluster.get_nodes() or []:
+            name = getattr(node, "hostname", None) or getattr(node, "shortname", None)
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+    return names
+
+
+def apply_zone_failure_domains(shell_fn: Callable, hosts: Sequence[str]) -> None:
+    """Create region/zone CRUSH hierarchy and move hosts under zones."""
+    if len(hosts) < 3:
+        LOG.warning(
+            "Need at least 3 hosts for zone failure domains (have %s); skipping zones",
+            len(hosts),
+        )
+        return
+
+    zone_hosts = list(hosts[:3])
+    LOG.info("Applying zone-based CRUSH hierarchy for hosts %s", zone_hosts)
+
+    _crush(shell_fn, "add-bucket", "region-1", "region")
+    _crush(shell_fn, "move", "region-1", "root=default")
+    for zone in ("zone-a", "zone-b", "zone-c"):
+        _crush(shell_fn, "add-bucket", zone, "zone")
+        _crush(shell_fn, "move", zone, "region=region-1")
+
+    for host, zone in zip(zone_hosts, ("zone-a", "zone-b", "zone-c")):
+        # Host bucket name in CRUSH is typically the short hostname
+        short = host.split(".")[0]
+        out = _crush(shell_fn, "move", short, f"zone={zone}")
+        LOG.debug("crush move %s -> %s: %s", short, zone, out)
+
+
+def apply_per_pool_crush_rules(shell_fn: Callable) -> None:
+    """Create zone-aware replicated CRUSH rules (pools left to callers/suites)."""
+    LOG.info("Creating zone-aware CRUSH rules odf-block / odf-fs-meta / odf-fs-data")
+    for rule in ("odf-block", "odf-fs-meta", "odf-fs-data"):
+        out = _shell(
+            shell_fn,
+            "ceph",
+            "osd",
+            "crush",
+            "rule",
+            "create-replicated",
+            rule,
+            "default",
+            "zone",
+            check_status=False,
+        )
+        LOG.debug("create-replicated %s: %s", rule, out)
+
+
+def apply_container_resource_limits(shell_fn: Callable, installer_node) -> None:
+    """Apply ODF-like memory/CPU limits via cephadm orch service specs."""
+    LOG.info("Applying ODF-like container resource limits via orch specs")
+    spec = f"""service_type: osd
+service_id: all-available-devices
+placement:
+  host_pattern: "*"
+extra_container_args:
+  - "--cpus={OSD_CPUS}"
+  - "--memory={OSD_MEMORY}"
+---
+service_type: mon
+service_name: mon
+placement:
+  host_pattern: "*"
+extra_container_args:
+  - "--cpus={MON_CPUS}"
+  - "--memory={MON_MEMORY}"
+---
+service_type: mds
+service_id: cephfs
+placement:
+  label: mds
+extra_container_args:
+  - "--cpus={MDS_CPUS}"
+  - "--memory={MDS_MEMORY}"
+"""
+    temp = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w")
+    try:
+        temp.write(spec)
+        temp.flush()
+        # installer may be CephObject (has .node) or a raw CephNode
+        remote_node = getattr(installer_node, "node", installer_node)
+        remote = remote_node.remote_file(sudo=True, file_name=temp.name, file_mode="w")
+        remote.write(spec)
+        remote.flush()
+        _shell(shell_fn, "ceph", "orch", "apply", "-i", temp.name, check_status=False)
+    except Exception as exc:  # noqa: BLE001
+        LOG.warning(
+            "Container resource limit apply failed (may OOM on small VMs): %s", exc
+        )
+    finally:
+        temp.close()
+
+
+def apply_msgr2_only(shell_fn: Callable) -> None:
+    """
+    Post-deploy msgr2 helper (optional topology step ``msgr2``).
+
+    Sets monmap to v2-only addrs (ODF style) and ``rbd_default_map_options``.
+    Does not set ``ms_bind_msgr1=false`` (ODF leaves that true).
+    Prefer ``apply-odf-defaults`` which runs ``apply_v2_only_mon_addrs`` after deploy.
+    """
+    LOG.info("Configuring msgr2-only style settings (post-deploy)")
+    apply_v2_only_mon_addrs(shell_fn)
+    _shell(
+        shell_fn,
+        "ceph",
+        "config",
+        "set",
+        "global",
+        "rbd_default_map_options",
+        "ms_mode=prefer-crc",
+    )
+
+
+def apply_ssd_device_class(shell_fn: Callable) -> None:
+    """Set CRUSH device class label to ssd for all OSDs (label only)."""
+    LOG.info("Setting OSD CRUSH device class to ssd (label only)")
+    try:
+        out = _shell(shell_fn, "ceph", "osd", "ls")
+        osd_ids = out.split()
+        if not osd_ids:
+            LOG.warning("No OSDs found for device class update")
+            return
+        _shell(shell_fn, "ceph", "osd", "crush", "set-device-class", "ssd", *osd_ids)
+    except Exception as exc:  # noqa: BLE001
+        LOG.warning("SSD device class apply failed: %s", exc)
+
+
+def apply_odf_topology(
+    ceph_cluster,
+    shell_fn: Callable,
+    installer_node=None,
+    overrides: Optional[Dict] = None,
+    steps: Optional[Sequence[str]] = None,
+) -> None:
+    """
+    Apply ODF-like topology/platform settings when ``apply-odf-topology`` is set.
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        shell_fn: cephadm.shell-compatible callable
+        installer_node: installer CephNode (for writing orch specs)
+        overrides: custom_config_dict / config overrides
+        steps: optional subset of
+               ``zones``, ``crush_rules``, ``container_limits``, ``ssd_class``,
+               and optionally ``msgr2`` (post-deploy; prefer bootstrap for msgr2)
+    """
+    if overrides is not None and not overrides_enabled(
+        overrides, APPLY_ODF_TOPOLOGY_KEY
+    ):
+        return
+
+    wanted = set(steps or DEFAULT_TOPOLOGY_STEPS)
+    hosts = _hostnames_from_cluster(ceph_cluster)
+    LOG.info("Applying ODF topology steps %s on hosts %s", sorted(wanted), hosts)
+
+    if "zones" in wanted:
+        apply_zone_failure_domains(shell_fn, hosts)
+    if "crush_rules" in wanted:
+        apply_per_pool_crush_rules(shell_fn)
+    if "container_limits" in wanted:
+        node = installer_node
+        if node is None:
+            nodes = ceph_cluster.get_nodes(role="installer")
+            node = nodes[0] if nodes else None
+        if node is None:
+            LOG.warning("No installer node for container limits; skipping")
+        else:
+            apply_container_resource_limits(shell_fn, node)
+    if "msgr2" in wanted:
+        apply_msgr2_only(shell_fn)
+    if "ssd_class" in wanted:
+        apply_ssd_device_class(shell_fn)
+
+    LOG.info("ODF topology apply complete")
+
+
+def topology_status_snapshot(shell_fn: Callable) -> Dict[str, Any]:
+    """Return a small JSON-friendly snapshot for verification/logging."""
+    snap: Dict[str, Any] = {}
+    try:
+        snap["osd_tree"] = _shell(shell_fn, "ceph", "osd", "tree")
+    except Exception as exc:  # noqa: BLE001
+        snap["osd_tree_error"] = str(exc)
+    try:
+        snap["crush_rules"] = _shell(shell_fn, "ceph", "osd", "crush", "rule", "ls")
+    except Exception as exc:  # noqa: BLE001
+        snap["crush_rules_error"] = str(exc)
+    try:
+        snap["device_classes"] = _shell(shell_fn, "ceph", "osd", "crush", "class", "ls")
+    except Exception as exc:  # noqa: BLE001
+        snap["device_classes_error"] = str(exc)
+    try:
+        snap["mon_dump"] = _shell(shell_fn, "ceph", "mon", "dump")
+    except Exception as exc:  # noqa: BLE001
+        snap["mon_dump_error"] = str(exc)
+    try:
+        snap["rbd_default_map_options"] = _shell(
+            shell_fn, "ceph", "config", "get", "global", "rbd_default_map_options"
+        )
+    except Exception as exc:  # noqa: BLE001
+        snap["rbd_default_map_options_error"] = str(exc)
+    return snap

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -615,21 +615,33 @@ def set_config_param(node):
 
 def kernel_mount(mounting_dir, mon_node_ip, kernel_clients):
     try:
+        from utility.odf_defaults import (
+            format_mons_for_kernel_mount,
+            is_msgr1_disabled,
+            kernel_ms_mode_opt,
+        )
+
         for client in kernel_clients:
             out, err = client.exec_command(
                 cmd="sudo ceph auth get-key client.%s" % (client.hostname)
             )
             secret_key = out.rstrip("\n")
             mon_node_ip = mon_node_ip.replace(" ", "")
+            use_msgr2 = is_msgr1_disabled(client)
+            mons = format_mons_for_kernel_mount(mon_node_ip, use_msgr2)
+            ms_opt = kernel_ms_mode_opt(use_msgr2)
             client.exec_command(
-                cmd="sudo mount -t ceph %s:6789:/ %s -o name=%s,secret=%s"
-                % (mon_node_ip, mounting_dir, client.hostname, secret_key)
+                cmd="sudo mount -t ceph %s:/ %s -o name=%s,secret=%s%s"
+                % (mons, mounting_dir, client.hostname, secret_key, ms_opt)
             )
             out, err = client.exec_command(cmd="mount")
             mount_output = out.split()
 
             log.info("Checking if kernel mount is is passed of failed:")
-            if "%s:6789:/" % (mon_node_ip) in mount_output:
+            # Device may be bare IP:port or IP:3300 after msgr2 adjust
+            if any(mounting_dir.rstrip("/") == m for m in mount_output) or any(
+                mons in m for m in mount_output
+            ):
                 log.info("kernel mount passed")
             else:
                 log.error("kernel mount failed")


### PR DESCRIPTION
As part of the ODF testing, the rook default settings for ceph cluster what been configured for ODF storage cluster is been added now with custom-config argument approach.

```
--custom-config apply-odf-defaults=true
--custom-config apply-odf-topology=true
--custom-config verify-odf-defaults=true
```

apply-odf-topology is partially applied (do-not-use) on the clusters as these configurations comes after bootstrap and OSD, Pool creation.

- creating and moving devices to different CRUSH locations has issues.
- per-pool CRUSH rule additions are problematic, since pool creation called at many places and called in many different ways.

## Test results (BVT)

**Logs:** https://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/apply-odf-defaults-cephci-run-Y29L5K/

Example run (IBM, tentacle smoke BVT, ODF defaults only):

```bash
python run.py --cloud openstack --osp-cred <cred> \
  --inventory conf/inventory/rhel-10-latest.yaml \
  --instances-name sunilkumar-00 --release 9.2 --platform rhel-10 \
  --build stable --global-conf conf/tentacle/common/3node-1client.yaml \
  --suite suites/tentacle/smoke/bvt.yaml --log-level DEBUG --product ibm \
  --custom-config apply-odf-defaults=true --store
```

Recommended for ODF interop (adds monmap/config verification):

```bash
  --custom-config apply-odf-defaults=true \
  --custom-config verify-odf-defaults=true
```

Look for log lines: `Applying v2-only mon addrs`, `Merged ODF Rook defaults`, and (if verify enabled) `ODF defaults verified`.

Design doc: `docs/odf_rook_defaults.md`

## Review follow-up (Manimaran-MM)

Addressed in commit `aa2a10736`:

- `apply_v2_only_mon_addrs` returns failure list; bootstrap raises `CommandFailed`, deploy/mon tests return 1 on failure.
- CephFS mount in `core_workflows` requires `mon_addr` when msgr2 is needed and verifies with `findmnt`.
- Topology `container_limits` uses installer path `/tmp/odf_container_limits.yaml` and raises on orch apply failure.