### PR TITLE
nfs: fix Prometheus ceph-common install and F-02B recovery wait

### DIFF
--- a/tests/nfs/nfs_prometheus_stats_utils.py
+++ b/tests/nfs/nfs_prometheus_stats_utils.py
@@ -458,6 +458,12 @@ def get_installer(ceph_cluster):
 
 
 def _install_ceph_common_if_needed(node):
+    """Install ceph-common when the node has no ``ceph`` CLI.
+
+    ``exec_command(..., check_ec=False)`` returns ``(stdout, stderr)``, not
+    an exit code. dnf/yum write progress to stderr, so treating the second
+    tuple item as ``rc`` fails a successful install.
+    """
     out, _ = node.exec_command(
         sudo=True,
         cmd="command -v ceph && echo present || echo absent",
@@ -469,12 +475,19 @@ def _install_ceph_common_if_needed(node):
         "dnf install -y ceph-common --nogpgcheck",
         "yum install -y ceph-common --nogpgcheck",
     ):
-        _, rc = node.exec_command(
+        _, err = node.exec_command(
             sudo=True, cmd=install_cmd, check_ec=False, timeout=600
         )
-        if rc == 0:
+        if int(getattr(node, "exit_status", 1)) == 0:
             log.info("Installed ceph-common on %s", node.hostname)
             return
+        log.warning(
+            "ceph-common install via '%s' failed on %s (rc=%s): %s",
+            install_cmd,
+            node.hostname,
+            getattr(node, "exit_status", None),
+            (err or "").strip()[:500],
+        )
     raise OperationFailedError("Failed to install ceph-common on %s" % node.hostname)
 
 
@@ -2708,9 +2721,19 @@ def verify_f02_enable_metrics_reload_vs_restart(ctx):
     )
     ctx.refresh_container_id()
     verify_monitoring_port_listening(ctx.nfs_node, port)
-    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+    recovery_timeout = int(ctx.config.get("f02_metrics_recovery_timeout", 120))
+    try:
+        wait_metrics_recovery(
+            ctx.client, ctx.nfs_ip, port, timeout=recovery_timeout
+        )
+    except OperationFailedError as exc:
         raise OperationFailedError(
             "F-02B: metrics not restored after redeploy with enable_metrics=true"
+        ) from exc
+    if not metrics_scrape_ok(ctx.client, ctx.nfs_ip, port):
+        raise OperationFailedError(
+            "F-02B: metrics endpoint up but rpcs_received_total missing after "
+            "enable_metrics=true redeploy"
         )
     log.info("F-02B: enable_metrics=true restored after redeploy")
 


### PR DESCRIPTION
## Problem

Two `tier2-nfs-prometheus-stats` automation issues:

1. **CEPH-83632509 regression** — `_install_ceph_common_if_needed()` treated `exec_command(..., check_ec=False)` stderr as the exit code. dnf/yum write progress to stderr, so a successful install raised `Failed to install ceph-common`.
2. **F-02B functional (CEPH-83632505)** — after redeploy with `enable_metrics=true` on alternate monitoring port 9588, port is listening but client scrape never returns HTTP 200 within the test window (executor #2797, #2805). After cleanup restores port 9587, metrics work again.

## Solution

- Use `node.exit_status` for the dnf/yum install result (same pattern as other NFS helpers)
- After `enable_metrics=true` redeploy in F-02B, poll `wait_metrics_recovery()` (default 120s, configurable via `f02_metrics_recovery_timeout`) before final `metrics_scrape_ok()` check

**Note:** Executor #2805 still failed F-02B after the full 120s poll — likely a Ceph/NFS-Ganesha product issue with metrics restoration on alt port after enable_metrics toggle.

## Changes

- `tests/nfs/nfs_prometheus_stats_utils.py` only

## Test suites to run

- `suites/tentacle/nfs/tier2-nfs-prometheus-stats.yaml`
- Jenkins: `tentacle-test-executor` with `GLOBAL_CONF=conf/tentacle/nfs/1admin-7node-3client.yaml`

**Executor validation (#2805):** sanity S-01–S-08 **Pass**; CEPH-83632509 regression **Pass**; F-02B failed (possible product bug)

## Related

- #6128 — hard-links reboot fix (separate PR)

## Checklist

- [x] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve

Made with [Cursor](https://cursor.com)