### PR TITLE
[Test] Validate the ceph-smb-ctl remote control 

### DIFF
--- a/suites/tentacle/smb/tier-1-smb-remote-control.yaml
+++ b/suites/tentacle/smb/tier-1-smb-remote-control.yaml
@@ -1,0 +1,209 @@
+tests:
+  - test:
+      name: setup pre-requisites
+      desc: Install software pre-requisites for cluster deployment
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Deploy cluster using cephadm
+      desc: Bootstrap and deploy services
+      module: test_cephadm.py
+      polarion-id: CEPH-83573713
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: configure client
+      desc: Configure the Linux SMB client
+      module: test_client.py
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - samba-client
+          - cifs-utils
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Deploy an SMB cluster with the remote-control service
+      desc: Create SMB shares and enable local Unix-socket remote control.
+      module: smb_remote_control_setup.py
+      polarion-id: CEPH-83632924
+      abort-on-fail: true
+      config:
+        file_type: yaml
+        file_mount: /tmp
+        spec:
+          - resource_type: ceph.smb.cluster
+            cluster_id: smb1
+            auth_mode: user
+            user_group_settings:
+              - { source_type: resource, ref: ug1 }
+            placement:
+              label: smb
+            remote_control:
+              locally_enabled: true
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            values:
+              users:
+                - { name: user1, password: passwd }
+              groups: []
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: smb1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+
+  - test:
+      name: Verify the local remote-control configuration
+      desc: Verify remote_control.locally_enabled using ceph smb show.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632925
+      config:
+        smb_cluster_id: smb1
+        operation: verify_configuration
+
+  - test:
+      name: Verify the remotectl sidecar container
+      desc: Verify the remotectl sidecar using podman ps.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632926
+      config:
+        smb_cluster_id: smb1
+        operation: verify_sidecar
+
+  - test:
+      name: List ceph-smb-ctl remote-control commands
+      desc: Verify that the Ceph container provides the expected ceph-smb-ctl commands.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632927
+      config:
+        smb_cluster_id: smb1
+        operation: help
+
+  - test:
+      name: Get SMB server information using the local Unix socket
+      desc: Validate ceph-smb-ctl info against the local SMB service.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632928
+      config:
+        smb_cluster_id: smb1
+        operation: info
+
+  - test:
+      name: Get SMB status using the local Unix socket
+      desc: Validate the JSON status returned by ceph-smb-ctl.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632929
+      config:
+        smb_cluster_id: smb1
+        operation: status
+
+  - test:
+      name: Select an SMB cluster using ceph-smb-ctl
+      desc: Validate explicit local Unix-socket selection with the --cluster option.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632930
+      config:
+        smb_cluster_id: smb1
+        operation: status
+        select_cluster: true
+
+  - test:
+      name: Dump the SMB configuration using the local Unix socket
+      desc: Validate that ceph-smb-ctl can retrieve the Samba configuration.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632931
+      config:
+        smb_cluster_id: smb1
+        operation: config_dump
+        config_format: samba
+
+  - test:
+      name: Get and set an SMB subsystem debug level
+      desc: Change the smbd debug level, verify it, and restore the original value.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632932
+      config:
+        smb_cluster_id: smb1
+        operation: debug_level
+        subsystem: smbd
+        debug_level: 5
+
+  - test:
+      name: Terminate an SMB client connection using ceph-smb-ctl
+      desc: Mount a share and terminate that client connection by IP address.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632933
+      config:
+        smb_cluster_id: smb1
+        operation: kill_client_connection
+        cifs_mount_point: /mnt/ceph-smb-ctl
+
+  - test:
+      name: Close an active SMB share using ceph-smb-ctl
+      desc: Validate close-share while a client is connected to the selected share.
+      module: smb_ceph_smb_ctl_operations.py
+      polarion-id: CEPH-83632934
+      config:
+        smb_cluster_id: smb1
+        operation: close_share
+        cifs_mount_point: /mnt/ceph-smb-ctl
+        smb_cluster_cleanup: true

--- a/tests/smb/smb_ceph_smb_ctl_operations.py
+++ b/tests/smb/smb_ceph_smb_ctl_operations.py
@@ -1,0 +1,278 @@
+import json
+import shlex
+
+from smb_operations import (
+    check_smb_cluster,
+    get_smb_shares,
+    smb_cifs_mount,
+    smb_cleanup,
+    verify_smb_service,
+)
+
+from ceph.waiter import WaitUntil
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+COMMANDS = (
+    "info",
+    "status",
+    "close-share",
+    "kill-client-connection",
+    "config-dump",
+    "get-debug-level",
+    "set-debug-level",
+)
+
+
+def _ceph_smb_ctl(node, args, cluster_id=None):
+    """Run ceph-smb-ctl against a local Unix socket.
+
+    Args:
+        node: Node on which cephadm shell is invoked.
+        args: ceph-smb-ctl command and arguments.
+        cluster_id: SMB cluster ID used to select a local Unix socket.
+    """
+    ctl_args = []
+    if cluster_id:
+        ctl_args.extend(["--cluster", cluster_id])
+
+    quoted_args = " ".join(shlex.quote(str(arg)) for arg in [*ctl_args, *args])
+    cmd = f"cephadm shell -- ceph-smb-ctl {quoted_args}"
+    log.info("Running ceph-smb-ctl on %s: %s", node.hostname, cmd)
+    return node.exec_command(sudo=True, cmd=cmd)[0].strip()
+
+
+def _validate_json(output, command):
+    """Return parsed ceph-smb-ctl JSON output."""
+    try:
+        return json.loads(output)
+    except (TypeError, json.JSONDecodeError) as error:
+        raise OperationFailedError(
+            f"ceph-smb-ctl {command} did not return valid JSON: {output}"
+        ) from error
+
+
+def _verify_configuration(installer, cluster_id):
+    """Verify locally_enabled in the applied SMB cluster resource."""
+    cmd = f"cephadm shell -- ceph smb show ceph.smb.cluster.{shlex.quote(cluster_id)}"
+    output = installer.exec_command(sudo=True, cmd=cmd)[0].strip()
+    resource = _validate_json(output, "ceph smb show")
+    if isinstance(resource, list):
+        resources = resource
+        resource = next(
+            (
+                item
+                for item in resources
+                if item.get("resource_type") == "ceph.smb.cluster"
+                and item.get("cluster_id") == cluster_id
+            ),
+            {},
+        )
+    elif "resources" in resource:
+        resources = resource["resources"]
+        resource = next(
+            (
+                item
+                for item in resources
+                if item.get("resource_type") == "ceph.smb.cluster"
+                and item.get("cluster_id") == cluster_id
+            ),
+            {},
+        )
+    if resource.get("remote_control", {}).get("locally_enabled") is not True:
+        raise OperationFailedError(
+            f"remote_control.locally_enabled is not true for {cluster_id}: {output}"
+        )
+
+
+def _verify_sidecar(smb_node):
+    """Verify the remotectl sidecar using podman."""
+    output, _ = smb_node.exec_command(sudo=True, cmd="podman ps | grep remotectl")
+    output = output.strip()
+    if "remotectl" not in output:
+        raise OperationFailedError(
+            f"Remote-control sidecar is not running on {smb_node.hostname}"
+        )
+
+
+def _mount_client(smb_node, client, share, config):
+    smb_cifs_mount(
+        smb_node,
+        client,
+        share,
+        config.get("smb_user_name", "user1"),
+        config.get("smb_user_password", "passwd"),
+        config.get("auth_mode", "user"),
+        config.get("domain_realm"),
+        config.get("cifs_mount_point", "/mnt/smb"),
+    )
+
+
+def _unmount_client(client, mount_point):
+    client.exec_command(sudo=True, cmd=f"umount {shlex.quote(mount_point)}")
+
+
+def _test_help(command_node, cluster_id):
+    output = _ceph_smb_ctl(command_node, ["--help"], cluster_id)
+    missing = [command for command in COMMANDS if command not in output]
+    if missing:
+        raise OperationFailedError(
+            f"ceph-smb-ctl --help is missing commands: {', '.join(missing)}"
+        )
+
+
+def _test_debug_level(command_node, cluster_id, config):
+    subsystem = config.get("subsystem", "smbd")
+    requested_level = str(config.get("debug_level", 5))
+    original = _ceph_smb_ctl(command_node, ["get-debug-level", subsystem], cluster_id)
+    try:
+        _ceph_smb_ctl(
+            command_node,
+            ["set-debug-level", subsystem, requested_level],
+            cluster_id,
+        )
+        current = _ceph_smb_ctl(
+            command_node, ["get-debug-level", subsystem], cluster_id
+        )
+        if requested_level not in current:
+            raise OperationFailedError(
+                f"Debug level for {subsystem} was not set to {requested_level}: "
+                f"{current}"
+            )
+    finally:
+        # The get command can return either a bare level or a JSON response.
+        try:
+            original_level = str(json.loads(original).get("level"))
+        except (AttributeError, json.JSONDecodeError):
+            original_level = original.strip()
+        if original_level and original_level != "None":
+            _ceph_smb_ctl(
+                command_node,
+                ["set-debug-level", subsystem, original_level],
+                cluster_id,
+            )
+
+
+def _test_kill_client(command_node, smb_node, client, share, cluster_id, config):
+    mount_point = config.get("cifs_mount_point", "/mnt/smb")
+    _mount_client(smb_node, client, share, config)
+    try:
+        status = _ceph_smb_ctl(command_node, ["status"], cluster_id)
+        if client.ip_address not in status:
+            raise OperationFailedError(
+                f"Client {client.ip_address} is not present in SMB status"
+            )
+        _ceph_smb_ctl(
+            command_node,
+            ["kill-client-connection", client.ip_address],
+            cluster_id,
+        )
+        for attempt in WaitUntil(timeout=30, interval=5):
+            status = _ceph_smb_ctl(command_node, ["status"], cluster_id)
+            if client.ip_address not in status:
+                break
+        if attempt.expired:
+            raise OperationFailedError(
+                f"Client {client.ip_address} remains connected after kill request"
+            )
+    finally:
+        _unmount_client(client, mount_point)
+
+
+def _test_close_share(command_node, smb_node, client, share, cluster_id, config):
+    """Invoke close-share while the selected share has an active client."""
+    mount_point = config.get("cifs_mount_point", "/mnt/smb")
+    _mount_client(smb_node, client, share, config)
+    try:
+        status = _ceph_smb_ctl(command_node, ["status"], cluster_id)
+        if share not in status:
+            raise OperationFailedError(
+                f"Share {share} is not present in SMB status before close-share"
+            )
+        _ceph_smb_ctl(command_node, ["close-share", share], cluster_id)
+    finally:
+        _unmount_client(client, mount_point)
+
+
+def run(ceph_cluster, **kw):
+    """Validate ceph-smb-ctl over a local Unix socket."""
+    config = kw.get("config") or {}
+    operation = config.get("operation")
+    cluster_id = config.get("smb_cluster_id")
+    if not operation:
+        raise ConfigError("Mandatory config 'operation' not provided")
+    if not cluster_id:
+        raise ConfigError("Mandatory config 'smb_cluster_id' not provided")
+
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    smb_nodes = ceph_cluster.get_nodes("smb")
+    clients = ceph_cluster.get_nodes(role="client")
+    if not smb_nodes:
+        raise ConfigError("No node with the 'smb' role is available")
+
+    smb_node = smb_nodes[0]
+    command_node = smb_node
+    command_cluster_id = cluster_id if config.get("select_cluster") else None
+
+    check_smb_cluster(installer, cluster_id)
+    verify_smb_service(installer, service_name="smb")
+    shares = get_smb_shares(installer, cluster_id)
+
+    try:
+        if operation == "verify_configuration":
+            _verify_configuration(installer, cluster_id)
+        elif operation == "verify_sidecar":
+            _verify_sidecar(smb_node)
+        elif operation == "help":
+            _test_help(command_node, command_cluster_id)
+        elif operation in ("info", "status"):
+            output = _ceph_smb_ctl(command_node, [operation], command_cluster_id)
+            _validate_json(output, operation)
+        elif operation == "config_dump":
+            output = _ceph_smb_ctl(
+                command_node,
+                ["config-dump", config.get("config_format", "samba")],
+                command_cluster_id,
+            )
+            if not output:
+                raise OperationFailedError("ceph-smb-ctl config-dump returned no data")
+        elif operation == "debug_level":
+            _test_debug_level(command_node, command_cluster_id, config)
+        elif operation == "kill_client_connection":
+            if not clients:
+                raise ConfigError("No node with the 'client' role is available")
+            if not shares:
+                raise ConfigError(f"SMB cluster {cluster_id} has no shares")
+            _test_kill_client(
+                command_node,
+                smb_node,
+                clients[0],
+                shares[0],
+                command_cluster_id,
+                config,
+            )
+        elif operation == "close_share":
+            if not clients:
+                raise ConfigError("No node with the 'client' role is available")
+            if not shares:
+                raise ConfigError(f"SMB cluster {cluster_id} has no shares")
+            _test_close_share(
+                command_node,
+                smb_node,
+                clients[0],
+                shares[0],
+                command_cluster_id,
+                config,
+            )
+        else:
+            raise ConfigError(f"Unsupported ceph-smb-ctl operation: {operation}")
+    except Exception as error:
+        log.error("ceph-smb-ctl operation %s failed: %s", operation, error)
+        return 1
+    finally:
+        if config.get("smb_cluster_cleanup"):
+            smb_cleanup(installer, shares, cluster_id)
+    return 0

--- a/tests/smb/smb_remote_control_setup.py
+++ b/tests/smb/smb_remote_control_setup.py
@@ -1,0 +1,105 @@
+from smb_operations import deploy_smb_service_declarative, smbclient_check_shares
+
+from cli.exceptions import ConfigError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def _parse_spec(spec):
+    """Extract values needed by the SMB deployment helper."""
+    values = {"shares": [], "subvolumes": [], "domain_realm": None}
+    for resource in spec:
+        resource_type = resource["resource_type"]
+        if resource_type == "ceph.smb.cluster":
+            values.update(
+                {
+                    "cluster_id": resource["cluster_id"],
+                    "auth_mode": resource["auth_mode"],
+                    "domain_realm": resource.get("domain_settings", {}).get("realm"),
+                }
+            )
+            if not resource.get("remote_control", {}).get("locally_enabled"):
+                raise ConfigError(
+                    "SMB spec must set remote_control.locally_enabled to true"
+                )
+        elif resource_type == "ceph.smb.usersgroups":
+            user = resource["values"]["users"][0]
+            values.update({"username": user["name"], "password": user["password"]})
+        elif resource_type == "ceph.smb.join.auth":
+            values.update(
+                {
+                    "username": resource["auth"]["username"],
+                    "password": resource["auth"]["password"],
+                }
+            )
+        elif resource_type == "ceph.smb.share":
+            cephfs = resource["cephfs"]
+            values.update(
+                {
+                    "volume": cephfs["volume"],
+                    "subvolume_group": cephfs["subvolumegroup"],
+                }
+            )
+            values["subvolumes"].append(cephfs["subvolume"])
+            values["shares"].append(resource["share_id"])
+
+    required = (
+        "cluster_id",
+        "auth_mode",
+        "username",
+        "password",
+        "volume",
+        "subvolume_group",
+    )
+    missing = [name for name in required if name not in values]
+    if missing:
+        raise ConfigError(f"SMB spec is missing required values: {', '.join(missing)}")
+    return values
+
+
+def run(ceph_cluster, **kw):
+    """Deploy SMB with local Unix-socket remote-control support."""
+    config = kw.get("config") or {}
+    file_type = config.get("file_type")
+    spec = config.get("spec")
+    if not file_type:
+        raise ConfigError("Mandatory config 'file_type' not provided")
+    if not spec:
+        raise ConfigError("Mandatory config 'spec' not provided")
+
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    smb_nodes = ceph_cluster.get_nodes("smb")
+    clients = ceph_cluster.get_nodes(role="client")
+    if not smb_nodes:
+        raise ConfigError("No node with the 'smb' role is available")
+    if not clients:
+        raise ConfigError("No node with the 'client' role is available")
+
+    values = _parse_spec(spec)
+
+    try:
+        deploy_smb_service_declarative(
+            installer,
+            values["volume"],
+            values["subvolume_group"],
+            values["subvolumes"],
+            values["cluster_id"],
+            config.get("smb_subvolume_mode", "0777"),
+            file_type,
+            spec,
+            config.get("file_mount", "/tmp"),
+        )
+        smbclient_check_shares(
+            smb_nodes,
+            clients[0],
+            values["shares"],
+            values["username"],
+            values["password"],
+            values["auth_mode"],
+            values["domain_realm"],
+        )
+    except Exception as error:
+        log.error("Failed to set up SMB remote control: %s", error)
+        return 1
+    return 0


### PR DESCRIPTION
# Description

SMB Remote Control (ceph-smb-ctl) feature using local remote: 

- Enable local SMB Remote Control
- Verify local Remote Control configuration
- Verify remotectl sidecar container
- Verify ceph-smb-ctl command discovery
- Retrieve SMB server information over the local Unix socket
- Retrieve SMB status over the local Unix socket
- Select an SMB cluster explicitly
- Retrieve the Samba configuration
- Get and set the Samba debug level
- Terminate an SMB client connection by IP address
- Close an active SMB share