### PR TITLE
Fix flake8 F811: duplicate NVMeoF subsystem add_network/del_network

### DIFF
--- a/ceph/nvmeof/cli/v1/subsystem.py
+++ b/ceph/nvmeof/cli/v1/subsystem.py
@@ -35,11 +35,3 @@ class Subsystem:
 
     def list(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "list", **kwargs)
-
-    def add_network(self, **kwargs):
-        """Add a network mask to a subsystem (auto-create listeners in subnet)."""
-        return self.base.run_nvme_cli(self.name, "add_network", **kwargs)
-
-    def del_network(self, **kwargs):
-        """Delete a network mask from a subsystem."""
-        return self.base.run_nvme_cli(self.name, "del_network", **kwargs)

--- a/ceph/nvmeof/cli/v2/subsystem.py
+++ b/ceph/nvmeof/cli/v2/subsystem.py
@@ -44,11 +44,3 @@ class Subsystem:
 
     def list(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "list", **kwargs)
-
-    def add_network(self, **kwargs):
-        """Add a network mask to a subsystem (auto-create listeners in subnet)."""
-        return self.base.run_nvme_cli(self.name, "add_network", **kwargs)
-
-    def del_network(self, **kwargs):
-        """Delete a network mask from a subsystem."""
-        return self.base.run_nvme_cli(self.name, "del_network", **kwargs)


### PR DESCRIPTION
## Summary
- Remove duplicate `add_network` / `del_network` methods in `ceph/nvmeof/cli/v1/subsystem.py` and `ceph/nvmeof/cli/v2/subsystem.py`
- These duplicates landed when #6042 and #6047 both added the same CLI wrappers; flake8 F811 now fails tox on subsequent PRs (e.g. https://github.com/red-hat-storage/cephci/actions/runs/30520886776/job/90800783232)

## Test plan
- [x] `python3 -m flake8 ceph/nvmeof/cli/v1/subsystem.py ceph/nvmeof/cli/v2/subsystem.py` passes locally
- [x] Confirm tox flake8 job is green on this PR
- [x] No functional change — keep the earlier method definitions from #6047
