### PR TITLE
Skip CephFS mirror sync-perf tests on RHCS builds older than 9.1.

### DIFF
--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_large_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_large_files.py
@@ -5,6 +5,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -109,6 +111,10 @@ def run(ceph_cluster, **kw):
         )
 
         build = config.get("build", config.get("rhbuild"))
+        if LooseVersion(build) < LooseVersion("9.1"):
+            log.info("Skipping test: requires Ceph version >= 9.1 (build=%s)", build)
+            return 0
+
         source_clients = ceph_cluster_dict.get("ceph1").get_ceph_objects("client")
         target_clients = ceph_cluster_dict.get("ceph2").get_ceph_objects("client")
         cephfs_mirror_node = ceph_cluster_dict.get("ceph1").get_ceph_objects(

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_mixed_files.py
@@ -5,6 +5,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -134,6 +136,10 @@ def run(ceph_cluster, **kw):
         )
 
         build = config.get("build", config.get("rhbuild"))
+        if LooseVersion(build) < LooseVersion("9.1"):
+            log.info("Skipping test: requires Ceph version >= 9.1 (build=%s)", build)
+            return 0
+
         source_clients = ceph_cluster_dict.get("ceph1").get_ceph_objects("client")
         target_clients = ceph_cluster_dict.get("ceph2").get_ceph_objects("client")
         cephfs_mirror_node = ceph_cluster_dict.get("ceph1").get_ceph_objects(

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_small_files.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_snapshot_sync_perf_small_files.py
@@ -6,6 +6,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -118,6 +120,10 @@ def run(ceph_cluster, **kw):
         )
 
         build = config.get("build", config.get("rhbuild"))
+        if LooseVersion(build) < LooseVersion("9.1"):
+            log.info("Skipping test: requires Ceph version >= 9.1 (build=%s)", build)
+            return 0
+
         source_clients = ceph_cluster_dict.get("ceph1").get_ceph_objects("client")
         target_clients = ceph_cluster_dict.get("ceph2").get_ceph_objects("client")
         cephfs_mirror_node = ceph_cluster_dict.get("ceph1").get_ceph_objects(


### PR DESCRIPTION
Added a check to run test for build >= 9.1.
Logs with 8.1 : http://10.64.24.74/logs/ceph-qe-logs/IBM/8.1/rhel-9/executor/19.2.1-397/cephfs/286/logs/tier_2_cephfs_mirror_snapshot_sync_perf/CephFS_Mirror_snapshot_sync_performance_-_large_files_0.log