### PR TITLE
Modified upgrade suites to run FIO and upgrade in parallel

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
@@ -111,8 +111,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 8
-                size: 3G
+              - count: 4
+                size: 15G
             listener_port: 4420
             listeners:
               - node6

--- a/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
@@ -108,8 +108,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 15G
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
@@ -116,8 +116,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 8
-                size: 5G
+              - count: 4
+                size: 15G
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_7x-to-9x_upgrade.yaml
@@ -110,8 +110,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 8
-                size: 5G
+              - count: 4
+                size: 15G
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_8x-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_8x-to-9x_upgrade.yaml
@@ -113,8 +113,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 8
-                size: 5G
+              - count: 4
+                size: 15G
                 ns_create_image: true
             listener_port: 4420
             allow_host: "*"

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_90-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_90-to-9x_upgrade.yaml
@@ -113,8 +113,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 8
-                size: 5G
+              - count: 4
+                size: 15G
                 ns_create_image: true
             listener_port: 4420
             allow_host: "*"

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_91-to-9x_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_91-to-9x_upgrade.yaml
@@ -113,8 +113,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-              - count: 8
-                size: 5G
+              - count: 4
+                size: 15G
                 ns_create_image: true
             listener_port: 4420
             allow_host: "*"

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
@@ -109,8 +109,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 15G
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
@@ -109,8 +109,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 8
-              size: 5G
+            - count: 4
+              size: 15G
             listener_port: 4420
             listeners:
               - node6

--- a/tests/nvmeof/test_ceph_nvmeof_upgrade.py
+++ b/tests/nvmeof/test_ceph_nvmeof_upgrade.py
@@ -214,6 +214,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     overrides = kwargs.get("test_data", {}).get("custom_config_dict")
 
     io_tasks = []
+    initiator_objs = []
     executor = ThreadPoolExecutor()
 
     try:
@@ -241,10 +242,13 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             initiator_obj = NVMeInitiator(client)
             initiator_obj.connect_targets(nvmegwcli, initiator)
             paths = initiator_obj.list_devices()
-            i = initiator_obj.start_fio(paths=paths, **initiator)
-            LOG.info(f"FIO Result: {i}")
+            LOG.info(f"Starting FIO in background on {client.hostname}, paths={paths}")
+            io_tasks.append(
+                executor.submit(initiator_obj.start_fio, paths=paths, **initiator)
+            )
+            initiator_objs.append(initiator_obj)
 
-        # Setup regisgtry
+        # Setup registry
         upg_cfg = {
             "release": upgrade.get("release") or config.get("rhbuild"),
             "cdn": upgrade["cdn"],
@@ -287,7 +291,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         LOG.error(err)
     finally:
         if io_tasks:
-            LOG.info("Waiting for completion of IOs.")
+            LOG.info("Stopping background FIO on all initiator nodes.")
+            for initiator_obj in initiator_objs:
+                initiator_obj.stop_fio()
+            LOG.info("Shutting down IO executor.")
             executor.shutdown(wait=True, cancel_futures=True)
         if config.get("cleanup"):
             teardown(nvme_service, rbd_obj)


### PR DESCRIPTION
Modified upgrade suites to run FIO and upgrade in parallel

Modified NS count and NS size because we need larger images during upgrade to fill IO
Attached the logs because couldn't create magna link

```
2026-09-09 08:22:36,730 - cephci - test_ceph_nvmeof_upgrade:245 - INFO - Starting FIO in background on ceph-nvmeof39-ll8n-76mbbq-node10, paths=['/dev/nvme1n1', '/dev/nvme1n2', '/dev/nvme1n3', '/dev/nvme1n4']
2026-09-09 08:22:36,730 - cephci - initiator:284 - INFO - Paths provided are ['/dev/nvme1n1', '/dev/nvme1n2', '/dev/nvme1n3', '/dev/nvme1n4']
2026-09-09 08:22:36,731 - cephci - test_ceph_nvmeof_upgrade:259 - INFO - Upgrade prerequisites
2026-09-09 08:22:36,731 - cephci - configs:27 - INFO - Loading config file - /Users/pjayaprakash/.cephci.yaml
2026-09-09 08:22:36,746 - cephci - configs:79 - INFO - Loading registry credentials for server 'stage' and build 'ibm'
2026-09-09 08:22:36,746 - cephci - configs:88 - INFO - Loaded registry credentials for server - cp.stg.icr.io
2026-09-09 08:22:36,993 - cephci - ceph:2006 - INFO - Execute cp /etc/ssh/sshd_config /etc/ssh/sshd_config.backup on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:37,010 - cephci - ceph:2006 - INFO - Execute podman login --username cp --password <masked> cp.stg.icr.io on ceph-nvmeof39-ll8n-76mbbq-node1-installer [10.0.65.81]
2026-09-09 08:22:38,260 - cephci - ceph:2041 - INFO - Execution of cp /etc/ssh/sshd_config /etc/ssh/sshd_config.backup took 1.266001 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:38,282 - cephci - ceph:1212 - DEBUG - Login Succeeded!
2026-09-09 08:22:38,283 - cephci - ceph:2041 - INFO - Execution of podman login --username cp --password <masked> cp.stg.icr.io took 1.272518 seconds on ceph-nvmeof39-ll8n-76mbbq-node1-installer by user root [10.0.65.81]
2026-09-09 08:22:38,528 - cephci - ceph:2006 - INFO - Execute sed -i 's/^#*MaxSessions.*/MaxSessions 18/' /etc/ssh/sshd_config on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:38,707 - cephci - ceph:2006 - INFO - Execute cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> on ceph-nvmeof39-ll8n-76mbbq-node1-installer [10.0.65.81]
2026-09-09 08:22:39,809 - cephci - ceph:2041 - INFO - Execution of sed -i 's/^#*MaxSessions.*/MaxSessions 18/' /etc/ssh/sshd_config took 1.279783 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:39,976 - cephci - ceph:2041 - INFO - Execution of cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> took 1.268997 seconds on ceph-nvmeof39-ll8n-76mbbq-node1-installer by user root [10.0.65.81]
2026-09-09 08:22:39,977 - cephci - registry_login:61 - DEBUG - 
2026-09-09 08:22:40,070 - cephci - ceph:2006 - INFO - Execute grep -q '^MaxSessions' /etc/ssh/sshd_config || echo 'MaxSessions 18' >> /etc/ssh/sshd_config on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:40,237 - cephci - ceph:2006 - INFO - Execute podman login --username cp --password <masked> cp.stg.icr.io on ceph-nvmeof39-ll8n-76mbbq-node2 [10.0.64.167]
2026-09-09 08:22:41,337 - cephci - ceph:2041 - INFO - Execution of grep -q '^MaxSessions' /etc/ssh/sshd_config || echo 'MaxSessions 18' >> /etc/ssh/sshd_config took 1.26695 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:41,504 - cephci - ceph:1212 - DEBUG - Login Succeeded!
2026-09-09 08:22:41,505 - cephci - ceph:2041 - INFO - Execution of podman login --username cp --password <masked> cp.stg.icr.io took 1.266867 seconds on ceph-nvmeof39-ll8n-76mbbq-node2 by user root [10.0.64.167]
2026-09-09 08:22:41,601 - cephci - ceph:2006 - INFO - Execute systemctl restart sshd on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:41,971 - cephci - ceph:2006 - INFO - Execute cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> on ceph-nvmeof39-ll8n-76mbbq-node2 [10.0.64.167]
2026-09-09 08:22:42,866 - cephci - ceph:2041 - INFO - Execution of systemctl restart sshd took 1.264331 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:42,867 - cephci - initiator:351 - INFO - Configured SSH MaxSessions to 18 for max_workers=8
2026-09-09 08:22:43,236 - cephci - ceph:2041 - INFO - Execution of cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> took 1.264969 seconds on ceph-nvmeof39-ll8n-76mbbq-node2 by user root [10.0.64.167]
2026-09-09 08:22:43,237 - cephci - registry_login:61 - DEBUG - 
2026-09-09 08:22:43,497 - cephci - ceph:2006 - INFO - Execute podman login --username cp --password <masked> cp.stg.icr.io on ceph-nvmeof39-ll8n-76mbbq-node3 [10.0.67.84]
2026-09-09 08:22:44,763 - cephci - ceph:1212 - DEBUG - Login Succeeded!
2026-09-09 08:22:44,764 - cephci - ceph:2041 - INFO - Execution of podman login --username cp --password <masked> cp.stg.icr.io took 1.266526 seconds on ceph-nvmeof39-ll8n-76mbbq-node3 by user root [10.0.67.84]
2026-09-09 08:22:45,069 - cephci - ceph:2006 - INFO - Execute cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> on ceph-nvmeof39-ll8n-76mbbq-node3 [10.0.67.84]
2026-09-09 08:22:46,131 - cephci - ceph:2006 - INFO - Execute blkdiscard /dev/nvme1n1 on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:46,332 - cephci - ceph:2041 - INFO - Execution of cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> took 1.26283 seconds on ceph-nvmeof39-ll8n-76mbbq-node3 by user root [10.0.67.84]
2026-09-09 08:22:46,333 - cephci - registry_login:61 - DEBUG - 
2026-09-09 08:22:46,593 - cephci - ceph:2006 - INFO - Execute podman login --username cp --password <masked> cp.stg.icr.io on ceph-nvmeof39-ll8n-76mbbq-node4 [10.0.65.160]
2026-09-09 08:22:47,396 - cephci - ceph:2041 - INFO - Execution of blkdiscard /dev/nvme1n1 took 1.264887 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:47,397 - cephci - utils:2378 - DEBUG - Config Received for fio: {'size': '100%', 'device_name': '/dev/nvme1n1', 'client_node': <ceph.ceph.CephNode object at 0x1092c1b50>, 'long_running': True, 'cmd_timeout': 'notimeout', 'verbose': True}
2026-09-09 08:22:47,667 - cephci - ceph:2006 - INFO - Execute blkdiscard /dev/nvme1n2 on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:47,869 - cephci - ceph:1212 - DEBUG - Login Succeeded!
2026-09-09 08:22:47,869 - cephci - ceph:2041 - INFO - Execution of podman login --username cp --password <masked> cp.stg.icr.io took 1.275478 seconds on ceph-nvmeof39-ll8n-76mbbq-node4 by user root [10.0.65.160]
2026-09-09 08:22:47,932 - cephci - ceph:2006 - INFO - Execute fio  --ioengine libaio --filename /dev/nvme1n1 --size 100% --name test-1 --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:48,309 - cephci - ceph:2006 - INFO - Execute cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> on ceph-nvmeof39-ll8n-76mbbq-node4 [10.0.65.160]
2026-09-09 08:22:49,197 - cephci - ceph:2041 - INFO - Execution of blkdiscard /dev/nvme1n2 took 1.529255 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:49,198 - cephci - utils:2378 - DEBUG - Config Received for fio: {'size': '100%', 'device_name': '/dev/nvme1n2', 'client_node': <ceph.ceph.CephNode object at 0x1092c1b50>, 'long_running': True, 'cmd_timeout': 'notimeout', 'verbose': True}
2026-09-09 08:22:49,463 - cephci - ceph:1212 - DEBUG - test-1: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=8
2026-09-09 08:22:49,463 - cephci - ceph:2006 - INFO - Execute blkdiscard /dev/nvme1n3 on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:49,464 - cephci - ceph:1212 - DEBUG - fio-3.36
2026-09-09 08:22:49,464 - cephci - ceph:1212 - DEBUG - Starting 1 process
2026-09-09 08:22:49,609 - cephci - ceph:2041 - INFO - Execution of cephadm registry-login  --registry-url cp.stg.icr.io --registry-username cp --registry-password <masked> took 1.299228 seconds on ceph-nvmeof39-ll8n-76mbbq-node4 by user root [10.0.65.160]
2026-09-09 08:22:49,610 - cephci - registry_login:61 - DEBUG - 
2026-09-09 08:22:49,727 - cephci - ceph:2006 - INFO - Execute fio  --ioengine libaio --filename /dev/nvme1n2 --size 100% --name test-1 --numjobs 1 --rw write --iodepth 8 --fsync 32 --group_reporting --bs 4k on ceph-nvmeof39-ll8n-76mbbq-node10 [10.0.65.228]
2026-09-09 08:22:49,871 - cephci - ceph:2006 - INFO - Execute podman login --username cp --password <masked> cp.stg.icr.io on ceph-nvmeof39-ll8n-76mbbq-node5 [10.0.67.141]
2026-09-09 08:22:50,991 - cephci - ceph:2041 - INFO - Execution of blkdiscard /dev/nvme1n3 took 1.527486 seconds on ceph-nvmeof39-ll8n-76mbbq-node10 by user root [10.0.65.228]
2026-09-09 08:22:50,993 - cephci - utils:2378 - DEBUG - Config Received for fio: {'size': '100%', 'device_name': '/dev/nvme1n3', 'client_node': <ceph.ceph.CephNode object at 0x1092c1b50>, 'long_running': True, 'cmd_timeout': 'notimeout', 'verbose': True}
2026-09-09 08:22:51,142 - cephci - ceph:1212 - DEBUG - Login Succeeded!
2026-09-09 08:22:51,143 - cephci - ceph:2041 - INFO - Execution of podman login --username cp --password <masked> cp.stg.icr.io took 1.271601 seconds on ceph-nvmeof39-ll8n-76mbbq-node5 by user root [10.0.67.141]
2026-09-09 08:22:51,255 - cephci - ceph:1212 - DEBUG - test-1: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=8
2026-09-09 08:22:51,256 - cephci - ceph:1212 - DEBUG - fio-3.36
2026-09-09 08:22:51,256 - cephci - ceph:1212 - DEBUG - Starting 1 process
```

[Upgrade_Cluster_to_latest_9.x_from_9.0_CDN_ceph_version_0.log](https://github.com/user-attachments/files/31996011/Upgrade_Cluster_to_latest_9.x_from_9.0_CDN_ceph_version_0.log)
