### PR TITLE
Cephfs upgrade io timeout 1800 seconds

### DIFF
--- a/suites/reef/cephfs/tier-0_cephfs_mirrror_upgrade_5x_to_6x_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_mirrror_upgrade_5x_to_6x_to_7x.yaml
@@ -170,7 +170,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process
@@ -221,7 +220,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_5x_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_5x_to_7x.yaml
@@ -136,7 +136,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
             name: "creation of Prerequisites for Upgrade"

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_61_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_61_to_7x.yaml
@@ -136,7 +136,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_7x_latest_to_71x_latest.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_7x_latest_to_71x_latest.yaml
@@ -136,7 +136,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_7x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_7x_to_8x.yaml
@@ -187,7 +187,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process
@@ -238,7 +237,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml
@@ -136,7 +136,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml
@@ -136,7 +136,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_8x_latest_to_81x_latest.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_8x_latest_to_81x_latest.yaml
@@ -136,7 +136,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
@@ -200,7 +200,7 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
+              timeout: 600
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process
@@ -251,7 +251,7 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
+              timeout: 600
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process

--- a/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x_to_9x.yaml
@@ -200,7 +200,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 600
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process
@@ -251,7 +250,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 600
               client_upgrade: 1
               client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
@@ -144,7 +144,7 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
+              timeout: 600
               client_upgrade: 1
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml
@@ -144,7 +144,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 600
               client_upgrade: 1
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
@@ -163,7 +163,7 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
+              timeout: 600
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
@@ -163,7 +163,7 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 600
+              timeout: 1800
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_81_to_9x.yaml
@@ -163,7 +163,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 1800
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process

--- a/suites/tentacle/cephfs/tier-0_cephfs_upgrade_9x_to_91x.yaml
+++ b/suites/tentacle/cephfs/tier-0_cephfs_upgrade_9x_to_91x.yaml
@@ -163,7 +163,6 @@ tests:
         - test:
             abort-on-fail: false
             config:
-              timeout: 30
               client_upgrade: 1
               client_upgrade_node: "node8"
             desc: Runs IOs in parallel with upgrade process


### PR DESCRIPTION
Remove cephfs_io timeout overrides in CephFS upgrade suites
## Summary
- Remove suite-level `timeout` so parallel upgrade IO (`cephfs_upgrade.cephfs_io.py`) runs with the default **1800 seconds**.
- Cluster upgrade takes ~20 mins. Using the default 1800s timeout ensures IOs continue through the whole upgrade process.
- Applied across active tentacle, squid, and reef CephFS upgrade suites.

Logs: http://10.64.24.74/logs/ceph-qe-logs//IBM/9.0/rhel-9/upgrade/20.1.0-221/cephfs/111/logs/