### PR TITLE
nfs: fix hard-link reboot hang and Prometheus ceph-common install

### DIFF
--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -1,7 +1,15 @@
+import json
 from time import sleep
 
-from nfs_operations import cleanup_cluster, setup_nfs_cluster
+from nfs_operations import (
+    cleanup_cluster,
+    get_nfs_cluster_backend_endpoint,
+    setup_nfs_cluster,
+    wait_for_nfs_endpoint_ready,
+)
 
+from ceph.ceph import Ceph
+from ceph.waiter import WaitUntil
 from cli.exceptions import ConfigError, OperationFailedError
 from cli.utilities.utils import reboot_node
 from utility.log import Log
@@ -9,8 +17,55 @@ from utility.log import Log
 log = Log(__name__)
 
 
+def _inode_or_none(client, path):
+    """Return inode as string, or None if ls times out / fails (hard-mount hang)."""
+    try:
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=f"timeout 30 ls -i {path} | awk '{{print $1}}'",
+            check_ec=False,
+            timeout=45,
+        )
+    except Exception:
+        return None
+    if int(getattr(client, "exit_status", 1)) != 0:
+        return None
+    inode = (out or "").strip()
+    return inode or None
+
+
+def _lazy_unmount(clients, nfs_mount):
+    """Drop a stuck hard NFS mount so cleanup rm does not block."""
+    for client in clients:
+        client.exec_command(
+            sudo=True,
+            cmd=f"umount -f -l {nfs_mount} >/dev/null 2>&1 || true",
+            check_ec=False,
+            timeout=30,
+        )
+
+
+def _nfs_backend_endpoint(client, nfs_name, nfs_node, port):
+    """Best-effort backend IP:port for TCP probes after reboot (no orch ps wait)."""
+    try:
+        raw = Ceph(client).nfs.cluster.info(nfs_name)
+        if isinstance(raw, str):
+            info = json.loads(raw)
+        else:
+            info = raw or {}
+        backend_ip, backend_port = get_nfs_cluster_backend_endpoint(info, nfs_name)
+        return backend_ip, str(backend_port)
+    except Exception as exc:
+        log.info(
+            "Using NFS node IP for post-reboot probe (%s); cluster info unavailable: %s",
+            nfs_node.hostname,
+            exc,
+        )
+        return nfs_node.ip_address, str(port)
+
+
 def run(ceph_cluster, **kw):
-    """Verify symbolic links scenarios
+    """Verify hard links remain valid after an NFS server reboot.
     Args:
         **kw: Key/value pairs of configuration information to be used in the test.
     """
@@ -52,6 +107,13 @@ def run(ceph_cluster, **kw):
             rdma_port=config.get("rdma_port"),
         )
 
+        # Drop leftovers from a prior reuse run so ln is not EEXIST.
+        clients[0].exec_command(
+            sudo=True,
+            cmd=f"rm -f {nfs_mount}/test_file {nfs_mount}/link_file",
+            check_ec=False,
+        )
+
         # Create file in local file system
         cmd = f"touch {nfs_mount}/test_file"
         clients[0].exec_command(cmd=cmd)
@@ -63,29 +125,50 @@ def run(ceph_cluster, **kw):
         # Reboot NFS server
         reboot_node(nfs_node)
 
-        # After reboot, Verify hardlink
-        original_file_inode = (
-            clients[0]
-            .exec_command(cmd="ls -i /mnt/nfs/test_file | awk '{print $1}'")[0]
-            .strip()
+        # SSH reconnect is not enough: a hard NFS mount blocks until Ganesha
+        # listens again. Do not wait on ``ceph orch ps`` here — mgr cache
+        # defaults to ~10 minutes and keeps "host is offline" after the node
+        # is back (https://docs.ceph.com/en/latest/cephadm/services/).
+        backend_ip, backend_port = _nfs_backend_endpoint(
+            clients[0], nfs_name, nfs_node, port
         )
-        hard_link_file_inode = (
-            clients[0]
-            .exec_command(cmd="ls -i /mnt/nfs/link_file | awk '{print $1}'")[0]
-            .strip()
-        )
+        wait_for_nfs_endpoint_ready(clients[0], backend_ip, backend_port, timeout=600)
+
+        original_file_inode = None
+        hard_link_file_inode = None
+        for _ in WaitUntil(timeout=300, interval=10):
+            original_file_inode = _inode_or_none(clients[0], f"{nfs_mount}/test_file")
+            hard_link_file_inode = _inode_or_none(clients[0], f"{nfs_mount}/link_file")
+            if original_file_inode and hard_link_file_inode:
+                break
+            log.info(
+                "NFS mount not readable yet after reboot (grace/reconnect); retrying"
+            )
+
+        if not original_file_inode or not hard_link_file_inode:
+            raise OperationFailedError(
+                "timed out waiting for NFS mount to recover after server reboot"
+            )
         if original_file_inode != hard_link_file_inode:
             raise OperationFailedError(
                 "hard link file not have same inode as original file"
             )
-            return 1
-        else:
-            log.info("iNode match for original and hard link file")
+        log.info(
+            "TEST PASSED - hard link inodes match after NFS server reboot "
+            "(CEPH-83575971)"
+        )
         return 0
     except Exception as e:
-        log.error(f"Error : {e}")
+        log.error("Error : %s", e)
+        return 1
     finally:
         log.info("Cleaning up")
         sleep(3)
-        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node)
-        log.info("Cleaning up successfull")
+        try:
+            _lazy_unmount(clients, nfs_mount)
+            cleanup_cluster(
+                clients, nfs_mount, nfs_name, nfs_export, nfs_nodes=nfs_node
+            )
+            log.info("Cleaning up successful")
+        except Exception as cleanup_err:
+            log.warning("Cleanup after hard-links reboot test failed: %s", cleanup_err)

--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -458,6 +458,12 @@ def get_installer(ceph_cluster):
 
 
 def _install_ceph_common_if_needed(node):
+    """Install ceph-common when the node has no ``ceph`` CLI.
+
+    ``exec_command(..., check_ec=False)`` returns ``(stdout, stderr)``, not
+    an exit code. dnf/yum write progress to stderr, so treating the second
+    tuple item as ``rc`` fails a successful install.
+    """
     out, _ = node.exec_command(
         sudo=True,
         cmd="command -v ceph && echo present || echo absent",
@@ -469,12 +475,19 @@ def _install_ceph_common_if_needed(node):
         "dnf install -y ceph-common --nogpgcheck",
         "yum install -y ceph-common --nogpgcheck",
     ):
-        _, rc = node.exec_command(
+        _, err = node.exec_command(
             sudo=True, cmd=install_cmd, check_ec=False, timeout=600
         )
-        if rc == 0:
+        if int(getattr(node, "exit_status", 1)) == 0:
             log.info("Installed ceph-common on %s", node.hostname)
             return
+        log.warning(
+            "ceph-common install via '%s' failed on %s (rc=%s): %s",
+            install_cmd,
+            node.hostname,
+            getattr(node, "exit_status", None),
+            (err or "").strip()[:500],
+        )
     raise OperationFailedError("Failed to install ceph-common on %s" % node.hostname)
 
 


### PR DESCRIPTION
## Problem

IBM 9.2 nfs-ganesha regression (job 137) failed two NFS automation paths that are not product regressions:

1. **Hard links after NFS server reboot** (CEPH-83575971) — after `reboot_node()`, the test ran `ls` on a hard NFS mount as soon as SSH came back. Ganesha was not listening yet, `ls` hung for 600s, and cleanup blocked on the stuck mount. Waiting on `ceph orch ps` is unreliable (mgr cache ~10 min).
2. **Prometheus `ceph-common` install** (CEPH-83632509) — `_install_ceph_common_if_needed()` treated `exec_command(..., check_ec=False)` stderr as the exit code. dnf/yum progress on stderr caused false `Failed to install ceph-common`.

**Out of scope (product bug):** F-02B functional failure (CEPH-83632505) — metrics not restored after `enable_metrics=true` on alternate monitoring port. Executor #2797/#2805: port listens but scrape never returns HTTP 200 even after 120s; works again after cleanup restores default port. No automation change planned.

## Solution

- After reboot, wait for Ganesha TCP (`wait_for_nfs_endpoint_ready`), bounded inode retries, lazy unmount, reuse-safe cleanup
- Use `node.exit_status` for ceph-common dnf/yum install result
- Terminal pass log: `TEST PASSED - hard link inodes match after NFS server reboot (CEPH-83575971)`

## Changes

- `tests/nfs/nfs_hard_links_server_reboot.py` — hard-link reboot hang fix
- `tests/nfs/nfs_prometheus_stats_utils.py` — ceph-common install fix only

## Test suites to run

- `suites/tentacle/nfs/tier1-nfs-ganesha-v4-2.yaml` — CEPH-83575971
- `suites/tentacle/nfs/tier2-nfs-prometheus-stats.yaml` — CEPH-83632509 regression block
- Jenkins: `tentacle-test-executor` with `GLOBAL_CONF=conf/tentacle/nfs/1admin-7node-3client.yaml`

## Validation

**Hard links — local reuse IBM 9.2 stable (`20.2.2-290`, RHEL 10)** — Pass (13m29s)

```
NFS endpoint 10.0.64.222:2049 reachable from ceph-harish-tfa-651kho-node4 after ~375s
TEST PASSED - hard link inodes match after NFS server reboot (CEPH-83575971)
```

**Prometheus ceph-common — executor #2805:** sanity S-01–S-08 and CEPH-83632509 regression R-01/R-02/R-04/R-05 **Pass**. F-02B failed (product bug).

Made with [Cursor](https://cursor.com)