### PR TITLE
logging improvent and fix for nfs upgrade failures for suite tier1-nf…

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
@@ -232,6 +232,7 @@ tests:
               dd_command_size_in_M: 10
               exports_number: 4
               loop_count: 4
+              nfs_wait_timeout: 600
       abort-on-fail: true
 
   - test:

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -1413,6 +1413,34 @@ def _cleanup_stale_nfs_mount(client, mount_name):
         log.debug("Ignoring unmount cleanup for %s: %s", mount_name, exc)
 
 
+def _nfs_export_is_listed(client, nfs_name, export_name):
+    """Return True when ``export_name`` appears in ``ceph nfs export ls``."""
+    try:
+        raw = Ceph(client).nfs.export.ls(nfs_name)
+        if not raw:
+            return False
+        if isinstance(raw, str):
+            try:
+                exports = json.loads(raw)
+            except json.JSONDecodeError:
+                return export_name in raw
+        else:
+            exports = raw
+        if isinstance(exports, list):
+            if export_name in exports:
+                return True
+            return any(export_name in str(entry) for entry in exports)
+        return export_name in str(exports)
+    except Exception as exc:
+        log.debug(
+            "nfs export ls check failed for %s on %s: %s",
+            export_name,
+            nfs_name,
+            exc,
+        )
+        return False
+
+
 def wait_for_nfs_and_mount(
     client,
     mount_name,
@@ -1438,8 +1466,9 @@ def wait_for_nfs_and_mount(
     ``mount_timeout``), not via NFS ``-o mounttimeout`` which mount.nfs
     rejects on RHEL.
 
-    Polls ``ceph orch ps`` for running NFS daemons, the NFS TCP port, and
-    export mountability before each mount attempt until ``nfs_wait_timeout``.
+    Polls ``ceph orch ps`` for running NFS daemons, the NFS TCP port,
+    ``ceph nfs export ls`` (when ``nfs_name`` is set), and export
+    mountability before each mount attempt until ``nfs_wait_timeout``.
     """
     mount_kwargs = normalize_mount_kwargs(
         {
@@ -1465,6 +1494,18 @@ def wait_for_nfs_and_mount(
             port,
             timeout=per_check_timeout,
         )
+        if nfs_name is not None and not _nfs_export_is_listed(
+            client, nfs_name, export_name
+        ):
+            log.warning(
+                "Export %s not yet listed for %s on %s (attempt %s, ~%ss)",
+                export_name,
+                nfs_name,
+                client.hostname,
+                w._attempt,
+                w._attempt * w.interval,
+            )
+            continue
         try:
             nfs_mount(
                 client,


### PR DESCRIPTION
Problem
In IBM Ceph CI run nfs-ganesha/89 (tier1-nfs-ganesha-upgrade-8x-to-9x-latest, build 20.2.2-220), the parallel test nfs operations during upgrade failed on loop 3/4 while cephadm upgrade was in progress.

Failure:

mount.nfs: mounting ...:/export/nfs_cephfs-nfs_2 failed,
reason given by server: No such file or directory
Context:

Loops 1 and 2 completed successfully (create → mount → IO → cleanup).
Loop 3 succeeded for exports 0 and 1, but failed mounting export 2 on client node6.
ceph nfs export create returned success and NFS-Ganesha was running with port 2049 reachable.
Mount retries ran for the full nfs_wait_timeout (~300s) and never recovered.
No Ceph/NFS crashes were observed; cluster upgrade continued and eventually passed.
Root cause: During upgrade, NFS export configuration can lag behind ceph nfs export create. wait_for_nfs_and_mount() checked daemon health and TCP connectivity, but did not wait for the export to appear in ceph nfs export ls before attempting mount. That allowed premature mount attempts against a Ganesha instance that had not yet published the export.

Changes
1. tests/nfs/nfs_operations.py
Added _nfs_export_is_listed() to check whether an export path is present in ceph nfs export ls.
Updated wait_for_nfs_and_mount() to poll export visibility (when nfs_name is provided) before each mount attempt, with clear warning logs when the export is not yet listed.
2. suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-8x-to-9x-latest.yaml
Increased nfs_wait_timeout from 300 to 600 seconds for the parallel nfs operations during upgrade test, giving more headroom during active upgrade load.
Impact / scope
wait_for_nfs_and_mount() is only used by test_nfs_io_operations_during_upgrade.py with during_upgrade=True.
mount_retry() and other NFS tests (BYOK, TLS, SNI, etc.) are unchanged.
No changes to single-cluster export creation logic in other callers.

old logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.2/rhel-9/upgrade/20.2.2-220/nfs-ganesha/89/logs/TEST_Ceph_NFS_Ganesha_Upgrade_from_8_0_to_9_0_Latest/

logs:https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.2/rhel-9/executor/20.2.2-220/nfs/2558/logs/tier1_nfs_ganesha_upgrade_8x_to_9x_latest/