### PR TITLE
Fio time optimization in HA suites in NVMEoF tests

### DIFF
--- a/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -173,7 +173,6 @@ tests:
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: NVMeoF 4-GW HA test with mTLS configuration
-      comments: product bug 2417229
       polarion-id: CEPH-83594616
 
   - test:
@@ -222,7 +221,7 @@ tests:
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: Switch NVMeoF with mTLS to Non-mTLS configuration
-      comments: product bug 2417229
+      comments: product bug IBMCEPH-14070
       polarion-id: CEPH-83595464
 
   # Non-mTLS Tests

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_hugepages_operations.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_hugepages_operations.yaml
@@ -101,6 +101,23 @@ tests:
                     group: gw_group1
                     enable_auth: false
                     spdk_mem_size: 4096
+          - config:
+              command: shell
+              args:
+                - ceph orch rm nvmeof.rbd.gw_group1
+          - config:
+              command: shell
+              args:              # sleep to get all services deleted
+                - sleep
+                - "60"
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
 
   #  Configure Ceph NVMeoF gateway
   #  Configure Initiators

--- a/tests/nvmeof/workflows/ha.py
+++ b/tests/nvmeof/workflows/ha.py
@@ -718,10 +718,20 @@ class HighAvailability:
                             )
                             validate_initiator(self.clients, active_gw_obj, ns_list, gw)
 
-                        # Wait for IO to complete and collect FIO outputs
+                        # Stop FIO and collect outputs.
+                        # cancel_futures=True only prevents queued futures from
+                        # starting; it does NOT interrupt threads already running
+                        # fio to 100%.  Kill the remote fio process on every
+                        # initiator node first so the blocked threads unblock
+                        # quickly, then shut down the pool.
                         fio_outputs = []
                         if io_tasks:
-                            LOG.info("Waiting for completion of IOs.")
+                            LOG.info(
+                                "Stopping IO on all initiator nodes before executor shutdown."
+                            )
+                            for initiator in self.clients:
+                                initiator.stop_fio()
+                            LOG.info("Shutting down IO executor.")
                             executor.shutdown(wait=True, cancel_futures=True)
 
                             for task in io_tasks:
@@ -788,10 +798,15 @@ class HighAvailability:
 
                             LOG.info("Validating IO after failback")
                             validate_io(self.orch, namespaces_for_io)
-                            # Wait for IO to complete and collect FIO outputs
+                            # Stop FIO and collect outputs (same pattern as failover).
                             fio_outputs = []
                             if io_tasks:
-                                LOG.info("Waiting for completion of IOs.")
+                                LOG.info(
+                                    "Stopping IO on all initiator nodes before executor shutdown."
+                                )
+                                for initiator in self.clients:
+                                    initiator.stop_fio()
+                                LOG.info("Shutting down IO executor.")
                                 executor.shutdown(wait=True, cancel_futures=True)
 
                                 for task in io_tasks:

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -240,14 +240,42 @@ class NVMeInitiator(Initiator):
         LOG.debug(targets)
         return targets
 
+    def stop_fio(self):
+        """Stop any running FIO processes on the client node.
+
+        Sends SIGTERM first to allow fio to flush, then SIGKILL after 5 seconds
+        if any processes remain.
+        """
+        LOG.info(f"Stopping FIO on node {self.node.hostname}")
+        try:
+            self.node.exec_command(cmd="pkill -SIGTERM fio", sudo=True)
+            sleep(5)
+        except Exception:
+            # pkill exits non-zero when no matching process is found; that is fine.
+            pass
+        try:
+            self.node.exec_command(cmd="pkill -9 fio", sudo=True)
+        except Exception:
+            pass
+        LOG.info(f"FIO stopped on node {self.node.hostname}")
+
     def start_fio(self, io_size="100%", runtime=None, paths=None, **kwargs):
         """Start FIO on the all targets on client node.
 
         Args:
             io_size: Size of the IO to be performed
+            runtime: Optional runtime in seconds; if None and io_size is set,
+                     FIO runs until io_size is fully written.
             paths: List of paths to perform IO on
+            stop_io (bool): When True, stop any running FIO processes on this
+                            node and return immediately without starting new IO.
             **kwargs: Additional arguments for FIO
         """
+        # Handle stop_io before any IO is set up.
+        if kwargs.get("stop_io"):
+            self.stop_fio()
+            return []
+
         if not paths:
             LOG.info("No paths provided, fetching all devices")
             paths = self.list_devices()


### PR DESCRIPTION
Fio time optimization in HA suites in NVMEoF tests
Currently we are waiting for 100% IO fill even our intended operations are completed
With current implementation once we are completed with intended operations, we are killing the FIO and going ahead with remaining test steps

logs after fix:- http://10.64.24.74/logs/ceph-qe-logs//IBM/9.2/rhel-10/executor/20.2.2-310/nvmeof/2876/logs/tier_2_nvmeof_4nodes_gateway_ha_tests/