### PR TITLE
fix: add RHEL 10 FIPS support using grubby kernel boot param

### DIFF
--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -425,24 +425,37 @@ def set_selinux_mode(nodes, enforcing_mode):
 def enable_fips_mode(node):
     """Enable FIPS mode on node
 
+    RHEL 8/9 uses fips-mode-setup; RHEL 10+ uses grubby to set the
+    fips=1 kernel boot parameter since fips-mode-setup is no longer
+    shipped.
+
     Args:
         node (CephNode): Ceph Node Object
     """
-    # Set FIPS commands
-    enable_fips = "fips-mode-setup --enable"
-    finish_fips_setup = "fips-finish-install --complete"
+    rhel_ver = int(os_major_version(node))
 
-    # Enable FIPS mode
-    out, err = node.exec_command(cmd=enable_fips, sudo=True)
-    if "FIPS mode will be enabled." not in out:
-        log.error(f"Failed to setup FIPS mode config. Error -\n{err}")
-        return False
+    if rhel_ver >= 10:
+        # RHEL 10+: enable FIPS via kernel boot parameter
+        grubby_cmd = 'grubby --update-kernel=DEFAULT --args="fips=1"'
+        out, err = node.exec_command(cmd=grubby_cmd, sudo=True)
+        if err:
+            log.error(f"Failed to set FIPS kernel param via grubby. Error -\n{err}")
+            return False
+        log.info("FIPS kernel boot parameter set via grubby (RHEL 10+)")
+    else:
+        # RHEL 8/9: use fips-mode-setup
+        enable_fips = "fips-mode-setup --enable"
+        finish_fips_setup = "fips-finish-install --complete"
 
-    # Finish FIPS mode
-    _, err = node.exec_command(cmd=finish_fips_setup, sudo=True)
-    if err:
-        log.error(f"Failed to setup enable mode. Error -\n{err}")
-        return False
+        out, err = node.exec_command(cmd=enable_fips, sudo=True)
+        if "FIPS mode will be enabled." not in out:
+            log.error(f"Failed to setup FIPS mode config. Error -\n{err}")
+            return False
+
+        _, err = node.exec_command(cmd=finish_fips_setup, sudo=True)
+        if err:
+            log.error(f"Failed to setup enable mode. Error -\n{err}")
+            return False
 
     return True
 
@@ -450,19 +463,29 @@ def enable_fips_mode(node):
 def is_fips_mode_enabled(node):
     """Check for FIPS mode on node
 
+    Uses /proc/sys/crypto/fips_enabled (works across all RHEL versions)
+    as the primary check, with fips-mode-setup --check as fallback for
+    RHEL 8/9.
+
     Args:
         node (CephNode): Ceph Node Object
     """
-    # Check FIPS command
-    check_fips_setup = "fips-mode-setup --check"
+    # Universal check: kernel flag (works on RHEL 8/9/10+)
+    out, _ = node.exec_command(cmd="cat /proc/sys/crypto/fips_enabled", sudo=True)
+    if out.strip() == "1":
+        return True
 
-    # Check for FIPS status
-    out, _ = node.exec_command(cmd=check_fips_setup, sudo=True)
-    if "FIPS mode is enabled" not in out:
-        log.error(f"FIPS mode is disabled on node '{node.hostname}'")
-        return False
+    # Fallback for RHEL 8/9 where the kernel flag may not yet reflect
+    # the state before reboot
+    rhel_ver = int(os_major_version(node))
+    if rhel_ver < 10:
+        check_fips_setup = "fips-mode-setup --check"
+        out, _ = node.exec_command(cmd=check_fips_setup, sudo=True)
+        if "FIPS mode is enabled" in out:
+            return True
 
-    return True
+    log.error(f"FIPS mode is disabled on node '{node.hostname}'")
+    return False
 
 
 def reboot_node(node):


### PR DESCRIPTION
RHEL 10 no longer ships fips-mode-setup. Use grubby to set the fips=1 kernel boot parameter instead. The existing fips-mode-setup path is preserved for RHEL 8/9.

Also update is_fips_mode_enabled() to use /proc/sys/crypto/fips_enabled as the primary check (works across all RHEL versions), with fips-mode-setup --check as fallback for RHEL 8/9.

Here's the comprehensive audit of both repos:

---

## ✅ No additional code changes needed for RHEL 10 FIPS

Both [cephci audit](37026099-14d1-420b-96bc-c6490a1b6abc) and [jenkins audit](e29fb9b8-56c2-4a92-aa8f-bff5c778aeb6) confirm the fix in `cli/utilities/utils.py` is **the only change required**.

### cephci repo — already covered

| File | Status |
|---|---|
| `cli/utilities/utils.py` — `enable_fips_mode` / `is_fips_mode_enabled` | ✅ **Fixed** (branch `fix/fips-rhel10-support`) |
| `run.py` — maps `enable-fips-mode` custom config flag | ✅ Safe — version-agnostic wiring |
| `tests/misc_env/install_prereq.py` — calls `enable_fips_mode()` / `is_fips_mode_enabled()` | ✅ Safe — delegates entirely to the fixed utils |
| `conf/inventory/ibm-eu-rhel-10.1-fips.yaml` — FIPS inventory image | ✅ Safe — uses pre-baked FIPS image |
| 3 suite YAMLs (`tentacle/squid/reef` `tier-2_nvmeof_e2e_fips.yaml`) | ✅ Safe — no FIPS CLI, no RHEL version constraints |

> `fips-mode-setup` / `fips-finish-install` appear **only** in `utils.py`, already gated behind `rhel_ver < 10`.

### jenkins repo — no changes needed

| Area | Status |
|---|---|
| `ENABLE_FIPS_MODE` boolean param (8 job DSLs) | ✅ Pass-through only |
| `generateJobConfigs.groovy` → `execTestSuites.groovy` | ✅ Emits `--custom-config enable-fips-mode=True` — no OS-level logic |
| 8 Jenkinsfiles | ✅ Forward flag to `execTestSuites` |
| Metadata FIPS suites (`tentacle/common.yaml`, `squid/common.yaml`) | ✅ No platform filter — will work on RHEL 10 |
| `casc.yaml` `cephQeSaSvcFips` credential | ✅ Unrelated — just an SSH key name |

> **No instances of `fips-mode-setup`, `grubby`, `crypto-policies`, or `fips=1` anywhere in the jenkins repo.** All FIPS enablement happens cephci-side.

### Data flow (unchanged, works for RHEL 10)

```
Jenkins booleanParam("ENABLE_FIPS_MODE")
  → generateJobConfigs.groovy (jobConfig.enableFipsMode)
    → execTestSuites.groovy (--custom-config enable-fips-mode=True)
      → cephci run.py → install_prereq.py → utils.enable_fips_mode()
        → RHEL 10: grubby --update-kernel=DEFAULT --args="fips=1"
        → RHEL 8/9: fips-mode-setup --enable
```

### Minor observations (non-blocking)

1. **Suite inventory comments** in `cephci` still reference RHEL 9 images (e.g., `rhel-9.6-server-x86_64-xlarge.yaml`). Consider updating to point at RHEL 10 inventories when RHEL 10 FIPS runs are needed.
2. **Metadata `enable-fips-mode: true`** in `metadata/{tentacle,squid}/common.yaml` is extracted by `fetchTestSuites.py` but never merged into the pipeline's custom config by Jenkinsfiles — it relies on the job-level `ENABLE_FIPS_MODE` param instead. This is a pre-existing design gap, not related to RHEL 10.

**Bottom line:** The change on branch `fix/fips-rhel10-support` in `cephci` is sufficient. No jenkins changes needed.

test logs:

- RH10: http://10.64.24.74/logs/ceph-qe-logs/IBM/9.2/rhel-10/executor/20.2.2-297/nvmeof/2814/logs/tier_2_nvmeof_e2e_fips/
- RH9: http://10.64.24.74/logs/ceph-qe-logs//IBM/9.2/rhel-9/executor/20.2.2-297/nvmeof/2818/logs/tier_2_nvmeof_e2e_fips/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
