### PR TITLE
fix: update 9x sanity upgrade source build from 9.0 to 9.1 released

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_upgrade_9xsanity_to_9xlatest.yaml
@@ -25,9 +25,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 9.0
-                    release: stable
-                    registry-url: registry.redhat.io
+                    rhcs-version: 9.1
+                    release: "released"
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
@@ -75,9 +74,8 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 9.0
-                    release: stable
-                    registry-url: registry.redhat.io
+                    rhcs-version: 9.1
+                    release: "released"
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123

--- a/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_upgrade_9xsanity_to_9xlatest.yaml
@@ -1,4 +1,4 @@
-#Objective: Testing single site upgrade from RHCS 9.0 sanity latest to 9.x latest build
+#Objective: Testing single site upgrade from RHCS 9.1 sanity latest to 9.x latest build
 #platform : RHEL-9
 #conf: conf/tentacle/rgw/tier-0_rgw.yaml
 
@@ -18,9 +18,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 9.0
-                release: stable
-                registry-url: registry.redhat.io
+                rhcs-version: 9.1
+                release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true

--- a/suites/tentacle/upgrades/tier1-upgrade-ibm-9x-released-to-9x-latest.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-ibm-9x-released-to-9x-latest.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Automation support for upgrade from IBMSC 9.0 to IBMSC 9.x latest in RHEL9
+# Automation support for upgrade from IBMSC 9.1 to IBMSC 9.x latest in RHEL9
 #
 #--------------------------------------------------------------------------------
 # Cluster Configuration: conf/tentacle/upgrades/1admin-3node-1client-upgrade.yaml
@@ -7,8 +7,8 @@
 #
 # Test Steps:
 #--------------------------------------------------------------------------------
-# - Deploy IBMSC 9.0 cluster in RHEL 9
-# - Upgrade cluster from IBMSC 9.0 to IBMSC 9.x latest
+# - Deploy IBMSC 9.1 cluster in RHEL 9
+# - Upgrade cluster from IBMSC 9.1 to IBMSC 9.x latest
 # - Validate cluster status
 # - Run I/O's
 #--------------------------------------------------------------------------------

--- a/suites/tentacle/upgrades/tier1-upgrade-ibm-9x-released-to-9x-latest.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-ibm-9x-released-to-9x-latest.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Automation support for upgrade from IBMSC 9.0 to IBMSC 9.x latest in RHEL9
+# Automation support for upgrade from IBMSC 9.1 to IBMSC 9.x latest in RHEL9
 #
 #--------------------------------------------------------------------------------
 # Cluster Configuration: conf/tentacle/upgrades/1admin-3node-1client-upgrade.yaml
@@ -7,8 +7,8 @@
 #
 # Test Steps:
 #--------------------------------------------------------------------------------
-# - Deploy IBMSC 9.0 cluster in RHEL 9
-# - Upgrade cluster from IBMSC 9.0 to IBMSC 9.x latest
+# - Deploy IBMSC 9.1 cluster in RHEL 9
+# - Upgrade cluster from IBMSC 9.1 to IBMSC 9.x latest
 # - Validate cluster status
 # - Run I/O's
 #--------------------------------------------------------------------------------
@@ -28,7 +28,7 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 9.0
+                rhcs-version: 9.1
                 release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true

--- a/suites/tentacle/upgrades/tier1-upgrade-rhcs-9x-released-to-9x-latest.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-rhcs-9x-released-to-9x-latest.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Automation support for upgrade from RHCS 9.0 to RHCS 9.x latest in RHEL9
+# Automation support for upgrade from RHCS 9.1 to RHCS 9.x latest in RHEL9
 #
 #--------------------------------------------------------------------------------
 # Cluster Configuration: conf/tentacle/upgrades/1admin-3node-1client-upgrade.yaml
@@ -7,8 +7,8 @@
 #
 # Test Steps:
 #--------------------------------------------------------------------------------
-# - Deploy RHCS 9.0 cluster in RHEL 9
-# - Upgrade cluster from RHCS 9.0 to RHCS 9.x latest
+# - Deploy RHCS 9.1 cluster in RHEL 9
+# - Upgrade cluster from RHCS 9.1 to RHCS 9.x latest
 # - Validate cluster status
 # - Run I/O's
 #--------------------------------------------------------------------------------

--- a/suites/tentacle/upgrades/tier1-upgrade-rhcs-9x-released-to-9x-latest.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-rhcs-9x-released-to-9x-latest.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Automation support for upgrade from RHCS 9.0 to RHCS 9.x latest in RHEL9
+# Automation support for upgrade from RHCS 9.1 to RHCS 9.x latest in RHEL9
 #
 #--------------------------------------------------------------------------------
 # Cluster Configuration: conf/tentacle/upgrades/1admin-3node-1client-upgrade.yaml
@@ -7,8 +7,8 @@
 #
 # Test Steps:
 #--------------------------------------------------------------------------------
-# - Deploy RHCS 9.0 cluster in RHEL 9
-# - Upgrade cluster from RHCS 9.0 to RHCS 9.x latest
+# - Deploy RHCS 9.1 cluster in RHEL 9
+# - Upgrade cluster from RHCS 9.1 to RHCS 9.x latest
 # - Validate cluster status
 # - Run I/O's
 #--------------------------------------------------------------------------------
@@ -28,7 +28,7 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 9.0
+                rhcs-version: 9.1
                 release: "released"
                 mon-ip: node1
                 orphan-initial-daemons: true


### PR DESCRIPTION
Both tier1-upgrade-rhcs-9x-released-to-9x-latest.yaml and tier1-upgrade-ibm-9x-released-to-9x-latest.yaml were bootstrapping from rhcs-version 9.0 released. Updated source to 9.1 released.