### PR TITLE
Add NVMeoF holistic cross-feature suite

### DIFF
--- a/ceph/nvmeof/initiators/linux/nvme_cli.py
+++ b/ceph/nvmeof/initiators/linux/nvme_cli.py
@@ -15,13 +15,71 @@ class NVMeCLI(Cli):
     """
 
     def configure(self):
-        """Install NVME CLI."""
+        """Install NVMe CLI and enable boot-time fabrics + autoconnect.
+
+        Customer-like initiator reboot reconnect requires:
+          1. ``nvme-fabrics`` loaded at boot (modules-load.d)
+          2. ``/etc/nvme/discovery.conf`` populated (done on connect)
+          3. ``nvmf-autoconnect.service`` enabled
+          4. ``nvme connect-all --persistent`` (see ``connect_all``)
+        """
         configure_cmds = [
             ("yum install -y nvme-cli fio", True),
             ("modprobe nvme-fabrics", True),
+            (
+                "bash -c 'echo nvme-fabrics > /etc/modules-load.d/nvme-fabrics.conf'",
+                True,
+            ),
+            ("mkdir -p /etc/nvme", True),
         ]
         for cmd in configure_cmds:
             self.execute(*cmd)
+        self.enable_nvmf_autoconnect()
+
+    def enable_nvmf_autoconnect(self):
+        """Enable systemd unit that runs connect-all at boot from discovery.conf."""
+        host = getattr(self, "node", None) or getattr(self, "ctx", None)
+        hostname = getattr(host, "hostname", host)
+        try:
+            self.execute(
+                "systemctl enable nvmf-autoconnect.service",
+                True,
+            )
+            LOG.info("Enabled nvmf-autoconnect.service on %s", hostname)
+        except Exception as err:
+            LOG.warning(
+                "Could not enable nvmf-autoconnect.service on %s: %s",
+                hostname,
+                err,
+            )
+
+    def configure_discovery_conf(self, traddr, trsvcid=8009, transport="tcp"):
+        """
+        Persist discovery controller endpoint in /etc/nvme/discovery.conf.
+
+        Used by ``nvmf-autoconnect.service`` (``nvme connect-all --context=autoconnect``)
+        so namespaces reappear after initiator reboot without a manual discover/connect.
+
+        Args:
+            traddr: Discovery / gateway IP
+            trsvcid: Discovery port (default 8009)
+            transport: Fabric transport (default tcp)
+        """
+        if not traddr:
+            raise ValueError("traddr is required for discovery.conf")
+        line = f"--transport={transport} --traddr={traddr} --trsvcid={trsvcid}"
+        self.execute("mkdir -p /etc/nvme", True)
+        # Idempotent append of discovery controller endpoint
+        self.execute(
+            (
+                'bash -c "'
+                f"grep -qxF '{line}' /etc/nvme/discovery.conf 2>/dev/null || "
+                f"echo '{line}' >> /etc/nvme/discovery.conf\""
+            ),
+            True,
+        )
+        LOG.info("Ensured /etc/nvme/discovery.conf contains: %s", line)
+        return line
 
     def gen_dhchap_key(self, **kwargs):
         """Generates the TLS key.
@@ -61,6 +119,7 @@ class NVMeCLI(Cli):
                 trsvcid: Transport port number  # Transport port number
                 nqn: Subsystem NQN Id           # Subsystem NQN
         """
+        kwargs.setdefault("persistent", True)
         return self.execute(
             cmd=f"nvme connect {config_dict_to_string(kwargs)}",
             sudo=True,
@@ -217,7 +276,24 @@ class NVMeCLI(Cli):
         return self.execute(cmd="nvme disconnect-all", sudo=True)
 
     def connect_all(self, **kwargs):
-        """Connects all controllers connected to subsystems."""
+        """Connects all controllers to discovered subsystems.
+
+        Always includes ``--persistent`` so connections are recorded for
+        reconnect after initiator reboot / nvme connect-all -P semantics.
+        Pass ``persistent=False`` to opt out for a specific call.
+
+        When ``traddr`` is provided, also updates ``/etc/nvme/discovery.conf``
+        and ensures ``nvmf-autoconnect.service`` is enabled for boot reconnect.
+        """
+        kwargs.setdefault("persistent", True)
+        traddr = kwargs.get("traddr")
+        if traddr:
+            self.configure_discovery_conf(
+                traddr=traddr,
+                trsvcid=kwargs.get("trsvcid", 8009),
+                transport=kwargs.get("transport", "tcp"),
+            )
+            self.enable_nvmf_autoconnect()
         return self.execute(
             cmd=f"nvme connect-all {config_dict_to_string(kwargs)}", sudo=True
         )

--- a/conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
+++ b/conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
@@ -1,0 +1,82 @@
+#===============================================================================================
+# Cluster configuration for IBM Ceph 9.2 NVMeoF holistic / customer-like system test
+#
+# Topology (12 nodes):
+#   node1-3     : mon/mgr (+ OSDs on node2/3)
+#   node4-5     : OSD + MDS/RGW + NVMeoF GW (2 GWs colocated with OSDs)
+#   node6-7     : 2 dedicated NVMeoF GWs
+#   node8       : spare NVMeoF GW host for load-balancing scale-up
+#   node9-12    : 4 NVMe initiator / FIO clients
+#
+# Initial GW placement: node4, node5, node6, node7 (node8 used only for LB scale-up)
+#
+# OSD disks sized for many 500G NVMeoF namespaces (12 x 1000G per OSD node)
+# Suite: suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+# Inventory: conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml (or later)
+#===============================================================================================
+globals:
+  - ceph-cluster:
+      name: ceph
+      vm-size: ci.standard.xl
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - mds
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - mds
+          - osd
+          - rgw
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        id: node6
+        role:
+          - nvmeof-gw
+      node7:
+        id: node7
+        role:
+          - nvmeof-gw
+      node8:
+        id: node8
+        role:
+          - nvmeof-gw
+      node9:
+        id: node9
+        role:
+          - client
+      node10:
+        id: node10
+        role:
+          - client
+      node11:
+        id: node11
+        role:
+          - client
+      node12:
+        id: node12
+        role:
+          - client

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml
@@ -1,0 +1,979 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_nvmeof_9-2_holistic_cross-feature.yaml
+# IBM Ceph: 9.2 — Customer-centric holistic system test (features under continuous IO)
+#
+# Cluster configuration:
+#   conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml
+# Inventory:
+#   conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml (or later)
+#
+# Model:
+#   1) Deploy full Ceph + NVMeoF once (nvmeof_metadata pool; 2 GWs colocated with OSDs)
+#      DHCHAP prerequisite: GW must be applied with encryption: true so orch
+#      injects encryption_key (IBM: RSA key in NVMeoF spec before in-band auth).
+#      Companions get this via install:true + inband_auth_mode → NVMeService.
+#   2) Configure tenant-style subsystems (standing config, no cleanup)
+#   3) Masking setup, reservation lifecycle + multi-init types on standing
+#      tenants, readonly NS / DHCHAP / DB where modules require dedicated NQNs
+#   4) Start multi-client background FIO, then run day-2 ops UNDER LOAD
+#      (QoS+IO validate, masking visibility, resize, GW scale-down/up, HA failover)
+#   5) Create EC RBD pool and add NVMeoF NS images on new subsystem cnode14
+#      via existing group1 (orch/GW OMAP stays on replicated nvmeof_metadata —
+#      do NOT apply nvmeof with the EC pool; EC has no omap. NS rbd-pool may
+#      differ from GW pool.)
+#
+# Coverage map:
+#   suites/tentacle/nvmeof/HOLISTIC_9-2_COVERAGE.md
+#
+# Standing NQN map (Phase 2 — shared customer tenants, numeric only):
+#   cnode1–2 : masked presentation (visibility churn under IO)
+#   cnode3   : prod open (QoS / resize / Phase 5 OLTP+backup)
+#   cnode4   : NQN-ACL tenant
+#   cnode5   : standing secure (DHCHAP hosts) — open vs secure customer split
+#   cnode6   : shared / reservations (Phase 4 + 4b multi-init types via connect-all)
+#   cnode7   : RADOS namespaces
+#   cnode8   : prod open HA/LB (+ Phase 4.5 autoconnect)
+# Day-2 / capability NQNs (not feature shells — only when module cannot reuse):
+#   cnode9–10 : secure DHCHAP per-host FIO (Phase 4d; separate from standing cnode5)
+#   cnode11–12: read-only presentation (Phase 4c; module always subsystem.add)
+#   cnode13   : application/DB volumes (Phase 4e; module add + FS format destructive)
+#   cnode14   : EC-backed NS only (Phase 6; rbd_ec — keep separate from standing)
+#
+# Tenant map / customer FIO personas (Phase 5 — Linux block emulation):
+#   node9  : OLTP database   — 4k randrw 70/30, multi-queue, O_DIRECT
+#   node10 : VM boot + verify — 4k randrw 85/15 + crc32c (integrity under churn)
+#   node11 : AI/analytics     — 1M randread (dataset / checkpoint scan)
+#   node12 : Backup / media   — 1M sequential write (ingest / scratch)
+#   Secure : standing cnode5; Phase 4d DHCHAP FIO on cnode9/10; Masked : cnode1/2
+#
+# Workloads needing CSI/VMware/SAP/etc. stay companion — see HOLISTIC_9-2_WORKLOADS.md
+#
+# Profiles:
+#   Smoke : tier-2_nvmeof_9-2_holistic_smoke.yaml
+#
+# Companion suites (not inlined): upgrades, FIPS, mirror,
+# alerts break-GW, scale extremes, VMware, Dashboard, CSI, stretch HA.
+# ISCE-2203 auto-listeners: covered in-suite (Phase 2 derived network-mask +
+# Phase 5 assert_listeners); single-network only (no dual-iface).
+#===============================================================================================
+tests:
+  # --------------------------------------------------------------------------------------------
+  # Phase 0 — Deploy full Ceph stack + clients
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:
+                verbose: true
+              pos_args:
+                - cephfs
+              args:
+                placement:
+                  label: mds
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: Deploy IBM Ceph with mon/mgr/osd plus MDS and RGW
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy full Ceph cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node9
+          - node10
+          - node11
+          - node12
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure 4 NVMe initiator clients
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph clients for NVMe tests
+      polarion-id: CEPH-83573758
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 1 — Pools + NVMeoF (nvmeof_metadata; 2 colocated + 2 dedicated GWs)
+  # encryption: true → cephadm helper generates RSA key into spec.encryption_key
+  # (required before any host/subsystem --dhchap-key; plain `apply` omits it)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_metadata
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_1
+          - config:
+              command: shell
+              args:
+                - rbd namespace create rbd/rados_ns_2
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: nvmeof
+                  service_id: nvmeof_metadata.group1
+                  encryption: true
+                  placement:
+                    nodes:
+                      - node4
+                      - node5
+                      - node6
+                      - node7
+                  spec:
+                    pool: nvmeof_metadata
+                    group: group1
+      desc: Create rbd + nvmeof_metadata pools and deploy NVMeoF on 4 GWs
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service group1 (nvmeof_metadata)
+      polarion-id: CEPH-83595696
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 2 — Tenant configuration (standing; no cleanup)
+  # Auto-listeners (ISCE-2203), single-network only:
+  #   upstream configure_subsystems passes suite network-mask as CIDR, or derives
+  #   minimal CIDR from gw_nodes via get_network_mask().
+  #   node8 is NOT in Phase 2 gw_nodes; it joins only via Phase 5 day2 scale_up.
+  #   Auto-listeners/mask at create time are derived from node4–node7 only.
+  #   Auto-listener port defaults to 4420 (omit listener_port). Do not set static
+  #   listeners: on these subsystems — auto-listeners make the node list unnecessary.
+  # Coverage: Phase 2 mask (node4–7) + Phase 5 day2 assert_listeners after scale_up.
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        inband_auth_mode: bidirectional
+        subsystems:
+          # Masked tenant shells
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+
+          # Prod open + QoS / resize target
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # NQN-ACL tenant
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            max_ns: 128
+            no-group-append: true
+            hosts:
+              - node9
+              - node10
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Secure tenant — DHCHAP per host (needs Phase 1 encryption_key on GW)
+          - subnqn: nqn.2016-06.io.spdk:cnode5
+            serial: 5
+            max_ns: 128
+            no-group-append: true
+            inband_auth: true
+            hosts:
+              - node: node11
+                inband_auth: true
+              - node: node12
+                inband_auth: true
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+
+          # Shared — reservations (Phase 4 lifecycle + Phase 4b multi-init types)
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 6
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+
+          # Shared — RADOS namespaces
+          - nqn: nqn.2016-06.io.spdk:cnode7
+            serial: 7
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_1
+              - count: 4
+                size: 500G
+                ns_create_image: true
+                rados_namespace: rados_ns_2
+
+          # Prod open — HA/LB workload
+          - nqn: nqn.2016-06.io.spdk:cnode8
+            serial: 8
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+            bdevs:
+              - count: 8
+                size: 500G
+                ns_create_image: true
+      desc: Configure tenant subsystems (auto-listeners via derived network-mask + hosts/NS/auth/RADOS)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Configure tenant subsystems
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 3 — Masking setup on masked tenant (leave visible for under-load churn)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 2
+                namespaces: 16
+                pool: rbd
+                image_size: 500G
+                no-auto-visible: true
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: add_host
+              args:
+                subsystems: 2
+                namespaces: 16
+                initiators:
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+                validate_ns_masking_initiators: true
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 2
+                namespaces: 16
+                auto-visible: "yes"
+                group: group1
+                validate_ns_masking_initiators: true
+        initiators:
+          - node9
+          - node10
+          - node11
+          - node12
+      desc: Create masked namespaces then restore visibility for under-load churn
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Setup namespace masking tenant
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4 — Reservation lifecycle on standing tenants (release before continuous FIO)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        reservation:
+          - register_args:
+              rrega: 0
+          - acquire_args:
+              racqa: 0
+              rtype: 1
+          - release_args:
+              rrela: 0
+              rtype: 1
+          - unregister_args:
+              rrega: 1
+        initiators:
+          - node: node9
+            nqn: connect-all
+            listener_port: 4420
+          - node: node10
+            nqn: connect-all
+            listener_port: 4420
+        cleanup:
+          - disconnect_all
+      desc: Validate reservation lifecycle then disconnect before under-load FIO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_ns_reservation.py
+      name: Validate namespace reservations
+      polarion-id: CEPH-83626134
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4b — Multi-initiator reservation types on standing open tenants (ISCE-2086)
+  # Module always subsystem.add when subsystems: are listed — omit that block so
+  # connect-all reuses Phase 2 standing NQNs (cnode6 reservations / open *).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_node:
+          - node4
+          - node5
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        # No subsystems: — reuse standing tenants (see Phase 2 cnode6 / open *)
+        initiators:
+          - node9
+          - node10
+        cleanup:
+          - disconnect_all
+      desc: Verify reservation types across two initiators on standing open tenants
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_reservation_multi_init.py
+      name: Multi-initiator reservation type matrix
+      polarion-id: CEPH-83627298
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4c — Read-only namespaces on dedicated open presentation tenants (ISCE-2121)
+  # Module always subsystem.add and asserts path count == new RO NS only — cannot
+  # safely reuse standing NQNs (would fail add / break path-count vs Phase 5 writes).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        test_case: CEPH-83624617
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode11
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode12
+            allow_host: "*"
+        initiators:
+          - nqn: connect-all
+            listener_port: 4420
+            node: node9
+        cleanup:
+          - disconnect_all
+      desc: Validate read-only namespace create and write-fail behavior (ISCE-2121)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_readonly_ns.py
+      name: Validate read-only namespaces
+      polarion-id: CEPH-83624617
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4d — DHCHAP per-host FIO in SAME phase as key create (ISCE-3542)
+  # Requires Phase 1 GW encryption_key (suite auth flags alone are not enough).
+  # Secure vs open is a real customer split — dedicated cnode9/10 (not standing cnode5).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        mode: auth_fio
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        auth_fio:
+          inband_auth_mode: bidirectional
+          fio_runtime: 90
+          subsystems:
+            # Secure tenants after standing 1–8 (leave standing cnode5 untouched)
+            - subnqn: nqn.2016-06.io.spdk:cnode9
+              serial: 9
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              hosts:
+                - node: node11
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+            - subnqn: nqn.2016-06.io.spdk:cnode10
+              serial: 10
+              max_ns: 32
+              no-group-append: true
+              inband_auth: true
+              hosts:
+                - node: node12
+                  inband_auth: true
+              bdevs:
+                - count: 8
+                  size: 500G
+                  ns_create_image: true
+          initiators:
+            - nqn: nqn.2016-06.io.spdk:cnode9
+              listener_port: 4420
+              node: node11
+              io_args:
+                io_type: randrw
+                rwmixread: 70
+                iodepth: 8
+                run_time: 90
+                size: 1G
+                test_name: dhchap-host-c11
+                execute_blkdiscard: false
+            - nqn: nqn.2016-06.io.spdk:cnode10
+              listener_port: 4420
+              node: node12
+              io_args:
+                io_type: randwrite
+                iodepth: 8
+                run_time: 90
+                size: 1G
+                test_name: dhchap-host-c12
+                execute_blkdiscard: false
+      desc: >
+        ISCE-3542 — set controller/host DHCHAP keys and run authenticated FIO
+        in the same phase (keys never leave this TC; needs GW encryption_key)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: DHCHAP per-host authenticated FIO
+      polarion-id: CEPH-83632329
+
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4e — Real DB engines on NVMeoF (podman + FS on namespace)
+  #   Feasible: PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Cassandra
+  #   Skip: Oracle (license). MSSQL optional via accept_eula (not enabled here).
+  # Module always subsystem.add; FS format is destructive — keep dedicated cnode13
+  # application/DB tenant (do not reuse standing Phase 5 volumes).
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode13
+            serial: 13
+            max_ns: 64
+            no-group-append: true
+            allow_host: "*"
+            bdevs:
+              # 6 engines + spares (mssql / dual-volume growth)
+              - count: 10
+                size: 500G
+                ns_create_image: true
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode13
+            listener_port: 4420
+            node: node9
+        databases:
+          - engine: postgresql
+            duration: 60
+            scale: 10
+            clients: 8
+            jobs: 4
+          - engine: mysql
+            duration: 60
+            clients: 8
+            rows: 10000
+          - engine: mariadb
+            duration: 60
+            clients: 8
+            rows: 10000
+          - engine: mongodb
+            duration: 60
+            docs: 30000
+          - engine: redis
+            duration: 60
+            clients: 50
+          - engine: cassandra
+            ops: 10000
+          - engine: oracle
+            # always skipped — documents intentional exclusion
+        cleanup:
+          - disconnect_all
+      desc: >
+        Real DB I/O on NVMeoF — PostgreSQL/MySQL/MariaDB/MongoDB/Redis/Cassandra
+        with datadir on mounted namespaces (Oracle skipped)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_db_workloads.py
+      name: Database workloads on NVMeoF namespaces
+      polarion-id: CEPH-83575441
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 4.5 — Initiator reboot + nvmf-autoconnect (no manual discover/connect)
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        autoconnect_timeout: 300
+        post_reboot_settle: 15
+        fio_smoke: true
+        fio_runtime: 30
+        initiators:
+          # Open tenant only — avoid DHCHAP connect-all ambiguity
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode8
+        cleanup: []
+      desc: >
+        Reboot Linux initiator; assert namespace UUIDs return via --persistent,
+        discovery.conf, and nvmf-autoconnect without manual discover/connect
+      destroy-cluster: false
+      module: test_ceph_nvmeof_initiator_reboot_autoconnect.py
+      name: Initiator reboot persistent autoconnect
+      polarion-id: CEPH-83609777
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 5 — UNDER LOAD: background FIO + day-2 ops (customer system test)
+  #   Set fio_runtime: 1800 for soak profile.
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        fio_runtime: 600
+        fio_settle_seconds: 30
+        op_settle_seconds: 20
+        initiators:
+          # Persona: OLTP database (low-latency mixed 4k, multi-queue)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node9
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: randrw
+              rwmixread: 70
+              bs: 4k
+              iodepth: 32
+              num_jobs: 4
+              fsync: 32
+              direct: 1
+              run_time: 600
+              size: 1G
+              test_name: persona-oltp-db-c9
+              execute_blkdiscard: false
+          # Persona: VM boot disk + integrity (small random + crc32c under day-2)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node10
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode4
+              - nqn.2016-06.io.spdk:cnode7
+            io_args:
+              io_type: randrw
+              rwmixread: 85
+              bs: 4k
+              iodepth: 16
+              num_jobs: 2
+              direct: 1
+              run_time: 600
+              size: 1G
+              verify: crc32c
+              verify_fatal: 1
+              test_name: persona-vm-boot-integrity-c10
+              execute_blkdiscard: false
+          # Persona: AI/ML + analytics scan (large-block random read)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node11
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode2
+              - nqn.2016-06.io.spdk:cnode6
+            io_args:
+              io_type: randread
+              bs: 1M
+              iodepth: 32
+              num_jobs: 2
+              direct: 1
+              run_time: 600
+              size: 1G
+              test_name: persona-ai-analytics-c11
+              execute_blkdiscard: false
+          # Persona: backup repository / media ingest (large sequential write)
+          - nqn: discover-all
+            listener_port: 4420
+            node: node12
+            subsystems:
+              - nqn.2016-06.io.spdk:cnode3
+              - nqn.2016-06.io.spdk:cnode8
+            io_args:
+              io_type: write
+              bs: 1M
+              iodepth: 8
+              direct: 1
+              run_time: 600
+              size: 1G
+              test_name: persona-backup-media-c12
+              execute_blkdiscard: false
+        day2_ops:
+          # Richer QoS: set tight limit, validate observed IO, then relax
+          - op: qos_validate_io
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              initiator_node: node9
+              w-megabytes-per-second: 40
+              r-megabytes-per-second: 40
+              rw-megabytes-per-second: 60
+              io_runtime: 40
+            settle_seconds: 20
+          - op: set_qos
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode3
+              nsid: 1
+              r-megabytes-per-second: 200
+              w-megabytes-per-second: 200
+              rw-megabytes-per-second: 300
+            settle_seconds: 20
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "no"
+              force: true
+            settle_seconds: 15
+          - op: change_visibility
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode1
+              nsid: 1
+              auto-visible: "yes"
+              force: true
+            settle_seconds: 15
+          - op: resize
+            args:
+              subsystem: nqn.2016-06.io.spdk:cnode8
+              nsid: 1
+              size: 550G
+            settle_seconds: 30
+          - op: scale_down
+            args:
+              nodes: ["node6"]
+            settle_seconds: 30
+          # ISCE-2203: restore GW; auto-listeners must reappear via Phase 2 derived network-mask
+          - op: scale_up
+            args:
+              nodes: ["node6"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 30
+          - op: scale_down
+            args:
+              nodes: ["node7"]
+            settle_seconds: 30
+          # ISCE-2203: new spare GW (node8); auto-listeners via Phase 2 derived network-mask
+          - op: scale_up
+            args:
+              nodes: ["node8"]
+              assert_listeners:
+                subsystems:
+                  - nqn.2016-06.io.spdk:cnode3
+                  - nqn.2016-06.io.spdk:cnode8
+                  - nqn.2016-06.io.spdk:cnode4
+                  - nqn.2016-06.io.spdk:cnode7
+                listener_port: 4420
+            settle_seconds: 45
+          - op: assert_listeners
+            args:
+              subsystems:
+                - nqn.2016-06.io.spdk:cnode3
+                - nqn.2016-06.io.spdk:cnode8
+                - nqn.2016-06.io.spdk:cnode4
+                - nqn.2016-06.io.spdk:cnode7
+                - nqn.2016-06.io.spdk:cnode6
+              listener_port: 4420
+            settle_seconds: 5
+          - op: ha_failover
+            args:
+              tool: systemctl
+              nodes: ["node4"]
+            settle_seconds: 30
+      desc: >
+        Customer system test — FIO personas (OLTP, VM+integrity, AI scan,
+        backup/media) while QoS, visibility, resize, LB + listener asserts,
+        and HA failover execute under load
+      destroy-cluster: false
+      module: test_ceph_nvmeof_holistic_io.py
+      name: Under-load day-2 ops with multi-tenant FIO
+      polarion-id: CEPH-83575441
+
+  # --------------------------------------------------------------------------------------------
+  # Phase 6 — NVMeoF namespaces backed by an erasure-coded (EC) RBD pool
+  # --------------------------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd erasure-code-profile set nvmeof_ec_profile k=2 m=1
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd_ec 32 32 erasure nvmeof_ec_profile
+          - config:
+              command: shell
+              args:
+                - ceph osd pool set rbd_ec allow_ec_overwrites true
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd_ec
+      desc: >
+        Create EC profile + rbd_ec data pool (k=2,m=1, allow_ec_overwrites)
+        for NVMeoF namespace images (GW OMAP remains on nvmeof_metadata)
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: Create EC pool for NVMeoF namespaces
+      polarion-id: CEPH-83575441
+
+  - test:
+      abort-on-fail: false
+      config:
+        install: false
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        # Image default for this TC; GW OMAP still nvmeof_metadata / group1
+        rbd_pool: rbd_ec
+        nvme_metadata_pool: nvmeof_metadata
+        gw_group: group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        subsystems:
+          # New subsystem cnode14 — EC-backed NS only (pool: rbd_ec)
+          - nqn: nqn.2016-06.io.spdk:cnode14
+            serial: 14
+            max_ns: 128
+            no-group-append: true
+            allow_host: "*"
+            bdevs:
+              - count: 4
+                size: 50G
+                ns_create_image: true
+                pool: rbd_ec
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode14
+            listener_port: 4420
+            node: node9
+            io_args:
+              io_type: randrw
+              rwmixread: 70
+              iodepth: 8
+              run_time: 60
+              size: 1G
+              test_name: ec-pool-ns-c9
+              execute_blkdiscard: false
+        cleanup:
+          - disconnect_all
+      desc: >
+        Add EC-backed NS images (rbd_ec) on new subsystem cnode14
+        via group1 (metadata pool nvmeof_metadata unchanged; auto-listeners)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Configure NVMeoF entities on EC pool
+      polarion-id: CEPH-83575441

--- a/tests/nvmeof/test_ceph_nvmeof_db_workloads.py
+++ b/tests/nvmeof/test_ceph_nvmeof_db_workloads.py
@@ -1,0 +1,169 @@
+"""
+Run real database engines on NVMeoF namespaces (filesystem on device + podman).
+
+Config example::
+
+    databases:
+      - engine: postgresql
+        duration: 60
+        scale: 10
+      - engine: mysql
+      - engine: mariadb
+      - engine: mongodb
+      - engine: redis
+      - engine: cassandra
+      # oracle: always skipped (license)
+      # mssql: requires accept_eula: true
+
+    subsystems:   # provide at least one NS per DB entry
+      - nqn: nqn.2016-06.io.spdk:cnode_db
+        bdevs: [{count: 6, size: 50G, ns_create_image: true}]
+    initiators:
+      - nqn: nqn.2016-06.io.spdk:cnode_db
+        node: node9
+"""
+
+from ceph.ceph import Ceph
+from ceph.utils import get_node_by_id
+from tests.nvmeof.workflows.db_workloads import (
+    UNSUPPORTED,
+    ensure_podman,
+    podman_rm,
+    run_database_workload,
+    umount_quiet,
+)
+from tests.nvmeof.workflows.gateway_entities import (
+    configure_gw_entities,
+    disconnect_initiators,
+)
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Configure DB namespaces, mount, run engines, cleanup."""
+    config = kwargs["config"]
+    databases = config.get("databases") or []
+    if not databases:
+        LOG.error("config.databases list is required")
+        return 1
+
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    clients = []
+    results = []
+    rc = 1
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        configure_gw_entities(nvme_service, rbd_obj=rbd_obj, cluster=ceph_cluster)
+
+        initiators = config.get("initiators")
+        if not initiators:
+            raise ValueError("initiators required for DB workloads")
+
+        clients = prepare_io_execution(
+            initiators,
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        if not clients:
+            raise RuntimeError("Failed to prepare NVMe initiators for DB workloads")
+
+        client = clients[0]
+        node = client.node
+        ensure_podman(node)
+        paths = client.list_spdk_drives() or client.list_devices()
+        if not paths:
+            raise RuntimeError(f"No NVMe devices on {node.hostname}")
+
+        LOG.info(
+            "DB workload devices on %s: %s (engines=%s)",
+            node.hostname,
+            paths,
+            [d.get("engine") for d in databases],
+        )
+
+        errors = []
+        # Assign devices only to runnable engines (skipped engines do not consume NS)
+        device_idx = 0
+        for db_cfg in databases:
+            engine = (db_cfg.get("engine") or "").lower()
+            if engine in UNSUPPORTED:
+                LOG.warning("Skip %s: %s", engine, UNSUPPORTED[engine])
+                results.append(
+                    {"engine": engine, "skipped": True, "reason": UNSUPPORTED[engine]}
+                )
+                continue
+
+            if device_idx >= len(paths):
+                msg = (
+                    f"Not enough NVMe namespaces for {engine}; "
+                    f"need index {device_idx}, have {len(paths)} device(s). "
+                    f"Increase subsystem bdevs.count."
+                )
+                LOG.error(msg)
+                errors.append(msg)
+                continue
+
+            device = paths[device_idx]
+            device_idx += 1
+            db_cfg = dict(db_cfg)
+            slot = device_idx  # 1-based for naming after increment
+            db_cfg.setdefault("mount_point", f"/mnt/nvmeof-db-{engine}-{slot}")
+            db_cfg.setdefault("container_name", f"nvmeof-db-{engine}-{slot}")
+            if engine in ("mysql", "mariadb") and "port" not in db_cfg:
+                db_cfg["port"] = 3306 + slot
+            if engine in ("postgresql", "postgres") and "port" not in db_cfg:
+                db_cfg["port"] = 5432 + slot
+
+            try:
+                results.append(run_database_workload(node, device, db_cfg))
+            except Exception as err:
+                LOG.error("DB workload %s failed: %s", engine, err)
+                errors.append(f"{engine}: {err}")
+                podman_rm(
+                    node, db_cfg.get("container_name", f"nvmeof-db-{engine}-{slot}")
+                )
+                umount_quiet(node, db_cfg["mount_point"])
+
+        unused = len(paths) - device_idx
+        if unused > 0:
+            LOG.info("%s spare NVMe namespace(s) unused after DB mapping", unused)
+        LOG.info("DB workload results: %s", results)
+        if errors:
+            raise RuntimeError(f"Database workload failures: {errors}")
+        rc = 0
+    except Exception as err:
+        LOG.error(err)
+        rc = 1
+    finally:
+        if config.get("cleanup") and clients:
+            for client in clients:
+                try:
+                    client.node.exec_command(
+                        sudo=True,
+                        cmd=(
+                            "podman ps -a --format '{{.Names}}' | "
+                            "grep '^nvmeof-db-' | xargs -r podman rm -f || true"
+                        ),
+                        check_ec=False,
+                    )
+                except Exception:
+                    pass
+            if nvme_service is not None:
+                for initiator_cfg in config.get("initiators", []):
+                    node = get_node_by_id(ceph_cluster, initiator_cfg["node"])
+                    disconnect_initiators(nvme_service, node=node)
+    return rc

--- a/tests/nvmeof/test_ceph_nvmeof_holistic_io.py
+++ b/tests/nvmeof/test_ceph_nvmeof_holistic_io.py
@@ -1,0 +1,556 @@
+"""
+Customer-centric NVMeoF holistic IO + day-2 ops under load.
+
+Modes:
+  - default / under_load: background multi-tenant FIO + day2_ops
+  - auth_fio: configure DHCHAP tenants and run authenticated FIO in the
+    same phase (keys never leave this process)
+
+Does not tear down gateway/pool unless cleanup is requested.
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from copy import deepcopy
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin.orch import Orch
+from ceph.utils import get_node_by_id
+from tests.nvmeof.test_nvmeof_gwgroup_inbandauth import (
+    configure_gw_entities_with_encryption,
+)
+from tests.nvmeof.workflows.gateway_entities import (
+    _hostnames_match,
+    disconnect_initiators,
+    fetch_namespaces,
+    teardown,
+)
+from tests.nvmeof.workflows.ha import HighAvailability
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.load_balancing import scale_down, scale_up, validate_scaleup
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import (
+    check_and_set_nvme_cli_image,
+    check_gateway,
+    validate_qos,
+    verify_qos,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _run_client_fio(client, io_args):
+    """Run time-based FIO on all NVMe paths visible to one initiator."""
+    paths = client.list_spdk_drives() or client.list_devices()
+    if not paths:
+        raise RuntimeError(f"No NVMe paths on {client.node.hostname}")
+
+    LOG.info(
+        "Starting FIO on %s with %s device(s): %s",
+        client.node.hostname,
+        len(paths),
+        io_args,
+    )
+    runtime = str(io_args.get("run_time", 600))
+    fio_kwargs = {
+        "io_size": io_args.get("size", "1G"),
+        "runtime": runtime,
+        "paths": paths,
+        "io_type": io_args.get("io_type", "randrw"),
+        "iodepth": io_args.get("iodepth", 16),
+        "rwmixread": io_args.get("rwmixread"),
+        "test_name": io_args.get("test_name"),
+        "time_based": True,
+        "execute_blkdiscard": io_args.get("execute_blkdiscard", False),
+    }
+    if io_args.get("verify"):
+        fio_kwargs["verify"] = io_args["verify"]
+    if io_args.get("verify_fatal") is not None:
+        fio_kwargs["verify_fatal"] = io_args["verify_fatal"]
+    if io_args.get("bs"):
+        fio_kwargs["bs"] = io_args["bs"]
+    if io_args.get("num_jobs") is not None:
+        fio_kwargs["num_jobs"] = io_args["num_jobs"]
+    if io_args.get("fsync") is not None:
+        fio_kwargs["fsync"] = io_args["fsync"]
+    if io_args.get("direct") is not None:
+        fio_kwargs["direct"] = io_args["direct"]
+    return client.start_fio(**fio_kwargs)
+
+
+def _op_set_qos(gateway, args):
+    qos_args = deepcopy(args)
+    subsystem = qos_args["subsystem"]
+    nsid = qos_args["nsid"]
+    gateway.namespace.set_qos(**{"args": qos_args})
+    verify_qos(deepcopy(qos_args), gateway)
+    LOG.info("QoS applied under load: %s nsid=%s", subsystem, nsid)
+
+
+def _op_qos_validate_io(gateway, clients, ceph_cluster, args):
+    """Set QoS, briefly drive IO, validate observed bandwidth via iostat."""
+    _op_set_qos(gateway, args)
+    node_id = args.get("initiator_node")
+    if not node_id:
+        raise ValueError("qos_validate_io requires initiator_node")
+
+    client = next((c for c in clients if c.node.id == node_id), None)
+    if client is None:
+        node = get_node_by_id(ceph_cluster, node_id)
+        # Reconnect path if client object not in under-load set
+        from tests.nvmeof.workflows.initiator import NVMeInitiator
+
+        client = NVMeInitiator(node)
+
+    paths = client.list_spdk_drives() or client.list_devices()
+    if not paths:
+        raise RuntimeError(f"No devices on {node_id} for QoS IO validation")
+
+    device = paths[0].replace("/dev/", "")
+    io_mode = {
+        "r-megabytes-per-second": "read",
+        "w-megabytes-per-second": "write",
+        "rw-megabytes-per-second": "randrw",
+    }
+    # Prefer write validation when present
+    key = next(
+        (
+            k
+            for k in (
+                "w-megabytes-per-second",
+                "r-megabytes-per-second",
+                "rw-megabytes-per-second",
+            )
+            if k in args
+        ),
+        "w-megabytes-per-second",
+    )
+    runtime = str(args.get("io_runtime", 40))
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        fut = executor.submit(
+            client.start_fio,
+            io_size="1G",
+            runtime=runtime,
+            paths=[paths[0]],
+            io_type=io_mode.get(key, "write"),
+            iodepth=4,
+            time_based=True,
+            execute_blkdiscard=False,
+            test_name=f"qos-validate-{device}",
+        )
+        time.sleep(15)
+        limits = {k: args[k] for k in args if k.endswith("megabytes-per-second")}
+        validate_qos(client.node, device, **limits)
+        fut.result()
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+    # Also pull gateway-side IO stats when available
+    try:
+        out, _ = gateway.namespace.get_io_stats(
+            **{
+                "base_cmd_args": {"format": "json"},
+                "args": {"subsystem": args["subsystem"], "nsid": args["nsid"]},
+            }
+        )
+        LOG.info("Namespace IO stats after QoS validate: %s", out)
+    except Exception as err:
+        LOG.warning("get_io_stats not available/failed: %s", err)
+
+
+def _op_fio_burst(clients, ceph_cluster, args):
+    """
+    Short foreground FIO burst on one client (e.g. backup restore / media read)
+    while other persona FIO continues in the background.
+    """
+    node_id = args.get("initiator_node")
+    if not node_id:
+        raise ValueError("fio_burst requires initiator_node")
+
+    client = next((c for c in clients if c.node.id == node_id), None)
+    if client is None:
+        from tests.nvmeof.workflows.initiator import NVMeInitiator
+
+        client = NVMeInitiator(get_node_by_id(ceph_cluster, node_id))
+
+    paths = client.list_spdk_drives() or client.list_devices()
+    if not paths:
+        raise RuntimeError(f"No devices on {node_id} for fio_burst")
+
+    runtime = str(args.get("io_runtime", 60))
+    fio_kwargs = {
+        "io_size": args.get("size", "2G"),
+        "runtime": runtime,
+        "paths": [paths[0]],
+        "io_type": args.get("io_type", "read"),
+        "iodepth": args.get("iodepth", 16),
+        "bs": args.get("bs", "1M"),
+        "time_based": True,
+        "execute_blkdiscard": False,
+        "test_name": args.get("test_name", f"fio-burst-{node_id}"),
+        "direct": args.get("direct", 1),
+    }
+    if args.get("num_jobs") is not None:
+        fio_kwargs["num_jobs"] = args["num_jobs"]
+    LOG.info(
+        "fio_burst on %s path=%s io_type=%s bs=%s runtime=%s",
+        node_id,
+        paths[0],
+        fio_kwargs["io_type"],
+        fio_kwargs["bs"],
+        runtime,
+    )
+    client.start_fio(**fio_kwargs)
+
+
+def _op_change_visibility(gateway, args):
+    vis_args = {
+        "subsystem": args["subsystem"],
+        "nsid": args["nsid"],
+        "auto-visible": args.get("auto-visible", "yes"),
+    }
+    if args.get("force", True):
+        vis_args["force"] = ""
+    gateway.namespace.change_visibility(**{"args": vis_args})
+    LOG.info(
+        "change_visibility under load: %s nsid=%s auto-visible=%s",
+        args["subsystem"],
+        args["nsid"],
+        args.get("auto-visible"),
+    )
+
+
+def _op_resize(gateway, args):
+    resize_args = {
+        "subsystem": args["subsystem"],
+        "nsid": args["nsid"],
+        "size": args["size"],
+    }
+    gateway.namespace.resize(**{"args": resize_args})
+    LOG.info(
+        "resize under load: %s nsid=%s -> %s",
+        args["subsystem"],
+        args["nsid"],
+        args["size"],
+    )
+
+
+def _op_scale_down(nvme_service, orch, args):
+    nodes = args["nodes"]
+    if not isinstance(nodes, list):
+        nodes = [nodes]
+    LOG.info("scale_down under load: %s", nodes)
+    scale_down(nvme_service, orch, nodes)
+    remaining = [
+        n for n in nvme_service.config.get("gw_nodes", []) if n not in set(nodes)
+    ]
+    nvme_service.config["gw_nodes"] = remaining
+    LOG.info("GW membership after scale_down: %s", remaining)
+
+
+def _assert_listeners(nvme_service, args):
+    """
+    ISCE-2203-oriented check: every live GW must have a listener for each NQN.
+    """
+    nqns = args.get("subsystems") or args.get("nqns") or []
+    if not nqns:
+        raise ValueError("assert_listeners requires subsystems/nqns")
+    port = str(args.get("listener_port", 4420))
+    gateway = nvme_service.gateways[0]
+
+    for nqn in nqns:
+        out, _ = gateway.listener.list(
+            **{
+                "base_cmd_args": {"format": "json"},
+                "args": {"subsystem": nqn},
+            }
+        )
+        listeners = json.loads(out).get("listeners", []) if out else []
+        missing = []
+        for gw in nvme_service.gateways:
+            matched = any(
+                _hostnames_match(lst.get("host_name"), gw.hostname)
+                and str(lst.get("trsvcid")) == port
+                for lst in listeners
+            )
+            if not matched:
+                missing.append(gw.hostname)
+        if missing:
+            raise RuntimeError(
+                f"Listener assert failed for {nqn} port={port}: "
+                f"missing on GWs {missing}; have={listeners}"
+            )
+        LOG.info(
+            "Listener assert OK: %s port=%s on %s GW(s)",
+            nqn,
+            port,
+            len(nvme_service.gateways),
+        )
+
+
+def _op_scale_up(nvme_service, orch, args):
+    nodes = args["nodes"]
+    if not isinstance(nodes, list):
+        nodes = [nodes]
+    LOG.info("scale_up under load: %s", nodes)
+    namespaces = fetch_namespaces(nvme_service.gateways[0])
+    prev_gws = list(nvme_service.gateways)
+    scale_up(nvme_service, orch, nodes, prev_gws, namespaces)
+    validate_scaleup(nvme_service, orch, nodes, namespaces)
+    merged = list(dict.fromkeys(list(nvme_service.config.get("gw_nodes", [])) + nodes))
+    nvme_service.config["gw_nodes"] = merged
+    LOG.info("GW membership after scale_up: %s", merged)
+    # Optional post-LB auto-listener validation (ISCE-2203)
+    if args.get("assert_listeners"):
+        _assert_listeners(nvme_service, args["assert_listeners"])
+
+
+def _op_ha_failover(ceph_cluster, nvme_service, config, args):
+    tool = args.get("tool", "systemctl")
+    nodes = args["nodes"]
+    if not isinstance(nodes, list):
+        nodes = [nodes]
+
+    ha_cfg = deepcopy(config)
+    ha_cfg["nvme_service"] = nvme_service
+    ha = HighAvailability(ceph_cluster, config["gw_nodes"], **ha_cfg)
+    ha.gateways = nvme_service.gateways
+    ha.nvme_service = nvme_service
+
+    for node_id in nodes:
+        gw = check_gateway(nvme_service.gateways, node_id)
+        LOG.info("HA failover under load on %s via %s", node_id, tool)
+        ha.failover(gw, tool)
+        LOG.info("HA failback under load on %s via %s", node_id, tool)
+        ha.failback(gw, tool)
+
+
+def _run_day2_ops(ceph_cluster, nvme_service, orch, config, ops, clients):
+    gateway = nvme_service.gateways[0]
+
+    for idx, step in enumerate(ops, start=1):
+        op = step.get("op")
+        args = deepcopy(step.get("args", {}))
+        LOG.info("=== Day-2 op %s/%s: %s ===", idx, len(ops), op)
+
+        if op == "sleep":
+            time.sleep(int(args.get("seconds", 30)))
+        elif op == "set_qos":
+            _op_set_qos(gateway, args)
+        elif op == "qos_validate_io":
+            _op_qos_validate_io(gateway, clients, ceph_cluster, args)
+        elif op == "fio_burst":
+            _op_fio_burst(clients, ceph_cluster, args)
+        elif op == "change_visibility":
+            _op_change_visibility(gateway, args)
+        elif op == "resize":
+            _op_resize(gateway, args)
+        elif op == "scale_down":
+            _op_scale_down(nvme_service, orch, args)
+            gateway = nvme_service.gateways[0]
+        elif op == "scale_up":
+            _op_scale_up(nvme_service, orch, args)
+            gateway = nvme_service.gateways[0]
+        elif op == "assert_listeners":
+            _assert_listeners(nvme_service, args)
+        elif op == "ha_failover":
+            ha_config = deepcopy(config)
+            ha_config["gw_nodes"] = list(nvme_service.config.get("gw_nodes", []))
+            _op_ha_failover(ceph_cluster, nvme_service, ha_config, args)
+            nvme_service.gateways = []
+            nvme_service.init_gateways()
+            gateway = nvme_service.gateways[0]
+        else:
+            raise ValueError(f"Unsupported day2 op: {op}")
+
+        settle = int(step.get("settle_seconds", config.get("op_settle_seconds", 15)))
+        if settle:
+            time.sleep(settle)
+
+
+def _inventory_snapshot(gateway):
+    """Best-effort subsystem/namespace inventory for post-run logging."""
+    try:
+        out, _ = gateway.subsystem.list(
+            **{"base_cmd_args": {"format": "json"}, "args": {}}
+        )
+        subs = json.loads(out).get("subsystems", [])
+        LOG.info("Inventory: %s subsystems present after under-load ops", len(subs))
+        for sub in subs:
+            nqn = sub.get("nqn") or sub.get("subnqn")
+            ns_out, _ = gateway.namespace.list(
+                **{
+                    "base_cmd_args": {"format": "json"},
+                    "args": {"subsystem": nqn},
+                }
+            )
+            ns_count = len(json.loads(ns_out).get("namespaces", []))
+            LOG.info("  %s -> %s namespaces", nqn, ns_count)
+    except Exception as err:
+        LOG.warning("Inventory snapshot failed: %s", err)
+
+
+def _run_auth_fio(ceph_cluster, nvme_service, config, rbd_obj):
+    """
+    ISCE-3542 style: create DHCHAP keys and run authenticated FIO in one phase.
+    Uses unique NQNs so standing open tenants are untouched.
+    """
+    auth_cfg = config.get("auth_fio", {})
+    if not auth_cfg.get("subsystems") or not auth_cfg.get("initiators"):
+        raise ValueError("auth_fio requires subsystems and initiators")
+
+    gwgroup_config = {
+        "gw_group": config.get("gw_group"),
+        "gw_nodes": config.get("gw_nodes"),
+        "rbd_pool": config.get("rbd_pool", "rbd"),
+        "inband_auth_mode": auth_cfg.get("inband_auth_mode", "bidirectional"),
+        "subsystems": auth_cfg["subsystems"],
+        "hosts": [],
+    }
+    for sub in gwgroup_config["subsystems"]:
+        sub.setdefault("auth_mode", gwgroup_config["inband_auth_mode"])
+        sub.setdefault("subnqn", sub.get("nqn") or sub.get("subnqn"))
+
+    LOG.info("Configuring DHCHAP tenants and running authenticated FIO (same phase)")
+    keyed_initiators = configure_gw_entities_with_encryption(
+        gwgroup_config, ceph_cluster, nvme_service
+    )
+
+    clients = prepare_io_execution(
+        auth_cfg["initiators"],
+        gateways=nvme_service.gateways,
+        cluster=ceph_cluster,
+        return_clients=True,
+        pre_configured_initiators=keyed_initiators,
+    )
+    if not clients:
+        raise RuntimeError("Failed to prepare authenticated initiators")
+
+    errors = []
+    with ThreadPoolExecutor(max_workers=len(clients)) as executor:
+        futures = {}
+        for idx, client in enumerate(clients):
+            io_args = dict(auth_cfg["initiators"][idx].get("io_args", {}))
+            io_args.setdefault("run_time", auth_cfg.get("fio_runtime", 90))
+            io_args.setdefault("size", "1G")
+            io_args.setdefault("execute_blkdiscard", False)
+            futures[executor.submit(_run_client_fio, client, io_args)] = client
+        for future in as_completed(futures):
+            client = futures[future]
+            try:
+                future.result()
+                LOG.info("Authenticated FIO OK on %s", client.node.hostname)
+            except Exception as err:
+                LOG.error(
+                    "Authenticated FIO failed on %s: %s", client.node.hostname, err
+                )
+                errors.append(err)
+
+    for initiator_cfg in auth_cfg["initiators"]:
+        node = get_node_by_id(ceph_cluster, initiator_cfg["node"])
+        disconnect_initiators(nvme_service, node=node)
+
+    if errors:
+        raise RuntimeError(f"Authenticated FIO failures: {errors}")
+    return 0
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Entry: auth_fio mode or under-load day-2 orchestration."""
+    config = kwargs["config"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    executor = None
+    futures = {}
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+        orch = Orch(ceph_cluster, **{})
+
+        # --- Mode: DHCHAP configure + FIO same phase ---
+        if config.get("mode") == "auth_fio" or config.get("auth_fio"):
+            if config.get("mode") == "auth_fio" or not config.get("day2_ops"):
+                return _run_auth_fio(ceph_cluster, nvme_service, config, rbd_obj)
+            # If both present, run auth first then continue under-load
+            _run_auth_fio(ceph_cluster, nvme_service, config, rbd_obj)
+
+        initiators = config.get("initiators")
+        if not initiators:
+            raise ValueError("initiators config is required for under-load mode")
+
+        clients = prepare_io_execution(
+            initiators,
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        if not clients:
+            raise RuntimeError("Failed to prepare NVMe initiators for FIO")
+
+        work = []
+        for idx, client in enumerate(clients):
+            io_args = dict(initiators[idx].get("io_args", {}))
+            if "run_time" not in io_args:
+                io_args["run_time"] = config.get("fio_runtime", 600)
+            work.append((client, io_args))
+
+        LOG.info("Starting background customer FIO on %s clients", len(work))
+        executor = ThreadPoolExecutor(max_workers=len(work))
+        futures = {
+            executor.submit(_run_client_fio, client, io_args): client
+            for client, io_args in work
+        }
+
+        settle = int(config.get("fio_settle_seconds", 30))
+        LOG.info("Waiting %ss for FIO to settle before day-2 ops", settle)
+        time.sleep(settle)
+
+        day2_ops = config.get("day2_ops", [])
+        day2_error = None
+        if day2_ops:
+            try:
+                _run_day2_ops(
+                    ceph_cluster, nvme_service, orch, config, day2_ops, clients
+                )
+            except Exception as err:
+                day2_error = err
+                LOG.error("Day-2 op failed; cancelling background FIO: %s", err)
+                if executor is not None:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    executor = None
+
+        LOG.info("Waiting for background FIO to complete")
+        errors = []
+        for future in as_completed(list(futures.keys())):
+            client = futures[future]
+            try:
+                future.result()
+                LOG.info("FIO completed on %s", client.node.hostname)
+            except Exception as err:
+                LOG.error("FIO failed on %s: %s", client.node.hostname, err)
+                errors.append(f"{client.node.hostname}: {err}")
+
+        _inventory_snapshot(nvme_service.gateways[0])
+
+        if day2_error:
+            raise RuntimeError(f"Holistic day-2 failure: {day2_error}") from day2_error
+        if errors:
+            raise RuntimeError(f"Holistic under-load FIO failures: {errors}")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_obj)
+    return 1

--- a/tests/nvmeof/test_ceph_nvmeof_initiator_reboot_autoconnect.py
+++ b/tests/nvmeof/test_ceph_nvmeof_initiator_reboot_autoconnect.py
@@ -1,0 +1,256 @@
+"""
+Initiator reboot + persistent nvmf-autoconnect reconnect.
+
+Customer-like Linux initiator reboot path:
+  1. ``nvme connect`` / ``connect-all --persistent``
+  2. ``/etc/modules-load.d/nvme-fabrics.conf``
+  3. ``/etc/nvme/discovery.conf``
+  4. ``nvmf-autoconnect.service`` enabled
+
+After initiator reboot, namespace UUIDs must reappear via autoconnect
+WITHOUT a manual discover / connect-all.
+
+Contrasts with CEPH-83576087 (``test_ceph_83576087``), which explicitly
+reconnects after reboot.
+"""
+
+import time
+
+from ceph.ceph import Ceph
+from ceph.waiter import WaitUntil
+from cli.utilities.utils import reboot_node
+from tests.nvmeof.workflows.gateway_entities import configure_gw_entities, teardown
+from tests.nvmeof.workflows.initiator import prepare_io_execution
+from tests.nvmeof.workflows.nvme_service import NVMeService
+from tests.nvmeof.workflows.nvme_utils import check_and_set_nvme_cli_image
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def _read_cmd(node, cmd):
+    out, err = node.exec_command(sudo=True, cmd=cmd, check_ec=False)
+    return (out or "").strip(), (err or "").strip()
+
+
+def _assert_autoconnect_prereqs(initiator):
+    """Fail early if boot-reconnect plumbing is missing."""
+    node = initiator.node
+
+    conf, _ = _read_cmd(node, "cat /etc/nvme/discovery.conf 2>/dev/null || true")
+    if not conf.strip():
+        raise RuntimeError(
+            f"{node.hostname}: /etc/nvme/discovery.conf empty or missing "
+            "(required for nvmf-autoconnect)"
+        )
+    LOG.info("[%s] discovery.conf:\n%s", node.hostname, conf)
+
+    mods, _ = _read_cmd(
+        node, "cat /etc/modules-load.d/nvme-fabrics.conf 2>/dev/null || true"
+    )
+    if "nvme-fabrics" not in mods:
+        raise RuntimeError(
+            f"{node.hostname}: nvme-fabrics not in modules-load.d " f"(got: {mods!r})"
+        )
+
+    enabled, _ = _read_cmd(
+        node, "systemctl is-enabled nvmf-autoconnect.service 2>/dev/null || true"
+    )
+    if enabled not in ("enabled", "static", "indirect", "enabled-runtime"):
+        # Best-effort enable, then re-check
+        initiator.enable_nvmf_autoconnect()
+        enabled, _ = _read_cmd(
+            node, "systemctl is-enabled nvmf-autoconnect.service 2>/dev/null || true"
+        )
+        if enabled not in ("enabled", "static", "indirect", "enabled-runtime"):
+            raise RuntimeError(
+                f"{node.hostname}: nvmf-autoconnect.service not enabled "
+                f"(is-enabled={enabled!r})"
+            )
+    LOG.info("[%s] nvmf-autoconnect is-enabled=%s", node.hostname, enabled)
+
+
+def _capture_inventory(initiator):
+    """Return (uuids, device_paths) from lsblk WWN + nvme list."""
+    uuids = initiator.fetch_lsblk_nvme_devices() or []
+    try:
+        devices = initiator.list_spdk_drives() or []
+    except Exception as err:
+        LOG.warning("list_spdk_drives before reboot failed: %s", err)
+        devices = []
+    LOG.info(
+        "[%s] pre-reboot inventory: %d UUID(s), %d device(s)",
+        initiator.node.hostname,
+        len(uuids),
+        len(devices),
+    )
+    LOG.debug("UUIDs=%s devices=%s", uuids, devices)
+    return sorted(uuids), sorted(devices)
+
+
+def _wait_namespaces_after_reboot(initiator, expected_uuids, timeout, interval):
+    """Poll until expected namespace UUIDs reappear — no discover/connect."""
+    last_uuids = []
+    last_devices = []
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        try:
+            last_uuids = initiator.fetch_lsblk_nvme_devices() or []
+        except Exception as err:
+            LOG.warning("lsblk after reboot not ready: %s", err)
+            last_uuids = []
+        try:
+            last_devices = initiator.list_spdk_drives() or []
+        except Exception as err:
+            LOG.warning("nvme list after reboot not ready: %s", err)
+            last_devices = []
+
+        if expected_uuids:
+            missing = set(expected_uuids) - set(last_uuids)
+            if not missing:
+                LOG.info(
+                    "[%s] All %d pre-reboot UUIDs present after reboot",
+                    initiator.node.hostname,
+                    len(expected_uuids),
+                )
+                return sorted(last_uuids), sorted(last_devices)
+            LOG.warning(
+                "[%s] Waiting for autoconnect; missing UUIDs: %s "
+                "(have %d/%d, devices=%d)",
+                initiator.node.hostname,
+                sorted(missing),
+                len(expected_uuids) - len(missing),
+                len(expected_uuids),
+                len(last_devices),
+            )
+        elif last_devices:
+            LOG.info(
+                "[%s] Namespaces reappeared via devices (no UUID baseline): %s",
+                initiator.node.hostname,
+                last_devices,
+            )
+            return sorted(last_uuids), sorted(last_devices)
+
+    raise TimeoutError(
+        f"{initiator.node.hostname}: namespaces did not return within {timeout}s "
+        f"via nvmf-autoconnect (expected UUIDs={expected_uuids}, "
+        f"last_uuids={last_uuids}, last_devices={last_devices}). "
+        "Did NOT call discover/connect after reboot."
+    )
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Reboot Linux initiator and assert persistent autoconnect restores NS."""
+    config = kwargs["config"]
+    rbd_pool = initial_rbd_config(**kwargs)["rbd_reppool"]
+    custom_config = kwargs.get("test_data", {}).get("custom-config")
+    check_and_set_nvme_cli_image(ceph_cluster, config=custom_config)
+
+    nvme_service = None
+    try:
+        nvme_service = NVMeService(config, ceph_cluster)
+        if config.get("install"):
+            nvme_service.deploy()
+        nvme_service.init_gateways()
+
+        if config.get("subsystems"):
+            configure_gw_entities(nvme_service, rbd_obj=rbd_pool, cluster=ceph_cluster)
+
+        if not config.get("initiators"):
+            raise RuntimeError("config.initiators is required")
+
+        clients = prepare_io_execution(
+            config["initiators"],
+            gateways=nvme_service.gateways,
+            cluster=ceph_cluster,
+            return_clients=True,
+        )
+        initiator = clients[0]
+
+        # Reinforce boot-reconnect plumbing (configure already ran in prepare)
+        initiator.configure()
+        # Ensure discovery.conf points at the live gateway discovery port
+        gw = nvme_service.gateways[0]
+        initiator.configure_discovery_conf(
+            traddr=gw.node.ip_address,
+            trsvcid=initiator.discovery_port,
+            transport="tcp",
+        )
+        initiator.enable_nvmf_autoconnect()
+        _assert_autoconnect_prereqs(initiator)
+
+        before_uuids, before_devices = _capture_inventory(initiator)
+        if not before_uuids and not before_devices:
+            raise RuntimeError(
+                f"No NVMe namespaces on {initiator.node.hostname} before reboot"
+            )
+
+        min_ns = int(config.get("min_namespaces", 1))
+        count = len(before_uuids) or len(before_devices)
+        if count < min_ns:
+            raise RuntimeError(
+                f"Expected at least {min_ns} namespace(s) before reboot, found {count}"
+            )
+
+        LOG.info(
+            "Rebooting initiator %s — namespaces must return WITHOUT "
+            "manual discover/connect",
+            initiator.node.hostname,
+        )
+        if not reboot_node(initiator.node):
+            raise RuntimeError(
+                f"Initiator {initiator.node.hostname} did not come back after reboot"
+            )
+
+        # Brief settle for systemd / fabrics after SSH is up
+        time.sleep(int(config.get("post_reboot_settle", 15)))
+
+        # CRITICAL: do not call discover / connect / connect_all here
+        after_uuids, after_devices = _wait_namespaces_after_reboot(
+            initiator,
+            expected_uuids=before_uuids,
+            timeout=int(config.get("autoconnect_timeout", 300)),
+            interval=int(config.get("autoconnect_interval", 10)),
+        )
+
+        if before_uuids:
+            missing = set(before_uuids) - set(after_uuids)
+            if missing:
+                raise RuntimeError(
+                    f"UUIDs missing after reboot autoconnect: {sorted(missing)}"
+                )
+        elif before_devices and not after_devices:
+            raise RuntimeError("No NVMe devices after reboot autoconnect")
+
+        LOG.info(
+            "[%s] Autoconnect OK: %d UUID(s), %d device(s) after reboot",
+            initiator.node.hostname,
+            len(after_uuids),
+            len(after_devices),
+        )
+
+        if config.get("fio_smoke", True):
+            paths = after_devices or initiator.list_spdk_drives() or []
+            if not paths:
+                raise RuntimeError("No devices for post-reboot FIO smoke")
+            runtime = str(config.get("fio_runtime", 30))
+            LOG.info("Post-reboot FIO smoke on %s (runtime=%ss)", paths[:2], runtime)
+            initiator.start_fio(
+                io_size=config.get("fio_size", "256M"),
+                runtime=runtime,
+                paths=paths[:2],
+                io_type=config.get("io_type", "randrw"),
+                iodepth=8,
+                time_based=True,
+                execute_blkdiscard=False,
+                test_name=config.get("fio_test_name", "reboot-autoconnect-smoke"),
+            )
+
+        LOG.info("Initiator reboot + nvmf-autoconnect validation succeeded")
+        return 0
+    except Exception as err:
+        LOG.error(err)
+        return 1
+    finally:
+        if config.get("cleanup") and nvme_service is not None:
+            teardown(nvme_service, rbd_pool)

--- a/tests/nvmeof/workflows/db_workloads.py
+++ b/tests/nvmeof/workflows/db_workloads.py
@@ -1,0 +1,505 @@
+"""
+Customer database workloads on NVMeoF block devices.
+
+Pattern:
+  NVMe namespace -> mkfs/mount -> podman DB with data dir on mount -> native bench
+
+Feasible in cephci (no app licenses):
+  postgresql, mysql, mariadb, mongodb, redis, cassandra
+
+Not automated here (license / heavy external deps):
+  oracle, mssql  — logged as skipped unless explicitly enabled (mssql needs EULA)
+"""
+
+import time
+
+from utility.log import Log
+
+LOG = Log(__name__)
+
+# Public images — avoid registry.redhat.io auth requirements on bare clients
+DEFAULT_IMAGES = {
+    "postgresql": "docker.io/library/postgres:16",
+    "mysql": "docker.io/library/mysql:8.4",
+    "mariadb": "docker.io/library/mariadb:11.4",
+    "mongodb": "docker.io/library/mongo:7",
+    "redis": "docker.io/library/redis:7",
+    "cassandra": "docker.io/library/cassandra:4.1",
+    "mssql": "mcr.microsoft.com/mssql/server:2022-latest",
+}
+
+UNSUPPORTED = {
+    "oracle": "Oracle Database requires OTN license / proprietary container; skip in cephci",
+}
+
+
+def _run(node, cmd, timeout=600, check_ec=True):
+    out, err = node.exec_command(sudo=True, cmd=cmd, timeout=timeout, check_ec=check_ec)
+    return (out or "").strip(), (err or "").strip()
+
+
+def ensure_podman(node):
+    out, _ = _run(node, "command -v podman || true", check_ec=False)
+    if out:
+        return
+    LOG.info("Installing podman on %s", node.hostname)
+    _run(node, "yum install -y podman", timeout=900)
+
+
+def mkfs_and_mount(node, device, mount_point, fstype="xfs"):
+    """Format NVMe path and mount for DB datadir."""
+    _run(node, f"mkdir -p {mount_point}")
+    # Already mounted?
+    mounts, _ = _run(node, "findmnt -n -o TARGET || true", check_ec=False)
+    if mount_point in mounts.splitlines():
+        LOG.info("%s already mounted; reusing", mount_point)
+        return
+
+    if fstype == "xfs":
+        _run(node, f"mkfs.xfs -f {device}", timeout=300)
+    else:
+        _run(node, f"mkfs.ext4 -F {device}", timeout=300)
+    _run(node, f"mount {device} {mount_point}")
+    LOG.info("Mounted %s -> %s (%s)", device, mount_point, fstype)
+
+
+def umount_quiet(node, mount_point):
+    _run(node, f"umount {mount_point} || true", check_ec=False)
+
+
+def podman_rm(node, name):
+    _run(node, f"podman rm -f {name} || true", check_ec=False)
+
+
+def wait_container_running(node, name, timeout=180):
+    end = time.time() + timeout
+    while time.time() < end:
+        out, _ = _run(
+            node,
+            f"podman inspect -f '{{{{.State.Running}}}}' {name} 2>/dev/null || echo false",
+            check_ec=False,
+        )
+        if out.strip().lower() == "true":
+            return True
+        time.sleep(3)
+    return False
+
+
+def wait_cmd_ok(node, cmd, timeout=180, interval=5):
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            node.exec_command(sudo=True, cmd=cmd, timeout=60)
+            return True
+        except Exception:
+            time.sleep(interval)
+    LOG.error("Timed out waiting for: %s", cmd)
+    return False
+
+
+def _image(engine, cfg):
+    return cfg.get("image") or DEFAULT_IMAGES[engine]
+
+
+# ---------------------------------------------------------------------------
+# Engines
+# ---------------------------------------------------------------------------
+
+
+def run_postgresql(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-pg")
+    image = _image("postgresql", cfg)
+    db = cfg.get("db_name", "nvmeofdb")
+    user = cfg.get("user", "pguser")
+    password = cfg.get("password", "pgpassword")
+    port = int(cfg.get("port", 5432))
+    scale = int(cfg.get("scale", 20))
+    clients = int(cfg.get("clients", 8))
+    jobs = int(cfg.get("jobs", 4))
+    duration = int(cfg.get("duration", 60))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-e POSTGRES_USER={user} "
+            f"-e POSTGRES_PASSWORD={password} "
+            f"-e POSTGRES_DB={db} "
+            f"-v {data_dir}:/var/lib/postgresql/data:Z "
+            f"-p {port}:5432 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"PostgreSQL container {name} failed to start")
+    ready = f"podman exec {name} pg_isready -U {user} -d {db}"
+    if not wait_cmd_ok(node, ready, timeout=180):
+        raise RuntimeError("PostgreSQL not ready")
+
+    LOG.info("pgbench init scale=%s on %s", scale, data_dir)
+    _run(
+        node,
+        (f"podman exec {name} pgbench -i -s {scale} -U {user} -d {db}"),
+        timeout=3600,
+    )
+    LOG.info("pgbench run clients=%s jobs=%s duration=%ss", clients, jobs, duration)
+    _run(
+        node,
+        (
+            f"podman exec {name} pgbench -c {clients} -j {jobs} -T {duration} "
+            f"-U {user} -d {db}"
+        ),
+        timeout=duration + 600,
+    )
+    return {"engine": "postgresql", "container": name, "data_dir": data_dir}
+
+
+def run_mysql_family(node, data_dir, cfg, engine="mysql"):
+    """MySQL or MariaDB via sysbench-like mysqlslap / built-in mysql client."""
+    name = cfg.get("container_name", f"nvmeof-{engine}")
+    image = _image(engine, cfg)
+    db = cfg.get("db_name", "nvmeofdb")
+    root_pw = cfg.get("password", "RootPassw0rd!")
+    port = int(cfg.get("port", 3306 if engine == "mysql" else 3307))
+    duration = int(cfg.get("duration", 60))
+    concurrency = int(cfg.get("clients", 8))
+    datadir_ctr = "/var/lib/mysql"
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    env = f"-e MYSQL_ROOT_PASSWORD={root_pw} -e MYSQL_DATABASE={db}"
+    if engine == "mariadb":
+        env = f"-e MARIADB_ROOT_PASSWORD={root_pw} -e MARIADB_DATABASE={db}"
+
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} {env} "
+            f"-v {data_dir}:{datadir_ctr}:Z "
+            f"-p {port}:3306 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"{engine} container {name} failed to start")
+
+    ping = f"podman exec {name} mysqladmin ping -uroot -p{root_pw} --silent"
+    if not wait_cmd_ok(node, ping, timeout=240):
+        raise RuntimeError(f"{engine} not ready")
+
+    # Schema + bulk load via SQL
+    _run(
+        node,
+        (
+            f"podman exec {name} mysql -uroot -p{root_pw} {db} -e "
+            f'"CREATE TABLE IF NOT EXISTS kv (id INT PRIMARY KEY, val VARCHAR(128));"'
+        ),
+        timeout=120,
+    )
+    rows = int(cfg.get("rows", 20000))
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f"'mysql -uroot -p{root_pw} {db} -e "
+            f'"INSERT INTO kv (id, val) VALUES (1, \\"v1\\") '
+            f'ON DUPLICATE KEY UPDATE val=VALUES(val);" ; '
+            f"for i in $(seq 2 {rows}); do "
+            f'echo "INSERT INTO kv (id,val) VALUES ($i, \\"v$i\\") '
+            f'ON DUPLICATE KEY UPDATE val=VALUES(val);"; '
+            f"done | mysql -uroot -p{root_pw} {db}'"
+        ),
+        timeout=1800,
+    )
+
+    # mysqlslap OLTP-ish mixed statements
+    LOG.info("%s mysqlslap concurrency=%s duration~%ss", engine, concurrency, duration)
+    _run(
+        node,
+        (
+            f"podman exec {name} mysqlslap -uroot -p{root_pw} "
+            f"--concurrency={concurrency} --iterations=5 "
+            f"--number-of-queries={max(1000, duration * 50)} "
+            f"--create-schema={db} "
+            f'--query="SELECT val FROM kv WHERE id=FLOOR(1+RAND()*{rows}); '
+            f"UPDATE kv SET val=CONCAT('u', id) WHERE id=FLOOR(1+RAND()*{rows});\""
+        ),
+        timeout=duration + 900,
+    )
+    return {"engine": engine, "container": name, "data_dir": data_dir}
+
+
+def run_mongodb(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-mongo")
+    image = _image("mongodb", cfg)
+    port = int(cfg.get("port", 27017))
+    duration = int(cfg.get("duration", 60))
+    docs = int(cfg.get("docs", 50000))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-v {data_dir}:/data/db:Z "
+            f"-p {port}:27017 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"MongoDB container {name} failed to start")
+    ready = f"podman exec {name} mongosh --quiet --eval 'db.runCommand({{ ping: 1 }})'"
+    if not wait_cmd_ok(node, ready, timeout=180):
+        raise RuntimeError("MongoDB not ready")
+
+    LOG.info("MongoDB load %s docs then timed updates (%ss)", docs, duration)
+    _run(
+        node,
+        (
+            f"podman exec {name} mongosh --quiet --eval "
+            f'\'db = db.getSiblingDB("nvmeof"); '
+            f"db.dropDatabase(); "
+            f"const bulk=[]; for (let i=0;i<{docs};i++) "
+            f'bulk.push({{i:i, v:"x"+i, t:new Date()}}); '
+            f"while(bulk.length) {{ db.coll.insertMany(bulk.splice(0,1000)); }} "
+            f"db.coll.createIndex({{i:1}}); "
+            f"const end=Date.now()+{duration*1000}; let n=0; "
+            f"while(Date.now()<end) {{ "
+            f"db.coll.updateOne({{i: Math.floor(Math.random()*{docs})}}, "
+            f'{{$set:{{v:"u"+(n++)}}}}); '
+            f"db.coll.findOne({{i: Math.floor(Math.random()*{docs})}}); "
+            f"}} "
+            f'print("ops="+n);\''
+        ),
+        timeout=duration + 900,
+    )
+    return {"engine": "mongodb", "container": name, "data_dir": data_dir}
+
+
+def run_redis(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-redis")
+    image = _image("redis", cfg)
+    port = int(cfg.get("port", 6379))
+    duration = int(cfg.get("duration", 60))
+    clients = int(cfg.get("clients", 50))
+    requests = int(cfg.get("requests", max(100000, duration * 2000)))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    # AOF persistence on NVMe mount
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-v {data_dir}:/data:Z "
+            f"-p {port}:6379 "
+            f"{image} redis-server --appendonly yes --dir /data"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"Redis container {name} failed to start")
+    if not wait_cmd_ok(node, f"podman exec {name} redis-cli ping", timeout=120):
+        raise RuntimeError("Redis not ready")
+
+    LOG.info("redis-benchmark clients=%s requests=%s", clients, requests)
+    _run(
+        node,
+        (
+            f"podman exec {name} redis-benchmark -c {clients} -n {requests} "
+            f"-t set,get,lpush,lpop,hset -q"
+        ),
+        timeout=duration + 900,
+    )
+    # Force AOF rewrite to stress persistence path
+    _run(node, f"podman exec {name} redis-cli BGREWRITEAOF", check_ec=False)
+    time.sleep(5)
+    return {"engine": "redis", "container": name, "data_dir": data_dir}
+
+
+def run_cassandra(node, data_dir, cfg):
+    name = cfg.get("container_name", "nvmeof-cassandra")
+    image = _image("cassandra", cfg)
+    port = int(cfg.get("port", 9042))
+    ops = int(cfg.get("ops", 50000))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-e MAX_HEAP_SIZE=512M -e HEAP_NEWSIZE=128M "
+            f"-v {data_dir}:/var/lib/cassandra:Z "
+            f"-p {port}:9042 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError(f"Cassandra container {name} failed to start")
+
+    # Cassandra native start is slow
+    ready = f'podman exec {name} cqlsh -e "DESCRIBE KEYSPACES"'
+    if not wait_cmd_ok(node, ready, timeout=300, interval=10):
+        raise RuntimeError("Cassandra not ready")
+
+    LOG.info("Cassandra cql write/read stress ops~%s", ops)
+    _run(
+        node,
+        (
+            f"podman exec {name} cqlsh -e "
+            f'"CREATE KEYSPACE IF NOT EXISTS nvmeof WITH replication = '
+            f"{{'class':'SimpleStrategy','replication_factor':1}}; "
+            f'CREATE TABLE IF NOT EXISTS nvmeof.kv (id int PRIMARY KEY, v text);"'
+        ),
+        timeout=120,
+    )
+    # Batch inserts via python-less bash loop inside container
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f"'for i in $(seq 1 {min(ops, 20000)}); do "
+            f"echo \"INSERT INTO nvmeof.kv (id,v) VALUES ($i, '\\''v$i'\\'');\" ; "
+            f"done | cqlsh'"
+        ),
+        timeout=3600,
+    )
+    _run(
+        node,
+        (
+            f"podman exec {name} cqlsh -e "
+            f'"SELECT COUNT(*) FROM nvmeof.kv; '
+            f'SELECT * FROM nvmeof.kv WHERE id=1;"'
+        ),
+        timeout=300,
+    )
+    return {"engine": "cassandra", "container": name, "data_dir": data_dir}
+
+
+def run_mssql(node, data_dir, cfg):
+    """Optional — requires accept_eula: true and enough RAM."""
+    if not cfg.get("accept_eula"):
+        raise RuntimeError("mssql requires accept_eula: true in config")
+    name = cfg.get("container_name", "nvmeof-mssql")
+    image = _image("mssql", cfg)
+    password = cfg.get("password", "RootPassw0rd!")
+    port = int(cfg.get("port", 1433))
+    duration = int(cfg.get("duration", 60))
+
+    podman_rm(node, name)
+    _run(node, f"mkdir -p {data_dir} && chmod 777 {data_dir}")
+    _run(
+        node,
+        (
+            f"podman run -d --name {name} "
+            f"-e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD={password} "
+            f"-v {data_dir}:/var/opt/mssql:Z "
+            f"-p {port}:1433 "
+            f"{image}"
+        ),
+        timeout=300,
+    )
+    if not wait_container_running(node, name):
+        raise RuntimeError("MSSQL container failed to start")
+    # Wait for SQL ready
+    ready = (
+        f"podman exec {name} /opt/mssql-tools18/bin/sqlcmd "
+        f"-C -S localhost -U sa -P {password} -Q 'SELECT 1'"
+    )
+    # tools path varies; try without 18
+    if not wait_cmd_ok(node, ready, timeout=300):
+        ready2 = ready.replace("mssql-tools18", "mssql-tools")
+        if not wait_cmd_ok(node, ready2, timeout=120):
+            raise RuntimeError("MSSQL not ready")
+        ready = ready2
+
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f'"/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P {password} -Q '
+            f"'CREATE DATABASE nvmeofdb;' || "
+            f"/opt/mssql-tools/bin/sqlcmd -C -S localhost -U sa -P {password} -Q "
+            f"'CREATE DATABASE nvmeofdb;'\""
+        ),
+        check_ec=False,
+        timeout=120,
+    )
+    # Simple insert loop
+    _run(
+        node,
+        (
+            f"podman exec {name} bash -lc "
+            f"'end=$((SECONDS+{duration})); n=0; "
+            f"while [ $SECONDS -lt $end ]; do "
+            f"sqlcmd -C -S localhost -U sa -P {password} -d nvmeofdb "
+            f'-Q "IF OBJECT_ID(\\"dbo.kv\\") IS NULL '
+            f"CREATE TABLE kv(id INT PRIMARY KEY, v NVARCHAR(64)); "
+            f"MERGE kv AS t USING (SELECT $n AS id) AS s ON t.id=s.id "
+            f'WHEN MATCHED THEN UPDATE SET v=CONCAT(N\\"u\\", $n) '
+            f'WHEN NOT MATCHED THEN INSERT(id,v) VALUES($n, CONCAT(N\\"v\\", $n));" '
+            f">/dev/null; n=$((n+1)); done; echo ops=$n'"
+        ),
+        timeout=duration + 600,
+        check_ec=False,
+    )
+    return {"engine": "mssql", "container": name, "data_dir": data_dir}
+
+
+ENGINE_RUNNERS = {
+    "postgresql": run_postgresql,
+    "postgres": run_postgresql,
+    "mysql": lambda n, d, c: run_mysql_family(n, d, c, engine="mysql"),
+    "mariadb": lambda n, d, c: run_mysql_family(n, d, c, engine="mariadb"),
+    "mongodb": run_mongodb,
+    "mongo": run_mongodb,
+    "redis": run_redis,
+    "cassandra": run_cassandra,
+    "mssql": run_mssql,
+    "sqlserver": run_mssql,
+}
+
+
+def run_database_workload(node, device, cfg):
+    """
+    Mount device, run one DB engine workload, optionally cleanup container.
+
+    cfg keys:
+      engine, mount_point, fstype, duration, cleanup_container (default True)
+    """
+    engine = (cfg.get("engine") or "").lower()
+    if engine in UNSUPPORTED:
+        LOG.warning("Skipping %s: %s", engine, UNSUPPORTED[engine])
+        return {"engine": engine, "skipped": True, "reason": UNSUPPORTED[engine]}
+
+    if engine not in ENGINE_RUNNERS:
+        raise ValueError(f"Unsupported database engine: {engine}")
+
+    mount_point = cfg.get("mount_point") or f"/mnt/nvmeof-db-{engine}"
+    data_subdir = cfg.get("data_subdir", "data")
+    data_dir = f"{mount_point}/{data_subdir}"
+    fstype = cfg.get("fstype", "xfs")
+
+    ensure_podman(node)
+    mkfs_and_mount(node, device, mount_point, fstype=fstype)
+    _run(node, f"mkdir -p {data_dir}")
+
+    LOG.info("=== DB workload %s on %s (%s) ===", engine, device, data_dir)
+    result = ENGINE_RUNNERS[engine](node, data_dir, cfg)
+
+    if cfg.get("cleanup_container", True):
+        podman_rm(node, result.get("container", f"nvmeof-{engine}"))
+    if cfg.get("umount", True):
+        umount_quiet(node, mount_point)
+
+    result["device"] = device
+    result["skipped"] = False
+    return result

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -97,10 +97,10 @@ class NVMeInitiator(Initiator):
         nqns_discovered, _ = self.discover(**_disc_cmd)
         LOG.debug(nqns_discovered)
 
-        # connect-all
+        # connect-all (CLI layer also defaults --persistent)
         connect_all = {}
         if config["nqn"] == "connect-all":
-            connect_all = {"ctrl-loss-tmo": 3600}
+            connect_all = {"ctrl-loss-tmo": 3600, "persistent": True}
             # Add authentication parameters based on auth_mode
             if self.auth_mode == "bidirectional":
                 if not self.host_key or not self.subsys_key:
@@ -124,6 +124,13 @@ class NVMeInitiator(Initiator):
                     )
                 cmd_args.update({"dhchap-secret": self.host_key})
             cmd = {**discovery_port, **cmd_args, **connect_all}
+            # Persist discovery endpoint for nvmf-autoconnect after reboot
+            self.configure_discovery_conf(
+                traddr=cmd_args["traddr"],
+                trsvcid=self.discovery_port,
+                transport="tcp",
+            )
+            self.enable_nvmf_autoconnect()
             self.connect_all(**cmd)
             self.list()
             return
@@ -138,6 +145,15 @@ class NVMeInitiator(Initiator):
             allowed_subsystems = set(subsystems)
         else:
             allowed_subsystems = {subsystem}
+
+        # Still record discovery controller for reboot autoconnect
+        self.configure_discovery_conf(
+            traddr=cmd_args["traddr"],
+            trsvcid=self.discovery_port,
+            transport="tcp",
+        )
+        self.enable_nvmf_autoconnect()
+
         sub_endpoints = []
         discovered_records = json.loads(nqns_discovered)["records"]
 
@@ -195,6 +211,7 @@ class NVMeInitiator(Initiator):
                 "traddr": sub_endpoint["traddr"],
                 "trsvcid": sub_endpoint["trsvcid"],
                 "nqn": sub_endpoint["subnqn"],
+                "persistent": True,
             }
             if self.auth_mode == "bidirectional":
                 if not self.host_key or not self.subsys_key:
@@ -286,6 +303,21 @@ class NVMeInitiator(Initiator):
         # Update io_args if io_type is provided
         if kwargs.get("io_type"):
             io_args.update({"io_type": kwargs.get("io_type")})
+
+        # Forward data-integrity options to run_fio
+        if kwargs.get("verify"):
+            io_args.update({"verify": kwargs.get("verify")})
+        if kwargs.get("verify_fatal") is not None:
+            io_args.update({"verify_fatal": kwargs.get("verify_fatal")})
+        if kwargs.get("bs"):
+            io_args.update({"bs": kwargs.get("bs")})
+        # Customer-workload knobs (DB multi-queue, O_DIRECT, sync cadence)
+        if kwargs.get("num_jobs") is not None:
+            io_args.update({"num_jobs": kwargs.get("num_jobs")})
+        if kwargs.get("fsync") is not None:
+            io_args.update({"fsync": kwargs.get("fsync")})
+        if kwargs.get("direct") is not None:
+            io_args.update({"direct": kwargs.get("direct")})
 
         # Check whether to execute blkdiscard
         # For read only namespaces, blkdiscard is not required


### PR DESCRIPTION
## Summary
- Add the IBM Ceph 9.2 customer-centric NVMeoF holistic cross-feature suite (`tier-2_nvmeof_9-2_holistic_cross-feature.yaml`) with matching cluster conf.
- Include day-2 IO under load, DB workloads, initiator reboot + nvmf-autoconnect, and CLI/initiator helpers those tests need.
- Scope this PR to that suite path only (no smoke/soak/IBM BM companion suites).

## Test plan
- [ ] Run `suites/tentacle/nvmeof/tier-2_nvmeof_9-2_holistic_cross-feature.yaml` with `conf/tentacle/nvmeof/ceph_nvmeof_9-2_holistic.yaml`
- [ ] Confirm Phase 0 deploy (prereq, cephadm, 4 clients) then NVMeoF GW apply and standing tenants
- [ ] Confirm Phase 5 background FIO + day-2 ops and Phase 4.5 initiator reboot autoconnect
- [ ] Confirm remaining NVMeoF suites are unchanged


Made with [Cursor](https://cursor.com)