### PR TITLE
Copy RGW realm token without sshpass in rgw module suites

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_rgw_module.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_rgw_module.yaml
@@ -212,10 +212,13 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:india.primary} rgw_verify_ssl False"
               - "ceph orch restart {service_name:india.primary}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
               - "ceph rgw realm tokens | jq -r '.[0].token' > /home/cephuser/realm-token.txt"
-              - "sshpass -p 'passwd' scp /home/cephuser/realm-token.txt root@{node_ip:ceph-sec#node6}:/tmp/realm-token.txt"
+            copy_file:
+              src: /home/cephuser/realm-token.txt
+              dest: /tmp/realm-token.txt
+              dest_cluster: ceph-sec
+              dest_node: node6
         ceph-sec:
           config:
             cephadm: false
@@ -245,7 +248,7 @@ tests:
               - "ceph orch restart {service_name:india.secondary}"
               - "sleep 120"
       desc: Setting up RGW multisite replication environment using rgw module with token
-      module: exec.py
+      module: copy_cephadm_root_ca_cert.py
       name: setup multisite with rgw module
       polarion-id: CEPH-10362
   - test:

--- a/suites/squid/rgw/tier-2_rgw_ms_rgw_module.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_rgw_module.yaml
@@ -212,10 +212,13 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:india.primary} rgw_verify_ssl False"
               - "ceph orch restart {service_name:india.primary}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
               - "ceph rgw realm tokens | jq -r '.[0].token' > /home/cephuser/realm-token.txt"
-              - "sshpass -p 'passwd' scp /home/cephuser/realm-token.txt root@{node_ip:ceph-sec#node6}:/tmp/realm-token.txt"
+            copy_file:
+              src: /home/cephuser/realm-token.txt
+              dest: /tmp/realm-token.txt
+              dest_cluster: ceph-sec
+              dest_node: node6
         ceph-sec:
           config:
             cephadm: false
@@ -245,7 +248,7 @@ tests:
               - "ceph orch restart {service_name:india.secondary}"
               - "sleep 120"
       desc: Setting up RGW multisite replication environment using rgw module with token
-      module: exec.py
+      module: copy_cephadm_root_ca_cert.py
       name: setup multisite with rgw module
       polarion-id: CEPH-10362
   - test:

--- a/suites/tentacle/rgw/tier-2_rgw_ms_rgw_module.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms_rgw_module.yaml
@@ -212,10 +212,13 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:india.primary} rgw_verify_ssl False"
               - "ceph orch restart {service_name:india.primary}"
-              - "sudo yum install -y sshpass"
               - "sleep 120"
               - "ceph rgw realm tokens | jq -r '.[0].token' > /home/cephuser/realm-token.txt"
-              - "sshpass -p 'passwd' scp /home/cephuser/realm-token.txt root@{node_ip:ceph-sec#node6}:/tmp/realm-token.txt"
+            copy_file:
+              src: /home/cephuser/realm-token.txt
+              dest: /tmp/realm-token.txt
+              dest_cluster: ceph-sec
+              dest_node: node6
         ceph-sec:
           config:
             cephadm: false
@@ -245,7 +248,7 @@ tests:
               - "ceph orch restart {service_name:india.secondary}"
               - "sleep 120"
       desc: Setting up RGW multisite replication environment using rgw module with token
-      module: exec.py
+      module: copy_cephadm_root_ca_cert.py
       name: setup multisite with rgw module
       polarion-id: CEPH-10362
   - test:

--- a/tests/rgw/copy_cephadm_root_ca_cert.py
+++ b/tests/rgw/copy_cephadm_root_ca_cert.py
@@ -1,8 +1,10 @@
-"""Copy cephadm root CA cert to RGW and client nodes without sshpass."""
+"""Copy files to RGW and client nodes without sshpass."""
 
+import importlib
 import os
 import re
 
+from ceph.utils import get_node_by_id
 from utility.log import Log
 
 LOG = Log(__name__)
@@ -86,22 +88,73 @@ def copy_peer_cas_to_roles(cluster, ceph_cluster_dict, roles=("rgw", "client")):
                 install_cephadm_root_ca_cert(node, cert, cert_name=cert_name)
 
 
+def copy_file_to_node(src_node, dest_node, src_file, dest_file):
+    """Copy a file between nodes using remote_file."""
+    LOG.info(
+        "Copying %s from %s to %s on %s",
+        src_file,
+        src_node.hostname,
+        dest_file,
+        dest_node.hostname,
+    )
+    src = src_node.remote_file(sudo=True, file_name=src_file, file_mode="r")
+    content = src.read()
+    src.close()
+    dest = dest_node.remote_file(sudo=True, file_name=dest_file, file_mode="w")
+    dest.write(content)
+    dest.flush()
+    dest.close()
+    dest_node.exec_command(sudo=True, cmd=f"chmod 644 {dest_file}")
+
+
+def copy_file_to_cluster(ceph_cluster, ceph_cluster_dict, config):
+    """Copy a file from the current cluster to a peer cluster node."""
+    copy_cfg = config.get("copy_file", config)
+    src_file = copy_cfg["src"]
+    dest_file = copy_cfg["dest"]
+    dest_cluster = ceph_cluster_dict[copy_cfg["dest_cluster"]]
+    role = config.get("role", copy_cfg.get("role", "client"))
+    src_node = ceph_cluster.get_nodes(role=role)[config.get("idx", 0)]
+    if copy_cfg.get("dest_node"):
+        dest_node = get_node_by_id(dest_cluster, copy_cfg["dest_node"])
+    else:
+        dest_nodes = dest_cluster.get_nodes(role=copy_cfg.get("dest_role", "client"))
+        dest_node = dest_nodes[copy_cfg.get("idx", 0)]
+    if dest_node is None:
+        raise ValueError(
+            f"Unable to find dest node {copy_cfg.get('dest_node')} "
+            f"on {copy_cfg['dest_cluster']}"
+        )
+    copy_file_to_node(src_node, dest_node, src_file, dest_file)
+
+
 def run(ceph_cluster, **kwargs):
     """
-    Copy cephadm root CA cert to nodes by role.
-
-    Run after client setup in SSL RGW suites.
+    Copy files to RGW/client nodes without sshpass.
 
     Config keys:
-        roles: list of node roles (default: rgw, client)
+        roles: list of node roles for CA cert copy (default: rgw, client)
+        commands: optional exec.py command list; copy_file runs after commands
+        copy_file: copy a local file to a peer cluster
+            src, dest, dest_cluster, dest_node (optional)
     """
     config = kwargs.get("config", {})
     roles = config.get("roles", ["rgw", "client"])
     ceph_cluster_dict = kwargs.get("ceph_cluster_dict", {})
     try:
+        if config.get("commands"):
+            rc = importlib.import_module("exec").run(ceph_cluster, **kwargs)
+            if rc != 0:
+                return rc
+            if config.get("copy_file"):
+                copy_file_to_cluster(ceph_cluster, ceph_cluster_dict, config)
+            return 0
+        if config.get("copy_file") or (config.get("src") and config.get("dest_cluster")):
+            copy_file_to_cluster(ceph_cluster, ceph_cluster_dict, config)
+            return 0
         copy_cephadm_root_ca_cert_to_roles(ceph_cluster, roles=roles)
         copy_peer_cas_to_roles(ceph_cluster, ceph_cluster_dict, roles=roles)
     except Exception as exc:
-        LOG.error("Failed to copy cephadm root CA cert: %s", exc)
+        LOG.error("Failed to copy file: %s", exc)
         return 1
     return 0

--- a/tests/rgw/copy_cephadm_root_ca_cert.py
+++ b/tests/rgw/copy_cephadm_root_ca_cert.py
@@ -1,8 +1,10 @@
-"""Copy cephadm root CA cert to RGW and client nodes without sshpass."""
+"""Copy files to RGW and client nodes without sshpass."""
 
+import importlib
 import os
 import re
 
+from ceph.utils import get_node_by_id
 from utility.log import Log
 
 LOG = Log(__name__)
@@ -86,22 +88,75 @@ def copy_peer_cas_to_roles(cluster, ceph_cluster_dict, roles=("rgw", "client")):
                 install_cephadm_root_ca_cert(node, cert, cert_name=cert_name)
 
 
+def copy_file_to_node(src_node, dest_node, src_file, dest_file):
+    """Copy a file between nodes using remote_file."""
+    LOG.info(
+        "Copying %s from %s to %s on %s",
+        src_file,
+        src_node.hostname,
+        dest_file,
+        dest_node.hostname,
+    )
+    src = src_node.remote_file(sudo=True, file_name=src_file, file_mode="r")
+    content = src.read()
+    src.close()
+    dest = dest_node.remote_file(sudo=True, file_name=dest_file, file_mode="w")
+    dest.write(content)
+    dest.flush()
+    dest.close()
+    dest_node.exec_command(sudo=True, cmd=f"chmod 644 {dest_file}")
+
+
+def copy_file_to_cluster(ceph_cluster, ceph_cluster_dict, config):
+    """Copy a file from the current cluster to a peer cluster node."""
+    copy_cfg = config.get("copy_file", config)
+    src_file = copy_cfg["src"]
+    dest_file = copy_cfg["dest"]
+    dest_cluster = ceph_cluster_dict[copy_cfg["dest_cluster"]]
+    role = config.get("role", copy_cfg.get("role", "client"))
+    src_node = ceph_cluster.get_nodes(role=role)[config.get("idx", 0)]
+    if copy_cfg.get("dest_node"):
+        dest_node = get_node_by_id(dest_cluster, copy_cfg["dest_node"])
+    else:
+        dest_nodes = dest_cluster.get_nodes(role=copy_cfg.get("dest_role", "client"))
+        dest_node = dest_nodes[copy_cfg.get("idx", 0)]
+    if dest_node is None:
+        raise ValueError(
+            f"Unable to find dest node {copy_cfg.get('dest_node')} "
+            f"on {copy_cfg['dest_cluster']}"
+        )
+    copy_file_to_node(src_node, dest_node, src_file, dest_file)
+
+
 def run(ceph_cluster, **kwargs):
     """
-    Copy cephadm root CA cert to nodes by role.
-
-    Run after client setup in SSL RGW suites.
+    Copy files to RGW/client nodes without sshpass.
 
     Config keys:
-        roles: list of node roles (default: rgw, client)
+        roles: list of node roles for CA cert copy (default: rgw, client)
+        commands: optional exec.py command list; copy_file runs after commands
+        copy_file: copy a local file to a peer cluster
+            src, dest, dest_cluster, dest_node (optional)
     """
     config = kwargs.get("config", {})
     roles = config.get("roles", ["rgw", "client"])
     ceph_cluster_dict = kwargs.get("ceph_cluster_dict", {})
     try:
+        if config.get("commands"):
+            rc = importlib.import_module("exec").run(ceph_cluster, **kwargs)
+            if rc != 0:
+                return rc
+            if config.get("copy_file"):
+                copy_file_to_cluster(ceph_cluster, ceph_cluster_dict, config)
+            return 0
+        if config.get("copy_file") or (
+            config.get("src") and config.get("dest_cluster")
+        ):
+            copy_file_to_cluster(ceph_cluster, ceph_cluster_dict, config)
+            return 0
         copy_cephadm_root_ca_cert_to_roles(ceph_cluster, roles=roles)
         copy_peer_cas_to_roles(ceph_cluster, ceph_cluster_dict, roles=roles)
     except Exception as exc:
-        LOG.error("Failed to copy cephadm root CA cert: %s", exc)
+        LOG.error("Failed to copy file: %s", exc)
         return 1
     return 0


### PR DESCRIPTION
IBMc rejects the hardcoded sshpass scp of the realm token, so copy it with remote_file during the existing setup test.
pass log: 
https://149.81.216.83/job/tentacle-test-executor/2892/
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
