### PR TITLE
Tests(iscsi): run FIO sequentially with time-based lighter workload to reduce IBM Cloud flakiness

### DIFF
--- a/tests/iscsi/workflows/initiator.py
+++ b/tests/iscsi/workflows/initiator.py
@@ -1,5 +1,4 @@
 from ceph.iscsi.initiator import ISCSIInitiator
-from ceph.parallel import parallel
 from tests.iscsi.workflows.iscsi_utils import fetch_tcmu_devices, format_iscsiadm_output
 from utility.log import Log
 from utility.utils import run_fio
@@ -45,23 +44,35 @@ class Initiator(ISCSIInitiator):
         self.node.exec_command(cmd="dnf install -y fio", sudo=True)
         targets = fetch_tcmu_devices(self.node)
         results = []
-        io_args = {"size": "100%"}
-        with parallel() as p:
-            for serial, target in targets.items():
-                LOG.info(f"Starting FIO for Disk UUID {serial} and {target}....")
-                _io_args = {}
-                _io_args.update(
-                    {
-                        "test_name": f"test-{target['mapper_path'].replace('/', '_')}",
-                        "device_name": target["mapper_path"],
-                        "client_node": self.node,
-                        "long_running": True,
-                    }
-                )
-                _io_args = {**io_args, **_io_args}
-                p.spawn(run_fio, **_io_args)
-            for op in p:
-                results.append(op)
+        # Sequential, time-based FIO to avoid full-disk, parallel IO flakiness on network storage.
+        # Note: `run_fio()` sets FIO to time-based mode when `run_time` is present
+        # (it adds `--time_based`), so `size` is optional. Ensure `cmd_timeout`
+        # exceeds `run_time` + startup/teardown overhead.
+        io_args = {
+            "cmd_timeout": 300,
+            "io_type": "randrw",
+            "iodepth": "2",
+            "direct": "1",
+            "run_time": "60",
+            "rwmixread": "50",
+        }
+
+        for serial, target in targets.items():
+            LOG.info(f"Starting FIO for Disk UUID {serial} and {target}....")
+            _io_args = {}
+            _io_args.update(
+                {
+                    "test_name": f"test-{target['mapper_path'].replace('/', '_')}",
+                    "device_name": target["mapper_path"],
+                    "client_node": self.node,
+                    "long_running": False,
+                }
+            )
+            _io_args = {**io_args, **_io_args}
+            result = run_fio(**_io_args)
+            results.append(result)
+            LOG.info(f"Completed FIO for {target['mapper_path']}")
+
         LOG.info("Completed all IO executions.....")
         return results
 


### PR DESCRIPTION
<!DOCTYPE html><head></head><h1 dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-right: 0px; margin-bottom: var(--base-size-16); margin-left: 0px; font-size: 2em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Description</h1><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">Source of test case:</strong><span class="Apple-converted-space"> </span>Regression test fix (iSCSI sanity failure on IBM Cloud CI)</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">The iSCSI sanity test (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">suites/tentacle/iscsi/iscsi_sanity.yaml</code>) fails intermittently on IBM Cloud because<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">start_fio()</code><span class="Apple-converted-space"> </span>previously ran 5 parallel full-disk FIO writes (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--rw write --iodepth 8</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">size=100%</code>) on network-attached storage. Under I/O contention, operations could exceed the default 3600s timeout (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">fio failed to execute within 3600 seconds</code>), even though iSCSI setup and the Ceph cluster were healthy.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">This change updates<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">tests/iscsi/workflows/initiator.py</code><span class="Apple-converted-space"> </span>to improve CI reliability on IBM Cloud:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); padding: 0px; position: relative; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li style="box-sizing: border-box; margin-left: var(--base-size-24);">Run FIO<span class="Apple-converted-space"> </span><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">sequentially</strong><span class="Apple-converted-space"> </span>(one disk at a time) instead of in parallel</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Use a lighter FIO profile:<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--rw randrw</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--iodepth 2</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--direct=1</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Use time-based FIO (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">run_time: 60</code>) instead of filling the full disk (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">size=100%</code>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Set<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">cmd_timeout: 300</code><span class="Apple-converted-space"> </span>seconds per disk</li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">This is a<span class="Apple-converted-space"> </span><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">test reliability / CI infrastructure</strong><span class="Apple-converted-space"> </span>fix, not a Ceph product code change.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Summary</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); padding: 0px; position: relative; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li style="box-sizing: border-box; margin-left: var(--base-size-24);">Run iSCSI FIO sequentially in<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Initiator.start_fio()</code><span class="Apple-converted-space"> </span>to reduce I/O contention on IBM Cloud</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Change FIO workload from heavy sequential write/full-disk IO to lighter time-based<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">randrw</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Use<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">iodepth=2</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">direct=1</code>, and<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">run_time=60</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Add<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">cmd_timeout: 300</code><span class="Apple-converted-space"> </span>per FIO operation</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);">Remove unused<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">parallel</code><span class="Apple-converted-space"> </span>import from<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">initiator.py</code></li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Problem</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); padding: 0px; position: relative; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li style="box-sizing: border-box; margin-left: var(--base-size-24);"><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">Suite:</strong><span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">suites/tentacle/iscsi/iscsi_sanity.yaml</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);"><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">Failure:</strong><span class="Apple-converted-space"> </span>Parallel FIO on 5 x 1GB iSCSI disks times out on IBM Cloud (timeout after 3600s)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);"><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">Root cause:</strong><span class="Apple-converted-space"> </span>Slower network block storage + parallel / heavy FIO contention in CI, not iSCSI/Ceph functional failure</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Solution</h2><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">
Before | After
-- | --
5 parallel FIO jobs | Sequential FIO (one disk at a time)
--rw write --iodepth 8 | --rw randrw --iodepth 2 --direct=1
size=100% (fill full disk) | run_time=60 (time-based)
Default 3600s timeout | 300s per disk (cmd_timeout)
Flaky on IBM Cloud sanity | More predictable runtime (~5 min for 5 disks)

</markdown-accessiblity-table><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Files changed</h2><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); padding: 0px; position: relative; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li style="box-sizing: border-box; margin-left: var(--base-size-24);"><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">tests/iscsi/workflows/initiator.py</code></li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Test plan</h2><ul class="contains-task-list" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); padding: 0px; position: relative; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li class="task-list-item" style="box-sizing: border-box; list-style-type: none; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font-style: inherit; font-variant-caps: inherit; font-weight: inherit; font-width: inherit; font-size: inherit; line-height: inherit; font-family: inherit; font-size-adjust: inherit; font-kerning: inherit; font-variant-alternates: inherit; font-variant-ligatures: inherit; font-variant-numeric: inherit; font-variant-east-asian: inherit; font-variant-position: inherit; font-variant-emoji: inherit; font-feature-settings: inherit; font-optical-sizing: inherit; font-variation-settings: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span class="Apple-converted-space"> </span>Run<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">suites/tentacle/iscsi/iscsi_sanity.yaml</code><span class="Apple-converted-space"> </span>on IBM Cloud (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ibmc</code>) using branch<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">iscsi-fix</code></li><li class="task-list-item" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font-style: inherit; font-variant-caps: inherit; font-weight: inherit; font-width: inherit; font-size: inherit; line-height: inherit; font-family: inherit; font-size-adjust: inherit; font-kerning: inherit; font-variant-alternates: inherit; font-variant-ligatures: inherit; font-variant-numeric: inherit; font-variant-east-asian: inherit; font-variant-position: inherit; font-variant-emoji: inherit; font-feature-settings: inherit; font-optical-sizing: inherit; font-variation-settings: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span class="Apple-converted-space"> </span>Confirm logs show sequential<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Starting FIO</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Completed FIO</code><span class="Apple-converted-space"> </span>per disk</li><li class="task-list-item" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font-style: inherit; font-variant-caps: inherit; font-weight: inherit; font-width: inherit; font-size: inherit; line-height: inherit; font-family: inherit; font-size-adjust: inherit; font-kerning: inherit; font-variant-alternates: inherit; font-variant-ligatures: inherit; font-variant-numeric: inherit; font-variant-east-asian: inherit; font-variant-position: inherit; font-variant-emoji: inherit; font-feature-settings: inherit; font-optical-sizing: inherit; font-variation-settings: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span class="Apple-converted-space"> </span>Confirm FIO uses<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">randrw</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">iodepth 2</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">direct 1</code>,<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">runtime 60</code></li><li class="task-list-item" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font-style: inherit; font-variant-caps: inherit; font-weight: inherit; font-width: inherit; font-size: inherit; line-height: inherit; font-family: inherit; font-size-adjust: inherit; font-kerning: inherit; font-variant-alternates: inherit; font-variant-ligatures: inherit; font-variant-numeric: inherit; font-variant-east-asian: inherit; font-variant-position: inherit; font-variant-emoji: inherit; font-feature-settings: inherit; font-optical-sizing: inherit; font-variation-settings: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span class="Apple-converted-space"> </span>Confirm no<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">failed to execute within</code><span class="Apple-converted-space"> </span>timeout errors</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Validation evidence</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">Tested 3 times on IBM 9.1; all passed:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; padding: 0px; position: relative; caret-color: rgb(240, 246, 252); color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li style="box-sizing: border-box; margin-left: var(--base-size-24);"><a href="https://149.81.216.83/job/tentacle-test-executor/2374/" rel="nofollow" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: var(--fgColor-accent,var(--color-accent-fg)); text-decoration: underline; text-underline-offset: 0.2rem;">https://149.81.216.83/job/tentacle-test-executor/2374/</a></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);"><a href="https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-324/iscsi/2372/logs/" rel="nofollow" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: var(--fgColor-accent,var(--color-accent-fg)); text-decoration: underline; text-underline-offset: 0.2rem;">https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-324/iscsi/2372/logs/</a></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: var(--base-size-24);"><a href="https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-324/iscsi/2371/logs/" rel="nofollow" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: var(--fgColor-accent,var(--color-accent-fg)); text-decoration: underline; text-underline-offset: 0.2rem;">https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.1/rhel-10/executor/20.2.1-324/iscsi/2371/logs/</a></li></ul>