### PR TITLE
[TFA] add known issue for sync from testcase

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
+++ b/suites/squid/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
@@ -343,6 +343,7 @@ tests:
       desc: Test bucket granular sync with sync from different bucket
       polarion-id: CEPH-83575140
       module: sanity_rgw_multisite.py
+      comments: Known issue IBMCEPH-17820
       clusters:
         ceph-pri:
           config:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2201,11 +2201,11 @@ def clone_the_repo(config, node, path_to_clone):
           node and clone the repo in it.
     """
     log.info("cloning the repo")
-    branch = config.get("branch", "master")
+    branch = config.get("branch", "tfa_bgsp")
     log.info(f"branch: {branch}")
     repo_url = config.get("git-url")
     log.info(f"repo_url: {repo_url}")
-    git_clone_cmd = f"sudo git clone {repo_url} -b {branch}"
+    git_clone_cmd = f"sudo git clone https://github.com/anrao19/ceph-qe-scripts.git -b tfa_bgsp"
     node.exec_command(cmd=f"cd {path_to_clone} ; {git_clone_cmd}")
 
 
@@ -2313,7 +2313,7 @@ def get_utilized_space(node, pool_name=None):
 
 def perform_env_setup(config, node, ceph_cluster):
     config["git-url"] = config.get(
-        "git-url", "https://github.com/red-hat-storage/ceph-qe-scripts.git"
+        "git-url", "https://github.com/anrao19/ceph-qe-scripts.git"
     )
     config["test_folder"] = config.get("test_folder", "rgw-tests")
     test_folder_path = f"~/{config['test_folder']}"

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2201,11 +2201,11 @@ def clone_the_repo(config, node, path_to_clone):
           node and clone the repo in it.
     """
     log.info("cloning the repo")
-    branch = config.get("branch", "tfa_bgsp")
+    branch = config.get("branch", "master")
     log.info(f"branch: {branch}")
     repo_url = config.get("git-url")
     log.info(f"repo_url: {repo_url}")
-    git_clone_cmd = f"sudo git clone https://github.com/anrao19/ceph-qe-scripts.git -b tfa_bgsp"
+    git_clone_cmd = f"sudo git clone {repo_url} -b {branch}"
     node.exec_command(cmd=f"cd {path_to_clone} ; {git_clone_cmd}")
 
 
@@ -2313,7 +2313,7 @@ def get_utilized_space(node, pool_name=None):
 
 def perform_env_setup(config, node, ceph_cluster):
     config["git-url"] = config.get(
-        "git-url", "https://github.com/anrao19/ceph-qe-scripts.git"
+        "git-url", "https://github.com/red-hat-storage/ceph-qe-scripts.git"
     )
     config["test_folder"] = config.get("test_folder", "rgw-tests")
     test_folder_path = f"~/{config['test_folder']}"


### PR DESCRIPTION
# Description
https://ibm-ceph.atlassian.net/browse/IBMCEPH-17820
In a multisite setup (realm: india, zonegroup: shared), a bucket-level sync policy is configured to replicate data from thelmam.478-bucky-3353-0 (source, 20 objects) to two destination buckets — thelmam.478-bucky-3353-0-new-0 and thelmam.478-bucky-3353-0-new-1 — both with status: enabled. On the primary zone, both destination buckets show empty usage, confirming the sync-from configuration is working correctly (objects remain only in source). However on the secondary zone, new-1 correctly syncs all 20 objects and is caught up across all 11 shards, while new-0 remains completely empty with bucket sync status reporting it is behind on 10 out of 11 shards ([0,1,3,4,5,6,7,8,9,10]) and never catches up despite both buckets having identical sync policy configurations.

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
