### PR TITLE
Add suite for unordered listing of versioned buckets with delete markers

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -390,3 +390,15 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
             monitor-consistency-bucket-stats: true
+
+  - test:
+      name: listing flat unordered versioned buckets on primary
+      desc: unordered listing of versioned bucket with delete markers
+      polarion-id: CEPH-83632954
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered_versionsing.yaml
+            timeout: 5500

--- a/suites/tentacle/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/tentacle/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -364,3 +364,15 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
             monitor-consistency-bucket-stats: true
+
+  - test:
+      name: listing flat unordered versioned buckets on primary
+      desc: unordered listing of versioned bucket with delete markers
+      polarion-id: CEPH-83632954
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered_versionsing.yaml
+            timeout: 5500


### PR DESCRIPTION
# Description

Add coverage for unordered bucket listing on a versioned bucket with delete markers. Confirm listing completes with all versions plus delete markers, then run ordered listing on the same bucket and clean up versions and the bucket.

9.1 pass log -  https://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-KW64J7/listing_flat_unordered_versioned_buckets_on_primary_0.log
8.1 pass log - https://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-EABBIT/

Jira - https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-25631

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
