### PR TITLE
Add NVMeoF inhouse 4-GW E2E suite with QoS and multi-attach

### DIFF
--- a/conf/tentacle/nvmeof/ceph_nvmeof_4-nvmeof-gw_inhouse.yaml
+++ b/conf/tentacle/nvmeof/ceph_nvmeof_4-nvmeof-gw_inhouse.yaml
@@ -1,0 +1,56 @@
+# 4 NVMeoF GWs colocated on OSD nodes (node4–node7).
+# Two initiator clients (node8, node9) so one namespace can be attached
+# by more than one host (multi-attach / shared reservation tenant).
+globals:
+  - ceph-cluster:
+      name: ceph
+      vm-size: ci.standard.large
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - mds
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - mds
+          - osd
+          - rgw
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node7:
+        role:
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_Inhouse_nvmeof.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_e2e_Inhouse_nvmeof.yaml
@@ -1,0 +1,352 @@
+# Basic Ceph-NVMeoF E2E suite — 4 GWs colocated on OSD nodes
+# cluster configuration file: conf/tentacle/nvmeof/ceph_nvmeof_4-nvmeof-gw_inhouse.yaml
+# inventory: conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml
+#
+# Topology:
+#   NVMeoF GWs (all on OSD nodes): node4, node5, node6, node7
+#   Initiators: node8, node9
+#
+# Coverage (50 namespaces, combinations):
+#   - Basic E2E: 50 NS across 2 subsystems (25×1G + 25×2G), two initiators, FIO
+#   - QoS: 50 NS; set_qos + IO on three NSIDs (read / write / rw profiles)
+#   - Multi-attach: 50 shared NS (allow_host "*") visible to both hosts
+#       * reservation lifecycle on the shared tenant
+#       * multi-initiator reservation type matrix
+#     Concurrent writes are coordinated with NVMe reservations so hosts
+#     do not corrupt each other (same idea as OpenStack/RBD multiattach).
+#   - KMIP: no NVMeoF KMIP/BYOK tests exist in this repo (NFS/SMB/RGW only).
+#     Omitted until an NVMeoF KMIP module is added.
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node8
+          - node9
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup two NVMeoF initiator clients for multi-attach
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph clients for NVMe tests
+      polarion-id: CEPH-83573758
+
+  #  Configure Ceph NVMeoF gateway on 4 OSD-colocated GWs
+  #  Configure initiator and run IO on NVMe targets
+  - test:
+      abort-on-fail: true
+      config:
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+          - disconnect_all
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            max_ns: 128
+            no-group-append: true
+            bdevs:
+              count: 25
+              size: 1G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            max_ns: 128
+            no-group-append: true
+            bdevs:
+              count: 25
+              size: 2G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4421
+            allow_host: "*"
+        initiators:
+          - subnqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 4420
+            node: node8
+            io_args:
+              size: 100M
+          - subnqn: nqn.2016-06.io.spdk:cnode2
+            listener_port: 4421
+            node: node9
+            io_args:
+              size: 100M
+      desc: >
+        E2E 50 NS on 4 OSD-colocated GWs: 25×1G (cnode1/node8) + 25×2G (cnode2/node9)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Basic E2E 50-NS Ceph NVMeoF GW test with 4 GWs on OSD nodes
+      polarion-id: CEPH-83575442
+
+  #  Set QoS for namespaces and validate against FIO
+  - test:
+      abort-on-fail: false
+      config:
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            no-group-append: true
+            serial: 1
+            max_ns: 128
+            bdevs:
+              count: 50
+              size: 1G
+              ns_create_image: true
+              qos:
+                - subsystem: nqn.2016-06.io.spdk:cnode1
+                  nsid: 1
+                  r-megabytes-per-second: 90
+                  w-megabytes-per-second: 20
+                  rw-megabytes-per-second: 50
+                - subsystem: nqn.2016-06.io.spdk:cnode1
+                  nsid: 25
+                  r-megabytes-per-second: 20
+                  w-megabytes-per-second: 90
+                  rw-megabytes-per-second: 50
+                - subsystem: nqn.2016-06.io.spdk:cnode1
+                  nsid: 50
+                  r-megabytes-per-second: 40
+                  w-megabytes-per-second: 40
+                  rw-megabytes-per-second: 40
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+        initiators:
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 4420
+            node: node8
+      desc: >
+        E2E QoS on 50 NS: read-heavy (nsid 1), write-heavy (nsid 25),
+        balanced (nsid 50)
+      destroy-cluster: false
+      module: test_ceph_nvmeof_qos_tests.py
+      name: Basic E2E Ceph NVMeoF QoS on 50 NS with 3 profiles
+      polarion-id: CEPH-83612364
+
+  # ---------------------------------------------------------------------------
+  # Multi-attach — shared tenant (holistic cnode6): allow_host "*" so both
+  # initiators see the same RBD-backed NS. Phase 4 reservation lifecycle
+  # (register / acquire / IO / release / unregister) then disconnect.
+  # ---------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        gw_nodes:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        gw_group: gw_group1
+        install: true
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        cleanup:
+          - initiators
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 6
+            max_ns: 128
+            no-group-append: true
+            bdevs:
+              count: 50
+              size: 1G
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+        reservation:
+          - register_args:
+              rrega: 0
+          - acquire_args:
+              racqa: 0
+              rtype: 1
+          - release_args:
+              rrela: 0
+              rtype: 1
+          - unregister_args:
+              rrega: 1
+        initiators:
+          - node: node8
+            nqn: connect-all
+            listener_port: 4420
+          - node: node9
+            nqn: connect-all
+            listener_port: 4420
+      desc: >
+        Multi-attach: 50 shared NS (allow_host *) visible to two
+        initiators; reservation lifecycle plus IO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_ns_reservation.py
+      name: Multi-attach reservation lifecycle on 50 shared NS
+      polarion-id: CEPH-83626134
+
+  # ---------------------------------------------------------------------------
+  # Multi-attach Phase 4b — reservation type matrix across two initiators
+  # on a shared open tenant (allow_host *). Confirms both hosts can see
+  # the same NS and that write/read rights follow NVMe reservation types.
+  # ---------------------------------------------------------------------------
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node:
+          - node4
+          - node5
+          - node6
+          - node7
+        rbd_pool: rbd
+        nvme_metadata_pool: rbd
+        install: true
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        cleanup:
+          - subsystems
+          - disconnect_all
+          - pool
+          - gateway
+        subsystems:
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 6
+            max_ns: 128
+            no-group-append: true
+            bdevs:
+              count: 50
+              size: 1G
+              ns_create_image: true
+            listeners:
+              - node4
+              - node5
+              - node6
+              - node7
+            listener_port: 4420
+            allow_host: "*"
+        reservation:
+          - register_args:
+              rrega: 0
+          - acquire_args:
+              racqa: 0
+              rtype: 1
+          - release_args:
+              rrela: 0
+              rtype: 1
+          - unregister_args:
+              rrega: 1
+        initiators:
+          - node8
+          - node9
+      desc: >
+        Multi-attach: reservation types across two initiators on the
+        same 50 shared namespaces
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_reservation_multi_init.py
+      name: Multi-attach reservation type matrix on 50 shared NS
+      polarion-id: CEPH-83627298


### PR DESCRIPTION
## Summary
- Add the IBM Ceph inhouse NVMeoF E2E suite (`tier-2_nvmeof_e2e_Inhouse_nvmeof.yaml`) with matching cluster conf (`ceph_nvmeof_4-nvmeof-gw_inhouse.yaml`).
- Cover 4 GWs colocated on OSD nodes (`node4`–`node7`) with two initiator clients (`node8`, `node9`).
- Include basic IO, namespace QoS, and multi-attach (shared NS with `allow_host: "*"`, reservation lifecycle, and multi-initiator reservation types) at 50 namespaces.

## Coverage
| Test | What it does |
| --- | --- |
| Basic E2E | 50 NS: `cnode1` 25×1G (node8, 4420) + `cnode2` 25×2G (node9, 4421), FIO |
| QoS | 50×1G; `set_qos` + IO on nsid 1 (read-heavy), 25 (write-heavy), 50 (balanced) |
| Multi-attach | 50 shared NS visible to both hosts; reservation register/acquire/IO/release |
| Multi-attach types | Reservation type matrix across two initiators on the same NS |

KMIP is omitted: there is no NVMeoF KMIP/BYOK test module in this repo (NFS/SMB/RGW only).

## Test plan
- [ ] Run `suites/tentacle/nvmeof/tier-2_nvmeof_e2e_Inhouse_nvmeof.yaml` with `conf/tentacle/nvmeof/ceph_nvmeof_4-nvmeof-gw_inhouse.yaml`
- [ ] Inventory: `conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml` (or later)
- [ ] Confirm both clients see the shared tenant NS and reservation IO follows type rules
- [ ] Confirm QoS limits apply on nsid 1, 25, and 50
- [ ] Confirm remaining NVMeoF suites are unchanged

Made with [Cursor](https://cursor.com)