### PR TITLE
Cephfs mirror sync perf thread comparison

### DIFF
--- a/suites/tentacle/cephfs/tier-2_cephfs_mirror_snapshot_sync_perf.yaml
+++ b/suites/tentacle/cephfs/tier-2_cephfs_mirror_snapshot_sync_perf.yaml
@@ -220,6 +220,7 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirror_snapshot_sync_perf_large_files.py
       name: CephFS Mirror snapshot sync performance - large files
       polarion-id: "CEPH-83574100"
+      comments: IBMCEPH-13886
   - test:
       abort-on-fail: false
       desc: "Snapshot Sync Performance Test - Mixed dataset (100 small + 5x1GiB large across dirs) with varying datasync thread counts on kernel/fuse/NFS"
@@ -244,4 +245,5 @@ tests:
       module: cephfs_mirroring.test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
       name: CephFS Mirror snapshot sync performance - mixed files
       polarion-id: "CEPH-83574101"
+      comments: IBMCEPH-13886
 

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -7,6 +7,7 @@ It contains all the re-useable functions related to cephfs mirroring feature
 import csv
 import json
 import random
+import re
 import secrets
 import string
 import time
@@ -21,6 +22,170 @@ from utility.retry import retry
 from utility.utils import get_ceph_version_from_cluster
 
 log = Log(__name__)
+
+
+def parse_sync_duration_to_seconds(raw_duration):
+    """Convert daemon sync_duration values to float seconds.
+
+    Accepts numeric values and human-readable strings such as ``49s``,
+    ``1m 16``, ``1m 16s``, ``1h 2m 3s``, or plain ``76.5``.
+    Returns None when the value is missing or unparseable.
+    Zero is a valid duration and is preserved.
+    """
+    if raw_duration is None:
+        return None
+    if isinstance(raw_duration, (int, float)):
+        return float(raw_duration)
+
+    text = str(raw_duration).strip().lower()
+    if not text:
+        return None
+
+    # Plain seconds: "49", "49s", "76.5", "76.5s"
+    plain = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)\s*s?", text)
+    if plain:
+        return float(plain.group(1))
+
+    # Compound durations with at least one h/m unit, e.g. "1h 2m 3s", "1m 16".
+    compound = re.fullmatch(
+        r"(?:([0-9]+(?:\.[0-9]+)?)\s*h)?"
+        r"(?:\s*([0-9]+(?:\.[0-9]+)?)\s*m)?"
+        r"(?:\s*([0-9]+(?:\.[0-9]+)?)\s*s?)?",
+        text,
+    )
+    if not compound:
+        return None
+    hours, minutes, seconds = compound.groups()
+    if hours is None and minutes is None:
+        return None
+
+    total = 0.0
+    if hours is not None:
+        total += float(hours) * 3600
+    if minutes is not None:
+        total += float(minutes) * 60
+    if seconds is not None:
+        total += float(seconds)
+    return total
+
+
+def compare_and_validate_sync_durations(results):
+    """
+    Log a sync-duration comparison table and improvement vs 1-thread.
+
+    Multi-thread sync must be equal or faster than the 1-thread baseline
+    for the same mount type. Returns False if any multi-thread run is slower.
+
+    When the 1-thread baseline is missing or <= 0 (daemon may report 0s for
+    very short syncs), validation for that mount is skipped with a warning.
+    """
+
+    def _fmt(val, suffix=""):
+        return f"{val:.1f}{suffix}" if val is not None else "None"
+
+    durations = {}
+    thread_counts = sorted({r["thread_count"] for r in results})
+    mount_types = []
+    for r in results:
+        mtype = r["mount_type"]
+        if mtype not in durations:
+            durations[mtype] = {}
+            mount_types.append(mtype)
+        durations[mtype][r["thread_count"]] = r.get("sync_duration_sec")
+
+    log.info("=" * 70)
+    log.info("SYNC DURATION COMPARISON TABLE (seconds)")
+    log.info("=" * 70)
+    header = f"{'Mount':<10}" + "".join(f"{('t=' + str(t)):>14}" for t in thread_counts)
+    log.info(header)
+    log.info("-" * len(header))
+    for mtype in mount_types:
+        row = f"{mtype:<10}"
+        for t in thread_counts:
+            dur = durations[mtype].get(t)
+            row += f"{_fmt(dur):>14}"
+        log.info(row)
+
+    log.info("=" * 70)
+    log.info("SYNC DURATION IMPROVEMENT VS 1-THREAD")
+    log.info("Rule: multi-thread must be equal or faster than 1-thread")
+    log.info("=" * 70)
+
+    failed = False
+    for mtype in mount_types:
+        single = durations[mtype].get(1)
+        if single is None or single <= 0:
+            log.warning(
+                "No valid 1-thread baseline for mount=%s; skipping validation",
+                mtype,
+            )
+            continue
+
+        log.info("Mount=%s | 1-thread baseline: %.1fs", mtype, single)
+        prev_t = 1
+        prev_dur = single
+        for t in thread_counts:
+            if t == 1:
+                continue
+            multi = durations[mtype].get(t)
+            if multi is None:
+                log.error("Missing sync duration for mount=%s threads=%d", mtype, t)
+                failed = True
+                continue
+
+            saved_sec = single - multi
+            improve_pct = (saved_sec / single) * 100.0
+            vs_prev_sec = prev_dur - multi
+            vs_prev_pct = (vs_prev_sec / prev_dur) * 100.0 if prev_dur > 0 else 0.0
+
+            if multi > single:
+                log.error(
+                    "FAIL: mount=%s threads=%d duration=%.1fs is SLOWER than "
+                    "1-thread %.1fs (delta %+0.1fs / %+0.1f%%)",
+                    mtype,
+                    t,
+                    multi,
+                    single,
+                    multi - single,
+                    -improve_pct,
+                )
+                failed = True
+            elif multi == single:
+                log.info(
+                    "OK: mount=%s threads=%d duration=%.1fs EQUAL to 1-thread "
+                    "(no change)",
+                    mtype,
+                    t,
+                    multi,
+                )
+            else:
+                log.info(
+                    "OK: mount=%s threads=%d duration=%.1fs | improved by "
+                    "%.1fs (%.1f%%) vs 1-thread | vs t=%d: %+0.1fs (%+.1f%%)",
+                    mtype,
+                    t,
+                    multi,
+                    saved_sec,
+                    improve_pct,
+                    prev_t,
+                    vs_prev_sec,
+                    vs_prev_pct,
+                )
+            prev_t = t
+            prev_dur = multi
+
+    if failed:
+        log.error(
+            "Single vs multi-thread validation FAILED: "
+            "multi-thread sync duration must be equal or faster than 1-thread"
+        )
+        return False
+
+    log.info(
+        "Single vs multi-thread validation PASSED: "
+        "all multi-thread sync durations are equal or faster than 1-thread"
+    )
+    return True
 
 
 def _normalize_asok_peer_status(data):
@@ -982,15 +1147,23 @@ class CephfsMirroringUtils(object):
                     continue
                 if last_synced_snap.get("name") == snapshot_name:
                     raw_duration = last_synced_snap.get("sync_duration")
-                    sync_duration = (
-                        str(raw_duration).rstrip("s")
-                        if raw_duration is not None
-                        else None
-                    )
+                    sync_duration = parse_sync_duration_to_seconds(raw_duration)
+                    if sync_duration is None:
+                        log.error(
+                            "Snapshot %s matched but sync_duration is "
+                            "missing/unparseable (raw=%r)",
+                            snapshot_name,
+                            raw_duration,
+                        )
+                        raise CommandFailed(
+                            "sync_duration missing/unparseable for %s (raw=%r)"
+                            % (snapshot_name, raw_duration)
+                        )
                     log.info(
-                        "Snapshot %s synced: duration=%s, bytes=%s, files=%s",
+                        "Snapshot %s synced: duration=%s (raw=%s), bytes=%s, files=%s",
                         snapshot_name,
                         sync_duration,
+                        raw_duration,
                         last_synced_snap.get("sync_bytes"),
                         last_synced_snap.get("sync_files"),
                     )
@@ -1001,7 +1174,13 @@ class CephfsMirroringUtils(object):
                         "snaps_synced": path_status.get("snaps_synced"),
                     }
 
-        log.error("%s not synced, last synced data is %s", snapshot_name, data)
+        # Expected while still syncing; @retry will re-poll. Keep at info to avoid
+        # flooding .err with false failures during normal sync wait.
+        log.info(
+            "%s not synced yet (still syncing or pending). peer_status=%s",
+            snapshot_name,
+            data,
+        )
         raise CommandFailed("One or more snapshots are not synced")
 
     def remove_snapshot_mirror_peer(self, source_clients, fs_name, peer_uuid):

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -1174,9 +1174,7 @@ class CephfsMirroringUtils(object):
                         "snaps_synced": path_status.get("snaps_synced"),
                     }
 
-        # Expected while still syncing; @retry will re-poll. Keep at info to avoid
-        # flooding .err with false failures during normal sync wait.
-        log.info(
+        log.debug(
             "%s not synced yet (still syncing or pending). peer_status=%s",
             snapshot_name,
             data,
@@ -2631,6 +2629,17 @@ class CephfsMirroringUtils(object):
         log.info("FSID '%s' validated for %s", remote_fsid, fs_name)
 
 
+def _ensure_ceph_common(asok_file):
+    """One-shot helper: install ceph-common on every mirror-daemon node."""
+    for _node, asok in asok_file.items():
+        try:
+            asok[0].exec_command(
+                sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
+            )
+        except Exception as e:
+            log.warning("dnf install ceph-common failed (non-fatal): %s", e)
+
+
 @retry(CommandFailed, tries=10, delay=30, backoff=1)
 def wait_for_sync_idle(fs_name, fsid, asok_file, filesystem_id, peer_uuid, paths):
     """
@@ -2647,14 +2656,12 @@ def wait_for_sync_idle(fs_name, fsid, asok_file, filesystem_id, peer_uuid, paths
 
     Raises:
         CommandFailed: If any path is not in 'idle' state (triggers retry).
+        RuntimeError: If asok_file is empty.
     """
-    for node, asok in asok_file.items():
-        try:
-            asok[0].exec_command(
-                sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
-            )
-        except Exception as e:
-            log.warning("dnf install ceph-common failed (non-fatal): %s", e)
+    if not asok_file:
+        raise RuntimeError("asok_file dict is empty; no mirror daemon to query")
+
+    node, asok = next(iter(asok_file.items()))
     asok_basename = asok[1].rsplit("/", 1)[-1]
     asok_dir = f"/var/run/ceph/{fsid}"
     cmd = (

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_large_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_large_files.py
@@ -200,8 +200,7 @@ def run(ceph_cluster, **kw):
         est_total_mb = num_files * file_size_mb
 
         log.info(
-            "Test parameters: thread_counts=%s, num_files=%d, "
-            "file_size=%dMB, est_total=%dMB per subvolume",
+            "Test parameters: thread_counts=%s, num_files=%d, file_size=%dMB, est_total=%dMB per subvolume",
             thread_counts,
             num_files,
             file_size_mb,
@@ -444,8 +443,7 @@ def run(ceph_cluster, **kw):
 
                 if not result_snap:
                     log.error(
-                        "Snapshot %s (%s) did not sync within timeout "
-                        "for thread_count=%d",
+                        "Snapshot %s (%s) did not sync within timeout for thread_count=%d",
                         snap_name,
                         mtype,
                         thread_count,
@@ -456,16 +454,14 @@ def run(ceph_cluster, **kw):
                 daemon_sync_duration = parse_sync_duration_to_seconds(raw_duration)
                 if daemon_sync_duration is None:
                     log.error(
-                        "Snapshot %s (%s) reported synced but sync_duration is "
-                        "missing/unparseable (raw=%r)",
+                        "Snapshot %s (%s) reported synced but sync_duration is missing/unparseable (raw=%r)",
                         snap_name,
                         mtype,
                         raw_duration,
                     )
                     return 1
                 log.info(
-                    "Snapshot %s synced: daemon_duration=%.1fs, "
-                    "wall_clock=%.1fs, snaps_synced=%s",
+                    "Snapshot %s synced: daemon_duration=%.1fs, wall_clock=%.1fs, snaps_synced=%s",
                     snap_name,
                     daemon_sync_duration,
                     wall_clock_sec,
@@ -534,8 +530,7 @@ def run(ceph_cluster, **kw):
                 mbs_str = f"{mb_per_sec:.1f}" if mb_per_sec is not None else "None"
                 spd_str = f"{speedup:.1f}x" if speedup is not None else "None"
                 log.info(
-                    "RESULT | threads=%d | mount=%s | duration=%s | "
-                    "%s files/sec | %s MB/sec | %s speedup",
+                    "RESULT | threads=%d | mount=%s | duration=%s | %s files/sec | %s MB/sec | %s speedup",
                     thread_count,
                     mtype,
                     dur_str,
@@ -549,8 +544,7 @@ def run(ceph_cluster, **kw):
             idle_ok = True
             try:
                 log.info(
-                    "Waiting for all mirrored paths to reach idle after "
-                    "thread_count=%d syncs",
+                    "Waiting for all mirrored paths to reach idle after thread_count=%d syncs",
                     thread_count,
                 )
                 wait_for_sync_idle(
@@ -573,15 +567,20 @@ def run(ceph_cluster, **kw):
                 # Always clean even if idle wait fails to avoid suite leaks.
                 log.info("Cleaning up iteration for thread_count=%d", thread_count)
                 for mtype in MOUNT_TYPES:
-                    fs_util_ceph1.remove_snapshot(
-                        client=source_clients[0],
-                        vol_name=source_fs,
-                        subvol_name=created_subvols[mtype],
-                        snap_name=iter_snapshots[mtype],
-                        validate=True,
-                        group_name=subvol_group,
-                        force=True,
-                    )
+                    try:
+                        fs_util_ceph1.remove_snapshot(
+                            client=source_clients[0],
+                            vol_name=source_fs,
+                            subvol_name=created_subvols[mtype],
+                            snap_name=iter_snapshots[mtype],
+                            validate=True,
+                            group_name=subvol_group,
+                            force=True,
+                        )
+                    except Exception as snap_err:
+                        log.warning(
+                            "Failed to remove snapshot for %s: %s", mtype, snap_err
+                        )
 
                 for mtype in MOUNT_TYPES:
                     try:
@@ -651,10 +650,7 @@ def run(ceph_cluster, **kw):
             try:
                 source_clients[0].exec_command(
                     sudo=True,
-                    cmd=(
-                        "ceph config rm client.cephfs-mirror "
-                        "cephfs_mirror_max_datasync_threads"
-                    ),
+                    cmd="ceph config rm client.cephfs-mirror cephfs_mirror_max_datasync_threads",
                 )
             except Exception as e:
                 log.warning("Failed to reset thread config: %s", e)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_large_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_large_files.py
@@ -6,7 +6,12 @@ import time
 import traceback
 
 from ceph.ceph import CommandFailed
-from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
+    CephfsMirroringUtils,
+    compare_and_validate_sync_durations,
+    parse_sync_duration_to_seconds,
+    wait_for_sync_idle,
+)
 from tests.cephfs.cephfs_utilsV1 import FsUtils as FsUtilsV1
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from utility.log import Log
@@ -53,6 +58,8 @@ def run(ceph_cluster, **kw):
 
     Returns:
         0 on success, 1 on failure.
+        Also fails if any multi-thread sync duration is slower than the
+        1-thread baseline for the same mount type.
     """
 
     source_clients = None
@@ -446,19 +453,21 @@ def run(ceph_cluster, **kw):
                     return 1
 
                 raw_duration = result_snap.get("sync_duration")
-                if raw_duration is not None:
-                    daemon_sync_duration = float(raw_duration)
-                else:
-                    daemon_sync_duration = None
+                daemon_sync_duration = parse_sync_duration_to_seconds(raw_duration)
+                if daemon_sync_duration is None:
+                    log.error(
+                        "Snapshot %s (%s) reported synced but sync_duration is "
+                        "missing/unparseable (raw=%r)",
+                        snap_name,
+                        mtype,
+                        raw_duration,
+                    )
+                    return 1
                 log.info(
-                    "Snapshot %s synced: daemon_duration=%s, "
+                    "Snapshot %s synced: daemon_duration=%.1fs, "
                     "wall_clock=%.1fs, snaps_synced=%s",
                     snap_name,
-                    (
-                        f"{daemon_sync_duration:.1f}s"
-                        if daemon_sync_duration is not None
-                        else "None"
-                    ),
+                    daemon_sync_duration,
                     wall_clock_sec,
                     result_snap["snaps_synced"],
                 )
@@ -537,39 +546,69 @@ def run(ceph_cluster, **kw):
 
                 _append_csv_row(csv_file, result_entry)
 
-            # ---- 7. Cleanup this iteration (snapshots + data only) ----
-            log.info("Cleaning up iteration for thread_count=%d", thread_count)
-            for mtype in MOUNT_TYPES:
-                fs_util_ceph1.remove_snapshot(
-                    client=source_clients[0],
-                    vol_name=source_fs,
-                    subvol_name=created_subvols[mtype],
-                    snap_name=iter_snapshots[mtype],
-                    validate=True,
-                    group_name=subvol_group,
-                    force=True,
+            idle_ok = True
+            try:
+                log.info(
+                    "Waiting for all mirrored paths to reach idle after "
+                    "thread_count=%d syncs",
+                    thread_count,
                 )
-
-            for mtype in MOUNT_TYPES:
-                try:
-                    log.info("Deleting generated files under %s", io_dir_paths[mtype])
-                    source_clients[0].exec_command(
-                        sudo=True,
-                        cmd=f"rm -rf {io_dir_paths[mtype]}",
-                        long_running=True,
-                        timeout=600,
+                wait_for_sync_idle(
+                    source_fs,
+                    fsid,
+                    asok_file,
+                    filesystem_id,
+                    peer_uuid,
+                    mirroring_paths,
+                )
+            except CommandFailed as e:
+                idle_ok = False
+                log.error(
+                    "Not all paths reached idle after syncs for " "thread_count=%d: %s",
+                    thread_count,
+                    e,
+                )
+            finally:
+                # ---- 7. Cleanup this iteration (snapshots + data only) ----
+                # Always clean even if idle wait fails to avoid suite leaks.
+                log.info("Cleaning up iteration for thread_count=%d", thread_count)
+                for mtype in MOUNT_TYPES:
+                    fs_util_ceph1.remove_snapshot(
+                        client=source_clients[0],
+                        vol_name=source_fs,
+                        subvol_name=created_subvols[mtype],
+                        snap_name=iter_snapshots[mtype],
+                        validate=True,
+                        group_name=subvol_group,
+                        force=True,
                     )
-                except Exception as e:
-                    log.warning("Failed to delete data in %s: %s", mtype, e)
-                    if mtype == "nfs":
-                        log.info("NFS data deletion failed, remounting NFS")
-                        _remount_nfs(
-                            source_clients[0],
-                            mount_dirs["nfs"],
-                            nfs_server,
-                            nfs_export_name,
-                            fs_util_ceph1,
+
+                for mtype in MOUNT_TYPES:
+                    try:
+                        log.info(
+                            "Deleting generated files under %s",
+                            io_dir_paths[mtype],
                         )
+                        source_clients[0].exec_command(
+                            sudo=True,
+                            cmd=f"rm -rf {io_dir_paths[mtype]}",
+                            long_running=True,
+                            timeout=600,
+                        )
+                    except Exception as e:
+                        log.warning("Failed to delete data in %s: %s", mtype, e)
+                        if mtype == "nfs":
+                            log.info("NFS data deletion failed, remounting NFS")
+                            _remount_nfs(
+                                source_clients[0],
+                                mount_dirs["nfs"],
+                                nfs_server,
+                                nfs_export_name,
+                                fs_util_ceph1,
+                            )
+
+            if not idle_ok:
+                return 1
 
         # ---- Final summary ----
         log.info("=" * 70)
@@ -595,6 +634,9 @@ def run(ceph_cluster, **kw):
                 _fmt(r["speedup"], "x"),
             )
         log.info("CSV results written to %s", csv_file)
+
+        if not compare_and_validate_sync_durations(results):
+            return 1
 
         return 0
 
@@ -747,7 +789,7 @@ def _generate_large_files_on_client(client, io_dir, num_files, file_size_mb, tim
         f"set -e; "
         f"for i in $(seq 1 {num_files}); do "
         f"dd if=/dev/urandom of='{io_dir}/large_file_$i' "
-        f"bs=1M count={file_size_mb}; "
+        f"bs=1M count={file_size_mb} status=none; "
         f"done"
     )
     client.exec_command(sudo=True, timeout=timeout, cmd=cmd, long_running=True)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
@@ -6,7 +6,12 @@ import time
 import traceback
 
 from ceph.ceph import CommandFailed
-from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
+    CephfsMirroringUtils,
+    compare_and_validate_sync_durations,
+    parse_sync_duration_to_seconds,
+    wait_for_sync_idle,
+)
 from tests.cephfs.cephfs_utilsV1 import FsUtils as FsUtilsV1
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from utility.log import Log
@@ -78,6 +83,8 @@ def run(ceph_cluster, **kw):
 
     Returns:
         0 on success, 1 on failure.
+        Also fails if any multi-thread sync duration is slower than the
+        1-thread baseline for the same mount type.
     """
 
     source_clients = None
@@ -499,19 +506,21 @@ def run(ceph_cluster, **kw):
                     return 1
 
                 raw_duration = result_snap.get("sync_duration")
-                if raw_duration is not None:
-                    daemon_sync_duration = float(raw_duration)
-                else:
-                    daemon_sync_duration = None
+                daemon_sync_duration = parse_sync_duration_to_seconds(raw_duration)
+                if daemon_sync_duration is None:
+                    log.error(
+                        "Snapshot %s (%s) reported synced but sync_duration is "
+                        "missing/unparseable (raw=%r)",
+                        snap_name,
+                        mtype,
+                        raw_duration,
+                    )
+                    return 1
                 log.info(
-                    "Snapshot %s synced: daemon_duration=%s, "
+                    "Snapshot %s synced: daemon_duration=%.1fs, "
                     "wall_clock=%.1fs, snaps_synced=%s",
                     snap_name,
-                    (
-                        f"{daemon_sync_duration:.1f}s"
-                        if daemon_sync_duration is not None
-                        else "None"
-                    ),
+                    daemon_sync_duration,
                     wall_clock_sec,
                     result_snap["snaps_synced"],
                 )
@@ -590,39 +599,69 @@ def run(ceph_cluster, **kw):
 
                 _append_csv_row(csv_file, result_entry)
 
-            # ---- 7. Cleanup this iteration (snapshots + data only) ----
-            log.info("Cleaning up iteration for thread_count=%d", thread_count)
-            for mtype in MOUNT_TYPES:
-                fs_util_ceph1.remove_snapshot(
-                    client=source_clients[0],
-                    vol_name=source_fs,
-                    subvol_name=created_subvols[mtype],
-                    snap_name=iter_snapshots[mtype],
-                    validate=True,
-                    group_name=subvol_group,
-                    force=True,
+            idle_ok = True
+            try:
+                log.info(
+                    "Waiting for all mirrored paths to reach idle after "
+                    "thread_count=%d syncs",
+                    thread_count,
                 )
-
-            for mtype in MOUNT_TYPES:
-                try:
-                    log.info("Deleting generated files under %s", io_dir_paths[mtype])
-                    source_clients[0].exec_command(
-                        sudo=True,
-                        cmd=f"rm -rf {io_dir_paths[mtype]}",
-                        long_running=True,
-                        timeout=600,
+                wait_for_sync_idle(
+                    source_fs,
+                    fsid,
+                    asok_file,
+                    filesystem_id,
+                    peer_uuid,
+                    mirroring_paths,
+                )
+            except CommandFailed as e:
+                idle_ok = False
+                log.error(
+                    "Not all paths reached idle after syncs for " "thread_count=%d: %s",
+                    thread_count,
+                    e,
+                )
+            finally:
+                # ---- 7. Cleanup this iteration (snapshots + data only) ----
+                # Always clean even if idle wait fails to avoid suite leaks.
+                log.info("Cleaning up iteration for thread_count=%d", thread_count)
+                for mtype in MOUNT_TYPES:
+                    fs_util_ceph1.remove_snapshot(
+                        client=source_clients[0],
+                        vol_name=source_fs,
+                        subvol_name=created_subvols[mtype],
+                        snap_name=iter_snapshots[mtype],
+                        validate=True,
+                        group_name=subvol_group,
+                        force=True,
                     )
-                except Exception as e:
-                    log.warning("Failed to delete data in %s: %s", mtype, e)
-                    if mtype == "nfs":
-                        log.info("NFS data deletion failed, remounting NFS")
-                        _remount_nfs(
-                            source_clients[0],
-                            mount_dirs["nfs"],
-                            nfs_server,
-                            nfs_export_name,
-                            fs_util_ceph1,
+
+                for mtype in MOUNT_TYPES:
+                    try:
+                        log.info(
+                            "Deleting generated files under %s",
+                            io_dir_paths[mtype],
                         )
+                        source_clients[0].exec_command(
+                            sudo=True,
+                            cmd=f"rm -rf {io_dir_paths[mtype]}",
+                            long_running=True,
+                            timeout=600,
+                        )
+                    except Exception as e:
+                        log.warning("Failed to delete data in %s: %s", mtype, e)
+                        if mtype == "nfs":
+                            log.info("NFS data deletion failed, remounting NFS")
+                            _remount_nfs(
+                                source_clients[0],
+                                mount_dirs["nfs"],
+                                nfs_server,
+                                nfs_export_name,
+                                fs_util_ceph1,
+                            )
+
+            if not idle_ok:
+                return 1
 
         # ---- Final summary ----
         log.info("=" * 70)
@@ -648,6 +687,9 @@ def run(ceph_cluster, **kw):
                 _fmt(r["speedup"], "x"),
             )
         log.info("CSV results written to %s", csv_file)
+
+        if not compare_and_validate_sync_durations(results):
+            return 1
 
         return 0
 

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
@@ -426,8 +426,7 @@ def run(ceph_cluster, **kw):
 
             # ---- 3. Generate mixed dataset sequentially per mount type ----
             log.info(
-                "Generating mixed dataset (%d small + %d large files) "
-                "sequentially on kernel/fuse/nfs",
+                "Generating mixed dataset (%d small + %d large files) sequentially on kernel/fuse/nfs",
                 num_small_files,
                 num_large_files,
             )
@@ -497,8 +496,7 @@ def run(ceph_cluster, **kw):
 
                 if not result_snap:
                     log.error(
-                        "Snapshot %s (%s) did not sync within timeout "
-                        "for thread_count=%d",
+                        "Snapshot %s (%s) did not sync within timeout for thread_count=%d",
                         snap_name,
                         mtype,
                         thread_count,
@@ -509,16 +507,14 @@ def run(ceph_cluster, **kw):
                 daemon_sync_duration = parse_sync_duration_to_seconds(raw_duration)
                 if daemon_sync_duration is None:
                     log.error(
-                        "Snapshot %s (%s) reported synced but sync_duration is "
-                        "missing/unparseable (raw=%r)",
+                        "Snapshot %s (%s) reported synced but sync_duration is missing/unparseable (raw=%r)",
                         snap_name,
                         mtype,
                         raw_duration,
                     )
                     return 1
                 log.info(
-                    "Snapshot %s synced: daemon_duration=%.1fs, "
-                    "wall_clock=%.1fs, snaps_synced=%s",
+                    "Snapshot %s synced: daemon_duration=%.1fs, wall_clock=%.1fs, snaps_synced=%s",
                     snap_name,
                     daemon_sync_duration,
                     wall_clock_sec,
@@ -587,8 +583,7 @@ def run(ceph_cluster, **kw):
                 mbs_str = f"{mb_per_sec:.1f}" if mb_per_sec is not None else "None"
                 spd_str = f"{speedup:.1f}x" if speedup is not None else "None"
                 log.info(
-                    "RESULT | threads=%d | mount=%s | duration=%s | "
-                    "%s files/sec | %s MB/sec | %s speedup",
+                    "RESULT | threads=%d | mount=%s | duration=%s | %s files/sec | %s MB/sec | %s speedup",
                     thread_count,
                     mtype,
                     dur_str,
@@ -602,8 +597,7 @@ def run(ceph_cluster, **kw):
             idle_ok = True
             try:
                 log.info(
-                    "Waiting for all mirrored paths to reach idle after "
-                    "thread_count=%d syncs",
+                    "Waiting for all mirrored paths to reach idle after thread_count=%d syncs",
                     thread_count,
                 )
                 wait_for_sync_idle(
@@ -626,15 +620,20 @@ def run(ceph_cluster, **kw):
                 # Always clean even if idle wait fails to avoid suite leaks.
                 log.info("Cleaning up iteration for thread_count=%d", thread_count)
                 for mtype in MOUNT_TYPES:
-                    fs_util_ceph1.remove_snapshot(
-                        client=source_clients[0],
-                        vol_name=source_fs,
-                        subvol_name=created_subvols[mtype],
-                        snap_name=iter_snapshots[mtype],
-                        validate=True,
-                        group_name=subvol_group,
-                        force=True,
-                    )
+                    try:
+                        fs_util_ceph1.remove_snapshot(
+                            client=source_clients[0],
+                            vol_name=source_fs,
+                            subvol_name=created_subvols[mtype],
+                            snap_name=iter_snapshots[mtype],
+                            validate=True,
+                            group_name=subvol_group,
+                            force=True,
+                        )
+                    except Exception as snap_err:
+                        log.warning(
+                            "Failed to remove snapshot for %s: %s", mtype, snap_err
+                        )
 
                 for mtype in MOUNT_TYPES:
                     try:
@@ -704,10 +703,7 @@ def run(ceph_cluster, **kw):
             try:
                 source_clients[0].exec_command(
                     sudo=True,
-                    cmd=(
-                        "ceph config rm client.cephfs-mirror "
-                        "cephfs_mirror_max_datasync_threads"
-                    ),
+                    cmd="ceph config rm client.cephfs-mirror cephfs_mirror_max_datasync_threads",
                 )
             except Exception as e:
                 log.warning("Failed to reset thread config: %s", e)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_small_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_small_files.py
@@ -470,8 +470,7 @@ def run(ceph_cluster, **kw):
 
                 if not result_snap:
                     log.error(
-                        "Snapshot %s (%s) did not sync within timeout "
-                        "for thread_count=%d",
+                        "Snapshot %s (%s) did not sync within timeout for thread_count=%d",
                         snap_name,
                         mtype,
                         thread_count,
@@ -482,16 +481,14 @@ def run(ceph_cluster, **kw):
                 daemon_sync_duration = parse_sync_duration_to_seconds(raw_duration)
                 if daemon_sync_duration is None:
                     log.error(
-                        "Snapshot %s (%s) reported synced but sync_duration is "
-                        "missing/unparseable (raw=%r)",
+                        "Snapshot %s (%s) reported synced but sync_duration is missing/unparseable (raw=%r)",
                         snap_name,
                         mtype,
                         raw_duration,
                     )
                     return 1
                 log.info(
-                    "Snapshot %s synced: daemon_duration=%.1fs, "
-                    "wall_clock=%.1fs, snaps_synced=%s",
+                    "Snapshot %s synced: daemon_duration=%.1fs, wall_clock=%.1fs, snaps_synced=%s",
                     snap_name,
                     daemon_sync_duration,
                     wall_clock_sec,
@@ -560,8 +557,7 @@ def run(ceph_cluster, **kw):
                 mbs_str = f"{mb_per_sec:.1f}" if mb_per_sec is not None else "None"
                 spd_str = f"{speedup:.1f}x" if speedup is not None else "None"
                 log.info(
-                    "RESULT | threads=%d | mount=%s | duration=%s | "
-                    "%s files/sec | %s MB/sec | %s speedup",
+                    "RESULT | threads=%d | mount=%s | duration=%s | %s files/sec | %s MB/sec | %s speedup",
                     thread_count,
                     mtype,
                     dur_str,
@@ -575,8 +571,7 @@ def run(ceph_cluster, **kw):
             idle_ok = True
             try:
                 log.info(
-                    "Waiting for all mirrored paths to reach idle after "
-                    "thread_count=%d syncs",
+                    "Waiting for all mirrored paths to reach idle after thread_count=%d syncs",
                     thread_count,
                 )
                 wait_for_sync_idle(
@@ -599,15 +594,20 @@ def run(ceph_cluster, **kw):
                 # Always clean even if idle wait fails to avoid suite leaks.
                 log.info("Cleaning up iteration for thread_count=%d", thread_count)
                 for mtype in MOUNT_TYPES:
-                    fs_util_ceph1.remove_snapshot(
-                        client=source_clients[0],
-                        vol_name=source_fs,
-                        subvol_name=created_subvols[mtype],
-                        snap_name=iter_snapshots[mtype],
-                        validate=True,
-                        group_name=subvol_group,
-                        force=True,
-                    )
+                    try:
+                        fs_util_ceph1.remove_snapshot(
+                            client=source_clients[0],
+                            vol_name=source_fs,
+                            subvol_name=created_subvols[mtype],
+                            snap_name=iter_snapshots[mtype],
+                            validate=True,
+                            group_name=subvol_group,
+                            force=True,
+                        )
+                    except Exception as snap_err:
+                        log.warning(
+                            "Failed to remove snapshot for %s: %s", mtype, snap_err
+                        )
 
                 for mtype in MOUNT_TYPES:
                     try:
@@ -677,10 +677,7 @@ def run(ceph_cluster, **kw):
             try:
                 source_clients[0].exec_command(
                     sudo=True,
-                    cmd=(
-                        "ceph config rm client.cephfs-mirror "
-                        "cephfs_mirror_max_datasync_threads"
-                    ),
+                    cmd="ceph config rm client.cephfs-mirror cephfs_mirror_max_datasync_threads",
                 )
             except Exception as e:
                 log.warning("Failed to reset thread config: %s", e)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_small_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_small_files.py
@@ -7,7 +7,12 @@ import time
 import traceback
 
 from ceph.ceph import CommandFailed
-from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
+from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
+    CephfsMirroringUtils,
+    compare_and_validate_sync_durations,
+    parse_sync_duration_to_seconds,
+    wait_for_sync_idle,
+)
 from tests.cephfs.cephfs_utilsV1 import FsUtils as FsUtilsV1
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from utility.log import Log
@@ -62,6 +67,8 @@ def run(ceph_cluster, **kw):
 
     Returns:
         0 on success, 1 on failure.
+        Also fails if any multi-thread sync duration is slower than the
+        1-thread baseline for the same mount type.
     """
 
     source_clients = None
@@ -472,19 +479,21 @@ def run(ceph_cluster, **kw):
                     return 1
 
                 raw_duration = result_snap.get("sync_duration")
-                if raw_duration is not None:
-                    daemon_sync_duration = float(raw_duration)
-                else:
-                    daemon_sync_duration = None
+                daemon_sync_duration = parse_sync_duration_to_seconds(raw_duration)
+                if daemon_sync_duration is None:
+                    log.error(
+                        "Snapshot %s (%s) reported synced but sync_duration is "
+                        "missing/unparseable (raw=%r)",
+                        snap_name,
+                        mtype,
+                        raw_duration,
+                    )
+                    return 1
                 log.info(
-                    "Snapshot %s synced: daemon_duration=%s, "
+                    "Snapshot %s synced: daemon_duration=%.1fs, "
                     "wall_clock=%.1fs, snaps_synced=%s",
                     snap_name,
-                    (
-                        f"{daemon_sync_duration:.1f}s"
-                        if daemon_sync_duration is not None
-                        else "None"
-                    ),
+                    daemon_sync_duration,
                     wall_clock_sec,
                     result_snap["snaps_synced"],
                 )
@@ -563,39 +572,69 @@ def run(ceph_cluster, **kw):
 
                 _append_csv_row(csv_file, result_entry)
 
-            # ---- 7. Cleanup this iteration (snapshots + data only) ----
-            log.info("Cleaning up iteration for thread_count=%d", thread_count)
-            for mtype in MOUNT_TYPES:
-                fs_util_ceph1.remove_snapshot(
-                    client=source_clients[0],
-                    vol_name=source_fs,
-                    subvol_name=created_subvols[mtype],
-                    snap_name=iter_snapshots[mtype],
-                    validate=True,
-                    group_name=subvol_group,
-                    force=True,
+            idle_ok = True
+            try:
+                log.info(
+                    "Waiting for all mirrored paths to reach idle after "
+                    "thread_count=%d syncs",
+                    thread_count,
                 )
-
-            for mtype in MOUNT_TYPES:
-                try:
-                    log.info("Deleting generated files under %s", io_dir_paths[mtype])
-                    source_clients[0].exec_command(
-                        sudo=True,
-                        cmd=f"rm -rf {io_dir_paths[mtype]}",
-                        long_running=True,
-                        timeout=600,
+                wait_for_sync_idle(
+                    source_fs,
+                    fsid,
+                    asok_file,
+                    filesystem_id,
+                    peer_uuid,
+                    mirroring_paths,
+                )
+            except CommandFailed as e:
+                idle_ok = False
+                log.error(
+                    "Not all paths reached idle after syncs for " "thread_count=%d: %s",
+                    thread_count,
+                    e,
+                )
+            finally:
+                # ---- 7. Cleanup this iteration (snapshots + data only) ----
+                # Always clean even if idle wait fails to avoid suite leaks.
+                log.info("Cleaning up iteration for thread_count=%d", thread_count)
+                for mtype in MOUNT_TYPES:
+                    fs_util_ceph1.remove_snapshot(
+                        client=source_clients[0],
+                        vol_name=source_fs,
+                        subvol_name=created_subvols[mtype],
+                        snap_name=iter_snapshots[mtype],
+                        validate=True,
+                        group_name=subvol_group,
+                        force=True,
                     )
-                except Exception as e:
-                    log.warning("Failed to delete data in %s: %s", mtype, e)
-                    if mtype == "nfs":
-                        log.info("NFS data deletion failed, remounting NFS")
-                        _remount_nfs(
-                            source_clients[0],
-                            mount_dirs["nfs"],
-                            nfs_server,
-                            nfs_export_name,
-                            fs_util_ceph1,
+
+                for mtype in MOUNT_TYPES:
+                    try:
+                        log.info(
+                            "Deleting generated files under %s",
+                            io_dir_paths[mtype],
                         )
+                        source_clients[0].exec_command(
+                            sudo=True,
+                            cmd=f"rm -rf {io_dir_paths[mtype]}",
+                            long_running=True,
+                            timeout=600,
+                        )
+                    except Exception as e:
+                        log.warning("Failed to delete data in %s: %s", mtype, e)
+                        if mtype == "nfs":
+                            log.info("NFS data deletion failed, remounting NFS")
+                            _remount_nfs(
+                                source_clients[0],
+                                mount_dirs["nfs"],
+                                nfs_server,
+                                nfs_export_name,
+                                fs_util_ceph1,
+                            )
+
+            if not idle_ok:
+                return 1
 
         # ---- Final summary ----
         log.info("=" * 70)
@@ -621,6 +660,9 @@ def run(ceph_cluster, **kw):
                 _fmt(r["speedup"], "x"),
             )
         log.info("CSV results written to %s", csv_file)
+
+        if not compare_and_validate_sync_durations(results):
+            return 1
 
         return 0
 


### PR DESCRIPTION
Logs: hhttp://10.64.24.74/logs/ceph-qe-logs//IBM/9.2/rhel-10/executor/20.2.2-220/cephfs/2525/logs/tier_2_cephfs_mirror_snapshot_sync_perf/

Added a comparision of sync duration between single and multi threaded mirroring.