### PR TITLE
Add missing export_mount_kwargs helper for NFS BYOK/TLS imports.

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha-grpc.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-grpc.yaml
@@ -134,7 +134,7 @@ tests:
         clients: 1
         nfs_version: 4.1
         port: 2049
-        comments: bug - IBMCEPH-16155
+        comments: "bug - IBMCEPH-16155"
 
   # =============================================================================
   # Test Scenario 2: Verify gRPC Service Discovery

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml
@@ -307,6 +307,9 @@ tests:
         number_of_clusters : 2
         timeout : 100
         nfs_instance_number: 6
+        # Cephadm defaults cluster_qos_port to 31311; concurrent instances on the
+        # same nfs hosts collide unless each service gets a unique qos port.
+        enable_cluster_qos_port: true
         spec:
           service_type: nfs
           service_id: nfs

--- a/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha.yaml
@@ -484,9 +484,11 @@ tests:
         clients: 1
         nfs_cluster_name: cephfs-nfs-tls
         operation: tls_deploy_mount_verify
+        # Happy-path kTLS mount logs "TLS connection established"; AUTH_TLS is
+        # probe/STARTTLS path only and is not present on a successful mount.
         tls_log_substrings:
-          - AUTH_TLS
-          - TLS
+          - TLS connection established
+          - "[TLS]"
         strict_tls_log_check: true
 
   - test:

--- a/tests/nfs/export_mount_kwargs.py
+++ b/tests/nfs/export_mount_kwargs.py
@@ -1,0 +1,43 @@
+"""Pure helpers for splitting export vs mount kwargs in NFS export/mount flows."""
+
+# kwargs accepted by Mount.nfs(); export-only keys (e.g. enctag) must stay out.
+MOUNT_OPTS_KEYS = frozenset(
+    (
+        "xprtsec",
+        "proto",
+        "extra_mount_options",
+        "mounttimeout",
+        "timeo",
+        "retrans",
+        "timeout",
+    )
+)
+
+# Upgrade-only kwargs; stripped before export.create() and never forwarded to mount.
+UPGRADE_KWARGS_KEYS = frozenset(
+    (
+        "installer_node",
+        "during_upgrade",
+        "nfs_wait_timeout",
+        "mount_timeout",
+        "mount_tries",
+    )
+)
+
+
+def mount_opts_from_kwargs(kwargs, chown_cephuser=False):
+    """Return mount kwargs without export-only or upgrade-only keys."""
+    mount_opts = {k: v for k, v in kwargs.items() if k in MOUNT_OPTS_KEYS}
+    mount_opts["chown_cephuser"] = chown_cephuser
+    return mount_opts
+
+
+def pop_upgrade_kwargs(kwargs):
+    """Remove upgrade-scenario kwargs; remaining kwargs are for export.create()."""
+    return {
+        "installer_node": kwargs.pop("installer_node", None),
+        "during_upgrade": kwargs.pop("during_upgrade", False),
+        "nfs_wait_timeout": kwargs.pop("nfs_wait_timeout", 300),
+        "mount_timeout": kwargs.pop("mount_timeout", 120),
+        "mount_tries": kwargs.pop("mount_tries", 2),
+    }

--- a/tests/nfs/security/security_utils.py
+++ b/tests/nfs/security/security_utils.py
@@ -385,20 +385,40 @@ def assert_mount_failed(mount_result, context, client_node=None, mount_path=None
 
 
 def assert_tlshd_handshake_failure(tlshd_status, context):
-    """Raise if recent tlshd journal output does not show a TLS handshake failure."""
+    """Raise if recent tlshd journal output does not show a TLS handshake failure.
+
+    Accept common ktls-utils / gnutls failure signals. When Ganesha TLS is broken
+    (e.g. corrupted server certs), tlshd often logs handshake timeout or unexpected
+    TLS packets rather than a literal 'Handshake ... failed' line. With a mismatched
+    client trust anchor, tlshd typically logs 'Certificate signer not found' instead.
+    """
     status = str(tlshd_status or "")
     status_lower = status.lower()
-    if "handshake" in status_lower and "failed" in status_lower:
+    if "handshake" in status_lower and (
+        "failed" in status_lower or "timeout" in status_lower
+    ):
         return
     if "eacces" in status_lower:
         return
     if "certificate verify failed" in status_lower:
         return
+    if "certificate signer not found" in status_lower:
+        return
     if "unable to get local issuer" in status_lower:
+        return
+    if "unexpected tls packet" in status_lower:
+        return
+    if "gnutls" in status_lower and (
+        "error" in status_lower
+        or "unexpected" in status_lower
+        or "failed" in status_lower
+        or "(-" in status_lower  # e.g. gnutls: ... (-15)
+    ):
         return
     raise OperationFailedError(
         f"{context}: tlshd status did not report a TLS handshake failure "
-        f"(expected 'Handshake ... failed' or EACCES in journal)"
+        f"(expected handshake failed/timeout, certificate signer not found, "
+        f"gnutls error, or EACCES in journal)"
     )
 
 

--- a/tests/nfs/security/test_tls_feature.py
+++ b/tests/nfs/security/test_tls_feature.py
@@ -306,7 +306,8 @@ def op_tls_deploy_mount_verify(client_node, nfs_node, config, nfs_name):
         config,
         "tls_log_substrings",
         "tc_01_log_expect",
-        default=["AUTH_TLS", "TLS"],
+        # Successful kTLS mount: Ganesha logs connection established, not AUTH_TLS.
+        default=["TLS connection established", "[TLS]"],
     )
 
     client_export_mount_dict = create_export_and_mount_for_existing_nfs_cluster(
@@ -467,7 +468,7 @@ def op_tls_logs_openssl_probe(installer_node, client_node, nfs_node, config, nfs
         "tls_log_substrings",
         "tc_03_log_expect",
         "tc_01_log_expect",
-        default=["AUTH_TLS", "TLS"],
+        default=["TLS connection established", "[TLS]"],
     )
     verify_tls_strings_in_nfs_logs(client_node, nfs_node, nfs_name, expect_logs)
 

--- a/tests/nfs/test_deploy_multiple_nfs_ganesha_concurrently.py
+++ b/tests/nfs/test_deploy_multiple_nfs_ganesha_concurrently.py
@@ -22,7 +22,10 @@ def run(ceph_cluster, **kw):
     installer = ceph_cluster.get_nodes(role="installer")[0]
     original_config = config.get("spec", None)
     timeout = int(config.get("timeout", 300))
-    # cluster_qos_port is Tentacle+ only; enable via suite config when needed
+    # Cephadm reserves cluster_qos_port (default 31311) for every NFS service.
+    # Concurrent instances sharing nfs hosts collide on that default unless each
+    # gets a unique qos port. Enable via suite config on Tentacle+ (field is
+    # Tentacle+ only); Squid suites leave this unset.
     use_cluster_qos = bool(
         config.get("enable_cluster_qos_port")
         or (original_config or {}).get("spec", {}).get("cluster_qos_port") is not None


### PR DESCRIPTION
what is included:

Wrt logs https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.2/rhel-10/regression/20.2.2-151/nfs-ganesha/126/logs/,
there was a automation issue which was causing the tests to skip, other small changes are added for cucurrently ganesha deployment and tls tests. 


logs:http://10.64.24.74/logs/ceph-qe-logs//IBM/9.2/rhel-10/regression/20.2.2-181/nfs-ganesha/129/logs/
<img width="1017" height="785" alt="Screenshot 2026-08-05 at 10 06 25 AM" src="https://github.com/user-attachments/assets/92df5009-d3fa-4c39-a158-7c24185f752f" />
