### PR TITLE
Fix post-upgrade clone validation file access

### DIFF
--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -519,12 +519,10 @@ def clone_test(clone_req_params):
         "Using existing mountpoint,verify clones are accessible, perform readwrite IO."
     )
     for sv in clone_data:
-        mnt_pt = clone_data[sv]["mnt_pt"]
+        mnt_pt = clone_data[sv]["mnt_pt"].rstrip("/")
         mnt_client_name = clone_data[sv]["mnt_client"]
         mnt_client = [i for i in clients if i.node.hostname == mnt_client_name][0]
-        cmd = f"ls {mnt_pt}/*"
-        out, rc = mnt_client.exec_command(sudo=True, cmd=cmd)
-        file_path = out.strip()
+        file_path = f"{mnt_pt}/dd_test_file"
         cmd = f"dd if={file_path} count=10 bs=1M > read_dd"
         out, rc = mnt_client.exec_command(sudo=True, cmd=cmd)
         dir_path = f"{mnt_pt}/smallfile_clone_dir"


### PR DESCRIPTION
## Summary

Fixes a false failure in `Validates NFS after upgrade` / `clone_test()` during CephFS upgrade validation.

### Problem
After upgrade, clone validation ran:

```bash
ls {mnt_pt}/*
```

On clone subvolume mount points this can return `Operation not permitted`, causing the test to fail even when NFS and upgrade itself succeeded.

### Changes
- `cephfs_post_upgrade_validation.py` — `clone_test()` now reads the known pre-upgrade file `{mnt_pt}/dd_test_file` directly (created in `upgrade_pre_req.py` before clone setup) instead of globbing the mount root

### Scope
- Single-file, isolated fix
- No suite YAML changes required

## Test plan
- [ ] `suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml` (reaches post-upgrade clone validation)
- [ ] Or `suites/tentacle/cephfs/tier-0_cephfs_upgrade_7x_to_9x.yaml`

Made with [Cursor](https://cursor.com)