### PR TITLE
Skip CephFS mirror 9.2 enhancement tests on RHCS < 9.2

### DIFF
--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -235,6 +235,16 @@ class CephfsMirroringUtils(object):
         self.fs_util_ceph2 = FsUtils(target_ceph_cluster)
 
     @staticmethod
+    def skip_if_rhcs_below(config, min_version="9.2"):
+        """Return True when the RHCS rhbuild is older than min_version.
+
+        rhbuild is typically ``9.2-rhel-9``; the numeric prefix is compared.
+        """
+        config = config or {}
+        rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+        return LooseVersion(rhbuild.split("-")[0]) < LooseVersion(min_version)
+
+    @staticmethod
     def verify_mount_points_responsive(client, mounting_dirs, timeout=30):
         """Verify mount points are not hung by touching a file on each.
 

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_asok_metrics_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_asok_metrics_92.py
@@ -4,6 +4,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -100,8 +102,15 @@ def run(ceph_cluster, **kw):
     Note: Scenario for sync failure in test_cephfs_mirror_disruptive_ops.py
     Note: Zero-file directory sync validated in test_cephfs_mirror_improved_stats (R12).
 
-    Returns 0 on success, 1 on failure.
+    Returns 0 on success, 1 on failure, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_asok_metrics_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_asok_metrics_92.py
@@ -4,8 +4,6 @@ import string
 import time
 import traceback
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -105,14 +103,14 @@ def run(ceph_cluster, **kw):
     Returns 0 on success, 1 on failure, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_checkpoints_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_checkpoints_92.py
@@ -4,6 +4,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -54,8 +56,15 @@ def run(ceph_cluster, **kw):
      5. Multiple checkpoints + ordering
      6. Checkpoint on older snapshot with snap schedule (BZ#XXXXXX)
 
-    Returns 0 on success, 1 on failure.
+    Returns 0 on success, 1 on failure, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_checkpoints_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_checkpoints_92.py
@@ -4,8 +4,6 @@ import string
 import time
 import traceback
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -59,14 +57,14 @@ def run(ceph_cluster, **kw):
     Returns 0 on success, 1 on failure, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_disruptive_ops.py
@@ -4,6 +4,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -27,8 +29,15 @@ def run(ceph_cluster, **kw):
         - Cross-check via both asok and MGR interface
 
     Returns:
-        0 if successful, 1 if any errors found.
+        0 if successful, 1 if any errors found, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_disruptive_ops.py
@@ -4,8 +4,6 @@ import string
 import time
 import traceback
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -32,14 +30,14 @@ def run(ceph_cluster, **kw):
         0 if successful, 1 if any errors found, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_improved_stats.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_improved_stats.py
@@ -4,6 +4,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -46,8 +48,15 @@ def run(ceph_cluster, **kw):
     R16: Snapdiff and blockdiff verification (asok + MGR)
 
     Returns:
-        0 if successful, 1 if any errors found.
+        0 if successful, 1 if any errors found, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_improved_stats.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_improved_stats.py
@@ -4,8 +4,6 @@ import string
 import time
 import traceback
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import (
     CephfsMirroringUtils,
@@ -51,14 +49,14 @@ def run(ceph_cluster, **kw):
         0 if successful, 1 if any errors found, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_mgr_interface_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_mgr_interface_92.py
@@ -5,8 +5,6 @@ import time
 import traceback
 from datetime import datetime
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -51,14 +49,14 @@ def run(ceph_cluster, **kw):
     Returns 0 on success, 1 on failure, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_mgr_interface_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_mgr_interface_92.py
@@ -5,6 +5,8 @@ import time
 import traceback
 from datetime import datetime
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -46,8 +48,15 @@ def run(ceph_cluster, **kw):
      9. MGR module disabled — clear error
      10. MGR CLI sanity — invalid inputs
 
-    Returns 0 on success, 1 on failure.
+    Returns 0 on success, 1 on failure, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_perf_dumps_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_perf_dumps_92.py
@@ -4,8 +4,6 @@ import string
 import time
 import traceback
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -62,14 +60,14 @@ def run(ceph_cluster, **kw):
     Returns 0 on success, 1 on failure, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_perf_dumps_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_perf_dumps_92.py
@@ -4,6 +4,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -57,8 +59,15 @@ def run(ceph_cluster, **kw):
      6. Multiple daemons/filesystems isolation
      7. Legacy counter groups still present
 
-    Returns 0 on success, 1 on failure.
+    Returns 0 on success, 1 on failure, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_tri_interface_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_tri_interface_92.py
@@ -4,6 +4,8 @@ import string
 import time
 import traceback
 
+from looseversion import LooseVersion
+
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -98,8 +100,15 @@ def run(ceph_cluster, **kw):
      3. Tri-interface snap lifecycle counters
      4. Tri-interface with multiple directories
 
-    Returns 0 on success, 1 on failure.
+    Returns 0 on success, 1 on failure, -1 if skipped.
     """
+    config = kw.get("config") or {}
+    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
+    rhcs = rhbuild.split("-")[0]
+    if LooseVersion(rhcs) < LooseVersion("9.2"):
+        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+        return -1
+
     try:
         config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_tri_interface_92.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_tri_interface_92.py
@@ -4,8 +4,6 @@ import string
 import time
 import traceback
 
-from looseversion import LooseVersion
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_mirroring.cephfs_mirroring_utils import CephfsMirroringUtils
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -103,14 +101,14 @@ def run(ceph_cluster, **kw):
     Returns 0 on success, 1 on failure, -1 if skipped.
     """
     config = kw.get("config") or {}
-    rhbuild = str(config.get("rhbuild") or config.get("build") or "0")
-    rhcs = rhbuild.split("-")[0]
-    if LooseVersion(rhcs) < LooseVersion("9.2"):
-        log.info("Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)", rhbuild)
+    if CephfsMirroringUtils.skip_if_rhcs_below(config):
+        log.info(
+            "Skipping test: requires Ceph version >= 9.2 (rhbuild=%s)",
+            config.get("rhbuild"),
+        )
         return -1
 
     try:
-        config = kw.get("config")
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
         test_data = kw.get("test_data")
         fs_util_ceph1 = FsUtils(ceph_cluster_dict.get("ceph1"), test_data=test_data)


### PR DESCRIPTION
## Summary
- Add an RHCS version gate so CephFS mirror 9.2 enhancement tests skip when `rhbuild` is older than 9.2.
- Return `-1` so CephCI reports **Skipped** (not Pass) when these features are unavailable on shared tentacle suites.
- Covers all feature tests in `suites/tentacle/cephfs/tier-2_cephfs_mirror_enhancements_92.yaml` (stats, disruptive ops, asok metrics, MGR interface, checkpoints, perf dumps, tri-interface).

## Test plan
- [x] Confirm tests run normally with `--rhbuild 9.2` (or later).
- [x] Confirm the same tests report Skipped with `--rhbuild 9.0` or `9.1`.
- [x] Confirm setup/deploy/client tests in the suite are not gated.

Logs for 8.1 : http://10.64.24.74/logs/ceph-qe-logs/IBM/8.1/rhel-9/executor/19.2.1-397/cephfs/298/logs/tier_2_cephfs_mirror_enhancements_92/


Made with [Cursor](https://cursor.com)