### PR TITLE
Add IBM Ceph 9.2 NVMeoF holistic suites and IBM cloud BM bug coverage

### DIFF
--- a/ceph/nvmeof/archieve/nvmeof/nvme_cli.py
+++ b/ceph/nvmeof/archieve/nvmeof/nvme_cli.py
@@ -139,7 +139,8 @@ class NVMeCLI(Cli):
         return self.execute(cmd="nvme disconnect-all", sudo=True)
 
     def connect_all(self, **kwargs):
-        """Connects all controllers connected to subsystems."""
+        """Connects all controllers to discovered subsystems."""
+        kwargs.setdefault("persistent", True)
         return self.execute(
             cmd=f"nvme connect-all {config_dict_to_string(kwargs)}", sudo=True
         )

--- a/ceph/nvmeof/initiators/linux/nvme_cli.py
+++ b/ceph/nvmeof/initiators/linux/nvme_cli.py
@@ -15,13 +15,71 @@ class NVMeCLI(Cli):
     """
 
     def configure(self):
-        """Install NVME CLI."""
+        """Install NVMe CLI and enable boot-time fabrics + autoconnect.
+
+        Customer-like initiator reboot reconnect requires:
+          1. ``nvme-fabrics`` loaded at boot (modules-load.d)
+          2. ``/etc/nvme/discovery.conf`` populated (done on connect)
+          3. ``nvmf-autoconnect.service`` enabled
+          4. ``nvme connect-all --persistent`` (see ``connect_all``)
+        """
         configure_cmds = [
             ("yum install -y nvme-cli fio", True),
             ("modprobe nvme-fabrics", True),
+            (
+                "bash -c 'echo nvme-fabrics > /etc/modules-load.d/nvme-fabrics.conf'",
+                True,
+            ),
+            ("mkdir -p /etc/nvme", True),
         ]
         for cmd in configure_cmds:
             self.execute(*cmd)
+        self.enable_nvmf_autoconnect()
+
+    def enable_nvmf_autoconnect(self):
+        """Enable systemd unit that runs connect-all at boot from discovery.conf."""
+        host = getattr(self, "node", None) or getattr(self, "ctx", None)
+        hostname = getattr(host, "hostname", host)
+        try:
+            self.execute(
+                "systemctl enable nvmf-autoconnect.service",
+                True,
+            )
+            LOG.info("Enabled nvmf-autoconnect.service on %s", hostname)
+        except Exception as err:
+            LOG.warning(
+                "Could not enable nvmf-autoconnect.service on %s: %s",
+                hostname,
+                err,
+            )
+
+    def configure_discovery_conf(self, traddr, trsvcid=8009, transport="tcp"):
+        """
+        Persist discovery controller endpoint in /etc/nvme/discovery.conf.
+
+        Used by ``nvmf-autoconnect.service`` (``nvme connect-all --context=autoconnect``)
+        so namespaces reappear after initiator reboot without a manual discover/connect.
+
+        Args:
+            traddr: Discovery / gateway IP
+            trsvcid: Discovery port (default 8009)
+            transport: Fabric transport (default tcp)
+        """
+        if not traddr:
+            raise ValueError("traddr is required for discovery.conf")
+        line = f"--transport={transport} --traddr={traddr} --trsvcid={trsvcid}"
+        self.execute("mkdir -p /etc/nvme", True)
+        # Idempotent append of discovery controller endpoint
+        self.execute(
+            (
+                'bash -c "'
+                f"grep -qxF '{line}' /etc/nvme/discovery.conf 2>/dev/null || "
+                f"echo '{line}' >> /etc/nvme/discovery.conf\""
+            ),
+            True,
+        )
+        LOG.info("Ensured /etc/nvme/discovery.conf contains: %s", line)
+        return line
 
     def gen_dhchap_key(self, **kwargs):
         """Generates the TLS key.
@@ -61,6 +119,7 @@ class NVMeCLI(Cli):
                 trsvcid: Transport port number  # Transport port number
                 nqn: Subsystem NQN Id           # Subsystem NQN
         """
+        kwargs.setdefault("persistent", True)
         return self.execute(
             cmd=f"nvme connect {config_dict_to_string(kwargs)}",
             sudo=True,
@@ -149,7 +208,24 @@ class NVMeCLI(Cli):
         return self.execute(cmd="nvme disconnect-all", sudo=True)
 
     def connect_all(self, **kwargs):
-        """Connects all controllers connected to subsystems."""
+        """Connects all controllers to discovered subsystems.
+
+        Always includes ``--persistent`` so connections are recorded for
+        reconnect after initiator reboot / nvme connect-all -P semantics.
+        Pass ``persistent=False`` to opt out for a specific call.
+
+        When ``traddr`` is provided, also updates ``/etc/nvme/discovery.conf``
+        and ensures ``nvmf-autoconnect.service`` is enabled for boot reconnect.
+        """
+        kwargs.setdefault("persistent", True)
+        traddr = kwargs.get("traddr")
+        if traddr:
+            self.configure_discovery_conf(
+                traddr=traddr,
+                trsvcid=kwargs.get("trsvcid", 8009),
+                transport=kwargs.get("transport", "tcp"),
+            )
+            self.enable_nvmf_autoconnect()
         return self.execute(
             cmd=f"nvme connect-all {config_dict_to_string(kwargs)}", sudo=True
         )

--- a/conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
+++ b/conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
@@ -1,0 +1,82 @@
+#===============================================================================================
+# Cluster configuration for IBM Ceph 9.2 NVMeoF holistic / customer-like system test
+#
+# Topology (12 nodes):
+#   node1-3     : mon/mgr (+ OSDs on node2/3)
+#   node4-5     : OSD + MDS/RGW + NVMeoF GW (2 GWs colocated with OSDs)
+#   node6-7     : 2 dedicated NVMeoF GWs
+#   node8       : spare NVMeoF GW host for load-balancing scale-up
+#   node9-12    : 4 NVMe initiator / FIO clients
+#
+# Initial GW placement: node4, node5, node6, node7 (node8 used only for LB scale-up)
+#
+# OSD disks sized for many 500G NVMeoF namespaces (12 x 1000G per OSD node)
+# Suite: suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+# Inventory: conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml (or later)
+#===============================================================================================
+globals:
+  - ceph-cluster:
+      name: ceph
+      vm-size: ci.standard.xl
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 12
+        disk-size: 1000
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 12
+        disk-size: 1000
+      node4:
+        role:
+          - mds
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 12
+        disk-size: 1000
+      node5:
+        role:
+          - mds
+          - osd
+          - rgw
+          - nvmeof-gw
+        no-of-volumes: 12
+        disk-size: 1000
+      node6:
+        id: node6
+        role:
+          - nvmeof-gw
+      node7:
+        id: node7
+        role:
+          - nvmeof-gw
+      node8:
+        id: node8
+        role:
+          - nvmeof-gw
+      node9:
+        id: node9
+        role:
+          - client
+      node10:
+        id: node10
+        role:
+          - client
+      node11:
+        id: node11
+        role:
+          - client
+      node12:
+        id: node12
+        role:
+          - client

--- a/suites/tentacle/nvmeof/HOLISTIC_9-2_COVERAGE.md
+++ b/suites/tentacle/nvmeof/HOLISTIC_9-2_COVERAGE.md
@@ -1,0 +1,125 @@
+# IBM Ceph 9.2 NVMeoF Holistic Coverage Map
+
+**Holistic suites:**  
+- Smoke: `tier-2_nvmeof_9-2_holistic_smoke.yaml` (`fio_runtime: 300`)  
+- Full: `tier-2_nvmeof_9-2_holistic_cross-feature.yaml` (`fio_runtime: 600`)  
+- Soak: `tier-2_nvmeof_9-2_holistic_soak.yaml` (`fio_runtime: 1800` + backup restore burst)  
+
+**Conf:** `conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml`  
+**Orchestrator:** `tests/nvmeof/test_ceph_nvmeof_holistic_io.py`  
+**Workload filter:** `HOLISTIC_9-2_WORKLOADS.md` (customer apps → FIO personas)  
+
+Under-load: OLTP / VM+crc32c / AI-scan / backup-media personas; `assert_listeners` after LB `scale_up`.
+
+This is a **customer-like system / soak** suite. It does **not** replace every tentacle NVMeoF suite. Use this matrix to decide what still needs companion runs.
+
+Legend:
+
+| Tag | Meaning |
+|-----|---------|
+| **H-full** | Exercised end-to-end in holistic (configure + validate/IO) |
+| **H-partial** | Present but thinner than the dedicated suite |
+| **Companion** | Keep running the listed suite(s); not suitable for standing “all-features” env |
+
+---
+
+## ISCE / RFE → holistic status
+
+| Item | Status | Holistic coverage | Companion suite(s) |
+|------|--------|-------------------|--------------------|
+| ISCE-2203 Auto-add listeners | H-partial | Phase 2 listeners + day2 `assert_listeners` after LB scale_up | `tier-2_nvmeof_e2e_refresh-network.yaml` |
+| ISCE-3542 DHCHAP key per host | H-full | Phase 4d same-phase key create + auth FIO; cnode5 also configured | `tier-2_nvmeof_9-1_feature.yaml`, inbandauth suites |
+| ISCE-2205 GW locale identification | Companion | — | *(no dedicated tentacle suite found)* |
+| ISCE-1424 Performance monitor | Companion | — | *(no dedicated suite; QoS/IO stats partial in day2)* |
+| ISCE-2122 Failover time | H-partial | day2 `ha_failover` under IO | `tier-1_nvmeof_ha_sanity.yaml`, `tier-2_nvmeof_4nodes_gateway_ha_tests.yaml` |
+| ISCE-2771 CSI driver | Companion | — (not DS) | out of cephci NVMeoF suites |
+| ISCE-2772 Metadata pool automation | H-full | `nvmeof_metadata` pos_args (not rbd) | sanity / gateway deploy suites |
+| ISCE-2682 Initiator interop | Companion | — | platform / interop outside this suite |
+| ISCE-3027 SPDK CRC reuse | Companion | — | *(no dedicated suite)* |
+| 3127 RADOS namespace in GWs | H-full | cnode7 + tenant FIO | `tier-2_nvmeof_9-1_feature.yaml` |
+| ISCE-3333 SPDK 25.09 | Companion | — | upgrade / build pipeline |
+| ISCE-2117 NVMEoF Cancel | Companion | — | *(no dedicated suite)* |
+| ISCE-2121 Read-only NS | H-full | Phase 4c `test_ceph_nvmeof_readonly_ns.py` | `tier-2_nvmeof_functional_Regression.yaml` |
+| ISCE-2119 4K namespaces | Companion | — | *(no dedicated suite found)* |
+| ISCE-2086 NS reservations | H-full | Phase 4 lifecycle + Phase 4b multi-init types | `tier-2_nvmeof_e2e_ns-reservation.yaml` |
+| ISCE-822 / Ceph CLI | H-partial | via gateway / masking / qos / resize CLIs | `tier-2_nvmeof_gateway_operations.yaml` |
+| ISCE-1885 Resize workflow | H-partial | day2 `resize` under IO | `tier-2_nvmeof_functional_Regression.yaml` (ns_resize) |
+| 1 GW per node restriction | H-partial | topology assumes 1 GW role/node | cephadm / neg placement tests |
+| Stretch Cluster HA | Companion | — | stretch / multi-site suites |
+| Scale and Longevity | Companion | smoke suite `fio_runtime: 300`; full `600` / soak `1800` | tier-3 scale suites |
+| Auto Namespace Load Balancing | H-full | day2 scale_down/up | `tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml` |
+| In-band authentication | H-full | cnode5 + Phase 4d DHCHAP FIO | inbandauth suites |
+| Per-namespace masking | H-full | Phase 3 setup + day2 visibility churn | `tier-2_nvmeof_e2e_ns-masking.yaml`, `tier-2_8-1-nvmeof_cross-feature.yaml` |
+| Upgrade Paths | Companion | — | `tier-2_nvmeof_*upgrade*.yaml` |
+| VMware vSphere Plugin | Companion | — | VMware client suites |
+| Dashboard multi-NS workflow | Companion | — | dashboard suites |
+| Events and Alerting | Companion | intentional break | `tier-2_nvmeof-alerts_health-checks-events.yaml` |
+| Multi-tenancy | H-partial | tenant ACL/masking/auth partition | masking + inbandauth + gwgroup suites |
+| FC → NVMe/TCP migration | Companion | — | *(no dedicated suite)* |
+| Backup ISV / SOS / call-home | Companion | — | *(no dedicated suite)* |
+| QoS | H-full | day2 `qos_validate_io` (set + iostat validate + relax) | `tier-2_nvmeof_qos_sanity_tests.yaml` |
+| Colocated GW + OSD | H-full | node4/node5 in conf | functional regression colocated TCs |
+| Multi-client realistic FIO | H-full | Phase 5 under-load (+ crc32c integrity client) | sanity / functional |
+| Initiator reboot autoconnect | H-full | Phase 4.5 `--persistent` + discovery.conf + nvmf-autoconnect; no manual reconnect | `tier-3_nvmeof_restart_operations.yaml` (manual reconnect path) |
+
+---
+
+## Tentacle suite folder → holistic disposition
+
+| Suite | Disposition |
+|-------|-------------|
+| `tier-1_nvmeof_sanity.yaml` | Companion (basic E2E depth) |
+| `tier-1_nvmeof_ha_sanity.yaml` | Companion (HA depth) |
+| `tier-1_nvmeof_plugin_test_bed.yaml` | Pattern borrowed (no cleanup) |
+| `tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml` | Companion (multi-group) |
+| `tier-2_8-1-nvmeof_cross-feature.yaml` | Pattern borrowed; masking covered in holistic |
+| `tier-2_nvmeof_9-2_holistic_cross-feature.yaml` | **Full holistic** |
+| `tier-2_nvmeof_9-2_holistic_smoke.yaml` | **Smoke holistic** (same conf) |
+| `tier-2_nvmeof_9-2_holistic_soak.yaml` | **Soak holistic** (1800s personas + restore burst) |
+| `tier-2_nvmeof_9-1_feature.yaml` | Companion depth; RADOS/DHCHAP also in holistic |
+| `tier-2_nvmeof_e2e_ns-masking.yaml` | Companion depth; H-full core in holistic |
+| `tier-2_nvmeof_e2e_ns-reservation.yaml` | Companion depth; H-full core + multi-init in holistic |
+| `tier-2_nvmeof_qos_sanity_tests.yaml` | Companion depth; H-full core via `qos_validate_io` |
+| `tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml` | Companion depth; H-full core scale story |
+| `tier-2_nvmeof_4nodes_gateway_ha_tests.yaml` | Companion (HA matrix / mTLS / tools) |
+| `tier-2_nvmeof_4-nvmeof-gwgroup_inbandauth*.yaml` | Companion (multi-group auth + HA) |
+| `tier-2_nvmeof_functional_Regression.yaml` | Companion (readonly/resize/data integrity depth) |
+| `tier-2_nvmeof_gateway_operations.yaml` | Companion (CLI OMAP matrix) |
+| `tier-2_nvmeof_e2e_refresh-network.yaml` | Companion (baremetal dual-NIC) |
+| `tier-2_nvmeof-alerts_health-checks-events.yaml` | Companion (destructive alerts) |
+| `tier-2_nvmeof_hugepages_operations.yaml` | Companion |
+| `tier-2_nvmeof_rest_sanity.yaml` | Companion |
+| `tier-2_nvmeof_rbd_mirror.yaml` | Companion (dual cluster) |
+| `tier-2_nvmeof_e2e_fips.yaml` | Companion |
+| `tier-2_nvmeof_*upgrade*.yaml` / b2b | Companion |
+| `tier-2_nvmeof_16K_namespace_masking_*.yaml` | Companion (scale extreme) |
+| All `tier-3_*` scale / restart / operational | Companion |
+| All `tier-4_*` neg / ns ops | Companion |
+
+---
+
+## Holistic phase checklist
+
+| Phase | What |
+|-------|------|
+| 0 | prereq + full Ceph (mon/mgr/osd/mds/rgw) + 4 clients |
+| 1 | `rbd` data + `nvmeof_metadata` + RADOS NS + NVMeoF on node4–7 |
+| 2 | 8 tenant subsystems (ACL mix, inband shell, RADOS, 100G NS) |
+| 3 | NS masking setup |
+| 4 | Reservation lifecycle |
+| 4b | Multi-initiator reservation types |
+| 4c | Read-only namespaces |
+| 4d | DHCHAP per-host authenticated FIO (same-phase keys) |
+| 4e | Real DB engines on NVMe mounts (PG/MySQL/MariaDB/Mongo/Redis[/Cassandra]) |
+| 4.5 | Initiator reboot + `nvmf-autoconnect` (UUIDs return without manual discover/connect) |
+| 5 | Customer FIO personas (OLTP/VM/AI/backup) + day2 (QoS, visibility, resize, LB + listener assert, HA; soak: fio_burst) |
+
+---
+
+## How to use
+
+- **CI / PR gate:** smoke suite.
+- **Release system qualification:** full suite; **soak** for longevity + restore burst.
+- **Customer workload mapping:** `HOLISTIC_9-2_WORKLOADS.md`.
+- **Feature depth / regressions:** companion suites from the tables above.
+- **Do not expect** holistic alone to gate upgrades, FIPS, mirror, alerts, 16K scale, VMware, CSI, or Dashboard.

--- a/suites/tentacle/nvmeof/HOLISTIC_9-2_WORKLOADS.md
+++ b/suites/tentacle/nvmeof/HOLISTIC_9-2_WORKLOADS.md
@@ -1,0 +1,109 @@
+# IBM Ceph 9.2 Holistic — Customer Workload Applicability
+
+cephci NVMeoF automation drives **Linux initiators + FIO against NVMe namespaces**.
+It does **not** run real VMware guests, CSI pods, SAP/Oracle, or backup ISVs.
+Where a customer workload fits, we **emulate** it with FIO personas under day-2 load.
+
+**Suites (same conf `ceph_nvmeof_9-2_holistic.yaml`):**
+
+| Profile | Suite | IO window |
+|---------|-------|-----------|
+| Smoke | `tier-2_nvmeof_9-2_holistic_smoke.yaml` | ~300s |
+| Full | `tier-2_nvmeof_9-2_holistic_cross-feature.yaml` | ~600s |
+| Soak | `tier-2_nvmeof_9-2_holistic_soak.yaml` | ~1800s + restore burst |
+
+---
+
+## Customer workload filter
+
+| Workload | Fit in cephci? | Holistic treatment | Notes |
+|----------|----------------|--------------------|-------|
+| **Virtual machines** (KVM-like block) | **Emulate** | node10: 4k `randrw` 85/15 + `crc32c` | Real VMware/ESX/OpenStack/Proxmox guests → companion / manual |
+| **Databases** (OLTP) | **Real + emulate** | Phase 4e real engines on NVMe mounts; node9 also FIO OLTP persona | See engines table below |
+| **Kubernetes CSI PVs** | **Out** | Companion | Needs K8s + CSI driver; not in this framework |
+| **AI/ML infrastructure** | **Emulate** | node11: 1M `randread`, qd32 | Dataset/checkpoint *scan* only; no GPU training stack |
+| **HPC** | **Partial** | Multi-client parallel personas | No MPI/Lustre/parallel FS; concurrent block IO only |
+| **Enterprise apps** (SAP/Oracle/MSSQL/ERP) | **Emulate as DB** | Same as OLTP persona | App stacks out of scope |
+| **Backup repositories** | **Emulate** | node12: 1M seq `write`; soak `fio_burst` seq `read` | No Commvault/Veeam; restore modeled as large read burst |
+| **VDI** | **Partial** | VM-boot persona approximates one desktop disk | No broker / boot-storm scale (only 4 clients) |
+| **Media production** | **Emulate** | node12 large seq write (+ soak restore read) | No NLE/transcode apps |
+| **SDS / HCI appliances** | **Topology** | Conf has GW colocated with OSD (node4/5) | No third-party HCI product under test |
+
+---
+
+## Phase 5 FIO personas (in suite)
+
+| Client | Persona | FIO shape | Why |
+|--------|---------|-----------|-----|
+| node9 | OLTP database | `randrw` 70/30, bs 4k, iodepth 32, num_jobs 4, fsync 32, direct | Low-latency mixed R/W |
+| node10 | VM boot + integrity | `randrw` 85/15, bs 4k, verify crc32c | Boot/OS disk + corruption detect under day-2 |
+| node11 | AI / analytics | `randread`, bs 1M, iodepth 32, num_jobs 2 | Large-block dataset scan |
+| node12 | Backup / media ingest | `write`, bs 1M, iodepth 8 | Sequential ingest / scratch |
+
+Day-2 under these personas: QoS validate, NS visibility, resize, LB + listener assert, HA failover.  
+**Soak only:** `fio_burst` sequential read on node12 (backup restore under load).
+
+**Phase 4.5 (before personas):** reboot node10 after persistent connect; assert namespace UUIDs return via `nvmf-autoconnect` / `discovery.conf` without manual discover/connect (short FIO smoke).
+
+---
+
+## Phase 4e — Real database engines (podman on NVMe FS)
+
+Module: `tests/nvmeof/test_ceph_nvmeof_db_workloads.py`  
+Workflow: `tests/nvmeof/workflows/db_workloads.py`
+
+Each engine gets its own NVMe namespace → `mkfs.xfs` → mount → podman with datadir on the mount → native bench.
+
+Namespace budget (`cnode_db` `bdevs.count`, `max_ns: 64`):
+
+| Profile | Namespaces | Size | Engines using NS | Spare |
+|---------|------------|------|------------------|-------|
+| Smoke | 8 | 500G | 5 | 3 |
+| Full | 10 | 500G | 6 | 4 |
+| Soak | 10 | 500G | 6 | 4 |
+
+Skipped engines (Oracle) do **not** consume a namespace.
+
+Standing tenant namespaces (Phase 2) are also **500G**: cnode3/4/5/8 × **8 NS**, cnode6 × **4**, cnode7 RADOS × **4+4**, masking × **16** per subsystem. Conf OSD nodes use **12 × 1000G** disks to back this.
+
+| Engine | In suite? | How IO is driven | Notes |
+|--------|-----------|------------------|-------|
+| **PostgreSQL** | Yes | `pgbench` init + timed run | docker.io/library/postgres:16 |
+| **MySQL** | Yes | load + `mysqlslap` | docker.io/library/mysql:8.4 |
+| **MariaDB** | Yes | load + `mysqlslap` | docker.io/library/mariadb:11.4 |
+| **MongoDB** | Yes | insertMany + timed update/find | docker.io/library/mongo:7 |
+| **Redis persistence** | Yes | AOF on mount + `redis-benchmark` | docker.io/library/redis:7 |
+| **Cassandra** | Full + soak | cql inserts/selects | Omitted from **smoke** (slow start) |
+| **Oracle Database** | **Skipped** | — | OTN/license; listed in suite only to document skip |
+| **Microsoft SQL Server** | **Not enabled** | Optional `accept_eula: true` path exists | Enable manually if lab policy allows |
+
+Requires client network pull of container images + `podman` (installed on demand).
+
+---
+
+## Extra workloads worth adding later (cephci-feasible)
+
+| Idea | Value | Effort |
+|------|-------|--------|
+| **DB journal companion** | Second path: 4k `randwrite` high sync | Low — 5th NS or second FIO on same client |
+| **Boot storm** | Many short 4k `randread` jobs | Med — more initiators or high `num_jobs` |
+| **Trim / discard under load** | Thin-provision / SSD reclaim | Low if `discard` io_type wired |
+| **FS-mounted app IO** | ext4/xfs + file FIO (closer to VMs) | Med — pattern exists in `test_ceph_nvmeof_data_integrity.py` |
+| **Snapshot/clone under IO** | VDI/backup story via RBD snap | Med — new day2 op |
+| **Dual-pattern QoS contention** | OLTP vs backup fighting QoS | Low — already partial via personas + qos_validate |
+| **Cold restore then verify** | `fio_burst` write → read → crc32c | Low — compose day2 ops |
+| **Multi-path ANA churn** | Failover while all personas run | Partial today via `ha_failover` |
+
+---
+
+## Explicitly not in holistic (companion / external)
+
+- Kubernetes CSI + stateful apps  
+- VMware ESX guest IO (ESX connect-only suite exists elsewhere)  
+- OpenStack Cinder attach path  
+- SAP / Oracle / Microsoft SQL application suites  
+- VDI broker pools  
+- Backup vendor integrations  
+- Stretch / multi-site / mirror dual-cluster depth  
+
+See also: `HOLISTIC_9-2_COVERAGE.md`

--- a/suites/tentacle/nvmeof/IBM_CLOUD_BAREMETAL_BUG_COVERAGE.md
+++ b/suites/tentacle/nvmeof/IBM_CLOUD_BAREMETAL_BUG_COVERAGE.md
@@ -1,0 +1,134 @@
+# IBM Cloud BareMetal Bug → Test Coverage (filter 10895)
+
+**Filter:** [10895 — IBM cloud bugs](https://ibm-ceph.atlassian.net/issues/?filter=10895)  
+**Auth:** Jira REST `POST /rest/api/3/search/jql` as `rahul.lepakshi@ibm.com` (token not stored in repo).  
+**Pulled:** 2026-08-03  
+**Hardened:** 2026-08-03 — quality pass (assertions / IO continuity / field fixes)
+
+## How bugs were sourced
+
+Rovo / Jira filter **10895** (“IBM cloud bugs”) was used to enumerate open BareMetal / `cloud-baremetal` NVMeoF bugs on ibm-ceph Atlassian. Filter metadata + issue list were pulled via the Jira REST API (`GET /rest/api/3/filter/10895`, then search with that JQL; credentials are local only and are **not** stored in this repo). Issues were then theme-grouped, gap-analyzed against existing cephci coverage, and mapped into the suite/modules below.
+
+## Filter definition
+
+| Field | Value |
+|-------|-------|
+| ID | **10895** |
+| Name | **IBM cloud bugs** |
+| JQL | `status IN (ASSIGNED, "Awaiting Feedback", "Blocked (migrated)", "In Progress", MODIFIED, "Need Information", New, ON_DEV, POST, Review, "To Do", Reviewing, ON_QA) AND labels IN (cloud-baremetal, BareMetal) AND type = Bug ORDER BY priority DESC` |
+
+**Open bugs in filter:** **13**
+
+---
+
+## Full bug list (filter 10895)
+
+| Key | Pri | Status | Summary |
+|-----|-----|--------|---------|
+| IBMCEPH-17250 | Blocker | ON_QA | CLONE - CLONE - Maintenance mode enter/exit results in gateway not receiving data traffic |
+| IBMCEPH-16125 | Blocker | New | CLONE - Maintenance mode enter/exit results in gateway not receiving data traffic |
+| IBMCEPH-16124 | Blocker | MODIFIED | CLONE - Maintenance mode enter/exit results in gateway not receiving data traffic |
+| IBMCEPH-15819 | Blocker | MODIFIED | Maintenance mode enter/exit results in gateway not receiving data traffic |
+| IBMCEPH-16447 | Major | ON_QA | [9.1z Backport] NVMeoF - avoid having plaintext keys in the nvmeof service spec file |
+| IBMCEPH-17223 | Normal | MODIFIED | Removing host during PSK rotation with keep-connections causes other GWs to restart/crash |
+| IBMCEPH-17197 | Normal | MODIFIED | Removing connected host from subsystem causes OMAP-sync GWs to crash/restart |
+| IBMCEPH-17007 | Normal | POST | CLONE - disable/enable NVMe-oF gateways during host maintenance |
+| IBMCEPH-16374 | Normal | New | Scale down on a gateway group shows a gateway node in DELETING |
+| IBMCEPH-16261 | Normal | MODIFIED | disable/enable NVMe-oF gateways during host maintenance |
+| IBMCEPH-15815 | Normal | New | NVMEoF Gateway failover taking longer than expected |
+| IBMCEPH-15769 | Normal | In Progress | namespaces were assigned a wrong anagrpid |
+| IBMCEPH-15679 | Normal | New | Add support to upgrade nvmeof daemons using staggered upgrade `--daemon-types` |
+
+---
+
+## Themes (ROI order)
+
+1. **Host maintenance × NVMeoF IO path** (Blockers 15819 + clones) — highest ROI  
+2. **GW disable/enable around maintenance** (16261 / 17007)  
+3. **Host ACL remove / keep-connections stability** (17197 / 17223)  
+4. **ANA / anagrpid integrity** (15769)  
+5. **Scale-down lifecycle stuck DELETING** (16374)  
+6. **Failover SLO** (15815)  
+7. **No plaintext keys in nvmeof orch spec** (16447)  
+8. **Staggered upgrade `--daemon-types nvmeof`** (15679)
+
+---
+
+## Quality gap analysis (pre-harden → fix)
+
+| Area | What was weak | What we hardened |
+|------|---------------|------------------|
+| Maintenance (15819) | Soft-swallowed `nvme-gw disable/enable`; string-search for `"failed"`; no `validate_io` during/after | Split pure vs disable/enable TCs; hard `Availability=AVAILABLE`; `validate_io` before/during/after; peer restart detection via container_id/started |
+| Disable/enable (16261) | Combined with blocker TC and soft-failed, so 16261 was effectively untested | Dedicated TC with `gw_disable_enable: true` and hard fail on disable/enable errors |
+| Host remove (17197/17223) | “Restart” helper only listed orch status; keep-connections treated FIO fail as OK for both paths | Real container_id/started restart detection; keep-connections **requires** FIO success; ACL path asserts host gone |
+| ANA (15769) | Looked for `anagrp-id` keys — real field is `load_balancing_group`; skipped missing ANA | Read `load_balancing_group`; fail on missing; optional `extra_ns_churn` re-assert |
+| Scale-down (16374) | Blob string search only; no IO; no remaining-AVAILABLE / health clear | Structured `Availability==DELETING`; remaining AVAILABLE; `NVMEOF_GATEWAY_DELETING` health clear; optional IO via initiators |
+| Failover SLO (15815) | Timed failover but soft on IO; no `validate_io` | Hard `validate_io` before/after failover+failback; SLO remains warn-by-default (`fail_on_slo: false`) |
+| Spec keys (16447) | Static export scan — adequate | Unchanged (probe-quality OK) |
+| daemon-types (15679) | Acceptance probe only — adequate | Unchanged; full staggered upgrade stays in companion upgrade suites |
+
+---
+
+## Test-miss analysis → suite TC mapping
+
+| Key(s) | Coverage | Suite TC / module | Notes |
+|--------|----------|-------------------|-------|
+| 15819, 16124, 16125, 17250 | **Hardened** | `Host maintenance under NVMeoF IO` → `test_ceph_nvmeof_host_maintenance_io.py` | `gw_disable_enable: false`; IO + AVAILABLE + peer stability |
+| 16261, 17007 | **Hardened** | `Maintenance with nvme-gw disable/enable` → same module | `gw_disable_enable: true`; disable/enable hard-fail |
+| 17197 | **Hardened** | `Host remove under IO stability` → `test_ceph_nvmeof_host_remove_stability.py` | Restart detection; ACL removed |
+| 17223 | **Hardened** | `Host remove keep-connections stability` → same module | `keep_connections: true`; FIO must continue |
+| 15769 | **Hardened** | `ANA group id integrity` → `test_ceph_nvmeof_anagrp_integrity.py` | `load_balancing_group` ∈ `[1..num_gws]` + churn |
+| 16374 | **Hardened** | `Scale-down DELETING lifecycle` → `test_ceph_nvmeof_gw_scale_deleting.py` | DELETING clear + remaining AVAILABLE + IO |
+| 15815 | **Hardened** | `Failover SLO check` → `test_ceph_nvmeof_failover_slo.py` | IO hard gate; SLO warn default |
+| 16447 | **Covered** | `Spec no plaintext keys` → `test_ceph_nvmeof_spec_no_plaintext_keys.py` | Export orch nvmeof specs; reject PEM private keys |
+| 15679 | **Covered (probe)** | `daemon-types nvmeof upgrade probe` → `test_ceph_nvmeof_daemon_types_upgrade.py` | Reject “unexpected daemon type nvmeof”; stop if started |
+
+---
+
+## Suite / modules
+
+| Artifact | Path |
+|----------|------|
+| Coverage map | `suites/tentacle/nvmeof/IBM_CLOUD_BAREMETAL_BUG_COVERAGE.md` |
+| Suite | `suites/tentacle/nvmeof/tier-2_nvmeof_ibm_cloud_baremetal_bug_coverage.yaml` |
+| Conf | `conf/tentacle/nvmeof/ceph_nvmeof_ha_cluster_4nodes.yaml` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_host_maintenance_io.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_host_remove_stability.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_anagrp_integrity.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_gw_scale_deleting.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_failover_slo.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_spec_no_plaintext_keys.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_daemon_types_upgrade.py` |
+| Module | `tests/nvmeof/test_ceph_nvmeof_initiator_reboot_autoconnect.py` |
+
+Companions (deeper coverage already elsewhere): HA suites, 8-GW loadbalancing, encryption/DHCHAP E2E, full version-to-version upgrade suites.
+
+---
+
+## Recommended run order / risk notes
+
+1. **Deploy** (prereq → cephadm → clients → 4-GW nvmeof) — abort-on-fail  
+2. **Spec plaintext keys** — cheap, non-destructive  
+3. **ANA integrity (+ churn)** — before placement mutations  
+4. **Initiator reboot autoconnect** — persistent / discovery.conf / nvmf-autoconnect; before host maintenance  
+5. **Pure maintenance under IO** (blocker) — needs healthy 4-GW set  
+6. **Maintenance + nvme-gw disable/enable** — uses alternate GW node  
+7. **Host remove** then **keep-connections** — peer-restart sensitive; abort-on-fail false  
+8. **Scale-down DELETING** — **mutates placement (drops node9)**; keep near end  
+9. **Failover SLO** — expects remaining 3 GWs after scale-down  
+10. **daemon-types probe** — stop upgrade if it starts  
+
+**Risks / env needs**
+
+- IBM cloud BM inventory + realistic maintenance latency; lab VMs may under-reproduce 15819.  
+- `keep-connections` requires GW CLI that supports the flag; older builds will surface as host.delete failures.  
+- Full PSK-rotation scenario for 17223 still needs encryption/DHCHAP companion (this suite covers keep-connections + crash storm only).  
+- `fail_on_slo: true` for 15815 should be enabled only after baselining BM timings.  
+- 15679 acceptance ≠ full staggered upgrade — use upgrade companion suites for image-to-image.
+
+---
+
+## Suggested gates
+
+- **Nightly IBM cloud BM:** this suite  
+- **Release:** plus HA depth / LB 8-GW / encryption E2E / full upgrade companions

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml
@@ -1,0 +1,901 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+# IBM Ceph: 9.2 — Customer-centric holistic system test (features under continuous IO)
+#
+# Cluster configuration:
+#   conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
+# Inventory:
+#   conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml (or later)
+#
+# Model:
+#   1) Deploy full Ceph + NVMeoF once (nvmeof_metadata pool; 2 GWs colocated with OSDs)
+#   2) Configure tenant-style subsystems (standing config, no cleanup)
+#   3) Masking setup, reservation lifecycle + multi-init types, readonly NS,
+#      DHCHAP per-host FIO (same-phase keys)
+#   4) Start multi-client background FIO, then run day-2 ops UNDER LOAD
+#      (QoS+IO validate, masking visibility, resize, GW scale-down/up, HA failover)
+#
+# Coverage map:
+#   suites/tentacle/nvmeof/HOLISTIC_9-2_COVERAGE.md
+#
+# Tenant map / customer FIO personas (Phase 5 — Linux block emulation):
+#   node9  : OLTP database   — 4k randrw 70/30, multi-queue, O_DIRECT
+#   node10 : VM boot + verify — 4k randrw 85/15 + crc32c (integrity under churn)
+#   node11 : AI/analytics     — 1M randread (dataset / checkpoint scan)
+#   node12 : Backup / media   — 1M sequential write (ingest / scratch)
+#   Secure : cnode5 — DHCHAP (Phase 4d); Masked : cnode1/2 visibility under IO
+#
+# Workloads needing CSI/VMware/SAP/etc. stay companion — see HOLISTIC_9-2_WORKLOADS.md
+#
+# Profiles:
+#   Smoke : tier-2_nvmeof_9-2_holistic_smoke.yaml
+#   Full  : this suite (fio_runtime 600)
+#   Soak  : tier-2_nvmeof_9-2_holistic_soak.yaml (fio_runtime 1800)
+#
+# Companion suites (not inlined): upgrades, FIPS, mirror, refresh-network BM,
+# alerts break-GW, scale extremes, VMware, Dashboard, CSI, stretch HA
+#===============================================================================================
+tests:
+  # --------------------------------------------------------------------------------------------
+  # Phase 0 — Deploy full Ceph stack + clients
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:
+                verbose: true
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: Deploy IBM Ceph with mon/mgr/osd plus MDS and RGW
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy full Ceph cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node9
+          - node10
+          - node11
+          - node12
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure 4 NVMe initiator clients
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph clients for NVMe tests
+      polarion-id: CEPH-83573758
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 1 — Pools + NVMeoF (nvmeof_metadata; 2 colocated + 2 dedicated GWs)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_1
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_2
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                    - node4
+                    - node5
+                    - node6
+                    - node7
+              pos_args:
+                - nvmeof_metadata
+                - group1
+      desc: Create rbd + nvmeof_metadata pools and deploy NVMeoF on 4 GWs
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service group1 (nvmeof_metadata)
+      polarion-id: CEPH-83595696
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 2 — Tenant configuration (standing; no cleanup)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        inband_auth_mode: bidirectional
+        subsystems:
+          # Masked tenant shells
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+
+          # Prod open + QoS / resize target
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # NQN-ACL tenant
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            hosts:
+              - node9
+              - node10
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Secure tenant — DHCHAP per host
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            serial: 5
+            max_ns: 128
+            no-group-append: true
+            inband_auth: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            hosts:
+              - node: node11
+                inband_auth: true
+              - node: node12
+                inband_auth: true
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Shared — reservations
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 6
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+
+          # Shared — RADOS namespaces
+          - nqn: nqn.2016-06.io.spdk:cnode7
+            serial: 7
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_1
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_2
+
+          # Prod open — HA/LB workload
+          - nqn: nqn.2016-06.io.spdk:cnode8
+            serial: 8
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+      desc: Configure tenant subsystems (listeners/hosts/NS/auth/RADOS) — persistent
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Configure tenant subsystems
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 3 — Masking setup on masked tenant (leave visible for under-load churn)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 2
+                namespaces: 16
+                pool: rbd
+                image_size: 500G
+                no-auto-visible: true
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: add_host
+              args:
+                subsystems: 2
+                namespaces: 16
+                initiators:
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 2
+                namespaces: 16
+                auto-visible: "yes"
+                group: group1
+                validate_ns_masking_initiators: true
+        initiators:
+          - node9
+          - node10
+          - node11
+          - node12
+      desc: Create masked namespaces then restore visibility for under-load churn
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Setup namespace masking tenant
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4 — Reservation lifecycle (release before continuous FIO)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        reservation:
+          - register_args:
+              rrega: 0
+          - acquire_args:
+              racqa: 0
+              rtype: 1
+          - release_args:
+              rrela: 0
+              rtype: 1
+          - unregister_args:
+              rrega: 1
+        initiators:
+          - node: node9
+            nqn: connect-all
+            listener_port: 4420
+          - node: node10
+            nqn: connect-all
+            listener_port: 4420
+        cleanup:
+          - disconnect_all
+      desc: Validate reservation lifecycle then disconnect before under-load FIO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_ns_reservation.py
+      name: Validate namespace reservations
+      polarion-id: CEPH-83626134
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4b — Multi-initiator reservation types (richer ISCE-2086 coverage)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_node:
+          - node4
+          - node5
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_rsv_multi1
+            serial: 81
+            bdevs:
+              count: 2
+              size: 500G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode_rsv_multi2
+            serial: 82
+            bdevs:
+              count: 2
+              size: 500G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - node9
+          - node10
+        cleanup:
+          - disconnect_all
+      desc: Verify reservation types across two initiators (write/read expectations)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_reservation_multi_init.py
+      name: Multi-initiator reservation type matrix
+      polarion-id: CEPH-83627298
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4c — Read-only namespaces (ISCE-2121)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        test_case: CEPH-83624617
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_ro1
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode_ro2
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node9
+        cleanup:
+          - disconnect_all
+      desc: Validate read-only namespace create and write-fail behavior (ISCE-2121)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_readonly_ns.py
+      name: Validate read-only namespaces
+      polarion-id: CEPH-83624617
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4d — DHCHAP per-host FIO in SAME phase as key create (ISCE-3542)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        mode: auth_fio
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        auth_fio:
+          inband_auth_mode: bidirectional
+          fio_runtime: 90
+          subsystems:
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap1
+              serial: 85
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              listener_port: 4420
+              listeners: [node4, node5, node6, node7]
+              hosts:
+                - node: node11
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap2
+              serial: 86
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              listener_port: 4420
+              listeners: [node4, node5, node6, node7]
+              hosts:
+                - node: node12
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+          initiators:
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap1
+              listener_port: 4420
+              node: node11
+              io_args:
+                io_type: randrw
+                rwmixread: 70
+                iodepth: 8
+                run_time: 90
+                size: 1G
+                test_name: dhchap-host-c11
+                execute_blkdiscard: false
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap2
+              listener_port: 4420
+              node: node12
+              io_args:
+                io_type: randwrite
+                iodepth: 8
+                run_time: 90
+                size: 1G
+                test_name: dhchap-host-c12
+                execute_blkdiscard: false
+      desc: >
+        ISCE-3542 — set controller/host DHCHAP keys and run authenticated FIO
+        in the same phase (keys never leave this TC)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: DHCHAP per-host authenticated FIO
+      polarion-id: CEPH-83632329
+
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4e — Real DB engines on NVMeoF (podman + FS on namespace)
+  #   Feasible: PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Cassandra
+  #   Skip: Oracle (license). MSSQL optional via accept_eula (not enabled here).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_db
+            serial: 90
+            max_ns: 64
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              # 6 engines + spares (mssql / dual-volume growth)
+              - count: 10
+                size: 500G
+                ns_create_image: true
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode_db
+            listener_port: 4420
+            node: node9
+        databases:
+          - engine: postgresql
+            duration: 60
+            scale: 10
+            clients: 8
+            jobs: 4
+          - engine: mysql
+            duration: 60
+            clients: 8
+            rows: 10000
+          - engine: mariadb
+            duration: 60
+            clients: 8
+            rows: 10000
+          - engine: mongodb
+            duration: 60
+            docs: 30000
+          - engine: redis
+            duration: 60
+            clients: 50
+          - engine: cassandra
+            ops: 10000
+          - engine: oracle
+            # always skipped — documents intentional exclusion
+        cleanup:
+          - disconnect_all
+      desc: >
+        Real DB I/O on NVMeoF — PostgreSQL/MySQL/MariaDB/MongoDB/Redis/Cassandra
+        with datadir on mounted namespaces (Oracle skipped)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_db_workloads.py
+      name: Database workloads on NVMeoF namespaces
+      polarion-id: CEPH-83575441
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4.5 — Initiator reboot + nvmf-autoconnect (no manual discover/connect)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        autoconnect_timeout: 300
+        post_reboot_settle: 15
+        fio_smoke: true
+        fio_runtime: 30
+        initiators:
+          # Open tenant only — avoid DHCHAP connect-all ambiguity
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode8
+        cleanup: []
+      desc: >
+        Reboot Linux initiator; assert namespace UUIDs return via --persistent,
+        discovery.conf, and nvmf-autoconnect without manual discover/connect
+      destroy-cluster: false
+      module: test_ceph_nvmeof_initiator_reboot_autoconnect.py
+      name: Initiator reboot persistent autoconnect
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 5 — UNDER LOAD: background FIO + day-2 ops (customer system test)
+  #   Set fio_runtime: 1800 for soak profile.
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        fio_runtime: 600
+        fio_settle_seconds: 30
+        op_settle_seconds: 20
+        initiators:
+          # Persona: OLTP database (low-latency mixed 4k, multi-queue)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node9
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: randrw
+              rwmixread: 70
+              bs: 4k
+              iodepth: 32
+              num_jobs: 4
+              fsync: 32
+              direct: 1
+              run_time: 600
+              size: 1G
+              test_name: persona-oltp-db-c9
+              execute_blkdiscard: false
+          # Persona: VM boot disk + integrity (small random + crc32c under day-2)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode4
+              - nqn.2016-06.io.spdk:cnode7
+            io_args:
+              io_type: randrw
+              rwmixread: 85
+              bs: 4k
+              iodepth: 16
+              num_jobs: 2
+              direct: 1
+              run_time: 600
+              size: 1G
+              verify: crc32c
+              verify_fatal: 1
+              test_name: persona-vm-boot-integrity-c10
+              execute_blkdiscard: false
+          # Persona: AI/ML + analytics scan (large-block random read)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node11
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode2
+              - nqn.2016-06.io.spdk:cnode6
+            io_args:
+              io_type: randread
+              bs: 1M
+              iodepth: 32
+              num_jobs: 2
+              direct: 1
+              run_time: 600
+              size: 1G
+              test_name: persona-ai-analytics-c11
+              execute_blkdiscard: false
+          # Persona: backup repository / media ingest (large sequential write)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node12
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: write
+              bs: 1M
+              iodepth: 8
+              direct: 1
+              run_time: 600
+              size: 1G
+              test_name: persona-backup-media-c12
+              execute_blkdiscard: false
+        day2_ops:
+          # Richer QoS: set tight limit, validate observed IO, then relax
+          - op: qos_validate_io
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              initiator_node: node9
+              w-megabytes-per-second: 40
+              r-megabytes-per-second: 40
+              rw-megabytes-per-second: 60
+              io_runtime: 40
+            settle_seconds: 20
+          - op: set_qos
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              r-megabytes-per-second: 200
+              w-megabytes-per-second: 200
+              rw-megabytes-per-second: 300
+            settle_seconds: 20
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "no"
+              force: true
+            settle_seconds: 15
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "yes"
+              force: true
+            settle_seconds: 15
+          - op: resize
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode8
+              nsid: 1
+              size: 550G
+            settle_seconds: 30
+          - op: scale_down
+            args:
+              nodes: ["node6"]
+            settle_seconds: 30
+          - op: scale_up
+            args:
+              nodes: ["node6"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 30
+          - op: scale_down
+            args:
+              nodes: ["node7"]
+            settle_seconds: 30
+          - op: scale_up
+            args:
+              nodes: ["node8"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 45
+          - op: assert_listeners
+            args:
+              subsystems:
+                - nqn.2016-06.io.spdk:cnode3
+                - nqn.2016-06.io.spdk:cnode8
+                - nqn.2016-06.io.spdk:cnode4
+                - nqn.2016-06.io.spdk:cnode7
+                - nqn.2016-06.io.spdk:cnode6
+              listener_port: 4420
+            settle_seconds: 5
+          - op: ha_failover
+            args:
+              tool: systemctl
+              nodes: ["node4"]
+            settle_seconds: 30
+      desc: >
+        Customer system test — FIO personas (OLTP, VM+integrity, AI scan,
+        backup/media) while QoS, visibility, resize, LB + listener asserts,
+        and HA failover execute under load
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: Under-load day-2 ops with multi-tenant FIO
+      polarion-id: CEPH-83575441

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_smoke.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_smoke.yaml
@@ -1,0 +1,808 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_nvmeof_9-2_holistic_smoke.yaml
+# IBM Ceph: 9.2 — Holistic SMOKE (same conf as full suite, shorter wall-clock)
+#
+# Cluster configuration:
+#   conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
+#
+# Smoke vs full (tier-2_nvmeof_9-2_holistic_cross-feature.yaml):
+#   - Skips multi-initiator reservation matrix (Phase 4b)
+#   - fio_runtime: 300 (~5 min IO window)
+#   - Single LB cycle (node6 down/up + listener assert); no node7→node8
+#   - Keeps: tenants, masking, reservation lifecycle, readonly, DHCHAP auth FIO,
+#     customer FIO personas (OLTP/VM/AI/backup), QoS validate, visibility, resize,
+#     HA failover
+#   - Personas use shorter run_time (300s); single LB cycle only
+#
+# Coverage map:
+#   suites/tentacle/nvmeof/HOLISTIC_9-2_COVERAGE.md
+#===============================================================================================
+tests:
+  # --------------------------------------------------------------------------------------------
+  # Phase 0 — Deploy full Ceph stack + clients
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:
+                verbose: true
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: Deploy IBM Ceph with mon/mgr/osd plus MDS and RGW
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy full Ceph cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node9
+          - node10
+          - node11
+          - node12
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure 4 NVMe initiator clients
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph clients for NVMe tests
+      polarion-id: CEPH-83573758
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 1 — Pools + NVMeoF (nvmeof_metadata; 2 colocated + 2 dedicated GWs)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_1
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_2
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                    - node4
+                    - node5
+                    - node6
+                    - node7
+              pos_args:
+                - nvmeof_metadata
+                - group1
+      desc: Create rbd + nvmeof_metadata pools and deploy NVMeoF on 4 GWs
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service group1 (nvmeof_metadata)
+      polarion-id: CEPH-83595696
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 2 — Tenant configuration (standing; no cleanup)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        inband_auth_mode: bidirectional
+        subsystems:
+          # Masked tenant shells
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+
+          # Prod open + QoS / resize target
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # NQN-ACL tenant
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            hosts:
+              - node9
+              - node10
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Secure tenant — DHCHAP per host
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            serial: 5
+            max_ns: 128
+            no-group-append: true
+            inband_auth: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            hosts:
+              - node: node11
+                inband_auth: true
+              - node: node12
+                inband_auth: true
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Shared — reservations
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 6
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+
+          # Shared — RADOS namespaces
+          - nqn: nqn.2016-06.io.spdk:cnode7
+            serial: 7
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_1
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_2
+
+          # Prod open — HA/LB workload
+          - nqn: nqn.2016-06.io.spdk:cnode8
+            serial: 8
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+      desc: Configure tenant subsystems (listeners/hosts/NS/auth/RADOS) — persistent
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Configure tenant subsystems
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 3 — Masking setup on masked tenant (leave visible for under-load churn)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 2
+                namespaces: 16
+                pool: rbd
+                image_size: 500G
+                no-auto-visible: true
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: add_host
+              args:
+                subsystems: 2
+                namespaces: 16
+                initiators:
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 2
+                namespaces: 16
+                auto-visible: "yes"
+                group: group1
+                validate_ns_masking_initiators: true
+        initiators:
+          - node9
+          - node10
+          - node11
+          - node12
+      desc: Create masked namespaces then restore visibility for under-load churn
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Setup namespace masking tenant
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4 — Reservation lifecycle (release before continuous FIO)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        reservation:
+          - register_args:
+              rrega: 0
+          - acquire_args:
+              racqa: 0
+              rtype: 1
+          - release_args:
+              rrela: 0
+              rtype: 1
+          - unregister_args:
+              rrega: 1
+        initiators:
+          - node: node9
+            nqn: connect-all
+            listener_port: 4420
+          - node: node10
+            nqn: connect-all
+            listener_port: 4420
+        cleanup:
+          - disconnect_all
+      desc: Validate reservation lifecycle then disconnect before under-load FIO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_ns_reservation.py
+      name: Validate namespace reservations
+      polarion-id: CEPH-83626134
+
+  # Phase 4b (multi-init reservation matrix) omitted in smoke — see full suite
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4c — Read-only namespaces (ISCE-2121)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        test_case: CEPH-83624617
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_ro1
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode_ro2
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node9
+        cleanup:
+          - disconnect_all
+      desc: Validate read-only namespace create and write-fail behavior (ISCE-2121)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_readonly_ns.py
+      name: Validate read-only namespaces
+      polarion-id: CEPH-83624617
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4d — DHCHAP per-host FIO in SAME phase as key create (ISCE-3542)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        mode: auth_fio
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        auth_fio:
+          inband_auth_mode: bidirectional
+          fio_runtime: 60
+          subsystems:
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap1
+              serial: 85
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              listener_port: 4420
+              listeners: [node4, node5, node6, node7]
+              hosts:
+                - node: node11
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap2
+              serial: 86
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              listener_port: 4420
+              listeners: [node4, node5, node6, node7]
+              hosts:
+                - node: node12
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+          initiators:
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap1
+              listener_port: 4420
+              node: node11
+              io_args:
+                io_type: randrw
+                rwmixread: 70
+                iodepth: 8
+                run_time: 60
+                size: 1G
+                test_name: dhchap-host-c11
+                execute_blkdiscard: false
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap2
+              listener_port: 4420
+              node: node12
+              io_args:
+                io_type: randwrite
+                iodepth: 8
+                run_time: 60
+                size: 1G
+                test_name: dhchap-host-c12
+                execute_blkdiscard: false
+      desc: >
+        ISCE-3542 — set controller/host DHCHAP keys and run authenticated FIO
+        in the same phase (keys never leave this TC)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: DHCHAP per-host authenticated FIO
+      polarion-id: CEPH-83632329
+
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4e — Real DB engines on NVMeoF (podman + FS on namespace)
+  #   Feasible: PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Cassandra
+  #   Skip: Oracle (license). MSSQL optional via accept_eula (not enabled here).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_db
+            serial: 90
+            max_ns: 64
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              # 5 engines + spares
+              - count: 8
+                size: 500G
+                ns_create_image: true
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode_db
+            listener_port: 4420
+            node: node9
+        databases:
+          - engine: postgresql
+            duration: 30
+            scale: 5
+            clients: 8
+            jobs: 4
+          - engine: mysql
+            duration: 30
+            clients: 8
+            rows: 5000
+          - engine: mariadb
+            duration: 30
+            clients: 8
+            rows: 5000
+          - engine: mongodb
+            duration: 30
+            docs: 10000
+          - engine: redis
+            duration: 30
+            clients: 50
+          # cassandra omitted in smoke (slow start); oracle always skipped
+        cleanup:
+          - disconnect_all
+      desc: >
+        Real DB I/O on NVMeoF — PostgreSQL/MySQL/MariaDB/MongoDB/Redis
+        with datadir on mounted namespaces (Oracle skipped; Cassandra smoke-omitted)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_db_workloads.py
+      name: Database workloads on NVMeoF namespaces
+      polarion-id: CEPH-83575441
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4.5 — Initiator reboot + nvmf-autoconnect (shorter smoke timeouts)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        autoconnect_timeout: 180
+        post_reboot_settle: 10
+        fio_smoke: true
+        fio_runtime: 15
+        initiators:
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode8
+        cleanup: []
+      desc: >
+        Smoke: reboot initiator; namespaces return via nvmf-autoconnect
+        without manual discover/connect
+      destroy-cluster: false
+      module: test_ceph_nvmeof_initiator_reboot_autoconnect.py
+      name: Initiator reboot persistent autoconnect
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 5 — UNDER LOAD (smoke): shorter FIO + single LB cycle
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        fio_runtime: 300
+        fio_settle_seconds: 20
+        op_settle_seconds: 15
+        initiators:
+          # Persona: OLTP database
+          - nqn: discover-all
+            listener_port: 4420
+            node: node9
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: randrw
+              rwmixread: 70
+              bs: 4k
+              iodepth: 32
+              num_jobs: 4
+              fsync: 32
+              direct: 1
+              run_time: 300
+              size: 1G
+              test_name: smoke-persona-oltp-db-c9
+              execute_blkdiscard: false
+          # Persona: VM boot + integrity
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode4
+              - nqn.2016-06.io.spdk:cnode7
+            io_args:
+              io_type: randrw
+              rwmixread: 85
+              bs: 4k
+              iodepth: 16
+              num_jobs: 2
+              direct: 1
+              run_time: 300
+              size: 1G
+              verify: crc32c
+              verify_fatal: 1
+              test_name: smoke-persona-vm-boot-integrity-c10
+              execute_blkdiscard: false
+          # Persona: AI/ML + analytics scan
+          - nqn: discover-all
+            listener_port: 4420
+            node: node11
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode2
+              - nqn.2016-06.io.spdk:cnode6
+            io_args:
+              io_type: randread
+              bs: 1M
+              iodepth: 32
+              num_jobs: 2
+              direct: 1
+              run_time: 300
+              size: 1G
+              test_name: smoke-persona-ai-analytics-c11
+              execute_blkdiscard: false
+          # Persona: backup / media ingest
+          - nqn: discover-all
+            listener_port: 4420
+            node: node12
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: write
+              bs: 1M
+              iodepth: 8
+              direct: 1
+              run_time: 300
+              size: 1G
+              test_name: smoke-persona-backup-media-c12
+              execute_blkdiscard: false
+        day2_ops:
+          - op: qos_validate_io
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              initiator_node: node9
+              w-megabytes-per-second: 40
+              r-megabytes-per-second: 40
+              rw-megabytes-per-second: 60
+              io_runtime: 30
+            settle_seconds: 15
+          - op: set_qos
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              r-megabytes-per-second: 200
+              w-megabytes-per-second: 200
+              rw-megabytes-per-second: 300
+            settle_seconds: 15
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "no"
+              force: true
+            settle_seconds: 10
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "yes"
+              force: true
+            settle_seconds: 10
+          - op: resize
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode8
+              nsid: 1
+              size: 550G
+            settle_seconds: 20
+          - op: scale_down
+            args:
+              nodes: ["node6"]
+            settle_seconds: 25
+          - op: scale_up
+            args:
+              nodes: ["node6"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 25
+          - op: assert_listeners
+            args:
+              subsystems:
+                - nqn.2016-06.io.spdk:cnode3
+                - nqn.2016-06.io.spdk:cnode8
+                - nqn.2016-06.io.spdk:cnode4
+                - nqn.2016-06.io.spdk:cnode7
+                - nqn.2016-06.io.spdk:cnode6
+              listener_port: 4420
+            settle_seconds: 5
+          - op: ha_failover
+            args:
+              tool: systemctl
+              nodes: ["node4"]
+            settle_seconds: 25
+      desc: >
+        Smoke under-load — customer FIO personas with QoS, visibility, resize,
+        single LB cycle + listener assert, and HA failover
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: Smoke under-load day-2 ops with multi-tenant FIO
+      polarion-id: CEPH-83575441

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_soak.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_soak.yaml
@@ -1,0 +1,910 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_nvmeof_9-2_holistic_soak.yaml
+# IBM Ceph: 9.2 — Holistic SOAK (same conf/features as full; longer persona FIO window)
+#
+# Cluster configuration:
+#   conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
+# Inventory:
+#   conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml (or later)
+#
+# Model:
+#   1) Deploy full Ceph + NVMeoF once (nvmeof_metadata pool; 2 GWs colocated with OSDs)
+#   2) Configure tenant-style subsystems (standing config, no cleanup)
+#   3) Masking setup, reservation lifecycle + multi-init types, readonly NS,
+#      DHCHAP per-host FIO (same-phase keys)
+#   4) Start multi-client background FIO, then run day-2 ops UNDER LOAD
+#      (QoS+IO validate, masking visibility, resize, GW scale-down/up, HA failover)
+#
+# Coverage map:
+#   suites/tentacle/nvmeof/HOLISTIC_9-2_COVERAGE.md
+#
+# Tenant map / customer FIO personas (Phase 5 — Linux block emulation):
+#   node9  : OLTP database   — 4k randrw 70/30, multi-queue, O_DIRECT
+#   node10 : VM boot + verify — 4k randrw 85/15 + crc32c (integrity under churn)
+#   node11 : AI/analytics     — 1M randread (dataset / checkpoint scan)
+#   node12 : Backup / media   — 1M sequential write (ingest / scratch)
+#   Secure : cnode5 — DHCHAP (Phase 4d); Masked : cnode1/2 visibility under IO
+#
+# Workloads needing CSI/VMware/SAP/etc. stay companion — see HOLISTIC_9-2_WORKLOADS.md
+#
+# Profiles:
+#   Smoke : tier-2_nvmeof_9-2_holistic_smoke.yaml
+#   Full  : tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+#   Soak  : this suite (fio_runtime 1800 + restore-read day2)
+#
+# Companion suites (not inlined): upgrades, FIPS, mirror, refresh-network BM,
+# alerts break-GW, scale extremes, VMware, Dashboard, CSI, stretch HA
+#===============================================================================================
+tests:
+  # --------------------------------------------------------------------------------------------
+  # Phase 0 — Deploy full Ceph stack + clients
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:
+                verbose: true
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: Deploy IBM Ceph with mon/mgr/osd plus MDS and RGW
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy full Ceph cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node9
+          - node10
+          - node11
+          - node12
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure 4 NVMe initiator clients
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph clients for NVMe tests
+      polarion-id: CEPH-83573758
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 1 — Pools + NVMeoF (nvmeof_metadata; 2 colocated + 2 dedicated GWs)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_1
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_2
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                    - node4
+                    - node5
+                    - node6
+                    - node7
+              pos_args:
+                - nvmeof_metadata
+                - group1
+      desc: Create rbd + nvmeof_metadata pools and deploy NVMeoF on 4 GWs
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service group1 (nvmeof_metadata)
+      polarion-id: CEPH-83595696
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 2 — Tenant configuration (standing; no cleanup)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        inband_auth_mode: bidirectional
+        subsystems:
+          # Masked tenant shells
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+
+          # Prod open + QoS / resize target
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # NQN-ACL tenant
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            hosts:
+              - node9
+              - node10
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Secure tenant — DHCHAP per host
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            serial: 5
+            max_ns: 128
+            no-group-append: true
+            inband_auth: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            hosts:
+              - node: node11
+                inband_auth: true
+              - node: node12
+                inband_auth: true
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Shared — reservations
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 6
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+
+          # Shared — RADOS namespaces
+          - nqn: nqn.2016-06.io.spdk:cnode7
+            serial: 7
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_1
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_2
+
+          # Prod open — HA/LB workload
+          - nqn: nqn.2016-06.io.spdk:cnode8
+            serial: 8
+            max_ns: 128
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+      desc: Configure tenant subsystems (listeners/hosts/NS/auth/RADOS) — persistent
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Configure tenant subsystems
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 3 — Masking setup on masked tenant (leave visible for under-load churn)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 2
+                namespaces: 16
+                pool: rbd
+                image_size: 500G
+                no-auto-visible: true
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: add_host
+              args:
+                subsystems: 2
+                namespaces: 16
+                initiators:
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 2
+                namespaces: 16
+                auto-visible: "yes"
+                group: group1
+                validate_ns_masking_initiators: true
+        initiators:
+          - node9
+          - node10
+          - node11
+          - node12
+      desc: Create masked namespaces then restore visibility for under-load churn
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Setup namespace masking tenant
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4 — Reservation lifecycle (release before continuous FIO)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        reservation:
+          - register_args:
+              rrega: 0
+          - acquire_args:
+              racqa: 0
+              rtype: 1
+          - release_args:
+              rrela: 0
+              rtype: 1
+          - unregister_args:
+              rrega: 1
+        initiators:
+          - node: node9
+            nqn: connect-all
+            listener_port: 4420
+          - node: node10
+            nqn: connect-all
+            listener_port: 4420
+        cleanup:
+          - disconnect_all
+      desc: Validate reservation lifecycle then disconnect before under-load FIO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_ns_reservation.py
+      name: Validate namespace reservations
+      polarion-id: CEPH-83626134
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4b — Multi-initiator reservation types (richer ISCE-2086 coverage)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_node:
+          - node4
+          - node5
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_rsv_multi1
+            serial: 81
+            bdevs:
+              count: 2
+              size: 500G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode_rsv_multi2
+            serial: 82
+            bdevs:
+              count: 2
+              size: 500G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - node9
+          - node10
+        cleanup:
+          - disconnect_all
+      desc: Verify reservation types across two initiators (write/read expectations)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_reservation_multi_init.py
+      name: Multi-initiator reservation type matrix
+      polarion-id: CEPH-83627298
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4c — Read-only namespaces (ISCE-2121)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        test_case: CEPH-83624617
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_ro1
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode_ro2
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node9
+        cleanup:
+          - disconnect_all
+      desc: Validate read-only namespace create and write-fail behavior (ISCE-2121)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_readonly_ns.py
+      name: Validate read-only namespaces
+      polarion-id: CEPH-83624617
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4d — DHCHAP per-host FIO in SAME phase as key create (ISCE-3542)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        mode: auth_fio
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        auth_fio:
+          inband_auth_mode: bidirectional
+          fio_runtime: 90
+          subsystems:
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap1
+              serial: 85
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              listener_port: 4420
+              listeners: [node4, node5, node6, node7]
+              hosts:
+                - node: node11
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap2
+              serial: 86
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              listener_port: 4420
+              listeners: [node4, node5, node6, node7]
+              hosts:
+                - node: node12
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+          initiators:
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap1
+              listener_port: 4420
+              node: node11
+              io_args:
+                io_type: randrw
+                rwmixread: 70
+                iodepth: 8
+                run_time: 90
+                size: 1G
+                test_name: dhchap-host-c11
+                execute_blkdiscard: false
+            - nqn: nqn.2016-06.io.spdk:cnode_dhchap2
+              listener_port: 4420
+              node: node12
+              io_args:
+                io_type: randwrite
+                iodepth: 8
+                run_time: 90
+                size: 1G
+                test_name: dhchap-host-c12
+                execute_blkdiscard: false
+      desc: >
+        ISCE-3542 — set controller/host DHCHAP keys and run authenticated FIO
+        in the same phase (keys never leave this TC)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: DHCHAP per-host authenticated FIO
+      polarion-id: CEPH-83632329
+
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4e — Real DB engines on NVMeoF (podman + FS on namespace)
+  #   Feasible: PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Cassandra
+  #   Skip: Oracle (license). MSSQL optional via accept_eula (not enabled here).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_db
+            serial: 90
+            max_ns: 64
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node4, node5, node6, node7]
+            allow_host: "*"
+            bdevs:
+              # 6 engines + spares (mssql / dual-volume growth)
+              - count: 10
+                size: 500G
+                ns_create_image: true
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode_db
+            listener_port: 4420
+            node: node9
+        databases:
+          - engine: postgresql
+            duration: 120
+            scale: 25
+            clients: 8
+            jobs: 4
+          - engine: mysql
+            duration: 120
+            clients: 8
+            rows: 20000
+          - engine: mariadb
+            duration: 120
+            clients: 8
+            rows: 20000
+          - engine: mongodb
+            duration: 120
+            docs: 50000
+          - engine: redis
+            duration: 120
+            clients: 50
+          - engine: cassandra
+            ops: 20000
+          - engine: oracle
+            # always skipped — documents intentional exclusion
+        cleanup:
+          - disconnect_all
+      desc: >
+        Real DB I/O on NVMeoF — PostgreSQL/MySQL/MariaDB/MongoDB/Redis/Cassandra
+        with datadir on mounted namespaces (Oracle skipped)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_db_workloads.py
+      name: Database workloads on NVMeoF namespaces
+      polarion-id: CEPH-83575441
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4.5 — Initiator reboot + nvmf-autoconnect (no manual discover/connect)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        autoconnect_timeout: 300
+        post_reboot_settle: 15
+        fio_smoke: true
+        fio_runtime: 30
+        initiators:
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode8
+        cleanup: []
+      desc: >
+        Reboot Linux initiator; assert namespace UUIDs return via --persistent,
+        discovery.conf, and nvmf-autoconnect without manual discover/connect
+      destroy-cluster: false
+      module: test_ceph_nvmeof_initiator_reboot_autoconnect.py
+      name: Initiator reboot persistent autoconnect
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 5 — UNDER LOAD: background FIO + day-2 ops (customer system test)
+  #   Soak wall-clock: fio_runtime 1800 (~30 min persona IO).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        fio_runtime: 1800
+        fio_settle_seconds: 30
+        op_settle_seconds: 20
+        initiators:
+          # Persona: OLTP database (low-latency mixed 4k, multi-queue)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node9
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: randrw
+              rwmixread: 70
+              bs: 4k
+              iodepth: 32
+              num_jobs: 4
+              fsync: 32
+              direct: 1
+              run_time: 1800
+              size: 1G
+              test_name: soak-persona-oltp-db-c9
+              execute_blkdiscard: false
+          # Persona: VM boot disk + integrity (small random + crc32c under day-2)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode4
+              - nqn.2016-06.io.spdk:cnode7
+            io_args:
+              io_type: randrw
+              rwmixread: 85
+              bs: 4k
+              iodepth: 16
+              num_jobs: 2
+              direct: 1
+              run_time: 1800
+              size: 1G
+              verify: crc32c
+              verify_fatal: 1
+              test_name: soak-persona-vm-boot-integrity-c10
+              execute_blkdiscard: false
+          # Persona: AI/ML + analytics scan (large-block random read)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node11
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode2
+              - nqn.2016-06.io.spdk:cnode6
+            io_args:
+              io_type: randread
+              bs: 1M
+              iodepth: 32
+              num_jobs: 2
+              direct: 1
+              run_time: 1800
+              size: 1G
+              test_name: soak-persona-ai-analytics-c11
+              execute_blkdiscard: false
+          # Persona: backup repository / media ingest (large sequential write)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node12
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: write
+              bs: 1M
+              iodepth: 8
+              direct: 1
+              run_time: 1800
+              size: 1G
+              test_name: soak-persona-backup-media-c12
+              execute_blkdiscard: false
+        day2_ops:
+          # Richer QoS: set tight limit, validate observed IO, then relax
+          - op: qos_validate_io
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              initiator_node: node9
+              w-megabytes-per-second: 40
+              r-megabytes-per-second: 40
+              rw-megabytes-per-second: 60
+              io_runtime: 40
+            settle_seconds: 20
+          - op: set_qos
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              r-megabytes-per-second: 200
+              w-megabytes-per-second: 200
+              rw-megabytes-per-second: 300
+            settle_seconds: 20
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "no"
+              force: true
+            settle_seconds: 15
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "yes"
+              force: true
+            settle_seconds: 15
+          - op: resize
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode8
+              nsid: 1
+              size: 550G
+            settle_seconds: 30
+          # Backup restore-like burst (large sequential read) while other personas run
+          - op: fio_burst
+            args:
+              initiator_node: node12
+              io_type: read
+              bs: 1M
+              iodepth: 16
+              io_runtime: 90
+              size: 2G
+              test_name: soak-backup-restore-burst
+            settle_seconds: 15
+          - op: scale_down
+            args:
+              nodes: ["node6"]
+            settle_seconds: 30
+          - op: scale_up
+            args:
+              nodes: ["node6"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 30
+          - op: scale_down
+            args:
+              nodes: ["node7"]
+            settle_seconds: 30
+          - op: scale_up
+            args:
+              nodes: ["node8"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 45
+          - op: assert_listeners
+            args:
+              subsystems:
+                - nqn.2016-06.io.spdk:cnode3
+                - nqn.2016-06.io.spdk:cnode8
+                - nqn.2016-06.io.spdk:cnode4
+                - nqn.2016-06.io.spdk:cnode7
+                - nqn.2016-06.io.spdk:cnode6
+              listener_port: 4420
+            settle_seconds: 5
+          - op: ha_failover
+            args:
+              tool: systemctl
+              nodes: ["node4"]
+            settle_seconds: 30
+      desc: >
+        Soak — 30 min customer FIO personas (OLTP, VM+integrity, AI scan,
+        backup/media) under QoS, visibility, resize, LB + listener asserts, HA
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: Soak under-load day-2 ops with customer FIO personas
+      polarion-id: CEPH-83575441

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_ibm_cloud_baremetal_bug_coverage.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_ibm_cloud_baremetal_bug_coverage.yaml
@@ -1,0 +1,482 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_nvmeof_ibm_cloud_baremetal_bug_coverage.yaml
+# Conf: conf/tentacle/nvmeof/ceph_nvmeof_ha_cluster_4nodes.yaml
+# Inventory: conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml (or BM inventory)
+#
+# Purpose: Regression coverage for Jira filter 10895 ("IBM cloud bugs")
+#   labels IN (cloud-baremetal, BareMetal) AND type = Bug (open statuses)
+# Coverage map: suites/tentacle/nvmeof/IBM_CLOUD_BAREMETAL_BUG_COVERAGE.md
+#
+# High-ROI gaps covered here (hardened assertions — see coverage doc):
+#   IBMCEPH-15819 (+ 16124/16125/17250)  pure host maintenance under IO
+#   IBMCEPH-16261 / 17007                 nvme-gw disable/enable around maintenance
+#   IBMCEPH-17197 / 17223                 host remove / keep-connections stability
+#   IBMCEPH-15769                         anagrpid integrity (+ NS churn)
+#   IBMCEPH-16374                         scale-down not stuck DELETING (+ IO)
+#   IBMCEPH-15815                         failover SLO (warn by default; IO hard gate)
+#   IBMCEPH-16447                         no plaintext keys in nvmeof orch export
+#   IBMCEPH-15679                         --daemon-types nvmeof upgrade acceptance
+#   (customer path)                       initiator reboot + nvmf-autoconnect
+#
+# Run order notes:
+#   - Spec/anagrp first (non-destructive)
+#   - Initiator reboot autoconnect early (before maintenance mutates hosts)
+#   - Maintenance pair before host-remove (needs full 4-GW set)
+#   - Scale-down mutates placement (drops node9) — keep near end before failover
+#   - Failover uses remaining 3 GWs after scale-down
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: Deploy Ceph cluster for IBM cloud BM bug coverage
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy Ceph cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+          - node11
+        install_packages:
+          - nvme-cli
+          - fio
+        copy_admin_keyring: true
+      desc: Configure clients
+      destroy-cluster: false
+      module: test_client.py
+      name: configure clients
+
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+          - config:
+              command: apply
+              service: nvmeof
+              pos_args:
+                - rbd
+                - group1
+              args:
+                placement:
+                  nodes:
+                    - node6
+                    - node7
+                    - node8
+                    - node9
+      desc: Deploy 4-GW NVMeoF group1
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy NVMeoF 4 gateways
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-16447 — no plaintext keys in exported nvmeof orch specs
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        require_nvmeof_spec: true
+      desc: Exported nvmeof orch specs must not embed plaintext private keys (IBMCEPH-16447)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_spec_no_plaintext_keys.py
+      name: Spec no plaintext keys
+      polarion-id: IBMCEPH-16447
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-15769 — anagrpid integrity
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        extra_ns_churn: 4
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_ana
+            serial: 201
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 20G
+                ns_create_image: true
+        cleanup: []
+      desc: Assert namespace load_balancing_group within 1..num_gws (+ churn) (IBMCEPH-15769)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_anagrp_integrity.py
+      name: ANA group id integrity
+      polarion-id: IBMCEPH-15769
+
+  # --------------------------------------------------------------------------------------------
+  # Customer path — initiator reboot + nvmf-autoconnect (no manual discover/connect)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        autoconnect_timeout: 300
+        post_reboot_settle: 15
+        fio_smoke: true
+        fio_runtime: 30
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_reboot
+            serial: 210
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        cleanup:
+          - initiators
+      desc: >
+        Reboot initiator; assert namespaces return via --persistent,
+        discovery.conf, nvmf-autoconnect (no manual discover/connect)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_initiator_reboot_autoconnect.py
+      name: Initiator reboot persistent autoconnect
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-15819 (+ clones) — pure maintenance under IO (blocker path, no nvme-gw disable)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        maintenance_node: node6
+        gw_disable_enable: false
+        fio_runtime: 300
+        fio_settle_seconds: 20
+        maint_hold_seconds: 120
+        post_maint_settle: 60
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_maint
+            serial: 202
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        cleanup:
+          - initiators
+      desc: >
+        Host maintenance enter/exit under NVMeoF IO without nvme-gw disable
+        (IBMCEPH-15819 / 16124 / 16125 / 17250)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_host_maintenance_io.py
+      name: Host maintenance under NVMeoF IO
+      polarion-id: IBMCEPH-15819
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-16261 / 17007 — maintenance with nvme-gw disable/enable
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        maintenance_node: node7
+        gw_disable_enable: true
+        soft_disable_enable: false
+        fio_runtime: 300
+        fio_settle_seconds: 20
+        maint_hold_seconds: 90
+        post_maint_settle: 60
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_gwdis
+            serial: 207
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        cleanup:
+          - initiators
+      desc: >
+        Host maintenance with nvme-gw disable/enable under IO
+        (IBMCEPH-16261 / IBMCEPH-17007)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_host_maintenance_io.py
+      name: Maintenance with nvme-gw disable/enable
+      polarion-id: IBMCEPH-16261
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-17197 — host remove while connected
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystem: nqn.2016-06.io.spdk:cnode_bm_hostrm
+        keep_connections: false
+        fio_runtime: 120
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_hostrm
+            serial: 203
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            hosts: [node10]
+            bdevs:
+              - count: 2
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_hostrm
+            listener_port: 4420
+            node: node10
+        cleanup:
+          - initiators
+      desc: Remove connected host under IO without GW crash storm (IBMCEPH-17197)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_host_remove_stability.py
+      name: Host remove under IO stability
+      polarion-id: IBMCEPH-17197
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-17223 — host remove with keep-connections
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystem: nqn.2016-06.io.spdk:cnode_bm_keepconn
+        keep_connections: true
+        fio_runtime: 120
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_keepconn
+            serial: 204
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            hosts: [node11]
+            bdevs:
+              - count: 2
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_keepconn
+            listener_port: 4420
+            node: node11
+        cleanup:
+          - initiators
+      desc: Host remove with keep-connections under IO (IBMCEPH-17223)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_host_remove_stability.py
+      name: Host remove keep-connections stability
+      polarion-id: IBMCEPH-17223
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-16374 — scale-down must not stick in DELETING (mutates placement: drops node9)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8, node9]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        scale_down_nodes: [node9]
+        deleting_timeout: 300
+        fio_runtime: 180
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_scaledel
+            serial: 205
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9]
+            allow_host: "*"
+            bdevs:
+              - count: 2
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        cleanup:
+          - initiators
+      desc: Scale-down GW must leave DELETING; remaining AVAILABLE; IO continues (IBMCEPH-16374)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gw_scale_deleting.py
+      name: Scale-down DELETING lifecycle
+      polarion-id: IBMCEPH-16374
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-15815 — failover SLO (warn by default)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes: [node6, node7, node8]
+        rbd_pool: rbd
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        failover_node: node6
+        tool: systemctl
+        failover_slo_seconds: 10
+        fail_on_slo: false
+        fio_runtime: 120
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode_bm_failoverslo
+            serial: 206
+            max_ns: 32
+            no-group-append: true
+            listener_port: 4420
+            listeners: [node6, node7, node8]
+            allow_host: "*"
+            bdevs:
+              - count: 2
+                size: 20G
+                ns_create_image: true
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        cleanup:
+          - initiators
+      desc: Measure failover duration vs SLO (IBMCEPH-15815)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_failover_slo.py
+      name: Failover SLO check
+      polarion-id: IBMCEPH-15815
+
+  # --------------------------------------------------------------------------------------------
+  # IBMCEPH-15679 — staggered upgrade accepts --daemon-types nvmeof
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        post_start_settle: 5
+      desc: Probe ceph orch upgrade --daemon-types nvmeof acceptance (IBMCEPH-15679)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_daemon_types_upgrade.py
+      name: daemon-types nvmeof upgrade probe
+      polarion-id: IBMCEPH-15679

--- a/tests/nvmeof/test_ceph_nvmeof_anagrp_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_anagrp_integrity.py
@@ -1,0 +1,121 @@
+"""
+IBMCEPH-15769 — namespaces assigned wrong anagrpid (exceeds max GW count).
+
+After configure (+ optional extra NS churn), assert every namespace
+load_balancing_group / anagrp-id is within [1 .. num_gateways].
+Missing ANA group ids on existing namespaces are treated as failures.
+"""
+
+import json
+
+from ceph.ceph import Ceph
+from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import generate_unique_id
+
+LOG = Log(__name__)
+
+
+def _ns_ana_group(ns):
+    """Resolve ANA / load-balancing group id from namespace list JSON."""
+    for key in (
+        "load_balancing_group",
+        "anagrp-id",
+        "ana_group_id",
+        "anagrpid",
+        "ana_group",
+    ):
+        if ns.get(key) is not None:
+            return int(ns[key])
+    return None
+
+
+def _assert_anagrp_bounds(gateway, subsystems, max_ana):
+    violations = []
+    missing = []
+    checked = 0
+    for sub in subsystems:
+        nqn = sub.get("nqn") or sub.get("subnqn")
+        out, _ = gateway.namespace.list(
+            **{
+                "base_cmd_args": {"format": "json"},
+                "args": {"subsystem": nqn},
+            }
+        )
+        namespaces = json.loads(out).get("namespaces", []) if out else []
+        for ns in namespaces:
+            checked += 1
+            ana = _ns_ana_group(ns)
+            if ana is None:
+                missing.append({"subsystem": nqn, "nsid": ns.get("nsid")})
+                continue
+            if ana < 1 or ana > max_ana:
+                violations.append(
+                    {"subsystem": nqn, "nsid": ns.get("nsid"), "anagrp-id": ana}
+                )
+    if missing:
+        raise RuntimeError(
+            f"namespaces missing load_balancing_group/anagrp-id: {missing}"
+        )
+    if violations:
+        raise RuntimeError(f"anagrpid out of range (max={max_ana}): {violations}")
+    if checked == 0:
+        raise RuntimeError("No namespaces found to validate anagrpid integrity")
+    LOG.info("Checked %s namespaces; all anagrp-ids within 1..%s", checked, max_ana)
+    return checked
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        max_ana = len(nvme_service.gateways)
+        gateway = nvme_service.gateways[0]
+        subsystems = config.get("subsystems", [])
+        _assert_anagrp_bounds(gateway, subsystems, max_ana)
+
+        # Optional churn: create extra namespaces and re-assert (catches assign-on-create bugs)
+        extra = int(config.get("extra_ns_churn", 0))
+        if extra > 0:
+            pool = config.get("rbd_pool") or config.get("rep_pool_config", {}).get(
+                "pool", "rbd"
+            )
+            nqn = subsystems[0].get("nqn") or subsystems[0].get("subnqn")
+            size = config.get("extra_ns_size", "2G")
+            LOG.info(
+                "Creating %s extra namespaces on %s for anagrpid churn", extra, nqn
+            )
+            for _ in range(extra):
+                img = f"{generate_unique_id(length=4)}-ana-churn"
+                rbd_obj.create_image(pool, img, size)
+                gateway.namespace.add(
+                    **{
+                        "args": {
+                            "subsystem": nqn,
+                            "rbd-pool": pool,
+                            "rbd-image": img,
+                        }
+                    }
+                )
+            _assert_anagrp_bounds(gateway, subsystems, max_ana)
+
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)

--- a/tests/nvmeof/test_ceph_nvmeof_daemon_types_upgrade.py
+++ b/tests/nvmeof/test_ceph_nvmeof_daemon_types_upgrade.py
@@ -1,0 +1,87 @@
+"""
+IBMCEPH-15679 — staggered upgrade must accept --daemon-types nvmeof.
+
+Uses the cluster's current image and attempts:
+  ceph orch upgrade start --image <current> --daemon-types nvmeof
+
+Pass criteria: command is NOT rejected with "unexpected daemon type" / unsupported
+nvmeof. If upgrade actually starts, stop it. Same-image / no-op outcomes are OK.
+"""
+
+import json
+import re
+import time
+
+from ceph.ceph import Ceph
+from utility.log import Log
+
+LOG = Log(__name__)
+
+_UNEXPECTED = re.compile(
+    r"unexpected daemon type|not a valid daemon type|Viable daemon types",
+    re.IGNORECASE,
+)
+
+
+def _current_image(installer):
+    out, _ = installer.exec_command(
+        cmd="ceph orch ps --daemon_type mgr --format json", sudo=True
+    )
+    rows = json.loads(out or "[]")
+    for row in rows:
+        img = row.get("container_image_id") or row.get("container_image_name")
+        if row.get("container_image_name"):
+            return row["container_image_name"]
+        if img:
+            return img
+    out2, _ = installer.exec_command(
+        cmd="ceph orch upgrade status --format json", sudo=True, check_ec=False
+    )
+    try:
+        st = json.loads(out2 or "{}")
+        if st.get("target_image"):
+            return st["target_image"]
+    except Exception:
+        pass
+    raise RuntimeError("Unable to determine current container image for upgrade probe")
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    image = config.get("upgrade_image")
+    try:
+        if not image:
+            image = _current_image(installer)
+        LOG.info("Probing --daemon-types nvmeof with image=%s", image)
+
+        cmd = f"ceph orch upgrade start --image {image} --daemon-types nvmeof"
+        # Do not raise on non-zero — we classify the stderr/stdout ourselves
+        out, err = installer.exec_command(cmd=cmd, sudo=True, check_ec=False)
+        combined = f"{out or ''}\n{err or ''}"
+        LOG.info("upgrade start output:\n%s", combined)
+
+        if _UNEXPECTED.search(combined) and "nvmeof" in combined.lower():
+            raise RuntimeError(
+                "IBMCEPH-15679: nvmeof still rejected by --daemon-types: "
+                + combined.strip()
+            )
+
+        # If an upgrade is in progress, stop it (probe only)
+        time.sleep(int(config.get("post_start_settle", 5)))
+        try:
+            st_out, _ = installer.exec_command(
+                cmd="ceph orch upgrade status --format json", sudo=True
+            )
+            st = json.loads(st_out or "{}")
+            if st.get("in_progress") or st.get("status", {}).get("in_progress"):
+                LOG.info("Stopping probe upgrade")
+                installer.exec_command(cmd="ceph orch upgrade stop", sudo=True)
+        except Exception as stop_err:
+            LOG.warning("upgrade status/stop best-effort: %s", stop_err)
+
+        LOG.info("--daemon-types nvmeof accepted (or non-rejection path)")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1

--- a/tests/nvmeof/test_ceph_nvmeof_db_workloads.py
+++ b/tests/nvmeof/test_ceph_nvmeof_db_workloads.py
@@ -1,0 +1,169 @@
+"""
+Run real database engines on NVMeoF namespaces (filesystem on device + podman).
+
+Config example::
+
+    databases:
+      - engine: postgresql
+        duration: 60
+        scale: 10
+      - engine: mysql
+      - engine: mariadb
+      - engine: mongodb
+      - engine: redis
+      - engine: cassandra
+      # oracle: always skipped (license)
+      # mssql: requires accept_eula: true
+
+    subsystems:   # provide at least one NS per DB entry
+      - nqn: nqn.2016-06.io.spdk:cnode_db
+        bdevs: [{count: 6, size: 50G, ns_create_image: true}]
+    initiators:
+      - nqn: nqn.2016-06.io.spdk:cnode_db
+        node: node9
+"""
+
+from ceph.ceph import Ceph
+from ceph.utils import get_node_by_id
+from tests.nvmeof.workflows.db_workloads import (
+    UNSUPPORTED,
+    ensure_podman,
+    podman_rm,
+    run_database_workload,
+    umount_quiet,
+)
+from tests.nvmeof.workflows.gateway_entities import (
+    configure_gw_entities,
+    disconnect_initiators,
+)
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Configure DB namespaces, mount, run engines, cleanup."""
+    config = kwargs["config"]
+    databases = config.get("databases") or []
+    if not databases:
+        LOG.error("config.databases list is required")
+        return 1
+
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    clients = []
+    results = []
+    rc = 1
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        initiators = config.get("initiators")
+        if not initiators:
+            raise ValueError("initiators required for DB workloads")
+
+        clients = prepare_io_execution(
+            initiators,
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        if not clients:
+            raise RuntimeError("Failed to prepare NVMe initiators for DB workloads")
+
+        client = clients[0]
+        node = client.node
+        ensure_podman(node)
+        paths = client.list_spdk_drives() or client.list_devices()
+        if not paths:
+            raise RuntimeError(f"No NVMe devices on {node.hostname}")
+
+        LOG.info(
+            "DB workload devices on %s: %s (engines=%s)",
+            node.hostname,
+            paths,
+            [d.get("engine") for d in databases],
+        )
+
+        errors = []
+        # Assign devices only to runnable engines (skipped engines do not consume NS)
+        device_idx = 0
+        for db_cfg in databases:
+            engine = (db_cfg.get("engine") or "").lower()
+            if engine in UNSUPPORTED:
+                LOG.warning("Skip %s: %s", engine, UNSUPPORTED[engine])
+                results.append(
+                    {"engine": engine, "skipped": True, "reason": UNSUPPORTED[engine]}
+                )
+                continue
+
+            if device_idx >= len(paths):
+                msg = (
+                    f"Not enough NVMe namespaces for {engine}; "
+                    f"need index {device_idx}, have {len(paths)} device(s). "
+                    f"Increase subsystem bdevs.count."
+                )
+                LOG.error(msg)
+                errors.append(msg)
+                continue
+
+            device = paths[device_idx]
+            device_idx += 1
+            db_cfg = dict(db_cfg)
+            slot = device_idx  # 1-based for naming after increment
+            db_cfg.setdefault("mount_point", f"/mnt/nvmeof-db-{engine}-{slot}")
+            db_cfg.setdefault("container_name", f"nvmeof-db-{engine}-{slot}")
+            if engine in ("mysql", "mariadb") and "port" not in db_cfg:
+                db_cfg["port"] = 3306 + slot
+            if engine in ("postgresql", "postgres") and "port" not in db_cfg:
+                db_cfg["port"] = 5432 + slot
+
+            try:
+                results.append(run_database_workload(node, device, db_cfg))
+            except Exception as err:
+                LOG.error("DB workload %s failed: %s", engine, err)
+                errors.append(f"{engine}: {err}")
+                podman_rm(
+                    node, db_cfg.get("container_name", f"nvmeof-db-{engine}-{slot}")
+                )
+                umount_quiet(node, db_cfg["mount_point"])
+
+        unused = len(paths) - device_idx
+        if unused > 0:
+            LOG.info("%s spare NVMe namespace(s) unused after DB mapping", unused)
+        LOG.info("DB workload results: %s", results)
+        if errors:
+            raise RuntimeError(f"Database workload failures: {errors}")
+        rc = 0
+    except Exception as err:
+        LOG.error(err)
+        rc = 1
+    finally:
+        if config.get("cleanup") and clients:
+            for client in clients:
+                try:
+                    client.node.exec_command(
+                        sudo=True,
+                        cmd=(
+                            "podman ps -a --format '{{.Names}}' | "
+                            "grep '^nvmeof-db-' | xargs -r podman rm -f || true"
+                        ),
+                        check_ec=False,
+                    )
+                except Exception:
+                    pass
+            if nvme_service is not None:
+                for initiator_cfg in config.get("initiators", []):
+                    node = get_node_by_id(ceph_cluster, initiator_cfg["node"])
+                    disconnect_initiators(nvme_service, node=node)
+    return rc

--- a/tests/nvmeof/test_ceph_nvmeof_failover_slo.py
+++ b/tests/nvmeof/test_ceph_nvmeof_failover_slo.py
@@ -1,0 +1,124 @@
+"""
+IBMCEPH-15815 — NVMeoF gateway failover taking longer than expected.
+
+Performs orch/systemctl daemon stop failover under IO.
+- Hard-fail: ANA failover completes; IO continues (validate_io)
+- Soft/hard SLO gate: elapsed time vs failover_slo_seconds (fail_on_slo)
+"""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin.orch import Orch
+from tests.nvmeof.workflows.gateway_entities import (
+    configure_gw_entities,
+    fetch_namespaces,
+    teardown,
+)
+from tests.nvmeof.workflows.ha import HighAvailability
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import (
+    check_and_set_nvme_cli_image,
+    check_gateway,
+    validate_io,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    executor = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        clients = prepare_io_execution(
+            config["initiators"],
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        client = clients[0]
+        paths = client.list_spdk_drives() or client.list_devices()
+        if not paths:
+            raise RuntimeError("No NVMe devices for failover SLO test")
+
+        orch = Orch(ceph_cluster, **{})
+        ana_ids = [gw.ana_group_id for gw in nvme_service.gateways]
+        ns_for_io = fetch_namespaces(nvme_service.gateways[0], ana_ids)
+        if not ns_for_io:
+            raise RuntimeError("No namespaces resolved for failover validate_io")
+
+        runtime = str(config.get("fio_runtime", 120))
+        executor = ThreadPoolExecutor(max_workers=1)
+        fut = executor.submit(
+            client.start_fio,
+            io_size="1G",
+            runtime=runtime,
+            paths=paths[:1],
+            io_type="randrw",
+            iodepth=16,
+            time_based=True,
+            execute_blkdiscard=False,
+            test_name="bm-failover-slo",
+        )
+        time.sleep(int(config.get("fio_settle_seconds", 15)))
+
+        LOG.info("Validating IO before failover")
+        validate_io(orch, ns_for_io)
+
+        node_id = config.get("failover_node", config["gw_nodes"][0])
+        ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
+        ha.gateways = nvme_service.gateways
+        ha.nvme_service = nvme_service
+        gw = check_gateway(nvme_service.gateways, node_id)
+
+        slo = float(config.get("failover_slo_seconds", 10))
+        fail_tool = config.get("tool", "systemctl")
+        start = time.perf_counter()
+        result = ha.failover(gw, fail_tool)
+        elapsed = time.perf_counter() - start
+        LOG.info("Failover elapsed=%.2fs slo=%.2fs result=%s", elapsed, slo, result)
+
+        LOG.info("Validating IO after failover (hard gate)")
+        validate_io(orch, ns_for_io)
+
+        ha.failback(gw, fail_tool)
+        LOG.info("Validating IO after failback")
+        validate_io(orch, ns_for_io)
+
+        try:
+            fut.result(timeout=int(runtime) + 60)
+        except Exception as err:
+            # FIO path flaps can happen; rbd-du validate_io is the hard gate above
+            LOG.warning("FIO after failover/failback: %s", err)
+
+        if elapsed > slo:
+            msg = f"Failover took {elapsed:.2f}s > SLO {slo}s (IBMCEPH-15815)"
+            if config.get("fail_on_slo", False):
+                raise RuntimeError(msg)
+            LOG.warning(msg)
+        else:
+            LOG.info("Failover within SLO (%.2fs <= %.2fs)", elapsed, slo)
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)

--- a/tests/nvmeof/test_ceph_nvmeof_gw_scale_deleting.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gw_scale_deleting.py
@@ -1,0 +1,201 @@
+"""
+IBMCEPH-16374 — after scale-down, removed GW must not remain Availability=DELETING.
+
+Scales down NVMeoF placement, optionally validating IO continuity, then polls
+`ceph nvme-gw show` until DELETING is gone. Remaining gateways must be AVAILABLE
+and NVMEOF_GATEWAY_DELETING health warning must clear.
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin.orch import Orch
+from cli.utilities.utils import get_nodes_by_ids
+from tests.nvmeof.workflows.gateway_entities import (
+    configure_gw_entities,
+    fetch_namespaces,
+    teardown,
+)
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image, validate_io
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _gw_rows(show):
+    if isinstance(show, dict):
+        return show.get("Created Gateways:") or show.get("gateways") or []
+    return []
+
+
+def _deleting_rows(show):
+    return [
+        g
+        for g in _gw_rows(show)
+        if str(g.get("Availability", "")).upper() == "DELETING"
+        or "DELETING" in str(g.get("Availability", "")).upper()
+    ]
+
+
+def _unavailable_remaining(show, remaining_hostnames):
+    remaining = {h.lower() for h in remaining_hostnames}
+    bad = []
+    for g in _gw_rows(show):
+        gw_id = str(g.get("gw-id") or g.get("name") or "").lower()
+        host = str(g.get("hostname") or "").lower()
+        # gw-id often embeds hostname
+        matched = host in remaining or any(h in gw_id for h in remaining)
+        if not matched:
+            continue
+        avail = str(g.get("Availability", "")).upper()
+        if avail and avail != "AVAILABLE":
+            bad.append(g)
+    return bad
+
+
+def _health_has_deleting(installer):
+    out, _ = installer.exec_command(cmd="ceph health detail --format json", sudo=True)
+    try:
+        health = json.loads(out or "{}")
+    except Exception:
+        return "NVMEOF_GATEWAY_DELETING" in (out or "")
+    checks = health.get("checks") or {}
+    return "NVMEOF_GATEWAY_DELETING" in checks
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    executor = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        nodes = config.get("scale_down_nodes") or [config["gw_nodes"][-1]]
+        if not isinstance(nodes, list):
+            nodes = [nodes]
+
+        remaining = list(set(nvme_service.config["gw_nodes"]) - set(nodes))
+        if not remaining:
+            raise RuntimeError("scale_down_nodes would remove all gateways")
+
+        orch = Orch(ceph_cluster, **{})
+        pool = config.get("rbd_pool", "rbd")
+        group = config.get("gw_group", "group1")
+        ns_for_io = None
+        if config.get("initiators"):
+            clients = prepare_io_execution(
+                config["initiators"],
+                gateways=nvme_service.gateways,
+                cluster=ceph_cluster,
+                return_clients=True,
+            )
+            client = clients[0]
+            paths = client.list_spdk_drives() or client.list_devices()
+            if not paths:
+                raise RuntimeError("No NVMe devices for scale-down IO")
+            ana_ids = [gw.ana_group_id for gw in nvme_service.gateways]
+            ns_for_io = fetch_namespaces(nvme_service.gateways[0], ana_ids)
+            runtime = str(config.get("fio_runtime", 180))
+            executor = ThreadPoolExecutor(max_workers=1)
+            executor.submit(
+                client.start_fio,
+                io_size="1G",
+                runtime=runtime,
+                paths=paths[:1],
+                io_type="randrw",
+                iodepth=8,
+                time_based=True,
+                execute_blkdiscard=False,
+                test_name="bm-scale-deleting",
+            )
+            time.sleep(int(config.get("fio_settle_seconds", 15)))
+            if ns_for_io:
+                LOG.info("Validating IO before scale-down")
+                validate_io(orch, ns_for_io)
+
+        LOG.info("Scaling down gateways %s; remaining %s", nodes, remaining)
+        nvme_service.config["gw_nodes"] = remaining
+        nvme_service.gw_nodes = get_nodes_by_ids(ceph_cluster, remaining)
+        nvme_service.deploy()
+        nvme_service.gateways = []
+        nvme_service.init_gateways()
+
+        remaining_hostnames = [n.hostname for n in nvme_service.gw_nodes]
+        timeout = int(config.get("deleting_timeout", 300))
+        end = time.time() + timeout
+        last = None
+        saw_deleting = False
+        while time.time() < end:
+            out, _ = orch.shell(args=["ceph", "nvme-gw", "show", pool, repr(group)])
+            try:
+                last = json.loads(out)
+            except Exception:
+                last = out
+
+            deleting = _deleting_rows(last) if isinstance(last, dict) else []
+            blob = (
+                json.dumps(last).upper() if not isinstance(last, str) else last.upper()
+            )
+            if deleting or "DELETING" in blob:
+                saw_deleting = True
+                LOG.warning("Still seeing DELETING in nvme-gw show; retrying...")
+                time.sleep(15)
+                continue
+
+            # DELETING cleared — remaining must be AVAILABLE
+            bad = (
+                _unavailable_remaining(last, remaining_hostnames)
+                if isinstance(last, dict)
+                else []
+            )
+            if bad:
+                LOG.warning("Remaining GWs not yet AVAILABLE: %s", bad)
+                time.sleep(15)
+                continue
+
+            # Health warning should clear after autoload finishes
+            installer = ceph_cluster.get_nodes(role="installer")[0]
+            if _health_has_deleting(installer):
+                LOG.warning("NVMEOF_GATEWAY_DELETING still in ceph health; retrying...")
+                time.sleep(15)
+                continue
+
+            if ns_for_io:
+                # Namespaces may have rebalanced; refresh from a remaining GW
+                ana_ids = [gw.ana_group_id for gw in nvme_service.gateways]
+                ns_after = (
+                    fetch_namespaces(nvme_service.gateways[0], ana_ids) or ns_for_io
+                )
+                LOG.info("Validating IO after scale-down")
+                validate_io(orch, ns_after)
+
+            LOG.info(
+                "Scale-down cleared DELETING (observed_transient=%s); remaining AVAILABLE",
+                saw_deleting,
+            )
+            return 0
+
+        raise RuntimeError(
+            f"Gateway still DELETING / unhealthy after {timeout}s: {last}"
+        )
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)

--- a/tests/nvmeof/test_ceph_nvmeof_holistic_io.py
+++ b/tests/nvmeof/test_ceph_nvmeof_holistic_io.py
@@ -1,0 +1,556 @@
+"""
+Customer-centric NVMeoF holistic IO + day-2 ops under load.
+
+Modes:
+  - default / under_load: background multi-tenant FIO + day2_ops
+  - auth_fio: configure DHCHAP tenants and run authenticated FIO in the
+    same phase (keys never leave this process)
+
+Does not tear down gateway/pool unless cleanup is requested.
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from copy import deepcopy
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin.orch import Orch
+from ceph.utils import get_node_by_id
+from tests.nvmeof.test_nvmeof_gwgroup_inbandauth import (
+    configure_gw_entities_with_encryption,
+)
+from tests.nvmeof.workflows.gateway_entities import (
+    _hostnames_match,
+    disconnect_initiators,
+    fetch_namespaces,
+    teardown,
+)
+from tests.nvmeof.workflows.ha import HighAvailability
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.load_balancing import scale_down, scale_up, validate_scaleup
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import (
+    check_and_set_nvme_cli_image,
+    check_gateway,
+    validate_qos,
+    verify_qos,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _run_client_fio(client, io_args):
+    """Run time-based FIO on all NVMe paths visible to one initiator."""
+    paths = client.list_spdk_drives() or client.list_devices()
+    if not paths:
+        raise RuntimeError(f"No NVMe paths on {client.node.hostname}")
+
+    LOG.info(
+        "Starting FIO on %s with %s device(s): %s",
+        client.node.hostname,
+        len(paths),
+        io_args,
+    )
+    runtime = str(io_args.get("run_time", 600))
+    fio_kwargs = {
+        "io_size": io_args.get("size", "1G"),
+        "runtime": runtime,
+        "paths": paths,
+        "io_type": io_args.get("io_type", "randrw"),
+        "iodepth": io_args.get("iodepth", 16),
+        "rwmixread": io_args.get("rwmixread"),
+        "test_name": io_args.get("test_name"),
+        "time_based": True,
+        "execute_blkdiscard": io_args.get("execute_blkdiscard", False),
+    }
+    if io_args.get("verify"):
+        fio_kwargs["verify"] = io_args["verify"]
+    if io_args.get("verify_fatal") is not None:
+        fio_kwargs["verify_fatal"] = io_args["verify_fatal"]
+    if io_args.get("bs"):
+        fio_kwargs["bs"] = io_args["bs"]
+    if io_args.get("num_jobs") is not None:
+        fio_kwargs["num_jobs"] = io_args["num_jobs"]
+    if io_args.get("fsync") is not None:
+        fio_kwargs["fsync"] = io_args["fsync"]
+    if io_args.get("direct") is not None:
+        fio_kwargs["direct"] = io_args["direct"]
+    return client.start_fio(**fio_kwargs)
+
+
+def _op_set_qos(gateway, args):
+    qos_args = deepcopy(args)
+    subsystem = qos_args["subsystem"]
+    nsid = qos_args["nsid"]
+    gateway.namespace.set_qos(**{"args": qos_args})
+    verify_qos(deepcopy(qos_args), gateway)
+    LOG.info("QoS applied under load: %s nsid=%s", subsystem, nsid)
+
+
+def _op_qos_validate_io(gateway, clients, ceph_cluster, args):
+    """Set QoS, briefly drive IO, validate observed bandwidth via iostat."""
+    _op_set_qos(gateway, args)
+    node_id = args.get("initiator_node")
+    if not node_id:
+        raise ValueError("qos_validate_io requires initiator_node")
+
+    client = next((c for c in clients if c.node.id == node_id), None)
+    if client is None:
+        node = get_node_by_id(ceph_cluster, node_id)
+        # Reconnect path if client object not in under-load set
+        from tests.nvmeof.workflows.initiator import NVMeInitiator
+
+        client = NVMeInitiator(node)
+
+    paths = client.list_spdk_drives() or client.list_devices()
+    if not paths:
+        raise RuntimeError(f"No devices on {node_id} for QoS IO validation")
+
+    device = paths[0].replace("/dev/", "")
+    io_mode = {
+        "r-megabytes-per-second": "read",
+        "w-megabytes-per-second": "write",
+        "rw-megabytes-per-second": "randrw",
+    }
+    # Prefer write validation when present
+    key = next(
+        (
+            k
+            for k in (
+                "w-megabytes-per-second",
+                "r-megabytes-per-second",
+                "rw-megabytes-per-second",
+            )
+            if k in args
+        ),
+        "w-megabytes-per-second",
+    )
+    runtime = str(args.get("io_runtime", 40))
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        fut = executor.submit(
+            client.start_fio,
+            io_size="1G",
+            runtime=runtime,
+            paths=[paths[0]],
+            io_type=io_mode.get(key, "write"),
+            iodepth=4,
+            time_based=True,
+            execute_blkdiscard=False,
+            test_name=f"qos-validate-{device}",
+        )
+        time.sleep(15)
+        limits = {k: args[k] for k in args if k.endswith("megabytes-per-second")}
+        validate_qos(client.node, device, **limits)
+        fut.result()
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+    # Also pull gateway-side IO stats when available
+    try:
+        out, _ = gateway.namespace.get_io_stats(
+            **{
+                "base_cmd_args": {"format": "json"},
+                "args": {"subsystem": args["subsystem"], "nsid": args["nsid"]},
+            }
+        )
+        LOG.info("Namespace IO stats after QoS validate: %s", out)
+    except Exception as err:
+        LOG.warning("get_io_stats not available/failed: %s", err)
+
+
+def _op_fio_burst(clients, ceph_cluster, args):
+    """
+    Short foreground FIO burst on one client (e.g. backup restore / media read)
+    while other persona FIO continues in the background.
+    """
+    node_id = args.get("initiator_node")
+    if not node_id:
+        raise ValueError("fio_burst requires initiator_node")
+
+    client = next((c for c in clients if c.node.id == node_id), None)
+    if client is None:
+        from tests.nvmeof.workflows.initiator import NVMeInitiator
+
+        client = NVMeInitiator(get_node_by_id(ceph_cluster, node_id))
+
+    paths = client.list_spdk_drives() or client.list_devices()
+    if not paths:
+        raise RuntimeError(f"No devices on {node_id} for fio_burst")
+
+    runtime = str(args.get("io_runtime", 60))
+    fio_kwargs = {
+        "io_size": args.get("size", "2G"),
+        "runtime": runtime,
+        "paths": [paths[0]],
+        "io_type": args.get("io_type", "read"),
+        "iodepth": args.get("iodepth", 16),
+        "bs": args.get("bs", "1M"),
+        "time_based": True,
+        "execute_blkdiscard": False,
+        "test_name": args.get("test_name", f"fio-burst-{node_id}"),
+        "direct": args.get("direct", 1),
+    }
+    if args.get("num_jobs") is not None:
+        fio_kwargs["num_jobs"] = args["num_jobs"]
+    LOG.info(
+        "fio_burst on %s path=%s io_type=%s bs=%s runtime=%s",
+        node_id,
+        paths[0],
+        fio_kwargs["io_type"],
+        fio_kwargs["bs"],
+        runtime,
+    )
+    client.start_fio(**fio_kwargs)
+
+
+def _op_change_visibility(gateway, args):
+    vis_args = {
+        "subsystem": args["subsystem"],
+        "nsid": args["nsid"],
+        "auto-visible": args.get("auto-visible", "yes"),
+    }
+    if args.get("force", True):
+        vis_args["force"] = ""
+    gateway.namespace.change_visibility(**{"args": vis_args})
+    LOG.info(
+        "change_visibility under load: %s nsid=%s auto-visible=%s",
+        args["subsystem"],
+        args["nsid"],
+        args.get("auto-visible"),
+    )
+
+
+def _op_resize(gateway, args):
+    resize_args = {
+        "subsystem": args["subsystem"],
+        "nsid": args["nsid"],
+        "size": args["size"],
+    }
+    gateway.namespace.resize(**{"args": resize_args})
+    LOG.info(
+        "resize under load: %s nsid=%s -> %s",
+        args["subsystem"],
+        args["nsid"],
+        args["size"],
+    )
+
+
+def _op_scale_down(nvme_service, orch, args):
+    nodes = args["nodes"]
+    if not isinstance(nodes, list):
+        nodes = [nodes]
+    LOG.info("scale_down under load: %s", nodes)
+    scale_down(nvme_service, orch, nodes)
+    remaining = [
+        n for n in nvme_service.config.get("gw_nodes", []) if n not in set(nodes)
+    ]
+    nvme_service.config["gw_nodes"] = remaining
+    LOG.info("GW membership after scale_down: %s", remaining)
+
+
+def _assert_listeners(nvme_service, args):
+    """
+    ISCE-2203-oriented check: every live GW must have a listener for each NQN.
+    """
+    nqns = args.get("subsystems") or args.get("nqns") or []
+    if not nqns:
+        raise ValueError("assert_listeners requires subsystems/nqns")
+    port = str(args.get("listener_port", 4420))
+    gateway = nvme_service.gateways[0]
+
+    for nqn in nqns:
+        out, _ = gateway.listener.list(
+            **{
+                "base_cmd_args": {"format": "json"},
+                "args": {"subsystem": nqn},
+            }
+        )
+        listeners = json.loads(out).get("listeners", []) if out else []
+        missing = []
+        for gw in nvme_service.gateways:
+            matched = any(
+                _hostnames_match(lst.get("host_name"), gw.hostname)
+                and str(lst.get("trsvcid")) == port
+                for lst in listeners
+            )
+            if not matched:
+                missing.append(gw.hostname)
+        if missing:
+            raise RuntimeError(
+                f"Listener assert failed for {nqn} port={port}: "
+                f"missing on GWs {missing}; have={listeners}"
+            )
+        LOG.info(
+            "Listener assert OK: %s port=%s on %s GW(s)",
+            nqn,
+            port,
+            len(nvme_service.gateways),
+        )
+
+
+def _op_scale_up(nvme_service, orch, args):
+    nodes = args["nodes"]
+    if not isinstance(nodes, list):
+        nodes = [nodes]
+    LOG.info("scale_up under load: %s", nodes)
+    namespaces = fetch_namespaces(nvme_service.gateways[0])
+    prev_gws = list(nvme_service.gateways)
+    scale_up(nvme_service, orch, nodes, prev_gws, namespaces)
+    validate_scaleup(nvme_service, orch, nodes, namespaces)
+    merged = list(dict.fromkeys(list(nvme_service.config.get("gw_nodes", [])) + nodes))
+    nvme_service.config["gw_nodes"] = merged
+    LOG.info("GW membership after scale_up: %s", merged)
+    # Optional post-LB auto-listener validation (ISCE-2203)
+    if args.get("assert_listeners"):
+        _assert_listeners(nvme_service, args["assert_listeners"])
+
+
+def _op_ha_failover(ceph_cluster, nvme_service, config, args):
+    tool = args.get("tool", "systemctl")
+    nodes = args["nodes"]
+    if not isinstance(nodes, list):
+        nodes = [nodes]
+
+    ha_cfg = deepcopy(config)
+    ha_cfg["nvme_service"] = nvme_service
+    ha = HighAvailability(ceph_cluster, config["gw_nodes"], **ha_cfg)
+    ha.gateways = nvme_service.gateways
+    ha.nvme_service = nvme_service
+
+    for node_id in nodes:
+        gw = check_gateway(nvme_service.gateways, node_id)
+        LOG.info("HA failover under load on %s via %s", node_id, tool)
+        ha.failover(gw, tool)
+        LOG.info("HA failback under load on %s via %s", node_id, tool)
+        ha.failback(gw, tool)
+
+
+def _run_day2_ops(ceph_cluster, nvme_service, orch, config, ops, clients):
+    gateway = nvme_service.gateways[0]
+
+    for idx, step in enumerate(ops, start=1):
+        op = step.get("op")
+        args = deepcopy(step.get("args", {}))
+        LOG.info("=== Day-2 op %s/%s: %s ===", idx, len(ops), op)
+
+        if op == "sleep":
+            time.sleep(int(args.get("seconds", 30)))
+        elif op == "set_qos":
+            _op_set_qos(gateway, args)
+        elif op == "qos_validate_io":
+            _op_qos_validate_io(gateway, clients, ceph_cluster, args)
+        elif op == "fio_burst":
+            _op_fio_burst(clients, ceph_cluster, args)
+        elif op == "change_visibility":
+            _op_change_visibility(gateway, args)
+        elif op == "resize":
+            _op_resize(gateway, args)
+        elif op == "scale_down":
+            _op_scale_down(nvme_service, orch, args)
+            gateway = nvme_service.gateways[0]
+        elif op == "scale_up":
+            _op_scale_up(nvme_service, orch, args)
+            gateway = nvme_service.gateways[0]
+        elif op == "assert_listeners":
+            _assert_listeners(nvme_service, args)
+        elif op == "ha_failover":
+            ha_config = deepcopy(config)
+            ha_config["gw_nodes"] = list(nvme_service.config.get("gw_nodes", []))
+            _op_ha_failover(ceph_cluster, nvme_service, ha_config, args)
+            nvme_service.gateways = []
+            nvme_service.init_gateways()
+            gateway = nvme_service.gateways[0]
+        else:
+            raise ValueError(f"Unsupported day2 op: {op}")
+
+        settle = int(step.get("settle_seconds", config.get("op_settle_seconds", 15)))
+        if settle:
+            time.sleep(settle)
+
+
+def _inventory_snapshot(gateway):
+    """Best-effort subsystem/namespace inventory for post-run logging."""
+    try:
+        out, _ = gateway.subsystem.list(
+            **{"base_cmd_args": {"format": "json"}, "args": {}}
+        )
+        subs = json.loads(out).get("subsystems", [])
+        LOG.info("Inventory: %s subsystems present after under-load ops", len(subs))
+        for sub in subs:
+            nqn = sub.get("nqn") or sub.get("subnqn")
+            ns_out, _ = gateway.namespace.list(
+                **{
+                    "base_cmd_args": {"format": "json"},
+                    "args": {"subsystem": nqn},
+                }
+            )
+            ns_count = len(json.loads(ns_out).get("namespaces", []))
+            LOG.info("  %s -> %s namespaces", nqn, ns_count)
+    except Exception as err:
+        LOG.warning("Inventory snapshot failed: %s", err)
+
+
+def _run_auth_fio(ceph_cluster, nvme_service, config, rbd_obj):
+    """
+    ISCE-3542 style: create DHCHAP keys and run authenticated FIO in one phase.
+    Uses unique NQNs so standing open tenants are untouched.
+    """
+    auth_cfg = config.get("auth_fio", {})
+    if not auth_cfg.get("subsystems") or not auth_cfg.get("initiators"):
+        raise ValueError("auth_fio requires subsystems and initiators")
+
+    gwgroup_config = {
+        "gw_group": config.get("gw_group"),
+        "gw_nodes": config.get("gw_nodes"),
+        "rbd_pool": config.get("rbd_pool", "rbd"),
+        "inband_auth_mode": auth_cfg.get("inband_auth_mode", "bidirectional"),
+        "subsystems": auth_cfg["subsystems"],
+        "hosts": [],
+    }
+    for sub in gwgroup_config["subsystems"]:
+        sub.setdefault("auth_mode", gwgroup_config["inband_auth_mode"])
+        sub.setdefault("subnqn", sub.get("nqn") or sub.get("subnqn"))
+
+    LOG.info("Configuring DHCHAP tenants and running authenticated FIO (same phase)")
+    keyed_initiators = configure_gw_entities_with_encryption(
+        gwgroup_config, ceph_cluster, nvme_service
+    )
+
+    clients = prepare_io_execution(
+        auth_cfg["initiators"],
+        gateways=nvme_service.gateways,
+        cluster=ceph_cluster,
+        return_clients=True,
+        pre_configured_initiators=keyed_initiators,
+    )
+    if not clients:
+        raise RuntimeError("Failed to prepare authenticated initiators")
+
+    errors = []
+    with ThreadPoolExecutor(max_workers=len(clients)) as executor:
+        futures = {}
+        for idx, client in enumerate(clients):
+            io_args = dict(auth_cfg["initiators"][idx].get("io_args", {}))
+            io_args.setdefault("run_time", auth_cfg.get("fio_runtime", 90))
+            io_args.setdefault("size", "1G")
+            io_args.setdefault("execute_blkdiscard", False)
+            futures[executor.submit(_run_client_fio, client, io_args)] = client
+        for future in as_completed(futures):
+            client = futures[future]
+            try:
+                future.result()
+                LOG.info("Authenticated FIO OK on %s", client.node.hostname)
+            except Exception as err:
+                LOG.error(
+                    "Authenticated FIO failed on %s: %s", client.node.hostname, err
+                )
+                errors.append(err)
+
+    for initiator_cfg in auth_cfg["initiators"]:
+        node = get_node_by_id(ceph_cluster, initiator_cfg["node"])
+        disconnect_initiators(nvme_service, node=node)
+
+    if errors:
+        raise RuntimeError(f"Authenticated FIO failures: {errors}")
+    return 0
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Entry: auth_fio mode or under-load day-2 orchestration."""
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    executor = None
+    futures = {}
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        orch = Orch(ceph_cluster, **{})
+
+        # --- Mode: DHCHAP configure + FIO same phase ---
+        if config.get("mode") == "auth_fio" or config.get("auth_fio"):
+            if config.get("mode") == "auth_fio" or not config.get("day2_ops"):
+                return _run_auth_fio(ceph_cluster, nvme_service, config, rbd_obj)
+            # If both present, run auth first then continue under-load
+            _run_auth_fio(ceph_cluster, nvme_service, config, rbd_obj)
+
+        initiators = config.get("initiators")
+        if not initiators:
+            raise ValueError("initiators config is required for under-load mode")
+
+        clients = prepare_io_execution(
+            initiators,
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        if not clients:
+            raise RuntimeError("Failed to prepare NVMe initiators for FIO")
+
+        work = []
+        for idx, client in enumerate(clients):
+            io_args = dict(initiators[idx].get("io_args", {}))
+            if "run_time" not in io_args:
+                io_args["run_time"] = config.get("fio_runtime", 600)
+            work.append((client, io_args))
+
+        LOG.info("Starting background customer FIO on %s clients", len(work))
+        executor = ThreadPoolExecutor(max_workers=len(work))
+        futures = {
+            executor.submit(_run_client_fio, client, io_args): client
+            for client, io_args in work
+        }
+
+        settle = int(config.get("fio_settle_seconds", 30))
+        LOG.info("Waiting %ss for FIO to settle before day-2 ops", settle)
+        time.sleep(settle)
+
+        day2_ops = config.get("day2_ops", [])
+        day2_error = None
+        if day2_ops:
+            try:
+                _run_day2_ops(
+                    ceph_cluster, nvme_service, orch, config, day2_ops, clients
+                )
+            except Exception as err:
+                day2_error = err
+                LOG.error("Day-2 op failed; cancelling background FIO: %s", err)
+                if executor is not None:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    executor = None
+
+        LOG.info("Waiting for background FIO to complete")
+        errors = []
+        for future in as_completed(list(futures.keys())):
+            client = futures[future]
+            try:
+                future.result()
+                LOG.info("FIO completed on %s", client.node.hostname)
+            except Exception as err:
+                LOG.error("FIO failed on %s: %s", client.node.hostname, err)
+                errors.append(f"{client.node.hostname}: {err}")
+
+        _inventory_snapshot(nvme_service.gateways[0])
+
+        if day2_error:
+            raise RuntimeError(f"Holistic day-2 failure: {day2_error}") from day2_error
+        if errors:
+            raise RuntimeError(f"Holistic under-load FIO failures: {errors}")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)
+    return 1

--- a/tests/nvmeof/test_ceph_nvmeof_host_maintenance_io.py
+++ b/tests/nvmeof/test_ceph_nvmeof_host_maintenance_io.py
@@ -1,0 +1,290 @@
+"""
+IBMCEPH-15819 / 16124 / 16125 / 17250 / 16261 / 17007
+
+Host maintenance enter/exit with continuous NVMeoF IO, optionally using
+nvme-gw disable/enable around maintenance for faster failover/failback.
+
+Hard assertions:
+- FIO / rbd-du IO continues during and after maintenance
+- Target GW returns to Availability=AVAILABLE after exit (+ enable)
+- nvme-gw disable/enable succeed when gw_disable_enable is requested
+- Peer GWs do not crash/restart during the maintenance window
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin.orch import Orch
+from ceph.utils import get_node_by_id
+from ceph.waiter import WaitUntil
+from cli.ops.host import host_maintenance_enter, host_maintenance_exit
+from tests.nvmeof.workflows.gateway_entities import (
+    configure_gw_entities,
+    fetch_namespaces,
+    teardown,
+)
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import (
+    ana_states,
+    check_and_set_nvme_cli_image,
+    check_gateway,
+    check_gateway_availability,
+    get_optimized_state,
+    validate_io,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _nvme_gw_cmd(installer, *args):
+    cmd = "ceph nvme-gw " + " ".join(str(a) for a in args)
+    return installer.exec_command(cmd=cmd, sudo=True)
+
+
+def _snapshot_nvmeof_daemons(installer):
+    """Return {daemon_name: {container_id, started, status, host}} for restart detection."""
+    out, _ = installer.exec_command(
+        cmd="ceph orch ps --daemon_type nvmeof --format json", sudo=True
+    )
+    rows = json.loads(out or "[]")
+    snap = {}
+    for r in rows:
+        name = r.get("daemon_name") or ""
+        if "nvmeof" not in name:
+            continue
+        snap[name] = {
+            "container_id": r.get("container_id") or r.get("container_id_short"),
+            "started": r.get("started") or r.get("start_time"),
+            "status": r.get("status_desc") or r.get("status"),
+            "host": r.get("hostname"),
+        }
+    return snap
+
+
+def _assert_no_peer_restarts(before, after, exclude_hosts=None):
+    """Fail if peer nvmeof daemons restarted (container_id / started changed)."""
+    exclude_hosts = {h.lower() for h in (exclude_hosts or [])}
+    restarted = []
+    for name, prev in before.items():
+        host = (prev.get("host") or "").lower()
+        if host in exclude_hosts:
+            continue
+        cur = after.get(name)
+        if not cur:
+            restarted.append({"daemon": name, "reason": "missing after maintenance"})
+            continue
+        status = str(cur.get("status", "")).lower()
+        if (
+            status
+            and status not in ("running", "1", "active")
+            and "running" not in status
+        ):
+            restarted.append(
+                {"daemon": name, "reason": f"unhealthy status={cur.get('status')}"}
+            )
+            continue
+        if prev.get("container_id") and cur.get("container_id"):
+            if prev["container_id"] != cur["container_id"]:
+                restarted.append(
+                    {
+                        "daemon": name,
+                        "reason": "container_id changed",
+                        "before": prev["container_id"],
+                        "after": cur["container_id"],
+                    }
+                )
+                continue
+        if (
+            prev.get("started")
+            and cur.get("started")
+            and prev["started"] != cur["started"]
+        ):
+            restarted.append(
+                {
+                    "daemon": name,
+                    "reason": "started timestamp changed",
+                    "before": prev["started"],
+                    "after": cur["started"],
+                }
+            )
+    if restarted:
+        raise RuntimeError(f"Peer NVMeoF daemons restarted/unhealthy: {restarted}")
+
+
+def _ns_for_validate_io(gateway, gateways):
+    ana_ids = [gw.ana_group_id for gw in gateways]
+    return fetch_namespaces(gateway, ana_ids)
+
+
+def _wait_gw_available(nvme_service, orch, ana_id, timeout=300, interval=10):
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        if check_gateway_availability(nvme_service, ana_id, orch, state="AVAILABLE"):
+            return True
+        LOG.warning("ANA group %s not yet AVAILABLE after maintenance", ana_id)
+    if w.expired:
+        states = ana_states(nvme_service, orch)
+        raise TimeoutError(
+            f"Gateway ANA {ana_id} not AVAILABLE within {timeout}s: {states}"
+        )
+    return False
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    executor = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        clients = prepare_io_execution(
+            config["initiators"],
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        client = clients[0]
+        paths = client.list_spdk_drives() or client.list_devices()
+        if not paths:
+            raise RuntimeError("No NVMe devices for maintenance IO test")
+
+        installer = ceph_cluster.get_nodes(role="installer")[0]
+        orch = Orch(ceph_cluster, **{})
+        pool = config.get("rbd_pool") or config.get("nvme_metadata_pool") or "rbd"
+        group = config.get("gw_group", "group1")
+        use_disable = config.get("gw_disable_enable", True)
+        soft_disable = config.get("soft_disable_enable", False)
+
+        maint_node_id = config.get("maintenance_node", config["gw_nodes"][0])
+        maint_node = get_node_by_id(ceph_cluster, maint_node_id)
+        maint_gw = check_gateway(nvme_service.gateways, maint_node_id)
+        ns_for_io = _ns_for_validate_io(nvme_service.gateways[0], nvme_service.gateways)
+        if not ns_for_io:
+            raise RuntimeError("No namespaces resolved for validate_io")
+
+        before_daemons = _snapshot_nvmeof_daemons(installer)
+        LOG.info("NVMeoF daemons before maintenance: %s", before_daemons)
+
+        runtime = str(config.get("fio_runtime", 300))
+        executor = ThreadPoolExecutor(max_workers=1)
+        fut = executor.submit(
+            client.start_fio,
+            io_size="1G",
+            runtime=runtime,
+            paths=paths[:2],
+            io_type=config.get("io_type", "randrw"),
+            iodepth=16,
+            time_based=True,
+            execute_blkdiscard=False,
+            test_name="bm-maint-under-io",
+        )
+        time.sleep(int(config.get("fio_settle_seconds", 20)))
+
+        LOG.info("Validating IO before maintenance")
+        validate_io(orch, ns_for_io)
+
+        if use_disable:
+            LOG.info("Disable NVMe GW on %s before maintenance", maint_node.hostname)
+            try:
+                _nvme_gw_cmd(installer, "disable", pool, group, maint_node.hostname)
+            except Exception as err:
+                if soft_disable:
+                    LOG.warning("nvme-gw disable failed/unsupported: %s", err)
+                else:
+                    raise RuntimeError(
+                        f"nvme-gw disable failed on {maint_node.hostname}: {err}"
+                    ) from err
+
+        LOG.info("Enter maintenance on %s", maint_node.hostname)
+        ok = host_maintenance_enter(
+            installer,
+            maint_node.hostname,
+            force=True,
+            yes_i_really_mean_it=True,
+            timeout=int(config.get("maint_timeout", 600)),
+        )
+        if not ok:
+            raise RuntimeError(f"Failed to enter maintenance on {maint_node.hostname}")
+
+        # During maintenance peer GWs must keep serving; rbd-du should still advance
+        time.sleep(int(config.get("maint_hold_seconds", 60)))
+        LOG.info("Validating IO during maintenance")
+        validate_io(orch, ns_for_io)
+
+        LOG.info("Exit maintenance on %s", maint_node.hostname)
+        ok = host_maintenance_exit(
+            installer,
+            maint_node.hostname,
+            timeout=int(config.get("maint_timeout", 600)),
+        )
+        if not ok:
+            raise RuntimeError(f"Failed to exit maintenance on {maint_node.hostname}")
+
+        if use_disable:
+            LOG.info("Enable NVMe GW on %s after maintenance", maint_node.hostname)
+            try:
+                _nvme_gw_cmd(installer, "enable", pool, group, maint_node.hostname)
+            except Exception as err:
+                if soft_disable:
+                    LOG.warning("nvme-gw enable failed/unsupported: %s", err)
+                else:
+                    raise RuntimeError(
+                        f"nvme-gw enable failed on {maint_node.hostname}: {err}"
+                    ) from err
+
+        settle = int(config.get("post_maint_settle", 60))
+        time.sleep(settle)
+
+        # Hard: recovered GW must be AVAILABLE (IBMCEPH-15819 class of failures)
+        _wait_gw_available(
+            nvme_service,
+            orch,
+            maint_gw.ana_group_id,
+            timeout=int(config.get("avail_timeout", 300)),
+        )
+        states = ana_states(nvme_service, orch)
+        LOG.info("nvme-gw ANA states after maintenance: %s", states)
+
+        # Soft-ish: prefer optimized path ownership returning to recovered GW
+        active = get_optimized_state(nvme_service, orch, maint_gw.ana_group_id)
+        if not active:
+            raise RuntimeError(
+                f"No ACTIVE/optimized path for ANA {maint_gw.ana_group_id} after maintenance"
+            )
+        LOG.info(
+            "Optimized path(s) for recovered ANA %s: %s",
+            maint_gw.ana_group_id,
+            active,
+        )
+
+        LOG.info("Validating IO after maintenance exit")
+        validate_io(orch, ns_for_io)
+
+        after_daemons = _snapshot_nvmeof_daemons(installer)
+        _assert_no_peer_restarts(
+            before_daemons, after_daemons, exclude_hosts=[maint_node.hostname]
+        )
+
+        fut.result(timeout=int(runtime) + 120)
+        LOG.info("Maintenance-under-IO completed successfully")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)

--- a/tests/nvmeof/test_ceph_nvmeof_host_remove_stability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_host_remove_stability.py
@@ -1,0 +1,225 @@
+"""
+IBMCEPH-17197 / IBMCEPH-17223
+
+Remove a connected host from a subsystem while IO is running.
+Optional keep-connections path for PSK-rotation style removals.
+
+Expect:
+- No GW crash/restart storm on peer (or any) gateways
+- keep_connections=true: IO continues on the still-connected session
+- keep_connections=false: host ACL removed; FIO may fail (expected)
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from ceph.ceph import Ceph
+from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _snapshot_nvmeof_daemons(installer):
+    out, _ = installer.exec_command(
+        cmd="ceph orch ps --daemon_type nvmeof --format json", sudo=True
+    )
+    rows = json.loads(out or "[]")
+    snap = {}
+    for r in rows:
+        name = r.get("daemon_name") or ""
+        if "nvmeof" not in name:
+            continue
+        snap[name] = {
+            "container_id": r.get("container_id") or r.get("container_id_short"),
+            "started": r.get("started") or r.get("start_time"),
+            "status": r.get("status_desc") or r.get("status"),
+            "host": r.get("hostname"),
+        }
+    return snap
+
+
+def _assert_daemons_stable(before, after, allow_missing=False):
+    """Fail on unhealthy status or container_id/started changes (crash/restart)."""
+    bad = []
+    for name, prev in before.items():
+        cur = after.get(name)
+        if not cur:
+            if allow_missing:
+                continue
+            bad.append({"daemon": name, "reason": "missing after host remove"})
+            continue
+        status = str(cur.get("status", "")).lower()
+        if (
+            status
+            and status not in ("running", "1", "active")
+            and "running" not in status
+        ):
+            bad.append(
+                {"daemon": name, "reason": f"unhealthy status={cur.get('status')}"}
+            )
+            continue
+        if prev.get("container_id") and cur.get("container_id"):
+            if prev["container_id"] != cur["container_id"]:
+                bad.append(
+                    {
+                        "daemon": name,
+                        "reason": "container_id changed (restart)",
+                        "before": prev["container_id"],
+                        "after": cur["container_id"],
+                    }
+                )
+                continue
+        if (
+            prev.get("started")
+            and cur.get("started")
+            and prev["started"] != cur["started"]
+        ):
+            bad.append(
+                {
+                    "daemon": name,
+                    "reason": "started timestamp changed (restart)",
+                    "before": prev["started"],
+                    "after": cur["started"],
+                }
+            )
+    if bad:
+        raise RuntimeError(f"NVMeoF daemon instability after host remove: {bad}")
+
+
+def _host_still_listed(gateway, subsystem, host_nqn):
+    out, _ = gateway.host.list(
+        **{
+            "base_cmd_args": {"format": "json"},
+            "args": {"subsystem": subsystem},
+        }
+    )
+    try:
+        data = json.loads(out or "{}")
+    except Exception:
+        return host_nqn in (out or "")
+    hosts = data.get("hosts") or data.get("Hosts") or []
+    if isinstance(hosts, list):
+        for h in hosts:
+            if isinstance(h, str) and h == host_nqn:
+                return True
+            if isinstance(h, dict) and host_nqn in (
+                h.get("nqn"),
+                h.get("host_nqn"),
+                h.get("hostnqn"),
+            ):
+                return True
+    return host_nqn in json.dumps(data)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    executor = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        clients = prepare_io_execution(
+            config["initiators"],
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        client = clients[0]
+        paths = client.list_spdk_drives() or client.list_devices()
+        if not paths:
+            raise RuntimeError("No NVMe devices for host-remove stability test")
+
+        installer = ceph_cluster.get_nodes(role="installer")[0]
+        before = _snapshot_nvmeof_daemons(installer)
+        LOG.info("GW daemons before host remove: %s", before)
+
+        runtime = str(config.get("fio_runtime", 180))
+        executor = ThreadPoolExecutor(max_workers=1)
+        fut = executor.submit(
+            client.start_fio,
+            io_size="1G",
+            runtime=runtime,
+            paths=paths[:1],
+            io_type="randwrite",
+            iodepth=8,
+            time_based=True,
+            execute_blkdiscard=False,
+            test_name="bm-host-remove-under-io",
+        )
+        time.sleep(int(config.get("fio_settle_seconds", 15)))
+
+        subsystem = config["subsystem"]
+        host_nqn = client.initiator_nqn()
+        gateway = nvme_service.gateways[0]
+        keep = config.get("keep_connections", False)
+        args = {"subsystem": subsystem, "host": host_nqn, "force": ""}
+        if keep:
+            args["keep-connections"] = ""
+
+        LOG.info(
+            "Removing host %s from %s (keep_connections=%s)",
+            host_nqn,
+            subsystem,
+            keep,
+        )
+        try:
+            gateway.host.delete(**{"args": args})
+        except Exception as err:
+            # Bug notes gRPC may fail even when remove succeeds — continue to validate GW health
+            LOG.warning("host.delete raised (may still have removed): %s", err)
+
+        time.sleep(int(config.get("post_remove_settle", 45)))
+        after = _snapshot_nvmeof_daemons(installer)
+        LOG.info("GW daemons after host remove: %s", after)
+        _assert_daemons_stable(before, after)
+
+        if not keep:
+            # ACL path: host should no longer be listed (best-effort; warn if CLI shape differs)
+            try:
+                if _host_still_listed(gateway, subsystem, host_nqn):
+                    raise RuntimeError(
+                        f"Host {host_nqn} still listed on {subsystem} after delete"
+                    )
+            except RuntimeError:
+                raise
+            except Exception as err:
+                LOG.warning("Could not verify host ACL removal via host.list: %s", err)
+
+            try:
+                fut.result(timeout=30)
+            except Exception as err:
+                LOG.info("FIO ended after ACL host remove (expected): %s", err)
+        else:
+            # keep-connections: session should remain usable — FIO must complete cleanly
+            try:
+                fut.result(timeout=int(runtime) + 60)
+            except Exception as err:
+                raise RuntimeError(
+                    f"FIO failed after host remove with keep-connections "
+                    f"(IBMCEPH-17223 path): {err}"
+                ) from err
+
+        LOG.info("Host-remove stability check passed (keep_connections=%s)", keep)
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)

--- a/tests/nvmeof/test_ceph_nvmeof_initiator_reboot_autoconnect.py
+++ b/tests/nvmeof/test_ceph_nvmeof_initiator_reboot_autoconnect.py
@@ -1,0 +1,256 @@
+"""
+Initiator reboot + persistent nvmf-autoconnect reconnect.
+
+Customer-like Linux initiator reboot path:
+  1. ``nvme connect`` / ``connect-all --persistent``
+  2. ``/etc/modules-load.d/nvme-fabrics.conf``
+  3. ``/etc/nvme/discovery.conf``
+  4. ``nvmf-autoconnect.service`` enabled
+
+After initiator reboot, namespace UUIDs must reappear via autoconnect
+WITHOUT a manual discover / connect-all.
+
+Contrasts with CEPH-83576087 (``test_ceph_83576087``), which explicitly
+reconnects after reboot.
+"""
+
+import time
+
+from ceph.ceph import Ceph
+from ceph.waiter import WaitUntil
+from cli.utilities.utils import reboot_node
+from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _read_cmd(node, cmd):
+    out, err = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    return (out or "").strip(), (err or "").strip()
+
+
+def _assert_autoconnect_prereqs(initiator):
+    """Fail early if boot-reconnect plumbing is missing."""
+    node = initiator.node
+
+    conf, _ = _read_cmd(node, "cat /etc/nvme/discovery.conf 2>/dev/null || true")
+    if not conf.strip():
+        raise RuntimeError(
+            f"{node.hostname}: /etc/nvme/discovery.conf empty or missing "
+            "(required for nvmf-autoconnect)"
+        )
+    LOG.info("[%s] discovery.conf:\n%s", node.hostname, conf)
+
+    mods, _ = _read_cmd(
+        node, "cat /etc/modules-load.d/nvme-fabrics.conf 2>/dev/null || true"
+    )
+    if "nvme-fabrics" not in mods:
+        raise RuntimeError(
+            f"{node.hostname}: nvme-fabrics not in modules-load.d " f"(got: {mods!r})"
+        )
+
+    enabled, _ = _read_cmd(
+        node, "systemctl is-enabled nvmf-autoconnect.service 2>/dev/null || true"
+    )
+    if enabled not in ("enabled", "static", "indirect", "enabled-runtime"):
+        # Best-effort enable, then re-check
+        initiator.enable_nvmf_autoconnect()
+        enabled, _ = _read_cmd(
+            node, "systemctl is-enabled nvmf-autoconnect.service 2>/dev/null || true"
+        )
+        if enabled not in ("enabled", "static", "indirect", "enabled-runtime"):
+            raise RuntimeError(
+                f"{node.hostname}: nvmf-autoconnect.service not enabled "
+                f"(is-enabled={enabled!r})"
+            )
+    LOG.info("[%s] nvmf-autoconnect is-enabled=%s", node.hostname, enabled)
+
+
+def _capture_inventory(initiator):
+    """Return (uuids, device_paths) from lsblk WWN + nvme list."""
+    uuids = initiator.fetch_lsblk_nvme_devices() or []
+    try:
+        devices = initiator.list_spdk_drives() or []
+    except Exception as err:
+        LOG.warning("list_spdk_drives before reboot failed: %s", err)
+        devices = []
+    LOG.info(
+        "[%s] pre-reboot inventory: %d UUID(s), %d device(s)",
+        initiator.node.hostname,
+        len(uuids),
+        len(devices),
+    )
+    LOG.debug("UUIDs=%s devices=%s", uuids, devices)
+    return sorted(uuids), sorted(devices)
+
+
+def _wait_namespaces_after_reboot(initiator, expected_uuids, timeout, interval):
+    """Poll until expected namespace UUIDs reappear — no discover/connect."""
+    last_uuids = []
+    last_devices = []
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        try:
+            last_uuids = initiator.fetch_lsblk_nvme_devices() or []
+        except Exception as err:
+            LOG.warning("lsblk after reboot not ready: %s", err)
+            last_uuids = []
+        try:
+            last_devices = initiator.list_spdk_drives() or []
+        except Exception as err:
+            LOG.warning("nvme list after reboot not ready: %s", err)
+            last_devices = []
+
+        if expected_uuids:
+            missing = set(expected_uuids) - set(last_uuids)
+            if not missing:
+                LOG.info(
+                    "[%s] All %d pre-reboot UUIDs present after reboot",
+                    initiator.node.hostname,
+                    len(expected_uuids),
+                )
+                return sorted(last_uuids), sorted(last_devices)
+            LOG.warning(
+                "[%s] Waiting for autoconnect; missing UUIDs: %s "
+                "(have %d/%d, devices=%d)",
+                initiator.node.hostname,
+                sorted(missing),
+                len(expected_uuids) - len(missing),
+                len(expected_uuids),
+                len(last_devices),
+            )
+        elif last_devices:
+            LOG.info(
+                "[%s] Namespaces reappeared via devices (no UUID baseline): %s",
+                initiator.node.hostname,
+                last_devices,
+            )
+            return sorted(last_uuids), sorted(last_devices)
+
+    raise TimeoutError(
+        f"{initiator.node.hostname}: namespaces did not return within {timeout}s "
+        f"via nvmf-autoconnect (expected UUIDs={expected_uuids}, "
+        f"last_uuids={last_uuids}, last_devices={last_devices}). "
+        "Did NOT call discover/connect after reboot."
+    )
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Reboot Linux initiator and assert persistent autoconnect restores NS."""
+    config = kwargs["config"]
+    rbd_pool = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+
+        if config.get("subsystems"):
+            configure_gw_entities(nvme_service, rbd_obj=rbd_pool, cluster=ceph_cluster)
+
+        if not config.get("initiators"):
+            raise RuntimeError("config.initiators is required")
+
+        clients = prepare_io_execution(
+            config["initiators"],
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        initiator = clients[0]
+
+        # Reinforce boot-reconnect plumbing (configure already ran in prepare)
+        initiator.configure()
+        # Ensure discovery.conf points at the live gateway discovery port
+        gw = nvme_service.gateways[0]
+        initiator.configure_discovery_conf(
+            traddr=gw.node.ip_address,
+            trsvcid=initiator.discovery_port,
+            transport="tcp",
+        )
+        initiator.enable_nvmf_autoconnect()
+        _assert_autoconnect_prereqs(initiator)
+
+        before_uuids, before_devices = _capture_inventory(initiator)
+        if not before_uuids and not before_devices:
+            raise RuntimeError(
+                f"No NVMe namespaces on {initiator.node.hostname} before reboot"
+            )
+
+        min_ns = int(config.get("min_namespaces", 1))
+        count = len(before_uuids) or len(before_devices)
+        if count < min_ns:
+            raise RuntimeError(
+                f"Expected at least {min_ns} namespace(s) before reboot, found {count}"
+            )
+
+        LOG.info(
+            "Rebooting initiator %s — namespaces must return WITHOUT "
+            "manual discover/connect",
+            initiator.node.hostname,
+        )
+        if not reboot_node(initiator.node):
+            raise RuntimeError(
+                f"Initiator {initiator.node.hostname} did not come back after reboot"
+            )
+
+        # Brief settle for systemd / fabrics after SSH is up
+        time.sleep(int(config.get("post_reboot_settle", 15)))
+
+        # CRITICAL: do not call discover / connect / connect_all here
+        after_uuids, after_devices = _wait_namespaces_after_reboot(
+            initiator,
+            expected_uuids=before_uuids,
+            timeout=int(config.get("autoconnect_timeout", 300)),
+            interval=int(config.get("autoconnect_interval", 10)),
+        )
+
+        if before_uuids:
+            missing = set(before_uuids) - set(after_uuids)
+            if missing:
+                raise RuntimeError(
+                    f"UUIDs missing after reboot autoconnect: {sorted(missing)}"
+                )
+        elif before_devices and not after_devices:
+            raise RuntimeError("No NVMe devices after reboot autoconnect")
+
+        LOG.info(
+            "[%s] Autoconnect OK: %d UUID(s), %d device(s) after reboot",
+            initiator.node.hostname,
+            len(after_uuids),
+            len(after_devices),
+        )
+
+        if config.get("fio_smoke", True):
+            paths = after_devices or initiator.list_spdk_drives() or []
+            if not paths:
+                raise RuntimeError("No devices for post-reboot FIO smoke")
+            runtime = str(config.get("fio_runtime", 30))
+            LOG.info("Post-reboot FIO smoke on %s (runtime=%ss)", paths[:2], runtime)
+            initiator.start_fio(
+                io_size=config.get("fio_size", "256M"),
+                runtime=runtime,
+                paths=paths[:2],
+                io_type=config.get("io_type", "randrw"),
+                iodepth=8,
+                time_based=True,
+                execute_blkdiscard=False,
+                test_name=config.get("fio_test_name", "reboot-autoconnect-smoke"),
+            )
+
+        LOG.info("Initiator reboot + nvmf-autoconnect validation succeeded")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_pool)

--- a/tests/nvmeof/test_ceph_nvmeof_spec_no_plaintext_keys.py
+++ b/tests/nvmeof/test_ceph_nvmeof_spec_no_plaintext_keys.py
@@ -1,0 +1,77 @@
+"""
+IBMCEPH-16447 — NVMeoF service specs must not embed plaintext encryption/mTLS keys.
+
+Exports applied nvmeof orch specs and fails if PEM private-key material or
+inline `encryption_key` / client|server_key blobs are present.
+"""
+
+import re
+
+from ceph.ceph import Ceph
+from utility.log import Log
+
+LOG = Log(__name__)
+
+# Private-key / PEM markers that must not appear in exported nvmeof specs
+_PEM_PRIVATE = re.compile(
+    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----",
+    re.IGNORECASE,
+)
+_SENSITIVE_INLINE = re.compile(
+    r"(?im)^\s*(encryption_key|server_key|client_key)\s*:\s*\|?\s*$"
+)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    config = kwargs["config"]
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    service = config.get("nvmeof_service")  # optional: nvmeof.rbd.group1
+    cmd = "ceph orch ls nvmeof --export"
+    if service:
+        cmd = f"ceph orch ls {service} --export"
+
+    try:
+        out, err = installer.exec_command(cmd=cmd, sudo=True)
+        blob = f"{out or ''}\n{err or ''}"
+        LOG.info("Exported nvmeof orch spec(s):\n%s", blob)
+
+        if "service_type: nvmeof" not in blob and "service_type:nvmeof" not in blob:
+            # No nvmeof service exported — treat as skip/soft pass unless forced
+            if config.get("require_nvmeof_spec", True):
+                raise RuntimeError(f"No nvmeof service found via: {cmd}")
+            LOG.warning("No nvmeof export content; skipping plaintext-key assert")
+            return 0
+
+        violations = []
+        if _PEM_PRIVATE.search(blob):
+            violations.append("PEM private key material found in exported nvmeof spec")
+        if _SENSITIVE_INLINE.search(blob) and "BEGIN" in blob.upper():
+            violations.append(
+                "Inline encryption_key/server_key/client_key block present in export"
+            )
+        # Single-line inline PEM / long base64 under sensitive keys (not a file path ref)
+        if re.search(
+            r"(?i)(encryption_key|server_key|client_key)\s*:\s*.*(BEGIN|MII[A-Za-z0-9+/=]{40,})",
+            blob,
+        ):
+            violations.append(
+                "encryption_key/server_key/client_key appears to contain inline key material"
+            )
+        # Reject obvious absolute key-file contents pasted as scalars (not path-only refs)
+        if re.search(
+            r"(?im)^\s*(encryption_key|server_key|client_key)\s*:\s*[\"']?[A-Za-z0-9+/=]{64,}[\"']?\s*$",
+            blob,
+        ):
+            violations.append(
+                "Sensitive key field looks like inline base64 material (not a path reference)"
+            )
+
+        if violations:
+            raise RuntimeError(
+                "IBMCEPH-16447 plaintext key check failed: " + "; ".join(violations)
+            )
+        LOG.info("No plaintext encryption/mTLS private keys in exported nvmeof specs")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1

--- a/tests/nvmeof/workflows/db_workloads.py
+++ b/tests/nvmeof/workflows/db_workloads.py
@@ -1,0 +1,505 @@
+"""
+Customer database workloads on NVMeoF block devices.
+
+Pattern:
+  NVMe namespace -> mkfs/mount -> podman DB with data dir on mount -> native bench
+
+Feasible in cephci (no app licenses):
+  postgresql, mysql, mariadb, mongodb, redis, cassandra
+
+Not automated here (license / heavy external deps):
+  oracle, mssql  — logged as skipped unless explicitly enabled (mssql needs EULA)
+"""
+
+import time
+
+from utility.log import Log
+
+LOG = Log(__name__)
+
+# Public images — avoid registry.redhat.io auth requirements on bare clients
+DEFAULT_IMAGES = {
+    "postgresql": "docker.io/library/postgres:16",
+    "mysql": "docker.io/library/mysql:8.4",
+    "mariadb": "docker.io/library/mariadb:11.4",
+    "mongodb": "docker.io/library/mongo:7",
+    "redis": "docker.io/library/redis:7",
+    "cassandra": "docker.io/library/cassandra:4.1",
+    "mssql": "mcr.microsoft.com/mssql/server:2022-latest",
+}
+
+UNSUPPORTED = {
+    "oracle": "Oracle Database requires OTN license / proprietary container; skip in cephci",
+}
+
+
+def _run(node, cmd, timeout=600, check_ec=True):
+    out, err = node.exec_command(sudo=True, cmd=cmd, timeout=timeout, check_ec=check_ec)
+    return (out or "").strip(), (err or "").strip()
+
+
+def ensure_podman(node):
+    out, _ = _run(node, "command -v podman || true", check_ec=False)
+    if out:
+        return
+    LOG.info("Installing podman on %s", node.hostname)
+    _run(node, "yum install -y podman", timeout=900)
+
+
+def mkfs_and_mount(node, device, mount_point, fstype="xfs"):
+    """Format NVMe path and mount for DB datadir."""
+    _run(node, f"mkdir -p {mount_point}")
+    # Already mounted?
+    mounts, _ = _run(node, "findmnt -n -o TARGET || true", check_ec=False)
+    if mount_point in mounts.splitlines():
+        LOG.info("%s already mounted; reusing", mount_point)
+        return
+
+    if fstype == "xfs":
+        _run(node, f"mkfs.xfs -f {device}", timeout=300)
+    else:
+        _run(node, f"mkfs.ext4 -F {device}", timeout=300)
+    _run(node, f"mount {device} {mount_point}")
+    LOG.info("Mounted %s -> %s (%s)", device, mount_point, fstype)
+
+
+def umount_quiet(node, mount_point):
+    _run(node, f"umount {mount_point} || true", check_ec=False)
+
+
+def podman_rm(node, name):
+    _run(node, f"podman rm -f {name} || true", check_ec=False)
+
+
+def wait_container_running(node, name, timeout=180):
+    end = time.time() + timeout
+    while time.time() < end:
+        out, _ = _run(
+            node,
+            f"podman inspect -f '{{{{.State.Running}}}}' {name} 2>/dev/null || echo false",
+            check_ec=False,
+        )
+        if out.strip().lower() == "true":
+            return True
+        time.sleep(3)
+    return False
+
+
+def wait_cmd_ok(node, cmd, timeout=180, interval=5):
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            node.exec_command(sudo=True, cmd=cmd, timeout=60)
+            return True
+        except Exception:
+            time.sleep(interval)
+    LOG.error("Timed out waiting for: %s", cmd)
+    return False
+
+
+def _image(engine, cfg):
+    return cfg.get("image") or DEFAULT_IMAGES[engine]
+
+
+# ---------------------------------------------------------------------------
+# Engines
+# ---------------------------------------------------------------------------
+
+
+def run_postgresql(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-pg")
+    image = _image("postgresql", cfg)
+    db = cfg.get("db_name", "nvmeofdb")
+    user = cfg.get("user", "pguser")
+    password = cfg.get("password", "pgpassword")
+    port = int(cfg.get("port", 5432))
+    scale = int(cfg.get("scale", 20))
+    clients = int(cfg.get("clients", 8))
+    jobs = int(cfg.get("jobs", 4))
+    duration = int(cfg.get("duration", 60))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-e POSTGRES_USER={user} "
+            f"-e POSTGRES_PASSWORD={password} "
+            f"-e POSTGRES_DB={db} "
+            f"-v {data_dir}:/var/lib/postgresql/data:Z "
+            f"-p {port}:5432 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"PostgreSQL container {name} failed to start")
+    ready = f"podman exec {name} pg_isready -U {user} -d {db}"
+    if not wait_cmd_ok(node, ready, timeout=180):
+        raise RuntimeError("PostgreSQL not ready")
+
+    LOG.info("pgbench init scale=%s on %s", scale, data_dir)
+    _run(
+        node,
+        (f"podman exec {name} pgbench -i -s {scale} -U {user} -d {db}"),
+        timeout=3600,
+    )
+    LOG.info("pgbench run clients=%s jobs=%s duration=%ss", clients, jobs, duration)
+    _run(
+        node,
+        (
+            f"podman exec {name} pgbench -c {clients} -j {jobs} -T {duration} "
+            f"-U {user} -d {db}"
+        ),
+        timeout=duration + 600,
+    )
+    return {"engine": "postgresql", "container": name, "data_dir": data_dir}
+
+
+def run_mysql_family(node, data_dir, cfg, engine="mysql"):
+    """MySQL or MariaDB via sysbench-like mysqlslap / built-in mysql client."""
+    name = cfg.get("container_name", f"nvmeof-{engine}")
+    image = _image(engine, cfg)
+    db = cfg.get("db_name", "nvmeofdb")
+    root_pw = cfg.get("password", "RootPassw0rd!")
+    port = int(cfg.get("port", 3306 if engine == "mysql" else 3307))
+    duration = int(cfg.get("duration", 60))
+    concurrency = int(cfg.get("clients", 8))
+    datadir_ctr = "/var/lib/mysql"
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    env = f"-e MYSQL_ROOT_PASSWORD={root_pw} -e MYSQL_DATABASE={db}"
+    if engine == "mariadb":
+        env = f"-e MARIADB_ROOT_PASSWORD={root_pw} -e MARIADB_DATABASE={db}"
+
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} {env} "
+            f"-v {data_dir}:{datadir_ctr}:Z "
+            f"-p {port}:3306 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"{engine} container {name} failed to start")
+
+    ping = f"podman exec {name} mysqladmin ping -uroot -p{root_pw} --silent"
+    if not wait_cmd_ok(node, ping, timeout=240):
+        raise RuntimeError(f"{engine} not ready")
+
+    # Schema + bulk load via SQL
+    _run(
+        node,
+        (
+            f"podman exec {name} mysql -uroot -p{root_pw} {db} -e "
+            f'"CREATE TABLE IF NOT EXISTS kv (id INT PRIMARY KEY, val VARCHAR(128));"'
+        ),
+        timeout=120,
+    )
+    rows = int(cfg.get("rows", 20000))
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f"'mysql -uroot -p{root_pw} {db} -e "
+            f'"INSERT INTO kv (id, val) VALUES (1, \\"v1\\") '
+            f'ON DUPLICATE KEY UPDATE val=VALUES(val);" ; '
+            f"for i in $(seq 2 {rows}); do "
+            f'echo "INSERT INTO kv (id,val) VALUES ($i, \\"v$i\\") '
+            f'ON DUPLICATE KEY UPDATE val=VALUES(val);"; '
+            f"done | mysql -uroot -p{root_pw} {db}'"
+        ),
+        timeout=1800,
+    )
+
+    # mysqlslap OLTP-ish mixed statements
+    LOG.info("%s mysqlslap concurrency=%s duration~%ss", engine, concurrency, duration)
+    _run(
+        node,
+        (
+            f"podman exec {name} mysqlslap -uroot -p{root_pw} "
+            f"--concurrency={concurrency} --iterations=5 "
+            f"--number-of-queries={max(1000, duration * 50)} "
+            f"--create-schema={db} "
+            f'--query="SELECT val FROM kv WHERE id=FLOOR(1+RAND()*{rows}); '
+            f"UPDATE kv SET val=CONCAT('u', id) WHERE id=FLOOR(1+RAND()*{rows});\""
+        ),
+        timeout=duration + 900,
+    )
+    return {"engine": engine, "container": name, "data_dir": data_dir}
+
+
+def run_mongodb(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-mongo")
+    image = _image("mongodb", cfg)
+    port = int(cfg.get("port", 27017))
+    duration = int(cfg.get("duration", 60))
+    docs = int(cfg.get("docs", 50000))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-v {data_dir}:/data/db:Z "
+            f"-p {port}:27017 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"MongoDB container {name} failed to start")
+    ready = f"podman exec {name} mongosh --quiet --eval 'db.runCommand({{ ping: 1 }})'"
+    if not wait_cmd_ok(node, ready, timeout=180):
+        raise RuntimeError("MongoDB not ready")
+
+    LOG.info("MongoDB load %s docs then timed updates (%ss)", docs, duration)
+    _run(
+        node,
+        (
+            f"podman exec {name} mongosh --quiet --eval "
+            f'\'db = db.getSiblingDB("nvmeof"); '
+            f"db.dropDatabase(); "
+            f"const bulk=[]; for (let i=0;i<{docs};i++) "
+            f'bulk.push({{i:i, v:"x"+i, t:new Date()}}); '
+            f"while(bulk.length) {{ db.coll.insertMany(bulk.splice(0,1000)); }} "
+            f"db.coll.createIndex({{i:1}}); "
+            f"const end=Date.now()+{duration*1000}; let n=0; "
+            f"while(Date.now()<end) {{ "
+            f"db.coll.updateOne({{i: Math.floor(Math.random()*{docs})}}, "
+            f'{{$set:{{v:"u"+(n++)}}}}); '
+            f"db.coll.findOne({{i: Math.floor(Math.random()*{docs})}}); "
+            f"}} "
+            f'print("ops="+n);\''
+        ),
+        timeout=duration + 900,
+    )
+    return {"engine": "mongodb", "container": name, "data_dir": data_dir}
+
+
+def run_redis(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-redis")
+    image = _image("redis", cfg)
+    port = int(cfg.get("port", 6379))
+    duration = int(cfg.get("duration", 60))
+    clients = int(cfg.get("clients", 50))
+    requests = int(cfg.get("requests", max(100000, duration * 2000)))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    # AOF persistence on NVMe mount
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-v {data_dir}:/data:Z "
+            f"-p {port}:6379 "
+            f"{image} redis-server --appendonly yes --dir /data"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"Redis container {name} failed to start")
+    if not wait_cmd_ok(node, f"podman exec {name} redis-cli ping", timeout=120):
+        raise RuntimeError("Redis not ready")
+
+    LOG.info("redis-benchmark clients=%s requests=%s", clients, requests)
+    _run(
+        node,
+        (
+            f"podman exec {name} redis-benchmark -c {clients} -n {requests} "
+            f"-t set,get,lpush,lpop,hset -q"
+        ),
+        timeout=duration + 900,
+    )
+    # Force AOF rewrite to stress persistence path
+    _run(node, f"podman exec {name} redis-cli BGREWRITEAOF", check_ec=False)
+    time.sleep(5)
+    return {"engine": "redis", "container": name, "data_dir": data_dir}
+
+
+def run_cassandra(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-cassandra")
+    image = _image("cassandra", cfg)
+    port = int(cfg.get("port", 9042))
+    ops = int(cfg.get("ops", 50000))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-e MAX_HEAP_SIZE=512M -e HEAP_NEWSIZE=128M "
+            f"-v {data_dir}:/var/lib/cassandra:Z "
+            f"-p {port}:9042 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"Cassandra container {name} failed to start")
+
+    # Cassandra native start is slow
+    ready = f'podman exec {name} cqlsh -e "DESCRIBE KEYSPACES"'
+    if not wait_cmd_ok(node, ready, timeout=300, interval=10):
+        raise RuntimeError("Cassandra not ready")
+
+    LOG.info("Cassandra cql write/read stress ops~%s", ops)
+    _run(
+        node,
+        (
+            f"podman exec {name} cqlsh -e "
+            f'"CREATE KEYSPACE IF NOT EXISTS nvmeof WITH replication = '
+            f"{{'class':'SimpleStrategy','replication_factor':1}}; "
+            f'CREATE TABLE IF NOT EXISTS nvmeof.kv (id int PRIMARY KEY, v text);"'
+        ),
+        timeout=120,
+    )
+    # Batch inserts via python-less bash loop inside container
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f"'for i in $(seq 1 {min(ops, 20000)}); do "
+            f"echo \"INSERT INTO nvmeof.kv (id,v) VALUES ($i, '\\''v$i'\\'');\" ; "
+            f"done | cqlsh'"
+        ),
+        timeout=3600,
+    )
+    _run(
+        node,
+        (
+            f"podman exec {name} cqlsh -e "
+            f'"SELECT COUNT(*) FROM nvmeof.kv; '
+            f'SELECT * FROM nvmeof.kv WHERE id=1;"'
+        ),
+        timeout=300,
+    )
+    return {"engine": "cassandra", "container": name, "data_dir": data_dir}
+
+
+def run_mssql(node, data_dir, cfg):
+    """Optional — requires accept_eula: true and enough RAM."""
+    if not cfg.get("accept_eula"):
+        raise RuntimeError("mssql requires accept_eula: true in config")
+    name = cfg.get("container_name", "nvmeof-mssql")
+    image = _image("mssql", cfg)
+    password = cfg.get("password", "RootPassw0rd!")
+    port = int(cfg.get("port", 1433))
+    duration = int(cfg.get("duration", 60))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD={password} "
+            f"-v {data_dir}:/var/opt/mssql:Z "
+            f"-p {port}:1433 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError("MSSQL container failed to start")
+    # Wait for SQL ready
+    ready = (
+        f"podman exec {name} /opt/mssql-tools18/bin/sqlcmd "
+        f"-C -S localhost -U sa -P {password} -Q 'SELECT 1'"
+    )
+    # tools path varies; try without 18
+    if not wait_cmd_ok(node, ready, timeout=300):
+        ready2 = ready.replace("mssql-tools18", "mssql-tools")
+        if not wait_cmd_ok(node, ready2, timeout=120):
+            raise RuntimeError("MSSQL not ready")
+        ready = ready2
+
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f'"/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P {password} -Q '
+            f"'CREATE DATABASE nvmeofdb;' || "
+            f"/opt/mssql-tools/bin/sqlcmd -C -S localhost -U sa -P {password} -Q "
+            f"'CREATE DATABASE nvmeofdb;'\""
+        ),
+        check_ec=False,
+        timeout=120,
+    )
+    # Simple insert loop
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f"'end=$((SECONDS+{duration})); n=0; "
+            f"while [ $SECONDS -lt $end ]; do "
+            f"sqlcmd -C -S localhost -U sa -P {password} -d nvmeofdb "
+            f'-Q "IF OBJECT_ID(\\"dbo.kv\\") IS NULL '
+            f"CREATE TABLE kv(id INT PRIMARY KEY, v NVARCHAR(64)); "
+            f"MERGE kv AS t USING (SELECT $n AS id) AS s ON t.id=s.id "
+            f'WHEN MATCHED THEN UPDATE SET v=CONCAT(N\\"u\\", $n) '
+            f'WHEN NOT MATCHED THEN INSERT(id,v) VALUES($n, CONCAT(N\\"v\\", $n));" '
+            f">/dev/null; n=$((n+1)); done; echo ops=$n'"
+        ),
+        timeout=duration + 600,
+        check_ec=False,
+    )
+    return {"engine": "mssql", "container": name, "data_dir": data_dir}
+
+
+ENGINE_RUNNERS = {
+    "postgresql": run_postgresql,
+    "postgres": run_postgresql,
+    "mysql": lambda n, d, c: run_mysql_family(n, d, c, engine="mysql"),
+    "mariadb": lambda n, d, c: run_mysql_family(n, d, c, engine="mariadb"),
+    "mongodb": run_mongodb,
+    "mongo": run_mongodb,
+    "redis": run_redis,
+    "cassandra": run_cassandra,
+    "mssql": run_mssql,
+    "sqlserver": run_mssql,
+}
+
+
+def run_database_workload(node, device, cfg):
+    """
+    Mount device, run one DB engine workload, optionally cleanup container.
+
+    cfg keys:
+      engine, mount_point, fstype, duration, cleanup_container (default True)
+    """
+    engine = (cfg.get("engine") or "").lower()
+    if engine in UNSUPPORTED:
+        LOG.warning("Skipping %s: %s", engine, UNSUPPORTED[engine])
+        return {"engine": engine, "skipped": True, "reason": UNSUPPORTED[engine]}
+
+    if engine not in ENGINE_RUNNERS:
+        raise ValueError(f"Unsupported database engine: {engine}")
+
+    mount_point = cfg.get("mount_point") or f"/mnt/nvmeof-db-{engine}"
+    data_subdir = cfg.get("data_subdir", "data")
+    data_dir = f"{mount_point}/{data_subdir}"
+    fstype = cfg.get("fstype", "xfs")
+
+    ensure_podman(node)
+    mkfs_and_mount(node, device, mount_point, fstype=fstype)
+    _run(node, f"mkdir -p {data_dir}")
+
+    LOG.info("=== DB workload %s on %s (%s) ===", engine, device, data_dir)
+    result = ENGINE_RUNNERS[engine](node, data_dir, cfg)
+
+    if cfg.get("cleanup_container", True):
+        podman_rm(node, result.get("container", f"nvmeof-{engine}"))
+    if cfg.get("umount", True):
+        umount_quiet(node, mount_point)
+
+    result["device"] = device
+    result["skipped"] = False
+    return result

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -97,10 +97,10 @@ class NVMeInitiator(Initiator):
         nqns_discovered, _ = self.discover(**_disc_cmd)
         LOG.debug(nqns_discovered)
 
-        # connect-all
+        # connect-all (CLI layer also defaults --persistent)
         connect_all = {}
         if config["nqn"] == "connect-all":
-            connect_all = {"ctrl-loss-tmo": 3600}
+            connect_all = {"ctrl-loss-tmo": 3600, "persistent": True}
             # Add authentication parameters based on auth_mode
             if self.auth_mode == "bidirectional":
                 if not self.host_key or not self.subsys_key:
@@ -124,6 +124,13 @@ class NVMeInitiator(Initiator):
                     )
                 cmd_args.update({"dhchap-secret": self.host_key})
             cmd = {**discovery_port, **cmd_args, **connect_all}
+            # Persist discovery endpoint for nvmf-autoconnect after reboot
+            self.configure_discovery_conf(
+                traddr=cmd_args["traddr"],
+                trsvcid=self.discovery_port,
+                transport="tcp",
+            )
+            self.enable_nvmf_autoconnect()
             self.connect_all(**cmd)
             self.list()
             return
@@ -138,6 +145,15 @@ class NVMeInitiator(Initiator):
             allowed_subsystems = set(subsystems)
         else:
             allowed_subsystems = {subsystem}
+
+        # Still record discovery controller for reboot autoconnect
+        self.configure_discovery_conf(
+            traddr=cmd_args["traddr"],
+            trsvcid=self.discovery_port,
+            transport="tcp",
+        )
+        self.enable_nvmf_autoconnect()
+
         sub_endpoints = []
         discovered_records = json.loads(nqns_discovered)["records"]
 
@@ -195,6 +211,7 @@ class NVMeInitiator(Initiator):
                 "traddr": sub_endpoint["traddr"],
                 "trsvcid": sub_endpoint["trsvcid"],
                 "nqn": sub_endpoint["subnqn"],
+                "persistent": True,
             }
             if self.auth_mode == "bidirectional":
                 if not self.host_key or not self.subsys_key:
@@ -286,6 +303,21 @@ class NVMeInitiator(Initiator):
         # Update io_args if io_type is provided
         if kwargs.get("io_type"):
             io_args.update({"io_type": kwargs.get("io_type")})
+
+        # Forward data-integrity options to run_fio
+        if kwargs.get("verify"):
+            io_args.update({"verify": kwargs.get("verify")})
+        if kwargs.get("verify_fatal") is not None:
+            io_args.update({"verify_fatal": kwargs.get("verify_fatal")})
+        if kwargs.get("bs"):
+            io_args.update({"bs": kwargs.get("bs")})
+        # Customer-workload knobs (DB multi-queue, O_DIRECT, sync cadence)
+        if kwargs.get("num_jobs") is not None:
+            io_args.update({"num_jobs": kwargs.get("num_jobs")})
+        if kwargs.get("fsync") is not None:
+            io_args.update({"fsync": kwargs.get("fsync")})
+        if kwargs.get("direct") is not None:
+            io_args.update({"direct": kwargs.get("direct")})
 
         # Check whether to execute blkdiscard
         # For read only namespaces, blkdiscard is not required


### PR DESCRIPTION
## Summary

- Add IBM Ceph 9.2 holistic NVMeoF end-to-end conf + smoke / full / soak suites with under-load day-2 ops, multi-tenant FIO personas, DB workloads, and initiator reboot autoconnect (Phase 4.5).
- Persist NVMe initiator connect paths (--persistent, discovery.conf, nvmf-autoconnect) so namespaces return after reboot without manual discover/connect.
- Add IBM cloud BareMetal bug-coverage suite and docs filtered to 10895, covering host maintenance IO, keep-connections, ANAGRP, scale-down DELETING, failover SLO, plaintext keys, and daemon-types upgrade probe.


## What's included

- **Holistic suites + conf**: `conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml` with smoke / full (`cross-feature`) / soak suites; docs `HOLISTIC_9-2_COVERAGE.md`, `HOLISTIC_9-2_WORKLOADS.md`
- **Under-load day-2 / personas**: holistic IO orchestration, FIO personas, host maintenance under IO, host-remove stability, GW scale-while-deleting, ANA integrity, failover SLO, daemon-types upgrade probe, DB workload helpers
- **Initiator persistence / reboot autoconnect (Phase 4.5)**: `--persistent` connect, discovery.conf, nvmf-autoconnect in Linux NVMe CLI helpers / initiator workflows + `test_ceph_nvmeof_initiator_reboot_autoconnect.py`


### Key files

- Suites/docs under `suites/tentacle/nvmeof/`
- `tests/nvmeof/test_ceph_nvmeof_holistic_io.py`
- `tests/nvmeof/test_ceph_nvmeof_initiator_reboot_autoconnect.py`
- `tests/nvmeof/test_ceph_nvmeof_host_maintenance_io.py`
- `tests/nvmeof/test_ceph_nvmeof_host_remove_stability.py`
- `tests/nvmeof/test_ceph_nvmeof_gw_scale_deleting.py`
- `tests/nvmeof/test_ceph_nvmeof_anagrp_integrity.py`
- `tests/nvmeof/test_ceph_nvmeof_failover_slo.py`
- `tests/nvmeof/test_ceph_nvmeof_daemon_types_upgrade.py`
- `tests/nvmeof/test_ceph_nvmeof_db_workloads.py` + `tests/nvmeof/workflows/db_workloads.py`
- `tests/nvmeof/test_ceph_nvmeof_spec_no_plaintext_keys.py`
- `ceph/nvmeof/initiators/linux/nvme_cli.py`, `tests/nvmeof/workflows/initiator.py` (autoconnect/persistence)

## Test plan

- [ ] Run holistic **smoke** suite against IBM Ceph 9.2 tentacle topology
- [ ] Run holistic **full/cross-feature** suite (or targeted day-2 phases under load)
- [ ] Validate Phase 4.5 reboot/autoconnect TC (`test_ceph_nvmeof_initiator_reboot_autoconnect`)
- [ ] Run IBM cloud BM bug-coverage suite scoped to filter **10895** only
- [ ] Spot-check new TCs: ANA integrity, failover SLO, host maintenance/remove, GW scale-deleting, DB workloads, no-plaintext-keys
- [ ] `tox` / black formatting clean on touched Python
- [ ] Confirm DCO / Signed-off-by on the single squash commit