### PR TITLE
Addressed failures in 9.2 Regression suite

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -91,8 +91,8 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -101,8 +101,8 @@ tests:
             serial: 2
             max_ns: 100
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -147,7 +147,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -156,7 +156,7 @@ tests:
             serial: 2
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -165,7 +165,7 @@ tests:
             serial: 3
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -174,7 +174,7 @@ tests:
             serial: 4
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9]
@@ -217,8 +217,8 @@ tests:
             serial: 1
             max_ns: 100
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7]
@@ -227,8 +227,8 @@ tests:
             serial: 2
             max_ns: 100
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7]
@@ -280,7 +280,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -289,7 +289,7 @@ tests:
             serial: 2
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -298,7 +298,7 @@ tests:
             serial: 3
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
@@ -307,7 +307,7 @@ tests:
             serial: 4
             bdevs:
             - count: 2
-              size: 5G
+              size: 8G
               ns_create_image: true
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]

--- a/tests/nvmeof/workflows/ha.py
+++ b/tests/nvmeof/workflows/ha.py
@@ -18,6 +18,7 @@ from tests.nvmeof.workflows.initiator import (
     compare_client_namespace,
     fetch_paths_for_namespaces,
     prepare_io_execution,
+    purge_cached_initiators,
     validate_initiator,
 )
 from tests.nvmeof.workflows.nvme_utils import (
@@ -541,13 +542,30 @@ class HighAvailability:
         initiators = self.config["initiators"]
 
         try:
+            # Non-auth HA only: drop leftover DHCHAP initiator cache from prior
+            # suite tests (e.g. inbandauth). Skip when pre_configured_initiators
+            # is set — that path is used by inband-auth and must keep keys.
+            pre_configured = self.config.get("pre_configured_initiators")
+            if not pre_configured:
+                initiator_nodes = {
+                    init["node"]
+                    for init in initiators
+                    if isinstance(init, dict) and init.get("node")
+                }
+                if initiator_nodes:
+                    LOG.info(
+                        "Purging cached initiators before non-auth HA connect: %s",
+                        sorted(initiator_nodes),
+                    )
+                    purge_cached_initiators(
+                        initiator_nodes, cluster=self.cluster, disconnect=True
+                    )
+
             # Prepare FIO Execution
             LOG.info("Fetching namespaces from all gateways")
             namespaces = fetch_namespaces(self.gateways[0])
 
             LOG.info("Preparing IO execution")
-            # Get pre-configured initiators if available
-            pre_configured = self.config.get("pre_configured_initiators")
             clients = prepare_io_execution(
                 initiators,
                 gateways=self.gateways,

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -594,6 +594,31 @@ def get_or_create_initiator(node_id, nqn, cluster):
     return Initiators[key]
 
 
+def purge_cached_initiators(node_ids, cluster=None, disconnect=True):
+    """Drop cached initiators for nodes so a later test starts without leftover DHCHAP.
+
+    Intended for non-auth HA after an inband-auth test in the same process.
+    Does not alter prepare_io_execution behavior.
+
+    Args:
+        node_ids: Node ids to purge (e.g. ``{\"node14\"}``).
+        cluster: Ceph cluster (required when disconnect=True).
+        disconnect: Run ``nvme disconnect-all`` on each node before purge.
+    """
+    node_ids = set(node_ids)
+    if disconnect:
+        if cluster is None:
+            raise ValueError("cluster is required when disconnect=True")
+        for nid in node_ids:
+            try:
+                Initiator(get_node_by_id(cluster, nid)).disconnect_all()
+            except Exception as err:
+                LOG.warning("disconnect_all failed for node=%s: %s", nid, err)
+    for key in [k for k in Initiators if k[0] in node_ids]:
+        LOG.info("Purging cached initiator entry %s", key)
+        del Initiators[key]
+
+
 def prepare_io_execution(
     io_clients,
     gateways=None,


### PR DESCRIPTION
Fixed issues seen in https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.2/rhel-10/regression/20.2.2-133/nvmeof/87/logs/

When combined inband and n-1 gw suites old cache is accessing initiator things so cleanup same

Adjusted load balancing tests suites sizes and images

Logs 
https://10.8.128.2/cephci-jenkins/inband_n_1_node_failures_30_jul
https://10.8.128.2/cephci-jenkins/loadbalancing_30_jul
https://10.8.128.2/cephci-jenkins/4gw_2_gatewaysfailover_30_jul/