### PR TITLE
nfs: run metrics post-upgrade validation before NFS cluster cleanup

### DIFF
--- a/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
+++ b/suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml
@@ -249,6 +249,19 @@ tests:
       abort-on-fail: true
 
   - test:
+      name: Nfs Ganesha metrics validation - post_upgrade
+      module: test_nfs_ganesha_metrics_upgrade_validation.py
+      desc: Verify Enable_Metrics in ganesha.conf and monitoring port after upgrade
+      polarion-id: CEPH-83620035
+      abort-on-fail: true
+      config:
+        operation: after_upgrade
+        nfs_name: cephfs-nfs
+        monitoring_port: 9587
+        configure_metrics: false
+        ensure_monitoring_port: false
+
+  - test:
       name: NFSv4 multiple operations - post_upgrade
       module: test_nfs_multiple_operations_for_upgrade.py
       desc: NFS ops after upgrade - create, delete, write, read, rename
@@ -262,19 +275,6 @@ tests:
         file_count: 50
         dd_command_size_in_M: 10
         operation: after_upgrade
-
-  - test:
-      name: Nfs Ganesha metrics validation - post_upgrade
-      module: test_nfs_ganesha_metrics_upgrade_validation.py
-      desc: Verify Enable_Metrics in ganesha.conf and monitoring port after upgrade
-      polarion-id: CEPH-83620035
-      abort-on-fail: true
-      config:
-        operation: after_upgrade
-        nfs_name: cephfs-nfs
-        monitoring_port: 9587
-        configure_metrics: false
-        ensure_monitoring_port: false
 
   - test:
       name: Nfs Verify rm write lookups in parellel from multi clients


### PR DESCRIPTION
## Problem

`tentacle-nfs-ganesha-upgrade-ci` RH build #101 and IBM build #98 failed on `Nfs Ganesha metrics validation - post_upgrade` with:

```
Timed out after 300s waiting for NFS daemons to reach running state
```

`ceph orch ps --daemon_type nfs` returned `[]` for the full wait window.

Root cause: `NFSv4 multiple operations - post_upgrade` runs before metrics post_upgrade and always calls `cleanup_cluster()` in its `finally` block, which deletes the `cephfs-nfs` cluster. Metrics validation then waits for daemons that no longer exist.

## Solution

Reorder post-upgrade steps in `tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml` so metrics validation runs **before** the NFS post-upgrade ops test that tears down the cluster.

## Changes

- `suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml` — move `Nfs Ganesha metrics validation - post_upgrade` above `NFSv4 multiple operations - post_upgrade`

## Test suites to run

- `tentacle-test-executor` with:
  - `SUITE=suites/tentacle/nfs/tier1-nfs-ganesha-upgrade-9x-to-9x-latest.yaml`
  - `GLOBAL_CONF=conf/tentacle/nfs/1admin-7node-3client.yaml`
  - `BUILD_VERSION=9.1`, `RELEASE=rc`, `BUILD_TYPE=RH`, `RHEL_VERSION=rhel-9`
- `tentacle-nfs-ganesha-upgrade-ci` (full parallel upgrade CI)

logs: http://10.64.24.74/logs/ceph-qe-logs//RH/9.1/rhel-9/executor/20.2.1-405/nfs/2858/logs/
