### PR TITLE
Fix NVMeoF orch service_id when metadata pool is .nvmeof

### DIFF
--- a/tests/nvmeof/workflows/nvme_service.py
+++ b/tests/nvmeof/workflows/nvme_service.py
@@ -2,7 +2,6 @@
 NVMe Service, Gateway Group, and Gateway classes for NVMeoF workflows.
 """
 
-import json
 import time
 
 from looseversion import LooseVersion
@@ -14,6 +13,8 @@ from tests.nvmeof.workflows.constants import DEFAULT_NVME_METADATA_POOL, DEFAULT
 from tests.nvmeof.workflows.nvme_gateway import create_gateway
 from tests.nvmeof.workflows.nvme_utils import (
     check_and_enable_nvmeof_module,
+    fetch_nvme_service_from_orch,
+    get_nvme_service_id,
     nvme_gw_cli_version_adapter,
     setup_firewalld,
 )
@@ -79,6 +80,8 @@ class NVMeService:
         """Delete the NVMe gateway service."""
         ceph_cluster = self.ceph_cluster
 
+        # Prefer live orch identity over a constructed/stale cached name
+        self.refresh_service_identity()
         service_name = self.service_name
         cfg = {
             "no_cluster_state": False,
@@ -99,7 +102,7 @@ class NVMeService:
         release = self.ceph_cluster.rhcs_version
         spec = {
             "service_type": "nvmeof",
-            "service_id": self.nvme_metadata_pool,
+            "service_id": get_nvme_service_id(self.nvme_metadata_pool),
             "mtls": self.mtls,
             "placement": self._get_placement_config(self.config, self.gw_nodes),
             "spec": {
@@ -147,9 +150,9 @@ class NVMeService:
                     raise ValueError("Gateway group not provided for RHCS 8+")
 
                 if self.is_spec_or_mtls:
-                    cfg["config"]["specs"][0][
-                        "service_id"
-                    ] = f"{self.nvme_metadata_pool}.{self.group}"
+                    cfg["config"]["specs"][0]["service_id"] = get_nvme_service_id(
+                        self.nvme_metadata_pool, self.group
+                    )
                     cfg["config"]["specs"][0]["spec"]["group"] = self.group
                 else:
                     if LooseVersion(self.ceph_version) >= LooseVersion("20.2.1"):
@@ -223,41 +226,22 @@ class NVMeService:
         if deploy_config:
             test_nvmeof.run(self.ceph_cluster, **deploy_config)
 
-        # Once the service is deployed, get the service name and service id and store it
-        ceph = Orch(self.ceph_cluster, **{})
-        cmd = "ceph orch ls nvmeof --format json"
-        out, _ = ceph.shell(args=[cmd])
-        services = json.loads(out)
-        self.service_name = None
-        self.service_id = None
-        for service in services:
-            # If we have multiple services in single cluster then we need to filter the service by group
-            # so that we will get the correct service name and service id for the group.
-            # when we take services[0]["service_name"] only first service name will be returned
-            # so we need to filter the service by group.
-            if "nvmeof" in service["service_name"]:
-                if self.group:
-                    if self.group in service["service_name"]:
-                        service_name = service["service_name"]
-                        service_id = service["service_id"]
-                        LOG.info(
-                            f"Service name: {service_name}, Service id: {service_id}"
-                        )
-                        self.service_name = service_name
-                        self.service_id = service_id
-                        break
-                else:
-                    service_name = service["service_name"]
-                    service_id = service["service_id"]
-                    LOG.info(f"Service name: {service_name}, Service id: {service_id}")
-                    self.service_name = service_name
-                    self.service_id = service_id
-                    break
+        # Once the service is deployed, resolve live service_name/id from orch export
+        self.refresh_service_identity()
+
+    def refresh_service_identity(self):
+        """Set ``service_name`` / ``service_id`` from ``ceph orch ls --export``."""
+        self.service_name, self.service_id = fetch_nvme_service_from_orch(
+            self.ceph_cluster, group=self.group
+        )
 
     def redeploy(self, wait_sec=30):
-        """Redeploy the NVMe-oF orchestrator service after spec apply."""
-        if not self.service_name:
-            raise RuntimeError("NVMe-oF service name not set; deploy the service first")
+        """Redeploy the NVMe-oF orchestrator service after spec apply.
+
+        Always re-fetch the live service name from orch export before redeploy
+        instead of trusting a constructed or stale cached name.
+        """
+        self.refresh_service_identity()
         orch = Orch(self.ceph_cluster, **{})
         cmd = f"ceph orch redeploy {self.service_name}"
         LOG.info("Redeploying NVMe-oF service: %s", cmd)

--- a/tests/nvmeof/workflows/nvme_utils.py
+++ b/tests/nvmeof/workflows/nvme_utils.py
@@ -35,11 +35,77 @@ class OMAPValidationFailure(Exception):
     pass
 
 
-def get_nvme_service_name(pool, group=None):
-    svc_name = f"nvmeof.{pool}"
+def get_nvme_service_id(pool, group=None):
+    """Build orch ``service_id`` for an nvmeof apply_spec.
+
+    Default metadata pool ``.nvmeof`` must keep its leading dot. Ceph names
+    the service ``nvmeof.<service_id>``, so pool ``.nvmeof`` + group
+    ``group1`` yields service_id ``.nvmeof.group1`` and full name
+    ``nvmeof..nvmeof.group1`` (current product naming after the cephadm
+    revert). Do not strip the leading dot.
+
+    For redeploy/delete/lookups, prefer resolving the live service_id from
+    ``ceph orch ls nvmeof --export`` instead of reconstructing from pool.
+    """
     if group:
-        svc_name = f"{svc_name}.{group}"
-    return svc_name
+        return f"{pool}.{group}"
+    return str(pool)
+
+
+def get_nvme_service_name(pool, group=None):
+    return f"nvmeof.{get_nvme_service_id(pool, group)}"
+
+
+def fetch_nvme_service_from_orch(ceph_cluster, group=None):
+    """Return ``(service_name, service_id)`` from ``ceph orch ls nvmeof --export``.
+
+    Prefer this over constructing names from pool/group. When *group* is set,
+    match the export entry whose ``service_id`` or ``spec.group`` contains it.
+    """
+    orch = Orch(ceph_cluster, **{})
+    out, _ = orch.shell(
+        args=["ceph orch ls nvmeof --export --format json"]
+    )
+    if not out or "No services reported" in out:
+        raise RuntimeError("No nvmeof services reported by ceph orch ls --export")
+
+    services = json.loads(out)
+    if isinstance(services, dict):
+        services = [services]
+
+    matched = None
+    for service in services:
+        if service.get("service_type") != "nvmeof":
+            continue
+        service_id = service.get("service_id", "")
+        spec_group = (service.get("spec") or {}).get("group")
+        if group:
+            if group == spec_group or (
+                isinstance(service_id, str) and group in service_id
+            ):
+                matched = service
+                break
+        else:
+            matched = service
+            break
+
+    if not matched:
+        raise RuntimeError(
+            "No nvmeof orch export entry found"
+            + (f" for group '{group}'" if group else "")
+        )
+
+    service_id = matched.get("service_id")
+    if not service_id:
+        raise RuntimeError("nvmeof orch export entry missing service_id")
+
+    # orch export carries service_id; full name is always service_type.service_id
+    service_name = matched.get("service_name") or f"nvmeof.{service_id}"
+    LOG.info(
+        "Resolved nvmeof service from orch export: "
+        f"service_name={service_name}, service_id={service_id}"
+    )
+    return service_name, service_id
 
 
 def setup_firewalld(nodes) -> None:
@@ -177,7 +243,7 @@ def apply_nvme_sdk_cli_support(ceph_cluster, config):
                 "specs": [
                     {
                         "service_type": "nvmeof",
-                        "service_id": rbd_pool,
+                        "service_id": get_nvme_service_id(rbd_pool),
                         "mtls": config.get("mtls", False),
                         "placement": {"nodes": [i.hostname for i in gw_nodes]},
                         "spec": {
@@ -196,7 +262,9 @@ def apply_nvme_sdk_cli_support(ceph_cluster, config):
             raise NVMeDeployArgumentError("Gateway group not provided..")
 
         if is_spec_or_mtls:
-            cfg["config"]["specs"][0]["service_id"] = f"{rbd_pool}.{gw_group}"
+            cfg["config"]["specs"][0]["service_id"] = get_nvme_service_id(
+                rbd_pool, gw_group
+            )
             cfg["config"]["specs"][0]["spec"]["group"] = gw_group
         else:
             cfg["config"]["pos_args"].append(gw_group)
@@ -243,8 +311,7 @@ def delete_nvme_service(ceph_cluster, config):
 
     for gwgroup_config in gw_groups:
         gw_group = gwgroup_config["gw_group"]
-        service_name = f"nvmeof.{config['rbd_pool']}"
-        service_name = f"{service_name}.{gw_group}" if gw_group else service_name
+        service_name = get_nvme_service_name(config["rbd_pool"], gw_group or None)
         cfg = {
             "no_cluster_state": False,
             "config": {


### PR DESCRIPTION
On ceph >= 20.2.1, NVMeoF uses metadata pool `.nvmeof`. Building orch `service_id` as `{pool}.{group}` produced `nvmeof..nvmeof.<group>`, so deploy validation never found the service and DHCHAP E2E failed with JSONDecodeError on "No services reported".