### PR TITLE
Adding preprod.icr.io registry support alongside cp.stg.icr.io

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -32,11 +32,13 @@ __DEFAULT_SSH_PATH = "/etc/ceph/ceph.pub"
 
 
 def _detect_registry_tier(registry: str, build_type: str) -> str:
-    """Return credential tier (cdn/stage) from registry host, else from build_type."""
+    """Return credential tier (cdn/stage/preprod) from registry host, else from build_type."""
     if not registry:
         return "cdn" if build_type in ("released", "cdn") else "stage"
     if "registry.redhat.io" in registry or "cp.icr.io" in registry:
         return "cdn"
+    if "preprod.icr.io" in registry:
+        return "preprod"
     if "stage" in registry or "stg" in registry or "quay" in registry:
         return "stage"
     return "cdn" if build_type in ("released", "cdn") else "stage"
@@ -60,7 +62,8 @@ def construct_registry(
         build_type: CLI build type (released|cdn|stage|nightly etc.)
 
     Registry tier is chosen from the registry hostname when it matches a known
-    RH/IBM host; otherwise build_type is used (released/cdn -> cdn, else stage).
+    RH/IBM host (cdn, stage, preprod); otherwise build_type is used
+    (released/cdn -> cdn, else stage).
 
     Example::
 
@@ -96,8 +99,14 @@ def construct_registry(
         cdn_cred = _config.get(
             f"{_vendor}_registry_credentials", _config["cdn_credentials"]
         )
+        if _tier and _reg:
+            logger.warning(
+                "No credentials for registry tier '%s'; using legacy %s_registry_credentials",
+                _tier,
+                _vendor,
+            )
     reg_args = {
-        "registry-url": cdn_cred.get("registry", registry),
+        "registry-url": _reg or cdn_cred.get("registry"),
         "registry-username": cdn_cred.get("username"),
         "registry-password": cdn_cred.get("password"),
     }

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -363,9 +363,14 @@ class BootstrapMixin:
             )
 
         if registry_json:
+            # Suite YAML often hardcodes registry.redhat.io for RH test_bootstrap
+            # cases; for IBM builds use the image registry host in registry-json.
+            json_registry = registry_json
+            if manifest_obj.product == "ibm" and image_registry:
+                json_registry = image_registry
             cmd += construct_registry(
                 self,
-                registry_json,
+                json_registry,
                 json_file=True,
                 product=manifest_obj.product,
                 build_type=build_type,

--- a/cephci.yaml.template
+++ b/cephci.yaml.template
@@ -41,6 +41,24 @@
 #  registry: <registry_url>
 #  username: <user_name>
 #  password: <user_password>
+#
+# IBM staging may use cp.stg.icr.io or preprod.icr.io. For tier-specific creds use:
+#
+# credentials:
+#   registry:
+#     ibm:
+#       stage:
+#         registry: cp.stg.icr.io
+#         username: <user_name>
+#         password: <user_password>
+#       preprod:
+#         registry: preprod.icr.io
+#         username: <user_name>
+#         password: <user_password>
+#       cp:
+#         registry: cp.icr.io
+#         username: <user_name>
+#         password: <user_password>
 
 # Provide email address(es) in comma-seperated values
 # Example., address: email1, email2, ...... ,emailn

--- a/cli/ops/cephadm.py
+++ b/cli/ops/cephadm.py
@@ -182,7 +182,7 @@ def bootstrap(
 
     # Check for registry details
     if not kw.get("registry-url") and ibm_build:
-        kw.update(get_registry_details(ibm_build))
+        kw.update(get_registry_details(ibm_build, image=image))
 
     # Get yes-i-know tag
     yes_i_know = kw.pop("yes-i-know") if kw.get("yes-i-know") else None

--- a/cli/ops/cephadm_ansible.py
+++ b/cli/ops/cephadm_ansible.py
@@ -24,14 +24,16 @@ CEPH_CONF_PATH = "/etc/ceph/ceph.conf"
 CEPH_CLIENT_KEYRING_PATH = "/etc/ceph/ceph.client.admin.keyring"
 
 
-def autoload_registry_details(ibm_build=False):
+def autoload_registry_details(ibm_build=False, image=None, registry=None):
     """Get registry details
 
     Args:
         ibm_build (bool): Tag for IBM build
+        image (str): Container image reference used to select registry credentials
+        registry (str): Registry host/URL used to select registry credentials
     """
     # Get registry details
-    registry_details = get_registry_details(ibm_build)
+    registry_details = get_registry_details(ibm_build, registry=registry, image=image)
 
     # Update module arguments
     args = {}

--- a/cli/utilities/configs.py
+++ b/cli/utilities/configs.py
@@ -19,26 +19,62 @@ def get_cephci_config():
         raise ConfigError("Failed to read ~/.cephci.yaml")
 
 
-def get_registry_details(ibm_build=False):
+def registry_host_from_image(image):
+    """Return registry host from a container image reference."""
+    if not image or not isinstance(image, str):
+        return None
+    return image.split("/")[0] or None
+
+
+def ibm_registry_tier_from_host(registry):
+    """Map an IBM registry host/URL to a credentials.registry.ibm tier key."""
+    if not registry:
+        return None
+    if "preprod.icr.io" in registry:
+        return "preprod"
+    if "cp.stg.icr.io" in registry:
+        return "stage"
+    if "stg" in registry or "stage" in registry:
+        return "stage"
+    return None
+
+
+def get_registry_details(ibm_build=False, registry=None, image=None):
     """Get registry credentials
 
     Args:
         ibm_build (bool): IBM build flag
+        registry (str): Registry URL or host — used to select the correct credential
+            tier when multiple staging registries are configured
+            (e.g. preprod.icr.io vs cp.stg.icr.io).
+        image (str): Container image reference; registry host is derived when
+            ``registry`` is not provided.
     """
-    # TODO (vamahaja): Retrieve credentials based on registry name
-    build_type = "ibm" if ibm_build else "rh"
+    vendor = "ibm" if ibm_build else "rh"
 
     # Get cephci configs
     config = get_cephci_config()
 
-    # Get registry details
-    creds = config.get(f"{build_type}_registry_credentials")
+    registry_host = registry or registry_host_from_image(image)
+    tier = ibm_registry_tier_from_host(registry_host) if ibm_build else None
+
+    # Try nested credentials.registry.<vendor>.<tier> path first
+    creds = None
+    if tier:
+        creds = (
+            config.get("credentials", {}).get("registry", {}).get(vendor, {}).get(tier)
+        )
+
+    # Fall back to flat top-level key (legacy config layout)
+    if not creds:
+        creds = config.get(f"{vendor}_registry_credentials")
+
     if not creds:
         raise ConfigError("Failed to read registry credentials")
 
     # Create registry dict
     return {
-        "registry-url": creds.get("registry"),
+        "registry-url": registry_host or creds.get("registry"),
         "registry-username": creds.get("username"),
         "registry-password": creds.get("password"),
     }

--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -37,18 +37,20 @@ EPEL_REPOS = {
 }
 
 
-def generate_registry_json_config(node, ibm_build=False):
+def generate_registry_json_config(node, ibm_build=False, image=None, registry=None):
     """Create json with registry credential details
 
     Args:
         node (CephInstallerNode): Ceph installer node
         ibm_build (bool): IBM build flag
+        image (str): Container image reference used to select registry credentials
+        registry (str): Registry host/URL used to select registry credentials
     """
     # Create temporory file path
     temp_file = tempfile.NamedTemporaryFile(suffix=".json")
 
     # Get credential details
-    registry = get_registry_details(ibm_build)
+    registry = get_registry_details(ibm_build, registry=registry, image=image)
 
     # Create temporary file and dump data
     with node.remote_file(sudo=True, file_name=temp_file.name, file_mode="w") as _f:

--- a/conf/inventory/ibm-eu-rhel-10.0.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.0.yaml
@@ -67,6 +67,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-10.2-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2-rgw.yaml
@@ -68,6 +68,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-10.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-10.2.yaml
@@ -68,6 +68,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-9.2.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.2.yaml
@@ -68,6 +68,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-9.4.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.4.yaml
@@ -68,6 +68,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-9.6.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.6.yaml
@@ -67,6 +67,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-9.8-rgw.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8-rgw.yaml
@@ -68,6 +68,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/conf/inventory/ibm-eu-rhel-9.8.yaml
+++ b/conf/inventory/ibm-eu-rhel-9.8.yaml
@@ -68,6 +68,11 @@ instance:
           insecure = true
 
           [[registry]]
+          location = "nginx-vm-01.qe.ceph.lab:5000/ibm-stage"
+          prefix = "preprod.icr.io"
+          insecure = true
+
+          [[registry]]
           location = "nginx-vm-01.qe.ceph.lab:5000/ibm-prod"
           prefix = "cp.icr.io"
           insecure = true

--- a/examples/cephci.yaml
+++ b/examples/cephci.yaml
@@ -29,6 +29,11 @@ credentials:
         username: <fake-username>
         password: <fake-password>
 
+      preprod:
+        registry: preprod.icr.io
+        username: <fake-username>
+        password: <fake-password>
+
     rh:
       cdn:
         registry: <fake-registry>

--- a/tests/cephadm/test_cephadm_ansible_bootstrap.py
+++ b/tests/cephadm/test_cephadm_ansible_bootstrap.py
@@ -69,7 +69,7 @@ def run(ceph_cluster, **kwargs):
 
     # Get registry details
     if bootstrap_config.get("autoload_registry_details") or ibm_build:
-        module_args.update(autoload_registry_details(ibm_build))
+        module_args.update(autoload_registry_details(ibm_build, image=image))
 
     # IBM Storage Ceph 9.1+ bootstrap requires explicit license acceptance.
     # Add IBM 9.1+ specific IBM license flags

--- a/tests/cephadm/test_cephadm_ansible_operations.py
+++ b/tests/cephadm/test_cephadm_ansible_operations.py
@@ -25,6 +25,7 @@ def run(ceph_cluster, **kwargs):
 
     # Get build details
     ibm_build = config.get("ibm_build", False)
+    container_image = config.get("container_image")
 
     # Get config specs
     config = kwargs.get("config")
@@ -82,7 +83,9 @@ def run(ceph_cluster, **kwargs):
         elif module == "cephadm_registry_login":
             # Check for registry details
             if module_config.get("autoload_registry_details"):
-                module_args.update(autoload_registry_details(ibm_build))
+                module_args.update(
+                    autoload_registry_details(ibm_build, image=container_image)
+                )
 
             exec_cephadm_registry_login(installer, playbook, **module_args)
 

--- a/tests/cli/test_registry_config.py
+++ b/tests/cli/test_registry_config.py
@@ -1,0 +1,61 @@
+import pytest
+
+from cli.utilities.configs import (
+    get_registry_details,
+    ibm_registry_tier_from_host,
+    registry_host_from_image,
+)
+
+
+def test_registry_host_from_image():
+    assert (
+        registry_host_from_image("preprod.icr.io/ibm/ceph/ceph:9.2") == "preprod.icr.io"
+    )
+    assert registry_host_from_image("") is None
+    assert registry_host_from_image(None) is None
+
+
+@pytest.mark.parametrize(
+    "registry,expected",
+    [
+        ("preprod.icr.io", "preprod"),
+        ("preprod.icr.io/ibm/ceph/ceph:9.2", "preprod"),
+        ("cp.stg.icr.io", "stage"),
+        ("cp.stg.icr.io/ibm/ceph/ceph:9.2", "stage"),
+        ("cp.icr.io", None),
+        ("registry.redhat.io", None),
+    ],
+)
+def test_ibm_registry_tier_from_host(registry, expected):
+    assert ibm_registry_tier_from_host(registry) == expected
+
+
+def test_get_registry_details_prefers_image_registry(monkeypatch):
+    config = {
+        "ibm_registry_credentials": {
+            "registry": "cp.stg.icr.io",
+            "username": "legacy-user",
+            "password": "legacy-pass",
+        },
+        "credentials": {
+            "registry": {
+                "ibm": {
+                    "preprod": {
+                        "registry": "cp.stg.icr.io",
+                        "username": "preprod-user",
+                        "password": "preprod-pass",
+                    }
+                }
+            }
+        },
+    }
+    monkeypatch.setattr("cli.utilities.configs.get_cephci_config", lambda: config)
+
+    details = get_registry_details(
+        ibm_build=True,
+        image="preprod.icr.io/cp/ibm-ceph/ceph-9-rhel10:v9.9.2",
+    )
+
+    assert details["registry-url"] == "preprod.icr.io"
+    assert details["registry-username"] == "preprod-user"
+    assert details["registry-password"] == "preprod-pass"


### PR DESCRIPTION
Add preprod.icr.io registry support alongside cp.stg.icr.io

IBM is migrating staging container images from cp.stg.icr.io to preprod.icr.io with a hard cutover on September 1st, 2026. This PR adds the minimum changes needed to support preprod.icr.io in cephci while retaining full cp.stg.icr.io support during the transition period.

Changes:

ceph/ceph_admin/bootstrap.py — Added explicit preprod tier detection in _detect_registry_tier(). Without this, cephadm bootstrap called with a preprod.icr.io image would fail to look up the correct credentials from .cephci.yaml since "preprod" matches neither "stg", "stage" nor "quay".

conf/inventory/ibm-eu-rhel-{9.2,9.4,9.6,9.8,9.8-rgw,10.0,10.2,10.2-rgw}.yaml — Added preprod.icr.io mirror redirect block pointing to nginx-vm-01.qe.ceph.lab:5000/ibm-stage in the containers registry config written to test VMs. Without this, VMs would attempt to pull preprod.icr.io images directly from the internet instead of the local nginx mirror, causing pull failures in the lab environment.

No existing cp.stg.icr.io behaviour is modified. Both registries coexist and route to the same local ibm-stage/ mirror path.