### PR TITLE
Add test suite for bucket deletion with location constraint validatio…

### DIFF
--- a/suites/tentacle/rgw/tier-2_rgw_ms-bucket-location.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_ms-bucket-location.yaml
@@ -442,14 +442,13 @@ tests:
       name: create non-tenanted user
       polarion-id: CEPH-83575199
 
-
   - test:
       clusters:
         ceph-pri:
           config:
             script-name: test_bucket_location_constraint.py
             config-file-name: test_bucket_location_constraint_primary.yaml
-      desc: Bucket creation in primary zonegroup with location constraint
+      desc: Bucket creation and deletion in primary zonegroup with location constraint
       module: sanity_rgw_multisite.py
       name: test bucket location constraint primary zg
       polarion-id: CEPH-83623503
@@ -460,7 +459,7 @@ tests:
           config:
             script-name: test_bucket_location_constraint.py
             config-file-name: test_bucket_location_constraint_tertiary.yaml
-      desc: Bucket creation in tertiary zonegroup with location constraint
+      desc: Bucket creation and deletion in tertiary zonegroup with location constraint
       module: sanity_rgw_multisite.py
       name: test bucket location constraint tertiary zg
       polarion-id: CEPH-83623503
@@ -471,8 +470,19 @@ tests:
           config:
             script-name: test_bucket_location_constraint.py
             config-file-name: test_bucket_location_constraint_default.yaml
-      desc: Bucket creation defaults to endpoint zonegroup without region
+      desc: Bucket creation and deletion defaults to endpoint zonegroup without region
       module: sanity_rgw_multisite.py
       name: test bucket location constraint default zg
+      polarion-id: CEPH-83623503
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_location_constraint.py
+            config-file-name: test_bucket_location_constraint_delete_with_objects.yaml
+      desc: Delete bucket with objects defaults to endpoint zonegroup without region
+      module: sanity_rgw_multisite.py
+      name: test bucket location constraint delete with objects with default zg
       polarion-id: CEPH-83623503
 


### PR DESCRIPTION

bucket deletion with location constraints across multisite zonegroups. It verifies bucket deletion with primary, tertiary, and default zonegroup location constraints using boto3, AWS CLI, and s3cmd, and confirms the assigned location through bucket location APIs.

pass log : https://magna002.ceph.redhat.com/cephci-jenkins/mreddem/cephci-run-C3DGSE/
jira : https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-24753

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
