### PR TITLE
nfs: BYOK GKLM failure logs, KMIP cert clock-skew, and secret redaction

### DIFF
--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_byok_functional.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_byok_functional.py
@@ -12,6 +12,7 @@ from tests.cephfs.cephfs_utilsV1 import FsUtils as FsUtilsv1
 from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
+    collect_gklm_logs_on_failure,
     get_enctag,
     load_gklm_config,
     nfs_byok_test_setup,
@@ -83,6 +84,8 @@ def run(ceph_cluster, **kw):
         Remove subvolumes and subvolumegroup
         Remove FS volume if created
     """
+    gklm_params = None
+    test_failed = True
     try:
         global byok_test_params, cephfs_common_utils, fs_util, fs_system_utils, fs_io
         test_data = kw.get("test_data")
@@ -201,6 +204,7 @@ def run(ceph_cluster, **kw):
             result_str = f"Test {test_name} passed"
             log.info(result_str)
 
+        test_failed = False
         return 0
     except Exception as e:
         log.error(e)
@@ -208,6 +212,8 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Clean Up in progess")
+        if test_failed:
+            collect_gklm_logs_on_failure(gklm_params)
         wait_time_secs = 300
         if cephfs_common_utils.wait_for_healthy_ceph(client, wait_time_secs):
             log.error(

--- a/tests/nfs/byok/byok_tools.py
+++ b/tests/nfs/byok/byok_tools.py
@@ -1,13 +1,18 @@
 import json
+import logging
+import os
+import shlex
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 
 import requests
 import yaml
 
 from ceph.waiter import WaitUntil
 from cli.ceph.ceph import Ceph
+from cli.connectible.remote import Remote
 from cli.exceptions import ConfigError
 from tests.nfs.nfs_operations import (
     _LiteralPemDumper,
@@ -26,9 +31,151 @@ from tests.nfs.test_nfs_multiple_operations_for_upgrade import (
 )
 from utility.gklm_client.gklm_client import build_gklm_client
 
-# GKLM needs wall-clock settle time after NFS apply/SIGHUP before KMIP certs
-# are queryable via REST. Prefer a named wait over an opaque magic sleep.
-_GKLM_CERT_SETTLE_SEC = 30
+# NFS-Ganesha needs wall-clock settle time after orch apply before KMIP/exports.
+# Prefer a named wait over an opaque magic sleep.
+_GKLM_CERT_SETTLE_SEC = 60
+
+# IBM GKLM 5.x default WAS_HOME on Linux (Fix Pack README / Support Matrix).
+# Product logs: <WAS_HOME>/products/sklm/logs/{sklm.log,debug,agent.log}
+# Audit:        <WAS_HOME>/products/sklm/logs/audit/sklm_audit.log
+# Liberty:      <WAS_HOME>/usr/servers/<server>/logs/{messages.log,console.log}
+# https://www.ibm.com/support/pages/ibm-guardium-key-lifecycle-manager-support-matrix
+# https://www.ibm.com/support/pages/ibm-guardium-key-lifecycle-manager-version-500-fix-pack-3-readme
+_GKLM_WAS_HOME_DEFAULT = "/opt/IBM/WebSphere/Liberty"
+_GKLM_LOG_TAIL_LINES = 250
+_GKLM_SECRET_KEYS = ("gklm_password", "gklm_node_password", "password")
+_KMIP_SECRET_SPEC_KEYS = ("kmip_key",)
+
+
+def _redact_secrets_for_log(obj):
+    """Return a deep copy with GKLM passwords and KMIP private keys removed."""
+    redacted = deepcopy(obj)
+    secret_keys = set(_GKLM_SECRET_KEYS + _KMIP_SECRET_SPEC_KEYS)
+
+    def walk(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_l = str(key).lower()
+                if key in secret_keys or "password" in key_l:
+                    node[key] = "<redacted>"
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(redacted)
+    return redacted
+
+
+def _cephci_run_log_dir():
+    """Directory of the current cephci test log file, if a FileHandler exists."""
+    try:
+        for handler in logging.getLogger("cephci").handlers:
+            path = getattr(handler, "baseFilename", None)
+            if path:
+                return os.path.dirname(os.path.abspath(path))
+    except Exception:
+        pass
+    return log.log_dir
+
+
+def collect_gklm_logs_on_failure(gklm_params, tail_lines=_GKLM_LOG_TAIL_LINES):
+    """
+    SSH to the GKLM 5.x host and dump recent product/Liberty logs into cephci logs.
+
+    Call from BYOK ``finally`` only when the test failed. Collection is non-fatal
+    so cleanup still runs. IBM GUI equivalent is Configuration → Audit and Debug
+    → Download log files (Getting Started Guide); this helper reads the same
+    on-disk locations over SSH.
+
+    Args:
+        gklm_params (dict): Output of ``load_gklm_config`` (or equivalent).
+        tail_lines (int): Lines to capture from each log file.
+    """
+    if not gklm_params:
+        log.warning("Skipping GKLM log collection; GKLM params not initialized")
+        return
+
+    host = gklm_params.get("gklm_ip") or gklm_params.get("gklm_hostname")
+    username = gklm_params.get("gklm_node_username") or gklm_params.get(
+        "gklm_node_user"
+    )
+    password = gklm_params.get("gklm_node_password")
+    was_home = gklm_params.get("gklm_was_home") or _GKLM_WAS_HOME_DEFAULT
+    hostname = gklm_params.get("gklm_hostname") or host
+
+    if not host or not username or not password:
+        log.warning(
+            "Skipping GKLM log collection; missing SSH host/user/password in GKLM params"
+        )
+        return
+
+    log.info(
+        "Collecting GKLM 5.x logs from %s (%s) WAS_HOME=%s (last %s lines per file)",
+        host,
+        hostname,
+        was_home,
+        tail_lines,
+    )
+
+    quoted_home = shlex.quote(was_home)
+    remote_cmd = (
+        f"WAS_HOME={quoted_home}; "
+        f"N={int(tail_lines)}; "
+        'echo "=== GKLM log directory listing ==="; '
+        'ls -la "$WAS_HOME/products/sklm/logs" '
+        '"$WAS_HOME/products/sklm/logs/audit" '
+        '"$WAS_HOME/products/sklm/logs/replication" '
+        "$WAS_HOME/usr/servers/*/logs 2>/dev/null || true; "
+        "for f in "
+        '"$WAS_HOME/products/sklm/logs/sklm.log" '
+        '"$WAS_HOME/products/sklm/logs/debug" '
+        '"$WAS_HOME/products/sklm/logs/debug.log" '
+        '"$WAS_HOME/products/sklm/logs/agent.log" '
+        '"$WAS_HOME/products/sklm/logs/audit/sklm_audit.log"; do '
+        '  if [ -f "$f" ]; then '
+        '    echo ""; echo "===== tail -n $N $f ====="; tail -n "$N" "$f"; '
+        "  fi; "
+        "done; "
+        "for f in $WAS_HOME/usr/servers/*/logs/messages.log "
+        "$WAS_HOME/usr/servers/*/logs/console.log; do "
+        '  if [ -f "$f" ]; then '
+        '    echo ""; echo "===== tail -n $N $f ====="; tail -n "$N" "$f"; '
+        "  fi; "
+        "done"
+    )
+
+    remote = None
+    try:
+        remote = Remote(host=host, username=username, password=password)
+        stdout, stderr = remote.run(cmd=remote_cmd, timeout=180)
+        banner = (
+            f"========== GKLM 5.x logs (test failure) "
+            f"host={hostname} ip={host} =========="
+        )
+        log.info("%s\n%s", banner, stdout or "(no GKLM log content returned)")
+        if stderr:
+            log.warning("GKLM log collection stderr: %s", stderr)
+
+        run_dir = _cephci_run_log_dir()
+        if run_dir and stdout:
+            dest_dir = os.path.join(run_dir, "gklm_logs")
+            os.makedirs(dest_dir, exist_ok=True)
+            dest = os.path.join(dest_dir, f"gklm-{hostname}-failure.log")
+            with open(dest, "w", encoding="utf-8", errors="replace") as fh:
+                fh.write(stdout)
+                if not stdout.endswith("\n"):
+                    fh.write("\n")
+            log.info("Wrote GKLM logs to %s", dest)
+    except Exception as ex:
+        log.warning("GKLM log collection failed (non-fatal): %s", ex)
+    finally:
+        if remote is not None:
+            try:
+                remote._client.close()
+            except Exception:
+                pass
 
 
 def is_gklm_auth_error(exc) -> bool:
@@ -314,7 +461,7 @@ def create_nfs_instance_for_byok(
             "kmip_host_list": [kmip_host_list],
         },
     }
-    log.debug(f"NFS service spec: {nfs_cluster_dict}")
+    log.debug("NFS service spec: %s", _redact_secrets_for_log(nfs_cluster_dict))
 
     create_nfs_via_file_and_verify(
         installer_node=installer,
@@ -579,13 +726,18 @@ def load_gklm_config(custom_data, config, cephci_data):
                         "gklm_node_password",
                         "gklm_hostname",
                         "gklm_rest_prefix",
+                        "gklm_was_home",
                     }
                     for k in gklm_yaml_keys:
                         if k in raw and raw[k] not in ("", None):
                             data[k] = raw[k]
             if data:
                 merged.update(data)
-                log.info("Loaded GKLM config from file '%s': %s", yaml_file, data)
+                log.info(
+                    "Loaded GKLM config from file '%s' (keys: %s)",
+                    yaml_file,
+                    sorted(data.keys()),
+                )
             else:
                 log.warning(
                     "GKLM section empty or missing under 'gklm:' in '%s'",
@@ -611,9 +763,13 @@ def load_gklm_config(custom_data, config, cephci_data):
             "gklm_node_password",
             "gklm_hostname",
             "gklm_rest_prefix",
+            "gklm_was_home",
         }:
             merged[key] = val
-            log.info("Overrode GKLM config '%s' via custom-config: %s", key, val)
+            if "password" in key.lower():
+                log.info("Overrode GKLM config '%s' via custom-config", key)
+            else:
+                log.info("Overrode GKLM config '%s' via custom-config: %s", key, val)
         else:
             log.warning("Unknown GKLM config key in custom-config: '%s'", key)
 
@@ -636,7 +792,8 @@ def load_gklm_config(custom_data, config, cephci_data):
     log.info(
         "Final GKLM configuration keys: %s",
         [k for k in required if k in merged]
-        + (["gklm_rest_prefix"] if merged.get("gklm_rest_prefix") else []),
+        + (["gklm_rest_prefix"] if merged.get("gklm_rest_prefix") else [])
+        + (["gklm_was_home"] if merged.get("gklm_was_home") else []),
     )
     return merged
 
@@ -780,7 +937,10 @@ def create_multiple_nfs_instance_for_byok(
         spec["kmip_key"] = (rsa_key.rstrip("\\n"),)
         spec["kmip_ca_cert"] = (ca_cert.rstrip("\\n"),)
         spec["kmip_host_list"] = [kmip_host_list]
-        log.debug(f"Prepared BYOK-enabled NFS Ganesha service spec:\n{spec}")
+        log.debug(
+            "Prepared BYOK-enabled NFS Ganesha service spec:\n%s",
+            _redact_secrets_for_log(spec),
+        )
 
         # Call core spec deployment function
         result = create_multiple_nfs_instance_via_spec_file(

--- a/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
+++ b/tests/nfs/byok/test_byok_neg_incorrect_key_cert.py
@@ -6,6 +6,7 @@ from cli.exceptions import ConfigError
 from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
+    collect_gklm_logs_on_failure,
     create_nfs_instance_for_byok,
     get_enctag,
     load_gklm_config,
@@ -45,6 +46,8 @@ def run(ceph_cluster, **kw):
     Cleanup:
      - Cleanup all resources on success or failure.
     """
+    gklm_params = None
+    test_failed = True
     try:
         global byok_setup_params, nfs_mount, nfs_export, port, clients, fs_name, config, client_export_mount_dict
         global setup_params, cephfs_common_utils
@@ -117,6 +120,7 @@ def run(ceph_cluster, **kw):
             log.error("FAIL:BYOK Test for Incorrect KMIP cert")
             return 1
         log.info("PASS:BYOK Test for Incorrect KMIP cert")
+        test_failed = False
         return 0
 
     except Exception as e:
@@ -125,6 +129,8 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         log.info("Clean Up in progess")
+        if test_failed:
+            collect_gklm_logs_on_failure(gklm_params)
         if incorrect_enctag_cleanup != 1 or incorrect_cert_cleanup != 1:
             clean_up_gklm(
                 gklm_rest_client=byok_setup_params["gklm_rest_client"],

--- a/tests/nfs/byok/test_byok_nfs_ha_failover_encryption.py
+++ b/tests/nfs/byok/test_byok_nfs_ha_failover_encryption.py
@@ -8,6 +8,7 @@ from cli.utilities.filesys import MountFailedError, Unmount
 from tests.ceph_ansible.purge_cluster import reboot_node
 from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
+    collect_gklm_logs_on_failure,
     create_in_file_certs,
     get_enctag,
     load_gklm_config,
@@ -161,6 +162,7 @@ def run(ceph_cluster, **kw):
     gkml_client_name = "automation"
     gklm_cert_alias = "cert2"
     client_export_mount_dict = None
+    test_failed = True
 
     try:
         log.info("Step 1: Setting up GKLM infrastructure")
@@ -304,14 +306,18 @@ def run(ceph_cluster, **kw):
             dd_command_size_in_M=10,
         )
 
+        test_failed = False
         return 0
     except MountFailedError:
         if operation == "correct_incorrect_key":
             log.info("Expected failure occurred during I/O with incorrect key scenario")
+            test_failed = False
             return 0
 
     finally:
         log.info("Step 9: Cleanup - GKLM, NFS clusters, and mounts")
+        if test_failed:
+            collect_gklm_logs_on_failure(gklm_params)
 
         # Clean GKLM resources
         clean_up_gklm(

--- a/tests/nfs/byok/test_byok_single_multi_restart.py
+++ b/tests/nfs/byok/test_byok_single_multi_restart.py
@@ -5,6 +5,7 @@ from cli.exceptions import ConfigError, OperationFailedError
 from cli.utilities.filesys import Unmount
 from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
+    collect_gklm_logs_on_failure,
     create_multiple_nfs_instance_for_byok,
     create_nfs_instance_for_byok,
     ensure_fresh_gklm_kmip_client,
@@ -235,6 +236,7 @@ def run(ceph_cluster, **kw):
     gklm_cert_alias = "cert2"
     client_export_mount_dict = None
     spec = config.get("spec")
+    test_failed = True
 
     try:
         log.info("Step 1: Setting up GKLM infrastructure")
@@ -487,6 +489,7 @@ def run(ceph_cluster, **kw):
                 is_multicluster=True,
             )
 
+        test_failed = False
         return 0
 
     except Exception as e:
@@ -496,6 +499,8 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleanup: GKLM, NFS clusters, and mounts")
+        if test_failed:
+            collect_gklm_logs_on_failure(gklm_params)
         if config.get("check_sighup", False):
             try:
                 ensure_gklm_login(gklm_rest_client)

--- a/tests/nfs/byok/test_sni_feature.py
+++ b/tests/nfs/byok/test_sni_feature.py
@@ -6,6 +6,7 @@ from cli.exceptions import ConfigError, OperationFailedError
 from cli.utilities.filesys import MountFailedError, Unmount
 from tests.nfs.byok.byok_tools import (
     clean_up_gklm,
+    collect_gklm_logs_on_failure,
     create_nfs_instance_for_byok,
     get_enctag,
     load_gklm_config,
@@ -122,6 +123,7 @@ def run(ceph_cluster, **kw):
     new_ca_cert_alias = "custom_sni_host"
     client_export_mount_dict = None
     gklm_rest_client = None
+    test_failed = True
 
     try:
         log.info("Step 1: Setting up GKLM infrastructure")
@@ -344,6 +346,7 @@ def run(ceph_cluster, **kw):
             )
             return 1
 
+        test_failed = False
         return 0
 
     except MountFailedError:
@@ -356,6 +359,7 @@ def run(ceph_cluster, **kw):
             log.info(
                 "Mount failed as expected due to hostname mismatch in GKLM certificate."
             )
+            test_failed = False
             return 0
 
     except Exception as e:
@@ -365,6 +369,8 @@ def run(ceph_cluster, **kw):
 
     finally:
         log.info("Cleanup: GKLM, NFS clusters, and mounts")
+        if test_failed:
+            collect_gklm_logs_on_failure(gklm_params)
         if operation not in [
             "Mismatch Validation Hostname",
             "No SNI - Validate Other Hostname",

--- a/tests/nfs/nfs_operations.py
+++ b/tests/nfs/nfs_operations.py
@@ -3,6 +3,7 @@ import os
 import re
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from datetime import datetime
 from threading import Thread
 from time import sleep
@@ -27,6 +28,25 @@ log = Log(__name__)
 ceph_cluster_obj = None
 setup_start_time = None
 GANESHA_SUBVOL_GROUP = "ganeshagroup"
+
+
+def _redact_kmip_key_for_log(obj):
+    """Deep-copy NFS spec(s) with kmip_key private key material removed."""
+    redacted = deepcopy(obj)
+
+    def walk(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "kmip_key":
+                    node[key] = "<redacted>"
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(redacted)
+    return redacted
 
 
 def ensure_ganeshagroup(
@@ -1705,7 +1725,7 @@ def create_multiple_nfs_instance_via_spec_file(
             f"Creating {replication_number} NFS Ganesha instance(s) "
             f"using base spec service_id='{spec['service_id']}'..."
         )
-        log.debug(f"Full generated specs: {new_objects}")
+        log.debug("Full generated specs: %s", _redact_kmip_key_for_log(new_objects))
 
         # Deploy the NFS service(s) via orchestrator
         if not create_nfs_via_file_and_verify(

--- a/utility/gklm_client/certs.py
+++ b/utility/gklm_client/certs.py
@@ -1,15 +1,77 @@
 import os
+import time
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
 import requests
 import urllib3
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
 
 from utility.gklm_client.auth import GklmAuth
-from utility.utils import generate_self_signed_certificate
+from utility.log import Log
+from utility.utils import generate_self_signed_certificate, get_cephqe_ca
+
+log = Log(__name__)
 
 # Suppress the InsecureRequestWarning
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Backdate KMIP client-cert NotBefore so a KMS clock a few minutes behind
+# the issuer does not raise CertificateNotYetValidException.
+KMIP_CLIENT_CERT_NOT_BEFORE_SKEW = timedelta(minutes=5)
+# Extra wait after NotBefore so a KMS that is still slightly behind the
+# issuer does not reject the brand-new cert.
+_KMIP_CERT_VALIDITY_BUFFER_SEC = 5
+
+
+def _backdate_kmip_client_cert(key_pem: str, cert_pem: str) -> str:
+    """Re-sign a KMIP client cert with NotBefore a few minutes in the past."""
+    orig = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
+    key = serialization.load_pem_private_key(key_pem.encode(), password=None)
+    ca_key, _ = get_cephqe_ca()
+    now = datetime.utcnow()
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(orig.subject)
+        .issuer_name(orig.issuer)
+        .public_key(orig.public_key())
+        .serial_number(orig.serial_number)
+        .not_valid_before(now - KMIP_CLIENT_CERT_NOT_BEFORE_SKEW)
+        .not_valid_after(now + timedelta(days=30))
+    )
+    try:
+        san = orig.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        builder = builder.add_extension(san.value, san.critical)
+    except x509.ExtensionNotFound:
+        pass
+    signed = builder.sign(ca_key if ca_key else key, hashes.SHA256(), default_backend())
+    return signed.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+
+
+def wait_until_kmip_client_cert_valid(
+    cert_pem: str, extra_buffer_sec: int = _KMIP_CERT_VALIDITY_BUFFER_SEC
+) -> None:
+    """Sleep until issuer clock is past cert NotBefore plus a small buffer."""
+    cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
+    not_before = getattr(cert, "not_valid_before_utc", None)
+    if not_before is None:
+        not_before = cert.not_valid_before
+    if getattr(not_before, "tzinfo", None) is None:
+        not_before = not_before.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    ready_at = not_before + timedelta(seconds=extra_buffer_sec)
+    wait_sec = (ready_at - now).total_seconds()
+    if wait_sec <= 0:
+        return
+    log.info(
+        "Waiting %.1fs until KMIP client cert NotBefore + %ss buffer",
+        wait_sec,
+        extra_buffer_sec,
+    )
+    time.sleep(wait_sec)
 
 
 def _coerce_certificate_list(data: Any) -> List[Dict[str, Any]]:
@@ -116,6 +178,13 @@ class GklmCertificate:
 
     def get_certificates(self, subject: dict, create_files=False) -> tuple:
         key, cert, ca = generate_self_signed_certificate(subject=subject)
+        cert = _backdate_kmip_client_cert(key, cert)
+        log.info(
+            "Issued KMIP client cert for CN=%s with NotBefore skewed back by %s",
+            subject.get("common_name"),
+            KMIP_CLIENT_CERT_NOT_BEFORE_SKEW,
+        )
+        wait_until_kmip_client_cert_valid(cert)
         if create_files:
             with open(f"{subject['common_name']}.key", "w") as f:
                 f.write(key)
@@ -130,7 +199,7 @@ class GklmCertificate:
                 os.path.abspath(f"{subject['common_name']}.ca") if ca else None,
             )
             return abs_path
-        return generate_self_signed_certificate(subject)
+        return key, cert, ca
 
     def list_system_certificates(self) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
## Problem
NFS BYOK tests with valid GKLM keys failed to mount (`No such file or directory`). RCA showed GKLM rejecting the KMIP client certificate as not yet valid when its clock was behind the cluster (`CertificateNotYetValidException`). Ganesha then never published the export. DEBUG logs also dumped GKLM passwords and KMIP private keys, and failed runs did not capture GKLM product logs.

## Solution
- Issue KMIP client certs with `NotBefore` a few minutes in the past, then wait until `NotBefore` plus a short buffer.
- Collect IBM GKLM 5.x logs over SSH on BYOK test failure (non-fatal).
- Redact GKLM passwords and `kmip_key` from DEBUG/INFO dumps.

## Changes
- `utility/gklm_client/certs.py` — KMIP client cert NotBefore skew (NFS BYOK path only; shared `utility/utils.py` unchanged)
- `tests/nfs/byok/byok_tools.py` — GKLM log collection, secret redaction, 60s settle after NFS create
- `tests/nfs/byok/test_byok_single_multi_restart.py`
- `tests/nfs/byok/test_sni_feature.py`
- `tests/nfs/byok/test_byok_neg_incorrect_key_cert.py`
- `tests/nfs/byok/test_byok_nfs_ha_failover_encryption.py`
- `tests/cephfs/cephfs_nfs/test_cephfs_nfs_byok_functional.py`
- `tests/nfs/nfs_operations.py` — redact `kmip_key` in DEBUG spec dumps (no Kerberos changes)

## Test suites to run
- `suites/tentacle/nfs/tier1-nfs-ganesha-byok.yaml`
- Jenkins: `tentacle-test-executor` with that suite

## Validation logs
http://magna002.ceph.redhat.com/ceph/ceph-qe-logs/byok/byok/

<details>
<summary>Automation development checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

Made with [Cursor](https://cursor.com)