### PR TITLE
adding check_crash_status and log_cluster_health, in nfs upgrade tests.

### DIFF
--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -1979,3 +1979,67 @@ def get_ceph_version(client, prefix_cephadm=False):
         raise RuntimeError("Failed to get ceph version from cluster")
     ceph_version_installed = match.group(1)
     return ceph_version_installed
+
+
+def init_cluster_health_check(ceph_cluster, config=None):
+    """
+    Create RadosOrchestrator and capture start timestamp for crash checks.
+
+    Returns:
+        tuple: (rados_obj, start_time) or (None, None) on failure.
+    """
+    try:
+        from ceph.ceph_admin import CephAdmin
+        from ceph.rados.core_workflows import RadosOrchestrator
+        from ceph.rados.utils import get_cluster_timestamp
+
+        # Only pass keys CephAdmin actually needs; NFS suite config must not
+        # be spread into CephAdmin (would poison / shadow attributes).
+        cephadm_config = {
+            k: config[k] for k in ("build", "rhbuild") if config and k in config
+        }
+        cephadm = CephAdmin(cluster=ceph_cluster, **cephadm_config)
+        rados_obj = RadosOrchestrator(node=cephadm)
+        start_time = get_cluster_timestamp(rados_obj.node)
+        log.debug(f"Crash-check window started at {start_time}")
+        return rados_obj, start_time
+    except Exception as e:
+        log.warning(f"Failed to initialize cluster health check: {e}")
+        return None, None
+
+
+def log_cluster_health_and_check_crashes(rados_obj, start_time, check_nfs=True):
+    """
+    Log cluster health and check for crashes since start_time.
+
+    Returns:
+        True if a crash was detected, False otherwise.
+    """
+    from ceph.rados.utils import get_cluster_timestamp
+
+    if not rados_obj or not start_time:
+        log.warning("Skipping health/crash check: rados_obj or start_time missing")
+        return False
+
+    # Best-effort health dump — must not skip the crash check on failure.
+    try:
+        rados_obj.log_cluster_health()
+    except Exception as e:
+        log.error(f"log_cluster_health() failed: {e}")
+
+    try:
+        end_time = get_cluster_timestamp(rados_obj.node)
+        log.debug(
+            f"Crash-check window completed. Start time: {start_time}, "
+            f"End time: {end_time}"
+        )
+        if rados_obj.check_crash_status(
+            start_time=start_time,
+            end_time=end_time,
+            check_nfs=check_nfs,
+        ):
+            log.error("Crash detected during test window")
+            return True
+    except Exception as e:
+        log.error(f"Crash status check failed: {e}")
+    return False

--- a/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
+++ b/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
@@ -1,7 +1,12 @@
 import time
 from threading import Thread
 
-from nfs_operations import cleanup_cluster, setup_nfs_cluster
+from nfs_operations import (
+    cleanup_cluster,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
+    setup_nfs_cluster,
+)
 
 from cli.exceptions import ConfigError, OperationFailedError
 from cli.io.io import linux_untar
@@ -40,6 +45,7 @@ def run(ceph_cluster, **kw):
     nfs_mount = "/mnt/nfs"
     fs = "cephfs"
     nfs_server_name = nfs_node.hostname
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
 
     try:
         if setup:
@@ -130,6 +136,7 @@ def run(ceph_cluster, **kw):
         log.error(f"Failed to validate multiple ios and lookups : {e}")
         return 1
     finally:
+        crash_detected = log_cluster_health_and_check_crashes(rados_obj, start_time)
         if cleanup:
             log.info("Cleaning up")
             # Wait for NFS operations to stabilize before cleanup
@@ -139,3 +146,5 @@ def run(ceph_cluster, **kw):
                 clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
             )
             log.info("Cleaning up successful")
+        if crash_detected:
+            return 1

--- a/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
+++ b/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
@@ -1,7 +1,12 @@
 import time
 from threading import Thread
 
-from nfs_operations import cleanup_cluster, setup_nfs_cluster
+from nfs_operations import (
+    cleanup_cluster,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
+    setup_nfs_cluster,
+)
 
 from ceph.ceph import CommandFailed
 from cli.exceptions import ConfigError, OperationFailedError
@@ -63,6 +68,7 @@ def run(ceph_cluster, **kw):
     fs = "cephfs"
     nfs_server_name = nfs_node.hostname
     file_count = 100
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
     try:
         # Setup nfs cluster
         setup_nfs_cluster(
@@ -105,11 +111,11 @@ def run(ceph_cluster, **kw):
 
         # Perform rm while file creation and lookup is in progress
         max_total_time = 300
-        start_time = time.time()
+        wall_start = time.time()
         iteration = 0
         log.info("Performing rm while file creation and lookup in progress")
         while operations[0].is_alive() or operations[1].is_alive():
-            if time.time() - start_time > max_total_time:
+            if time.time() - wall_start > max_total_time:
                 log.error(f"Operations exceeded {max_total_time}s timeout")
                 raise OperationFailedError("Parallel operations timed out")
 
@@ -139,8 +145,11 @@ def run(ceph_cluster, **kw):
         log.error(f"Failed to validate parallel write, lookup and rm: {e}")
         return 1
     finally:
+        crash_detected = log_cluster_health_and_check_crashes(rados_obj, start_time)
         log.info("Cleaning up")
         cleanup_cluster(
             clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
         )
         log.info("Cleaning up successful")
+        if crash_detected:
+            return 1

--- a/tests/nfs/nfs_verify_read_write_operations.py
+++ b/tests/nfs/nfs_verify_read_write_operations.py
@@ -1,4 +1,9 @@
-from nfs_operations import cleanup_cluster, setup_nfs_cluster
+from nfs_operations import (
+    cleanup_cluster,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
+    setup_nfs_cluster,
+)
 
 from cli.exceptions import ConfigError, OperationFailedError
 from utility.log import Log
@@ -32,6 +37,7 @@ def run(ceph_cluster, **kw):
     nfs_mount = "/mnt/nfs"
     fs = "cephfs"
     nfs_server_name = nfs_node.hostname
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
 
     try:
         # Setup nfs cluster
@@ -196,6 +202,7 @@ def run(ceph_cluster, **kw):
         log.error(f"Failed to validate read write operations: {e}")
         return 1
     finally:
+        crash_detected = log_cluster_health_and_check_crashes(rados_obj, start_time)
         # Clean up test user if it was created
         if operation in ["verify_permission", "mv_file"]:
             try:
@@ -209,3 +216,5 @@ def run(ceph_cluster, **kw):
 
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
         log.info("Cleaning up successful")
+        if crash_detected:
+            return 1

--- a/tests/nfs/nfs_verify_stress.py
+++ b/tests/nfs/nfs_verify_stress.py
@@ -2,7 +2,12 @@ import json
 from threading import Thread
 from time import sleep
 
-from nfs_operations import cleanup_cluster, setup_nfs_cluster
+from nfs_operations import (
+    cleanup_cluster,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
+    setup_nfs_cluster,
+)
 
 from cli.ceph.ceph import Ceph
 from cli.exceptions import ConfigError
@@ -43,6 +48,7 @@ def run(ceph_cluster, **kw):
     nfs_mount = "/mnt/nfs"
     fs = "cephfs"
     nfs_server_name = [nfs_node.hostname for nfs_node in servers]
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
 
     try:
         # Setup nfs cluster
@@ -107,8 +113,9 @@ def run(ceph_cluster, **kw):
 
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
         return 1
     finally:
+        crash_detected = log_cluster_health_and_check_crashes(rados_obj, start_time)
         cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=servers)
-        pass
+        if crash_detected:
+            return 1

--- a/tests/nfs/test_file_ops_copy.py
+++ b/tests/nfs/test_file_ops_copy.py
@@ -1,6 +1,11 @@
 from threading import Thread
 
-from nfs_operations import cleanup_cluster, setup_nfs_cluster
+from nfs_operations import (
+    cleanup_cluster,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
+    setup_nfs_cluster,
+)
 
 from cli.exceptions import ConfigError, OperationFailedError
 from cli.utilities.utils import perform_lookups
@@ -69,6 +74,7 @@ def run(ceph_cluster, **kw):
         raise ConfigError("The test requires more clients than available")
 
     clients = clients[:no_clients]  # Select only the required number of clients
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
 
     try:
         # Setup nfs cluster
@@ -120,9 +126,18 @@ def run(ceph_cluster, **kw):
         log.info("Successfully completed the copy tests for files and dirs")
         return 0
 
+    except (ConfigError, OperationFailedError) as e:
+        log.error(f"Failed to complete file copy operations: {e}")
+        return 1
+    except Exception as e:
+        log.error(f"Unexpected error during file copy test: {e}")
+        return 1
     finally:
+        crash_detected = log_cluster_health_and_check_crashes(rados_obj, start_time)
         log.info("Cleaning up")
         cleanup_cluster(
             clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_nodes[0]
         )
         log.info("Cleaning up successful")
+        if crash_detected:
+            return 1

--- a/tests/nfs/test_nfs_io_operations_during_upgrade.py
+++ b/tests/nfs/test_nfs_io_operations_during_upgrade.py
@@ -11,6 +11,8 @@ from tests.nfs.nfs_operations import (
     NfsCleanupFailed,
     _get_client_specific_mount_versions,
     exports_mounts_perclient,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
     mount_retry,
     wait_for_nfs_and_mount,
 )
@@ -474,6 +476,7 @@ def run(ceph_cluster, **kw):
     nfs_wait_timeout = config.get("nfs_wait_timeout", 300)
     mount_timeout = config.get("mount_timeout", 120)
     mount_tries = config.get("mount_tries", 2)
+    installer_node = ceph_cluster.get_nodes("installer")[0]
 
     # If the setup doesn't have required number of clients, exit.
     if no_clients > len(clients):
@@ -481,8 +484,7 @@ def run(ceph_cluster, **kw):
 
     clients = clients[:no_clients]
     client = clients[0]  # Select only the required number of clients
-    installer_nodes = ceph_cluster.get_nodes("installer")
-    installer_node = installer_nodes[0] if installer_nodes else None
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
 
     # 1. pick the existing NFS cluster
     nfs_cluster_name = Ceph(client).nfs.cluster.ls()[0]
@@ -538,4 +540,7 @@ def run(ceph_cluster, **kw):
         return 0
     except Exception as e:
         log.error(f"An error occurred during NFS IO operations: {e}")
-        raise OperationFailedError(f"NFS IO operations failed: {e}")
+        return 1
+    finally:
+        if log_cluster_health_and_check_crashes(rados_obj, start_time):
+            return 1

--- a/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
+++ b/tests/nfs/test_nfs_multiple_operations_for_upgrade.py
@@ -1,7 +1,12 @@
 from concurrent.futures import ThreadPoolExecutor
 
 from cli.exceptions import ConfigError, OperationFailedError
-from tests.nfs.nfs_operations import cleanup_cluster, setup_nfs_cluster
+from tests.nfs.nfs_operations import (
+    cleanup_cluster,
+    init_cluster_health_check,
+    log_cluster_health_and_check_crashes,
+    setup_nfs_cluster,
+)
 from utility.log import Log
 
 log = Log(__name__)
@@ -176,6 +181,8 @@ def run(ceph_cluster, **kw):
     if ha:
         nfs_server_name = [nfs_node.hostname for nfs_node in nfs_nodes[0:2]]
 
+    rados_obj, start_time = init_cluster_health_check(ceph_cluster, config)
+
     try:
         if operation == "before_upgrade":
             # Create NFS Cluster
@@ -341,8 +348,17 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         raise ConfigError(f"test_nfs_multiple_operations_for_upgrade: {e} failed")
     finally:
+        crash_detected = log_cluster_health_and_check_crashes(rados_obj, start_time)
         if operation == "after_upgrade":
             # Cleanup NFS Cluster
             cleanup_cluster(
                 clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node
             )
+        elif crash_detected:
+            log.warning(
+                "Crash detected during 'before_upgrade' phase. "
+                "NFS cluster intentionally left alive for after_upgrade step. "
+                "Manual cleanup may be required if the upgrade pipeline is aborted."
+            )
+        if crash_detected:
+            return 1


### PR DESCRIPTION
Enhancing the upgrade tests to have health and crash checks for nfs upgrades.

logs: http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/upgrades/checks/nfs/tier1_nfs_ganesha_upgrade_8x_to_9x_latest/