### PR TITLE
Add FIPS ssh key generated from RSA algorithm

### DIFF
--- a/conf/inventory/ibm-eu-rhel-10.0.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.0.yaml
@@ -98,6 +98,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-10.2-live-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2-live-rgw.yaml
@@ -28,6 +28,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-10.2-live.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2-live.yaml
@@ -28,6 +28,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-10.2-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2-rgw.yaml
@@ -99,6 +99,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-10.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2.yaml
@@ -129,6 +129,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.2.yaml
@@ -129,6 +129,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.4.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.4.yaml
@@ -129,6 +129,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.6.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.6.yaml
@@ -98,6 +98,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.8-live-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-live-rgw.yaml
@@ -28,6 +28,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.8-live.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-live.yaml
@@ -28,6 +28,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.8-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-rgw.yaml
@@ -99,6 +99,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false

--- a/conf/inventory/ibm-eu-rhel-9.8.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8.yaml
@@ -129,6 +129,7 @@ instance:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILuKaVnvq986B7zkgR0LyQbUo5F6JfrU9NnrRp1XbAYG ceph qe svc
           - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBNkaK5/dSj7VjggT4oCnc5nbf9AGAk6zduy0AiCWN/l5p9Q0r0e7rn81Pr8AMVpJL26Jr6ElWyJf1jF8rbxqbfTe6VwyRwQoHZETSqk9oDiSrsbZkNih/akwDlLcXVfWDw== ceph-qe-sa-sm@ibm.com
           - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKFa+YJXE5pBoRYrLsdTBjoR2ckoIv5Syn1H6I9Jt/iuVWupS3haQCAjuXe3f7f2s8EqauEvZYLro0NQEjWt4rg= psathyan mac laptop
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiyEczrypnoTNJHmzxegLvNjeU6hIh57KKvp63C3NbWfkIHO9rQES4NFQLR1yKFs9ow2hdzmjiGWYOEKRiMYOwllYjwCzOJnT/EnVMp79HmtXUfuWiVo5JYkZe1KVbIiSYRhrzJMU2eSuyIp6rPCaj+tF862fUZGJS2AFW6z7RJAOPjvJt1evG+Fc3i/Uwmr+dBBgpb/oEEqwIJN/kGJS9kLCfxDrGuqsCoVQ+3DpIUlHy624OzHordpCMYQP6CbSXbaLLNGbBen6ge1yg7UPkQP4UGnTwOcGOC/HAVyJii0bfUCdjPRTgbV95+XM7bt4A3lDB3Sg9MU1w5E4i3L7gEb5xgeWbPTkPPQ3u4hUTfirur/U4vm93CYU0C9Nvv94igr97k+VBWM82nuwCS0I3pk4mJEnhqRIOcYyUXYoKSSPXFZyjpqNoZp4aLE0Pgl0mT3d1GhevsPaGd/elecCdQx6zEkqo65XgtbKXuN+F5jpWcLreatKDhJ/+M85uH/U= ceph-qe-sa-sm@ibm.com
 
     chpasswd:
       expire: false


### PR DESCRIPTION
# Description

IBM Cloud does not support ECDSA alogorithm, it has to be RSA or ED25519 type. Adding the FIPS key that is supported by IBM Cloud.

- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve

*Unit tests*
```
2026-08-25 05:55:17,695 - cephci - bootstrap:344 - INFO - Auto-detected registry cp.stg.icr.io from container image, adding credentials
2026-08-25 05:55:17,701 - cephci - bootstrap:80 - DEBUG - Registry tier selection: registry='cp.stg.icr.io' tier='stage' build_type='nightly' vendor='ibm'
2026-08-25 05:55:17,702 - cephci - ceph:2004 - INFO - Execute cephadm --image cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel10:v9.9.2-23992 bootstrap --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> --mon-ip 10.243.100.232 --automatically-accept-license on ceph-pibvt-orstj6-node1-installer [10.243.100.232]
```