### PR TITLE
Fix sanity CI not honoring metadata enable-fips-mode

### DIFF
--- a/pipeline/scripts/ci/getTestsForPipeline.py
+++ b/pipeline/scripts/ci/getTestsForPipeline.py
@@ -64,6 +64,55 @@ def fetch_from_metadata(rhcephVersion):
     return metadata_content
 
 
+# run.py reads these only through --custom-config key=value, not as top-level flags.
+CUSTOM_CONFIG_OVERRIDE_KEYS = frozenset(
+    {
+        "enable-fips-mode",
+        "enable-firewall",
+        "podman-auth-file",
+    }
+)
+
+# Metadata / Jenkins override keys that are not run.py CLI arguments.
+PIPELINE_INTERNAL_KEYS = frozenset({"cloud_type"})
+
+
+def _custom_config_value(value):
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def append_run_py_args(execute_cli, suite_args):
+    """Append run.py CLI args, mapping pipeline custom keys to --custom-config."""
+    custom_config_entries = []
+    if "custom-config" in suite_args:
+        entries = suite_args.pop("custom-config")
+        if isinstance(entries, str):
+            entries = [entries]
+        custom_config_entries.extend(entries)
+
+    for key in list(suite_args.keys()):
+        if key in CUSTOM_CONFIG_OVERRIDE_KEYS:
+            custom_config_entries.append(
+                f"{key}={_custom_config_value(suite_args.pop(key))}"
+            )
+
+    for entry in custom_config_entries:
+        execute_cli += f" --custom-config {entry}"
+
+    for key, value in suite_args.items():
+        if key in PIPELINE_INTERNAL_KEYS:
+            continue
+        if isinstance(value, list):
+            for item in value:
+                execute_cli += f" --{key} {item}"
+        else:
+            execute_cli += f" --{key} {value}"
+
+    return execute_cli
+
+
 def is_final_stage_or_tier(stage_or_tier, data):
     """
     Returns whether the current stage specified in tags is the final stage
@@ -141,12 +190,7 @@ def construct_cli(
         test_suite.update(meta_overrides)
         test_suite.update(overrides)
 
-        for k, v in test_suite.items():
-            if isinstance(v, list):
-                for item in v:
-                    execute_cli += f" --{k} {item}"
-            else:
-                execute_cli += f" --{k} {v}"
+        execute_cli = append_run_py_args(execute_cli, test_suite)
 
         test_data.update(
             {
@@ -213,6 +257,8 @@ def fetch_tests(args):
                 "tags": comma separated string containing the tags based on which the stages should be filtered,
                 "overrides": <overrides in json format, all keys accepted by run.py are supported to be overridden
                             if any key similar to --store which does not have a value it can be passed as "store": ""
+                            Pipeline keys enable-fips-mode, enable-firewall, and podman-auth-file are
+                            translated to --custom-config entries for run.py.
             }
 
             Example:

--- a/pipeline/scripts/ci/test_get_tests_for_pipeline.py
+++ b/pipeline/scripts/ci/test_get_tests_for_pipeline.py
@@ -1,0 +1,41 @@
+import importlib.util
+import os
+import sys
+
+import pytest
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), "getTestsForPipeline.py")
+spec = importlib.util.spec_from_file_location("getTestsForPipeline", MODULE_PATH)
+get_tests = importlib.util.module_from_spec(spec)
+sys.modules["getTestsForPipeline"] = get_tests
+spec.loader.exec_module(get_tests)
+
+
+def test_enable_fips_mode_metadata_maps_to_custom_config():
+    suite_args = {
+        "suite": "suites/squid/nvmeof/tier-2_nvmeof_e2e_fips.yaml",
+        "global-conf": "conf/squid/nvmeof/ceph_nvmeof_sanity.yaml",
+        "platform": "rhel-9",
+        "rhbuild": "8.1",
+        "enable-fips-mode": True,
+    }
+    cli = get_tests.append_run_py_args(".venv/bin/python run.py", suite_args)
+    assert "--custom-config enable-fips-mode=true" in cli
+    assert "--enable-fips-mode" not in cli
+    assert "enable-fips-mode" not in suite_args
+
+
+def test_custom_config_list_is_preserved():
+    suite_args = {
+        "suite": "suites/example.yaml",
+        "custom-config": ["ibm-build=True", "enable-fips-mode=true"],
+    }
+    cli = get_tests.append_run_py_args("run.py", suite_args)
+    assert "--custom-config ibm-build=True" in cli
+    assert "--custom-config enable-fips-mode=true" in cli
+
+
+def test_cloud_type_is_not_passed_to_run_py():
+    suite_args = {"suite": "suites/example.yaml", "cloud_type": "ibmc"}
+    cli = get_tests.append_run_py_args("run.py", suite_args)
+    assert "--cloud_type" not in cli


### PR DESCRIPTION
## Summary

Sanity CI runs driven by pipeline metadata do not enable FIPS even when metadata sets `enable-fips-mode: true`. The same setting works when passed manually from Jenkins via `--custom-config enable-fips-mode=true`.

This PR fixes the metadata → CLI translation in `getTestsForPipeline.py` so pipeline override keys that `run.py` only understands through `--custom-config` are mapped correctly.

## Problem

`getTestsForPipeline.py` converts metadata and Jenkins override keys directly into `run.py` CLI arguments. For example:

```yaml
overrides:
  enable-fips-mode: true
```

was translated to:

```bash
--enable-fips-mode True
```

`run.py` does not define a `--enable-fips-mode` flag. It only reads FIPS from `--custom-config enable-fips-mode=true`, which is then passed to `install_prereq.py` as `config["enable_fips_mode"]`.

Jenkins manual overrides already worked when users passed the value via `custom-config` in the overrides JSON. Metadata used a top-level `enable-fips-mode` key, so FIPS was silently ignored in sanity runs.

## Solution

- Add `append_run_py_args()` to map pipeline-only keys to `--custom-config key=value`:
  - `enable-fips-mode`
  - `enable-firewall`
  - `podman-auth-file`
- Preserve existing `custom-config` list entries from metadata or Jenkins overrides.
- Skip `cloud_type` when building the `run.py` command (pipeline-internal key, not a `run.py` argument).
- Add unit tests covering the metadata FIPS mapping, `custom-config` preservation, and `cloud_type` filtering.

## Example

**Before**
```bash
.venv/bin/python run.py --suite ... --enable-fips-mode True
```

**After**
```bash
.venv/bin/python run.py --suite ... --custom-config enable-fips-mode=true
```

## Test plan

- [x] `pytest pipeline/scripts/ci/test_get_tests_for_pipeline.py`
- [ ] Trigger a sanity CI run for a suite with metadata `enable-fips-mode: true`
- [ ] Confirm `execute_cli` in Jenkins logs contains `--custom-config enable-fips-mode=true`
- [ ] Confirm `install_prereq` logs show FIPS mode enabled on the cluster nodes

## Out of scope

The following are tracked on separate branches for follow-up:
```bash
- `fix/scheduled-executor-overrides` — PSI/IBM scheduled executor default parameter handling
- `fix/run-py-config-flag-parsing` — optional `run.py` boolean normalization for custom-config values
```

## Tests

Before
```bash
.venv/bin/python getTestsForPipeline.py \
  --rhcephVersion 9.2 \
  --tags sanity,tier-1,stage-1,ibmc \
  --overrides '{"workspace":"/tmp","build_number":1}' \
  | grep -E 'cloud ibmc|platform rhel-10|custom-config|tier-2_nvmeof_e2e_fips|ibm-eu-rhel-10'
      ci-g6ikw --log-level DEBUG --cloud ibmc
      ibmc --suite suites/tentacle/nvmeof/tier-2_nvmeof_e2e_fips.yaml --global-conf
      conf/tentacle/nvmeof/ceph_nvmeof_sanity.yaml --platform rhel-10 --rhbuild 9.2
      --inventory conf/inventory/ibm-eu-rhel-10.2.yaml --enable-fips-mode True --custom-config
```

After
```bash
.venv/bin/python getTestsForPipeline.py \ 
  --rhcephVersion 9.2 \
  --tags sanity,tier-1,stage-1,ibmc \
  --overrides '{"workspace":"/tmp","build_number":1}' \
  | grep -E 'cloud ibmc|platform rhel-10|custom-config|tier-2_nvmeof_e2e_fips|ibm-eu-rhel-10'
      ci-jfkb6 --log-level DEBUG --cloud ibmc
      ibmc --custom-config ibm-build=True --custom-config enable-fips-mode=true --suite
      suites/tentacle/nvmeof/tier-2_nvmeof_e2e_fips.yaml --global-conf conf/tentacle/nvmeof/ceph_nvmeof_sanity.yaml
      --platform rhel-10 --rhbuild 9.2 --inventory conf/inventory/ibm-eu-rhel-10.2.yaml
```

```bash
(.venv) cephci % pytest pipeline/scripts/ci/test_get_tests_for_pipeline.py -v
=========================================================================================================================== test session starts ===========================================================================================================================
platform darwin -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0 -- /github/cephci/.venv/bin/python3.14
cachedir: .pytest_cache
rootdir: /github/cephci
configfile: pytest.ini
collected 3 items                                                                                                                                                                                                                                                         

pipeline/scripts/ci/test_get_tests_for_pipeline.py::test_enable_fips_mode_metadata_maps_to_custom_config PASSED                                                                                                                                                     [ 33%]
pipeline/scripts/ci/test_get_tests_for_pipeline.py::test_custom_config_list_is_preserved PASSED                                                                                                                                                                     [ 66%]
pipeline/scripts/ci/test_get_tests_for_pipeline.py::test_cloud_type_is_not_passed_to_run_py PASSED                                                                                                                                                                  [100%]

============================================================================================================================ 3 passed in 0.01s ============================================================================================================================
```

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
