### PR TITLE
Adding additional Test coverage for customer issue on case-sensitivity

### DIFF
--- a/suites/squid/cephfs/8_1_features_suite.yaml
+++ b/suites/squid/cephfs/8_1_features_suite.yaml
@@ -149,6 +149,24 @@ tests:
       polarion-id: CEPH-83617010
       desc: Test fs attributes for functional use case
       abort-on-fail: false
+  - test:
+      name: casefold subvolume multi-mds failover journal replay
+      module: cephfs_case_sensitivity.case_sensitivity_multimds_failover.py
+      polarion-id: CEPH-83632953
+      desc: >
+        Case-insensitive subvolume under max_mds>=4 with rename-heavy FUSE metadata
+        I/O; rotate mds fail across ranks mid-IO; verify no alternate_name journal
+        replay or rejoin auth crashes (IBMCEPH-16942 / #72399).
+      abort-on-fail: true
+      config:
+        max_mds: 4
+        fail_iterations: 10
+        fail_ranks: [0, 1, 2, 3]
+        storm_warmup_sec: 180
+        post_fail_sleep_sec: 5
+        health_wait: 300
+        mds_placement_count: 4
+        run_max_mds_scaleup: true
 
   ######################################################################################################################
   # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml

--- a/suites/squid/cephfs/tier-1_cephfs_case_sensitivity.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_case_sensitivity.yaml
@@ -5,6 +5,7 @@
 # Conf file : conf/squid/cephfs/tier-1_cephfs_smb_nfs.yaml
 # Test-Case Covered:
 # CEPH-83606639 Verify Case Sensitivity Functionality
+# CEPH-83632953 Casefold subvolume multi-MDS failover (IBMCEPH-16942 / #72399)
 #===============================================================================================
 tests:
   - test:
@@ -142,3 +143,23 @@ tests:
       polarion-id: CEPH-83617010
       desc: Test fs attributes for functional use case
       abort-on-fail: false
+  - test:
+      name: casefold subvolume multi-mds failover journal replay
+      module: cephfs_case_sensitivity.case_sensitivity_multimds_failover.py
+      polarion-id: CEPH-83632953
+      desc: >
+        Case-insensitive subvolume under max_mds>=4 with rename-heavy FUSE metadata
+        I/O; rotate mds fail across ranks mid-IO; verify no alternate_name journal
+        replay or rejoin auth crashes; max_mds scale-up under load (IBMCEPH-16942).
+      abort-on-fail: true
+      config:
+        max_mds: 4
+        fail_iterations: 10
+        fail_ranks: [0, 1, 2, 3]
+        storm_warmup_sec: 180
+        post_fail_sleep_sec: 5
+        health_wait: 300
+        mds_placement_count: 4
+        subvol_group: cs_mm_repro
+        subvol_name: casefold_sv
+        run_max_mds_scaleup: true

--- a/suites/tentacle/cephfs/8_1_features_suite.yaml
+++ b/suites/tentacle/cephfs/8_1_features_suite.yaml
@@ -149,6 +149,24 @@ tests:
       polarion-id: CEPH-83617010
       desc: Test fs attributes for functional use case
       abort-on-fail: false
+  - test:
+      name: casefold subvolume multi-mds failover journal replay
+      module: cephfs_case_sensitivity.case_sensitivity_multimds_failover.py
+      polarion-id: CEPH-83632953
+      desc: >
+        Case-insensitive subvolume under max_mds>=4 with rename-heavy FUSE metadata
+        I/O; rotate mds fail across ranks mid-IO; verify no alternate_name journal
+        replay or rejoin auth crashes (IBMCEPH-16942 / #72399).
+      abort-on-fail: true
+      config:
+        max_mds: 4
+        fail_iterations: 10
+        fail_ranks: [0, 1, 2, 3]
+        storm_warmup_sec: 180
+        post_fail_sleep_sec: 5
+        health_wait: 300
+        mds_placement_count: 4
+        run_max_mds_scaleup: true
 
   ######################################################################################################################
   # Conf File : conf/squid/cephfs/tier-2_cephfs_7-node-cluster.yaml

--- a/suites/tentacle/cephfs/tier-1_cephfs_case_sensitivity.yaml
+++ b/suites/tentacle/cephfs/tier-1_cephfs_case_sensitivity.yaml
@@ -5,6 +5,7 @@
 # Conf file : conf/squid/cephfs/tier-1_cephfs_smb_nfs.yaml
 # Test-Case Covered:
 # CEPH-83606639 Verify Case Sensitivity Functionality
+# CEPH-83632953 Casefold subvolume multi-MDS failover (IBMCEPH-16942 / #72399)
 #===============================================================================================
 tests:
   - test:
@@ -142,3 +143,23 @@ tests:
       polarion-id: CEPH-83617010
       desc: Test fs attributes for functional use case
       abort-on-fail: false
+  - test:
+      name: casefold subvolume multi-mds failover journal replay
+      module: cephfs_case_sensitivity.case_sensitivity_multimds_failover.py
+      polarion-id: CEPH-83632953
+      desc: >
+        Case-insensitive subvolume under max_mds>=4 with rename-heavy FUSE metadata
+        I/O; rotate mds fail across ranks mid-IO; verify no alternate_name journal
+        replay or rejoin auth crashes; max_mds scale-up under load (IBMCEPH-16942).
+      abort-on-fail: true
+      config:
+        max_mds: 4
+        fail_iterations: 10
+        fail_ranks: [0, 1, 2, 3]
+        storm_warmup_sec: 180
+        post_fail_sleep_sec: 5
+        health_wait: 300
+        mds_placement_count: 4
+        subvol_group: cs_mm_repro
+        subvol_name: casefold_sv
+        run_max_mds_scaleup: true

--- a/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_multimds_failover.py
+++ b/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_multimds_failover.py
@@ -1,0 +1,415 @@
+"""
+IBMCEPH-16942 / tracker #72399 — casefold subvolume under multi-active MDS.
+
+Regression coverage for MDS journal replay and rejoin failures involving
+``alternate_name`` and subtree authority after failover during case-insensitive
+metadata workloads.
+"""
+
+import json
+import os
+import random
+import string
+import time
+
+from cli.ceph.ceph import Ceph
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from tests.cephfs.exceptions import FsBaseException, log_and_fail
+from tests.cephfs.lib.cephfs_attributes_lib import CephFSAttributeUtilities
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+_ACCEPTABLE_FAILOVER_HEALTH_WARNINGS = (
+    "MDS_INSUFFICIENT_STANDBY",
+    "insufficient standby MDS daemons available",
+    "SLOW_OPS",
+)
+
+
+def _subvolume_is_case_insensitive(subvol_info):
+    val = subvol_info.get("casesensitive")
+    if val is False:
+        return True
+    return isinstance(val, str) and val.lower() == "false"
+
+
+def _remove_subvolume_if_exists(client, fs_name, subvol_name, subvol_group):
+    client.exec_command(
+        sudo=True,
+        cmd="ceph fs subvolume rm {} {} {} --force".format(
+            fs_name, subvol_name, subvol_group
+        ),
+        check_ec=False,
+    )
+
+
+def _mds_placement_hosts(ceph_cluster, count=4):
+    mds_nodes = ceph_cluster.get_ceph_objects("mds")
+    hostnames = [m.node.hostname for m in mds_nodes]
+    if len(hostnames) < 2:
+        raise FsBaseException(
+            "Multi-MDS casefold failover requires at least 2 MDS nodes, found {}".format(
+                len(hostnames)
+            )
+        )
+    use = min(count, len(hostnames))
+    return use, " ".join(hostnames[:use]) + " "
+
+
+def _parse_fs_status_rank(rank):
+    if rank is None:
+        return None
+    if isinstance(rank, int):
+        return rank
+    rank_str = str(rank).strip()
+    if rank_str.endswith("-s"):
+        return None
+    try:
+        return int(rank_str)
+    except ValueError:
+        return None
+
+
+def _wait_for_fs_ranks_active(client, fs_name, max_mds, timeout=600, interval=10):
+    max_mds = int(max_mds)
+    end = time.time() + timeout
+    while time.time() < end:
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd="ceph fs status {} -f json".format(fs_name),
+            client_exec=True,
+            check_ec=False,
+        )
+        try:
+            status = json.loads(out)
+        except json.JSONDecodeError:
+            time.sleep(interval)
+            continue
+
+        rank_states = {}
+        for m in status.get("mdsmap", []):
+            rank = _parse_fs_status_rank(m.get("rank"))
+            if rank is None:
+                continue
+            rank_states[rank] = m.get("state", "")
+
+        bad = [
+            (r, s)
+            for r, s in rank_states.items()
+            if r < max_mds and ("active" not in s or "damaged" in s or "failed" in s)
+        ]
+        if not bad:
+            active_count = sum(
+                1 for r, s in rank_states.items() if r < max_mds and "active" in s
+            )
+            if active_count >= max_mds:
+                log.info("All %s MDS ranks active for %s", max_mds, fs_name)
+                return True
+
+        log.info("Waiting for ranks active on %s (states=%s)", fs_name, rank_states)
+        time.sleep(interval)
+    return False
+
+
+def _assert_ok_after_failover(client, context=""):
+    health, _ = client.exec_command(sudo=True, cmd="ceph health", check_ec=False)
+    health = (health or "").strip()
+    if "HEALTH_OK" in health:
+        return True
+
+    detail, _ = client.exec_command(sudo=True, cmd="ceph health detail", check_ec=False)
+    detail = detail or ""
+    for pattern in (
+        "OSD_DOWN",
+        "OSD_HOST_DOWN",
+        "MDS_DAMAGE",
+        "MDS_ALL_DOWN",
+        "FS_DEGRADED",
+        "FS_DAMAGED",
+        "PG_UNAVAILABLE",
+    ):
+        if pattern in detail:
+            log.error(
+                "Unacceptable cluster health '%s' (%s)\n%s",
+                pattern,
+                context,
+                detail,
+            )
+            return False
+
+    if any(w in detail for w in _ACCEPTABLE_FAILOVER_HEALTH_WARNINGS):
+        log.info("Acceptable HEALTH_WARN during failover (%s): %s", context, health)
+        return True
+
+    log.error("Unexpected cluster health after failover (%s): %s", context, detail)
+    return False
+
+
+def _assert_post_fail_oracles(client, attr_util, fs_name, context):
+    if not attr_util.assert_no_damaged_mds_ranks(client, fs_name, context):
+        return False
+    if not attr_util.assert_no_mds_crashes(client, context=context):
+        return False
+    return _assert_ok_after_failover(client, context)
+
+
+def _resolve_fail_ranks(config, max_mds):
+    fail_ranks = config.get("fail_ranks")
+    if fail_ranks:
+        return [int(r) for r in fail_ranks]
+    return list(range(max_mds))
+
+
+def _usecase_multimds_failover(
+    ceph_cluster, client, fs_util, attr_util, common_util, config
+):
+    max_mds = int(config.get("max_mds", 4))
+    fail_iterations = int(config.get("fail_iterations", 10))
+    fail_ranks = _resolve_fail_ranks(config, max_mds)
+    storm_warmup_sec = int(config.get("storm_warmup_sec", 180))
+    post_fail_sleep_sec = int(config.get("post_fail_sleep_sec", 5))
+    health_wait = int(config.get("health_wait", 300))
+    subvol_group = config.get("subvol_group", "cs_mm_repro")
+    subvol_name = config.get("subvol_name", "casefold_sv")
+    mds_placement_count = int(config.get("mds_placement_count", 4))
+
+    fs_name = "case-sensitivity-mm-failover"
+    mounting_dir = "/mnt/cs_mm_failover_{}/".format(
+        "".join(random.choice(string.ascii_lowercase) for _ in range(8))
+    )
+    stop_flag = "/tmp/casefold_storm_{}.stop".format(fs_name.replace("-", "_"))
+
+    log.info(
+        "Usecase 1: casefold subvolume + max_mds=%s + %s fail iterations ranks=%s",
+        max_mds,
+        fail_iterations,
+        fail_ranks,
+    )
+
+    if common_util.wait_for_healthy_ceph(client, health_wait):
+        log.error("Cluster not healthy before Usecase 1")
+        return 1, fs_name, mounting_dir, stop_flag, None, None
+
+    attr_util.archive_mds_crashes(client)
+
+    host_count, mds_hosts = _mds_placement_hosts(ceph_cluster, mds_placement_count)
+    client.exec_command(
+        sudo=True,
+        cmd='ceph fs volume create {} --placement="{} {}"'.format(
+            fs_name, host_count, mds_hosts
+        ),
+    )
+    client.exec_command(
+        sudo=True, cmd="ceph fs set {} max_mds {}".format(fs_name, max_mds)
+    )
+    fs_util.wait_for_mds_process(client, fs_name)
+    fs_util.set_and_validate_mds_standby_replay(client, fs_name, 1)
+
+    ceph = Ceph(client)
+    ceph.fs.sub_volume_group.create(fs_name, subvol_group)
+    _remove_subvolume_if_exists(client, fs_name, subvol_name, subvol_group)
+    ceph.fs.sub_volume.create(
+        fs_name,
+        subvol_name,
+        **{
+            "group-name": subvol_group,
+            "casesensitive=": "false",
+            "normalization=": "nfd",
+        },
+    )
+
+    subvol_path = ceph.fs.sub_volume.getpath(
+        fs_name, subvol_name, **{"group-name": subvol_group}
+    ).strip()
+    log.info("Casefold subvolume path: %s", subvol_path)
+
+    if not _subvolume_is_case_insensitive(
+        ceph.fs.sub_volume.info(fs_name, subvol_name, **{"group-name": subvol_group})
+    ):
+        log.error("Subvolume casesensitive flag is not false")
+        return 1, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name
+
+    client.exec_command(sudo=True, cmd="mkdir -p {}".format(mounting_dir))
+    client.exec_command(
+        sudo=True,
+        cmd="mountpoint -q {} && fusermount -u {} -z || true".format(
+            mounting_dir, mounting_dir
+        ),
+        check_ec=False,
+    )
+    fs_util.fuse_mount(
+        [client],
+        mounting_dir,
+        extra_params=" -r {} --client_fs {}".format(subvol_path, fs_name),
+    )
+
+    probe = os.path.join(mounting_dir.rstrip("/"), ".repro_probe")
+    client.exec_command(sudo=True, cmd="echo ok > {!r}".format(probe))
+    out, _ = client.exec_command(
+        sudo=True, cmd="cat {!r}".format(probe), check_ec=False
+    )
+    if "ok" not in (out or "").strip():
+        log.error("FUSE write probe failed on casefold mount (output=%r)", out)
+        return 1, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name
+
+    attr_util.start_casefold_metadata_storm(client, mounting_dir, stop_flag)
+    log.info("Metadata storm warmup for %s seconds", storm_warmup_sec)
+    time.sleep(storm_warmup_sec)
+
+    for iteration in range(1, fail_iterations + 1):
+        rank_to_fail = fail_ranks[(iteration - 1) % len(fail_ranks)]
+        log.info(
+            "MDS fail iteration %s/%s (rank %s)",
+            iteration,
+            fail_iterations,
+            rank_to_fail,
+        )
+        out, err, exit_code, _ = client.exec_command(
+            sudo=True,
+            cmd="ceph mds fail {}".format(rank_to_fail),
+            check_ec=False,
+            verbose=True,
+        )
+        if exit_code != 0:
+            log.error(
+                "ceph mds fail rank %s failed exit_code=%s stdout=%r stderr=%r",
+                rank_to_fail,
+                exit_code,
+                out,
+                err,
+            )
+            return 1, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name
+        time.sleep(post_fail_sleep_sec)
+
+        if not _wait_for_fs_ranks_active(client, fs_name, max_mds):
+            log.error("Ranks did not return active after fail iteration %s", iteration)
+            return 1, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name
+
+        if not _assert_post_fail_oracles(
+            client, attr_util, fs_name, "iteration-{}".format(iteration)
+        ):
+            return 1, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name
+
+    log.info("Passed Usecase 1: multi-MDS casefold failover without MDS crashes")
+    return 0, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name
+
+
+def _usecase_max_mds_scaleup(client, fs_util, attr_util, fs_name, max_mds):
+    log.info("Usecase 2: max_mds scale-down to 1 then scale-up to %s", max_mds)
+
+    if not fs_util.set_and_validate_max_mds(client, fs_name, 1):
+        log.error("Failed to set max_mds=1")
+        return 1
+
+    fs_util.wait_for_stable_fs(client, "false", 120)
+    time.sleep(15)
+
+    if not attr_util.assert_no_damaged_mds_ranks(client, fs_name, "pre-scale-up"):
+        return 1
+
+    if not fs_util.set_and_validate_max_mds(client, fs_name, max_mds):
+        log.error("Failed to scale max_mds to %s", max_mds)
+        return 1
+
+    if not _wait_for_fs_ranks_active(client, fs_name, max_mds, timeout=900):
+        log.error("Ranks not active after max_mds scale-up to %s", max_mds)
+        return 1
+
+    if not _assert_post_fail_oracles(client, attr_util, fs_name, "post-scale-up"):
+        return 1
+
+    log.info("Passed Usecase 2: max_mds scale-up without damaged ranks")
+    return 0
+
+
+def run(ceph_cluster, **kw):
+    config = kw.get("config") or {}
+    fs_name = "case-sensitivity-mm-failover"
+    subvol_group = config.get("subvol_group", "cs_mm_repro")
+    subvol_name = config.get("subvol_name", "casefold_sv")
+    mounting_dir = None
+    stop_flag = None
+    client = None
+    fs_util = None
+    attr_util = None
+
+    try:
+        build = config.get("build", config.get("rhbuild"))
+        max_mds = int(config.get("max_mds", 4))
+        run_scaleup = config.get("run_max_mds_scaleup", True)
+
+        fs_util = FsUtils(ceph_cluster, test_data=kw.get("test_data"))
+        attr_util = CephFSAttributeUtilities(ceph_cluster)
+        common_util = CephFSCommonUtils(ceph_cluster)
+
+        clients = ceph_cluster.get_ceph_objects("client")
+        if not clients:
+            log.error("Requires at least 1 client node")
+            return 1
+
+        client = clients[0]
+        fs_util.prepare_clients([client], build)
+        fs_util.auth_list([client])
+
+        rc, fs_name, mounting_dir, stop_flag, subvol_group, subvol_name = (
+            _usecase_multimds_failover(
+                ceph_cluster, client, fs_util, attr_util, common_util, config
+            )
+        )
+        if rc != 0:
+            return rc
+
+        if run_scaleup:
+            rc = _usecase_max_mds_scaleup(client, fs_util, attr_util, fs_name, max_mds)
+            if rc != 0:
+                return rc
+
+        log.info(
+            "TEST PASSED | max_mds=%s | fail_iterations=%s | ranks=%s | scaleup=%s",
+            max_mds,
+            config.get("fail_iterations", 10),
+            _resolve_fail_ranks(config, max_mds),
+            run_scaleup,
+        )
+        return 0
+
+    except FsBaseException as exc:
+        log.error("FsBaseException during multi-MDS casefold failover test: %s", exc)
+        return log_and_fail(
+            "FsBaseException during multi-MDS casefold failover test", exc
+        )
+    except Exception as exc:
+        log.error("Unexpected error: %s", exc)
+        return 1
+
+    finally:
+        if client and stop_flag and attr_util:
+            try:
+                attr_util.stop_casefold_metadata_storm(client, stop_flag)
+            except Exception as exc:
+                log.warning("Storm stop during cleanup: %s", exc)
+
+        if client and mounting_dir:
+            try:
+                client.exec_command(
+                    sudo=True,
+                    cmd="fusermount -u {} -z".format(mounting_dir),
+                    check_ec=False,
+                )
+                client.exec_command(
+                    sudo=True, cmd="rm -rf {}".format(mounting_dir), check_ec=False
+                )
+            except Exception as exc:
+                log.warning("Unmount cleanup: %s", exc)
+
+        if client and fs_name and subvol_name and subvol_group and fs_util:
+            try:
+                Ceph(client).fs.sub_volume.rm(
+                    fs_name, subvol_name, group=subvol_group, force=True
+                )
+                Ceph(client).fs.sub_volume_group.rm(fs_name, subvol_group)
+                fs_util.remove_fs(client, fs_name, validate=False)
+            except Exception as exc:
+                log.warning("FS/subvolume cleanup: %s", exc)

--- a/tests/cephfs/lib/cephfs_attributes_lib.py
+++ b/tests/cephfs/lib/cephfs_attributes_lib.py
@@ -756,3 +756,158 @@ class CephFSAttributeUtilities(object):
         except Exception as e:
             log.error("Failed to fail filesystem '{}': {}".format(fs_name, e))
             return False
+
+    def archive_mds_crashes(self, client):
+        """Archive existing ceph crash records before a disruptive test window."""
+        client.exec_command(sudo=True, cmd="ceph crash archive-all", check_ec=False)
+        log.info("Archived pre-existing ceph crash records")
+
+    def assert_no_mds_crashes(
+        self,
+        client,
+        forbidden_signatures=None,
+        context="",
+    ):
+        """
+        Fail when new MDS crashes appear in ``ceph crash ls-new``.
+
+        Args:
+            client: Client node to run ceph commands.
+            forbidden_signatures (list): Substrings that must not appear in crash
+                metadata (default: IBMCEPH-16942 / #72399 signatures).
+            context (str): Label for log messages.
+
+        Returns:
+            bool: True if no matching crashes, False otherwise.
+        """
+        if forbidden_signatures is None:
+            forbidden_signatures = [
+                "alternate_name",
+                "journal.cc",
+                "auth >= 0",
+                "MDCache.cc",
+                "rejoin_send_rejoins",
+            ]
+
+        try:
+            crashes = self.fs_util.get_crash_ls_new(client)
+        except (json.JSONDecodeError, TypeError) as exc:
+            log.error("Could not parse ceph crash ls-new (%s): %s", context, exc)
+            return False
+
+        if not crashes:
+            log.info("No new ceph crashes (%s)", context or "check")
+            return True
+
+        if isinstance(crashes, dict):
+            items = list(crashes.items())
+        else:
+            items = [(e.get("crash_id") or e.get("id"), e) for e in crashes]
+
+        for crash_id, entry in items:
+            if not crash_id:
+                log.error("Crash entry without id (%s): %r", context, entry)
+                return False
+            out, _ = client.exec_command(
+                sudo=True,
+                cmd="ceph crash info {} -f json".format(crash_id),
+                check_ec=False,
+            )
+            try:
+                info = json.loads(out) if out and out.strip() else {}
+            except json.JSONDecodeError:
+                info = {"raw": out}
+
+            blob = json.dumps(info)
+            for needle in forbidden_signatures:
+                if needle in blob:
+                    log.error(
+                        "Forbidden crash signature '%s' in crash %s (%s): %s",
+                        needle,
+                        crash_id,
+                        context,
+                        blob,
+                    )
+                    return False
+            log.error("Unexpected ceph crash %s (%s): %s", crash_id, context, blob)
+            return False
+
+        return True
+
+    def assert_no_damaged_mds_ranks(self, client, fs_name, context=""):
+        """
+        Return False if any MDS rank for ``fs_name`` is in a damaged state.
+        """
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd="ceph fs status {} -f json".format(fs_name),
+            client_exec=True,
+            check_ec=False,
+        )
+        try:
+            status = json.loads(out)
+        except json.JSONDecodeError:
+            log.error("Failed to parse fs status for %s (%s)", fs_name, context)
+            return False
+
+        for mds in status.get("mdsmap", []):
+            state = mds.get("state", "")
+            if "damaged" in state or state == "failed":
+                log.error(
+                    "MDS rank %s in bad state '%s' for %s (%s)",
+                    mds.get("rank"),
+                    state,
+                    fs_name,
+                    context,
+                )
+                return False
+        return True
+
+    def start_casefold_metadata_storm(self, client, mount_path, stop_flag_path):
+        """
+        Start a background rename-heavy metadata workload on a casefold mount.
+
+        Uses mixed-case creates and case-changing renames to populate
+        ``alternate_name`` journal metadata (IBMCEPH-16942 repro amplifier).
+        """
+        client.exec_command(sudo=True, cmd="rm -f {}".format(stop_flag_path))
+        storm_script = (
+            "i=0; "
+            "while [ ! -f {stop} ]; do "
+            "i=$((i+1)); "
+            'd="{mnt}/w$((i%500))"; '
+            'mkdir -p "$d" 2>/dev/null || true; '
+            'f="AaBb_$i"; '
+            'echo x >"$d/$f" 2>/dev/null || true; '
+            'mv "$d/$f" "$d/aabb_$i" 2>/dev/null || true; '
+            "for c in A a B b C c; do "
+            'touch "$d/${{c}}_$i" 2>/dev/null || true; '
+            "done; "
+            "done"
+        ).format(stop=stop_flag_path, mnt=mount_path)
+
+        pid_file = "{}.pid".format(stop_flag_path)
+        log_file = "{}.log".format(stop_flag_path)
+        cmd = ("nohup bash -c {script!r} > {log} 2>&1 & echo $! > {pid}").format(
+            script=storm_script, log=log_file, pid=pid_file
+        )
+        client.exec_command(sudo=True, cmd=cmd)
+        log.info(
+            "Started casefold metadata storm on %s (stop=%s)",
+            mount_path,
+            stop_flag_path,
+        )
+
+    def stop_casefold_metadata_storm(self, client, stop_flag_path):
+        """Stop the background casefold metadata storm."""
+        client.exec_command(sudo=True, cmd="touch {}".format(stop_flag_path))
+        pid_file = "{}.pid".format(stop_flag_path)
+        client.exec_command(
+            sudo=True,
+            cmd=(
+                "if [ -f {pid} ]; then kill $(cat {pid}) 2>/dev/null || true; "
+                "rm -f {pid}; fi"
+            ).format(pid=pid_file),
+            check_ec=False,
+        )
+        log.info("Stopped casefold metadata storm (%s)", stop_flag_path)


### PR DESCRIPTION
# Description

## Summary
- Add CephCI regression test for IBMCEPH-16942 / tracker #72399
- Covers casefold subvolume under max_mds=4 with standby-replay, rename-heavy
  FUSE metadata storm, rotating mds fail (10×), and max_mds scale-up under load
- Adds lib helpers for crash/damaged-rank oracles and casefold metadata storm

## Polarion
CEPH-83632953

## Test plan
- [x] CephCI PASS: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0EPVFH/
- [x] Tier-1 case sensitivity suite on Tentacle
- [x] 8.1 features suite (Tentacle + Squid)

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
