### PR TITLE
Harden cephfs crash_check and annotate known suite issues

### DIFF
--- a/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml
@@ -282,7 +282,7 @@ tests:
       module: snapshot_clone.cg_snap_system_test.py
       name: "cg_snap_system_test"
       polarion-id: CEPH-83581468
-      comment: "IBMCEPH-17181"
+      comments: "Known issue IBMCEPH-17181 in 9.2"
   -
     test:
       abort-on-fail: false

--- a/suites/tentacle/nfs/tier1-nfs-ganesha-grpc.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-grpc.yaml
@@ -134,7 +134,7 @@ tests:
         clients: 1
         nfs_version: 4.1
         port: 2049
-        comments: "bug - IBMCEPH-16155"
+        comments: "bug - IBMCEPH-16155 in 9.2"
 
   # =============================================================================
   # Test Scenario 2: Verify gRPC Service Discovery

--- a/tests/cephfs/cephfs_system/cephfs_system_utils.py
+++ b/tests/cephfs/cephfs_system/cephfs_system_utils.py
@@ -168,7 +168,9 @@ class CephFSSystemUtils(object):
     def crash_check(self, client, crash_copy=1, daemon_list=["mds"]):
         """
         Check if Crash dir exists in all daemon hosting nodes, save meta file if crash exists
-        return 1 if crash exists, else 0
+        return 1 if crash exists, else 0.
+
+        A missing crash/coredump directory is treated as no crashes (not a failure).
         """
         daemon_nodes = {
             "mds": self.mdss,
@@ -193,12 +195,23 @@ class CephFSSystemUtils(object):
                         crash_dir = (
                             crash_dir1 if crash_type == "ceph_crash" else crash_dir2
                         )
-                        cmd = f"ls {crash_dir}"
-                        out, _ = node.exec_command(sudo=True, cmd=cmd)
+                        out, err = node.exec_command(
+                            sudo=True, cmd=f"ls {crash_dir}", check_ec=False
+                        )
+                        if node.node.exit_status != 0:
+                            log.info(
+                                f"No crash path at {crash_dir} on "
+                                f"{node.node.hostname}; treating as no crashes. "
+                                f"stderr={err}"
+                            )
+                            continue
                         crash_items = out.split()
                         log.info(crash_items)
                         if crash_type == "ceph_crash":
-                            crash_items.remove("posted")
+                            # "posted" is the staging dir; absent when no crashes yet
+                            crash_items = [
+                                item for item in crash_items if item != "posted"
+                            ]
                         if len(crash_items) > 0:
                             for crash_item in crash_items:
                                 if crash_type == "ceph_crash":


### PR DESCRIPTION
## Summary

Reduces false failures in CephFS crash-check tests and documents known product issues in suite metadata.

### Problem
`cephfs-crash-check` failed when the crash directory did not exist yet on a node (`ls /var/lib/ceph/<fsid>/crash` → `CommandFailed`), even though no daemon crashes had occurred.

### Changes
**Code — `cephfs_system_utils.py`**
- Treat missing crash/coredump directory as **no crashes** (log and continue)
- Use `check_ec=False` for crash dir listing
- Filter `posted` safely instead of `list.remove("posted")` when the staging dir is absent

**Suites — metadata only**
- `tier-1_cephfs_cg_quiesce_systemic.yaml`: fix `comment` → `comments`; note IBMCEPH-17181 (cephfs-mirror crash) in 9.2
- `tier1-nfs-ganesha-grpc.yaml`: clarify IBMCEPH-16155 comment for 9.2

### Scope
- Does not suppress real crashes when crash entries exist
- Suite comment changes are informational only

## Test plan
- [ ] `suites/tentacle/cephfs/tier-1_cephfs_cg_quiesce_systemic.yaml`
- [ ] Optional: `suites/tentacle/nfs/tier1-nfs-ganesha-grpc.yaml` (comment-only YAML change)

Made with [Cursor](https://cursor.com)