### PR TITLE
[CephFS]: fix subvolume metrics used_bytes assert and disruptive-ops waits

### DIFF
--- a/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
@@ -123,20 +123,45 @@ def _validate_metrics(
     log.info("Collecting metrics for stage: %s", stage)
     quota_attrs = fs_util.get_quota_attrs(client, fuse_mount_dir)
     expected_quota_bytes = int(quota_attrs.get("bytes", 0))
-    subvol_metrics = helper.collect_subvolume_metrics(
-        client=client,
-        fs_name=fs_name,
-        role="active",
-        ranks=None,
-        path_prefix=subvol_path,
-    )
+
+    # stage is the op label, e.g. "after MDS node reboot".
+    # After MDS restart/reboot the dump list starts empty until the next write
+    # lands on the new MDS. HEALTH_OK is not that moment, so retry the dump.
+    # @retry: first dump immediately, then every 30s (backoff=1, not 2).
+    # Last try starts at (21 - 1) * 30s = 600s (~10 min).
+    @retry(RuntimeError, tries=21, delay=30, backoff=1)
+    def _wait_for_subvol_metrics():
+        results = helper.collect_subvolume_metrics(
+            client=client,
+            fs_name=fs_name,
+            role="active",
+            ranks=None,
+            path_prefix=subvol_path,
+        )
+        # results is {mds_name: [rows]}. {} does not only mean "no MDS":
+        # collect_subvolume_metrics omits keys with no rows, so {} also happens
+        # when there is no active MDS yet, every dump failed, or the dump had
+        # no matching metrics (new MDS has not seen IO yet).
+        if not results:
+            raise RuntimeError(
+                f"{stage}: metrics dump has no MDS entries (empty dict)"
+            )
+        # Unlikely with current collect_subvolume_metrics (it does not store
+        # empty lists). Kept if a caller ever returns {mds: []}.
+        metric_rows = [row for rows in results.values() for row in rows]
+        if not metric_rows:
+            raise RuntimeError(
+                f"{stage}: dump listed MDS daemon(s) but none had subvolume "
+                "metrics yet (list empty until IO is seen on the new MDS)"
+            )
+        return results
+
+    subvol_metrics = _wait_for_subvol_metrics()
     log.info(
         "%s: expected values from CLI quota_bytes=%s",
         stage,
         expected_quota_bytes,
     )
-    if not subvol_metrics:
-        raise RuntimeError(f"{stage}: subvolume metrics are empty")
 
     found_subvol_item = False
     for mds_name, items in subvol_metrics.items():

--- a/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
@@ -27,9 +27,46 @@ def _get_unique_mds_hosts(ceph_cluster) -> List[str]:
 
 
 def _wait_for_mds_daemon_count(
-    client, fs_name: str, expected_count: int, timeout: int = 240
+    client,
+    fs_name: str,
+    expected_count: int,
+    timeout: int = 240,
+    match: str = "gte",
 ):
+    """
+    Wait until orch MDS daemons for fs_name satisfy expected_count.
+
+    Only daemons whose id starts with ``{fs_name}.`` and whose
+    ``status_desc`` is ``running`` are counted.
+
+    ``match`` exists because a single ``>= expected_count`` check is wrong
+    for scale-down. After ``ceph orch apply`` shrinks placement (e.g. 3
+    hosts -> 2), 3 daemons may still be running. ``3 >= 2`` would return
+    immediately, the next apply (2 -> 3) would race orch, and add would
+    time out waiting for 3 running MDS.
+
+    Args:
+        client: Ceph client node used to run ``ceph orch ps``.
+        fs_name: Filesystem whose MDS daemons to count.
+        expected_count: Target number of running MDS daemons.
+        timeout: Seconds to poll before giving up (default 240).
+        match: How to compare the running count to expected_count.
+            ``gte`` — ``running >= expected_count``. Use for setup and
+            scale-up: "at least N are up" (placing 3 hosts but only
+            requiring 2 is enough to continue).
+            ``eq`` — ``running == expected_count``. Use after remove so
+            shrink has finished before add, and after add so the count
+            is back to the original placement.
+
+    Returns:
+        0 if the condition matched within timeout, else 1.
+    """
+    if match not in ("gte", "eq"):
+        raise ValueError(f"match must be 'gte' or 'eq', got {match!r}")
+
     end_time = time.time() + timeout
+    last_fs_daemons = []
+    last_running = 0
     while time.time() < end_time:
         out, _ = client.exec_command(
             sudo=True,
@@ -37,15 +74,40 @@ def _wait_for_mds_daemon_count(
             check_ec=False,
         )
         daemons = json.loads(out)
-        running = [
-            d
-            for d in daemons
-            if d.get("daemon_id", "").startswith(f"{fs_name}.")
-            and d.get("status_desc") == "running"
+        fs_daemons = [
+            d for d in daemons if d.get("daemon_id", "").startswith(f"{fs_name}.")
         ]
-        if len(running) >= expected_count:
+        running = [d for d in fs_daemons if d.get("status_desc") == "running"]
+        last_fs_daemons = fs_daemons
+        last_running = len(running)
+        matched = (
+            last_running >= expected_count
+            if match == "gte"
+            else last_running == expected_count
+        )
+        if matched:
+            log.info(
+                "MDS count wait matched: match=%s expected=%s running=%s",
+                match,
+                expected_count,
+                last_running,
+            )
             return 0
+        log.info(
+            "MDS count wait: match=%s expected=%s running=%s statuses=%s",
+            match,
+            expected_count,
+            last_running,
+            [(d.get("daemon_id"), d.get("status_desc")) for d in fs_daemons],
+        )
         time.sleep(10)
+    log.error(
+        "MDS count wait failed: match=%s expected=%s running=%s daemons=%s",
+        match,
+        expected_count,
+        last_running,
+        [(d.get("daemon_id"), d.get("status_desc")) for d in last_fs_daemons],
+    )
     return 1
 
 
@@ -241,6 +303,7 @@ def run(ceph_cluster, **kw):
                 sudo=True,
                 cmd=f"ceph orch apply mds {fs_name} --placement='{len(selected_hosts)} {placement}'",
             )
+            # Default match="gte": placement may be 3 hosts; continue once at least 2 are running.
             if _wait_for_mds_daemon_count(client, fs_name, expected_count=2):
                 raise RuntimeError(
                     "MDS daemons did not reach expected count after placement apply"
@@ -373,8 +436,13 @@ def run(ceph_cluster, **kw):
                 sudo=True,
                 cmd=f"ceph orch apply mds {fs_name} --placement='{len(reduced_hosts)} {reduced_placement}'",
             )
+            # match="eq": wait until running count has actually dropped (not >= reduced).
+            # Otherwise add is issued while 3 MDS are still up and orch races.
             if _wait_for_mds_daemon_count(
-                client, fs_name, expected_count=len(reduced_hosts)
+                client,
+                fs_name,
+                expected_count=len(reduced_hosts),
+                match="eq",
             ):
                 raise RuntimeError("MDS count did not converge after remove operation")
 
@@ -383,8 +451,12 @@ def run(ceph_cluster, **kw):
                 cmd=f"ceph orch apply mds {fs_name} --placement='{len(fs_hosts)} {full_placement}'",
             )
 
+            # match="eq": original host count must be running again before metrics check.
             if _wait_for_mds_daemon_count(
-                client, fs_name, expected_count=len(fs_hosts)
+                client,
+                fs_name,
+                expected_count=len(fs_hosts),
+                match="eq",
             ):
                 out, _ = client.exec_command(
                     sudo=True,

--- a/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 from looseversion import LooseVersion
 
+from ceph.ceph import CommandFailed, SocketTimeoutException
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from tests.cephfs.lib.cephfs_subvol_metric_utils import MDSMetricsHelper
@@ -68,12 +69,22 @@ def _wait_for_mds_daemon_count(
     last_fs_daemons = []
     last_running = 0
     while time.time() < end_time:
-        out, _ = client.exec_command(
-            sudo=True,
-            cmd="ceph orch ps --daemon_type=mds --format json",
-            check_ec=False,
-        )
-        daemons = json.loads(out)
+        try:
+            out, _ = client.exec_command(
+                sudo=True,
+                cmd="ceph orch ps --daemon_type=mds --format json",
+                check_ec=False,
+                timeout=60,
+            )
+        except (CommandFailed, SocketTimeoutException):
+            log.info("ceph orch ps MDS list timed out or failed; retrying")
+            out = ""
+        try:
+            daemons = json.loads(out) if out else []
+        except json.JSONDecodeError:
+            daemons = []
+        if not isinstance(daemons, list):
+            daemons = []
         fs_daemons = [
             d for d in daemons if d.get("daemon_id", "").startswith(f"{fs_name}.")
         ]
@@ -119,6 +130,10 @@ def _wait_for_orch_host_not_offline(client, hostname: str, timeout: int = 600):
     Background refresh skips those hosts. ``--refresh`` forces mgr SSH
     (cephadm ls); a successful probe clears offline and updates cache.
 
+    Each ``--refresh`` is capped at 60s so a stuck mgr SSH cannot consume
+    this waiter's 600s budget in a single poll. Timeout raises; catch it and
+    keep polling.
+
     Returns:
         0 when at least one daemon is listed and none have status_desc
         ``host is offline``, else 1.
@@ -126,11 +141,19 @@ def _wait_for_orch_host_not_offline(client, hostname: str, timeout: int = 600):
     end_time = time.time() + timeout
     last_statuses = []
     while time.time() < end_time:
-        out, _ = client.exec_command(
-            sudo=True,
-            cmd=f"ceph orch ps {hostname} --refresh --format json",
-            check_ec=False,
-        )
+        try:
+            out, _ = client.exec_command(
+                sudo=True,
+                cmd=f"ceph orch ps {hostname} --refresh --format json",
+                check_ec=False,
+                timeout=60,
+            )
+        except (CommandFailed, SocketTimeoutException):
+            log.info(
+                "Orch ps --refresh for %s timed out or failed; retrying",
+                hostname,
+            )
+            out = ""
         try:
             daemons = json.loads(out) if out else []
         except json.JSONDecodeError:
@@ -570,7 +593,10 @@ def run(ceph_cluster, **kw):
                 fuse_mount_dir=fuse_mount_dir,
             )
 
-        log.info("All disruptive operations completed.")
+        log.info(
+            "TEST PASSED CEPH-83632428: metrics validated after MDS restart, "
+            "MGR restart, MDS reboot, and MDS remove-add"
+        )
         if stop_event:
             stop_event.set()
         if io_thread and io_thread.is_alive():

--- a/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
@@ -111,6 +111,58 @@ def _wait_for_mds_daemon_count(
     return 1
 
 
+def _wait_for_orch_host_not_offline(client, hostname: str, timeout: int = 600):
+    """
+    After test SSH is back, mgr can still list the host as offline.
+
+    ``ceph orch ps`` paints ``host is offline`` from mgr ``offline_hosts``.
+    Background refresh skips those hosts. ``--refresh`` forces mgr SSH
+    (cephadm ls); a successful probe clears offline and updates cache.
+
+    Returns:
+        0 when at least one daemon is listed and none have status_desc
+        ``host is offline``, else 1.
+    """
+    end_time = time.time() + timeout
+    last_statuses = []
+    while time.time() < end_time:
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=f"ceph orch ps {hostname} --refresh --format json",
+            check_ec=False,
+        )
+        try:
+            daemons = json.loads(out) if out else []
+        except json.JSONDecodeError:
+            daemons = []
+        if not isinstance(daemons, list):
+            daemons = []
+        last_statuses = [
+            (d.get("daemon_id"), d.get("status_desc")) for d in daemons
+        ]
+        offline = [d for d in daemons if d.get("status_desc") == "host is offline"]
+        if daemons and not offline:
+            log.info(
+                "Orch host %s is no longer offline after refresh; daemons=%s",
+                hostname,
+                last_statuses,
+            )
+            return 0
+        log.info(
+            "Orch host %s still offline or empty after refresh: %s",
+            hostname,
+            last_statuses,
+        )
+        time.sleep(10)
+    log.error(
+        "Orch host %s still offline after %ss: %s",
+        hostname,
+        timeout,
+        last_statuses,
+    )
+    return 1
+
+
 def _validate_metrics(
     stage: str,
     helper: MDSMetricsHelper,
@@ -431,6 +483,12 @@ def run(ceph_cluster, **kw):
                 raise RuntimeError("Active MDS node not found for reboot operation")
             fs_util.reboot_node(ceph_node=active_mds_node)
             log.info("Rebooted active MDS node: %s", active_host)
+            # Test SSH is back; orch may still show host is offline until mgr
+            # SSH succeeds. --refresh forces that probe before remove-add.
+            if _wait_for_orch_host_not_offline(client, active_host):
+                raise RuntimeError(
+                    f"Orch still reports host {active_host} offline after reboot"
+                )
 
         def _remove_add_mds_service():
             out, _ = client.exec_command(

--- a/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
+++ b/tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py
@@ -137,9 +137,7 @@ def _wait_for_orch_host_not_offline(client, hostname: str, timeout: int = 600):
             daemons = []
         if not isinstance(daemons, list):
             daemons = []
-        last_statuses = [
-            (d.get("daemon_id"), d.get("status_desc")) for d in daemons
-        ]
+        last_statuses = [(d.get("daemon_id"), d.get("status_desc")) for d in daemons]
         offline = [d for d in daemons if d.get("status_desc") == "host is offline"]
         if daemons and not offline:
             log.info(
@@ -195,9 +193,7 @@ def _validate_metrics(
         # when there is no active MDS yet, every dump failed, or the dump had
         # no matching metrics (new MDS has not seen IO yet).
         if not results:
-            raise RuntimeError(
-                f"{stage}: metrics dump has no MDS entries (empty dict)"
-            )
+            raise RuntimeError(f"{stage}: metrics dump has no MDS entries (empty dict)")
         # Unlikely with current collect_subvolume_metrics (it does not store
         # empty lists). Kept if a caller ever returns {mds: []}.
         metric_rows = [row for rows in results.values() for row in rows]

--- a/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
+++ b/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
@@ -82,7 +82,7 @@ def run(ceph_cluster, **kw):
     2. Remove quota via set_quota_attrs(client, "0", "0", mount_dir);
        verify quota_bytes in metrics is updated (0 for unlimited) and
        used_bytes == bytes_used + baseline.
-    3. Add 2G more data, then apply quota 5G via set_quota_attrs.
+    3. Apply quota 5G via set_quota_attrs, then add 2G more data.
     4. Verify quota_bytes = 5G and used_bytes == bytes_used + baseline.
 
     Returns 0 on success, 1 on failure.
@@ -273,7 +273,7 @@ def run(ceph_cluster, **kw):
             parent_rbytes_baseline,
         )
 
-        # Step 3: Add 2G more data (total 4G), then apply quota 5G via set_quota_attrs
+        # Step 3: Apply quota 5G, then add 2G more data (total 4G)
         log.info("Step 3: Set quota to 5G on mount, add 2G more data")
 
         log.info("Setting quota on %s: 5G bytes", fuse_mount_dir)

--- a/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
+++ b/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
@@ -80,7 +80,8 @@ def run(ceph_cluster, **kw):
        capture parent ceph.dir.rbytes as baseline, fill 2G data, verify quota_bytes
        in subvol metrics = 3G and used_bytes == subvolume info bytes_used + baseline.
     2. Remove quota via set_quota_attrs(client, "0", "0", mount_dir);
-       verify quota_bytes in metrics is 0 and used_bytes == bytes_used + baseline.
+       verify quota_bytes in metrics is updated (0 for unlimited) and
+       used_bytes == bytes_used + baseline.
     3. Add 2G more data, then apply quota 5G via set_quota_attrs.
     4. Verify quota_bytes = 5G and used_bytes == bytes_used + baseline.
 
@@ -249,6 +250,8 @@ def run(ceph_cluster, **kw):
         expected_metrics_used = helper.expected_metrics_used_bytes(
             expected_used_bytes, parent_rbytes_baseline
         )
+        # Unlimited quota is typically reported as 0 in Ceph
+        log.info("Step 2: quota_bytes after unlimited = %s", quota_bytes)
         if quota_bytes != 0:
             log.error("Step 2: Expected 0 for unlimited; got %s", quota_bytes)
             return 1
@@ -262,7 +265,9 @@ def run(ceph_cluster, **kw):
             )
             return 1
         log.info(
-            "Step 2 Passed: used_bytes = %s (bytes_used=%s baseline=%s)",
+            "Step 2 Passed: quota_bytes = %s (0 for unlimited), used_bytes = %s "
+            "(bytes_used=%s baseline=%s)",
+            quota_bytes,
             used_bytes,
             expected_used_bytes,
             parent_rbytes_baseline,

--- a/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
+++ b/tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py
@@ -8,7 +8,7 @@ import random
 import string
 import time
 import traceback
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict
 
 from looseversion import LooseVersion
 
@@ -25,26 +25,33 @@ QUOTA_5G = 5 * 1024 * 1024 * 1024  # 5368709120
 DATA_2G = 2 * 1024 * 1024 * 1024  # 2147483648
 
 
-def _get_quota_and_used_from_metrics(
-    helper: MDSMetricsHelper,
-    client,
-    default_fs: str,
-    subvol_path: str,
-    ranks: Optional[List[int]] = None,
-) -> Optional[Tuple[int, int]]:
-    """Collect subvolume metrics and return (quota_bytes, used_bytes) for the subvolume (first match)."""
-    results = helper.collect_subvolume_metrics(
-        client=client,
-        fs_name=default_fs,
-        role="active",
-        ranks=ranks or [0],
-        path_prefix=subvol_path,
+def _log_used_mismatch(
+    step: str,
+    used_bytes: int,
+    expected_metrics_used: int,
+    bytes_used: int,
+    baseline: int,
+):
+    """Fail path for used_bytes: stuck at parent baseline vs other mismatch."""
+    if used_bytes == baseline and expected_metrics_used != baseline:
+        log.error(
+            "%s: metrics used_bytes still at parent baseline %s after wait; "
+            "expected %s (bytes_used=%s)",
+            step,
+            baseline,
+            expected_metrics_used,
+            bytes_used,
+        )
+        return
+    log.error(
+        "%s: used_bytes mismatch used_bytes=%s, "
+        "expected bytes_used+baseline=%s (bytes_used=%s baseline=%s)",
+        step,
+        used_bytes,
+        expected_metrics_used,
+        bytes_used,
+        baseline,
     )
-    for _mds_name, items in results.items():
-        for it in items:
-            if "quota_bytes" in it and "used_bytes" in it:
-                return (int(it["quota_bytes"]), int(it["used_bytes"]))
-    return None
 
 
 def _fill_data(
@@ -69,12 +76,13 @@ def run(ceph_cluster, **kw):
     is varied from limited (non-zero) to unlimited and back to limited.
 
     Test steps:
-    1. Create subvolume with size 4G, mount, apply quota 3G via set_quota_attrs;
-       fill 2G data, verify quota_bytes in subvol metrics = 3G and used_bytes matches du -sb.
+    1. Create subvolume with size 4G, mount UUID + parent paths, apply quota 3G;
+       capture parent ceph.dir.rbytes as baseline, fill 2G data, verify quota_bytes
+       in subvol metrics = 3G and used_bytes == subvolume info bytes_used + baseline.
     2. Remove quota via set_quota_attrs(client, "0", "0", mount_dir);
-       verify quota_bytes in metrics is updated (0 for unlimited) and used_bytes matches du -sb.
+       verify quota_bytes in metrics is 0 and used_bytes == bytes_used + baseline.
     3. Add 2G more data, then apply quota 5G via set_quota_attrs.
-    4. Rerun subvolume metrics fetch and verify quota_bytes = 5G and used_bytes matches du -sb.
+    4. Verify quota_bytes = 5G and used_bytes == bytes_used + baseline.
 
     Returns 0 on success, 1 on failure.
     """
@@ -103,10 +111,13 @@ def run(ceph_cluster, **kw):
     ranks = [0]
     subvol_created = False
     fs_created = False
+    subv_metrics_window_interval_def = None
     mounting_dir = "".join(
         random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
     )
     fuse_mount_dir = f"/mnt/cephfs_fuse{mounting_dir}/"
+    parent_mount_dir = f"/mnt/cephfs_fuse{mounting_dir}_parent/"
+    parent_rbytes_baseline = 0
 
     try:
         fs_util.prepare_clients(clients, build)
@@ -137,6 +148,20 @@ def run(ceph_cluster, **kw):
             fuse_mount_dir,
             extra_params=f" -r {subvol_path} --client_fs {vol_name}",
         )
+        parent_path = helper.parent_subvol_path(subvol_path)
+        log.info("Parent path for rbytes/metrics: %s", parent_path)
+        fs_util.fuse_mount(
+            [client],
+            parent_mount_dir,
+            extra_params=f" -r {parent_path} --client_fs {vol_name}",
+        )
+
+        def _bytes_used() -> int:
+            info = fs_util.get_subvolume_info(
+                client, vol_name=vol_name, subvol_name=subvol_name
+            )
+            return int(info.get("bytes_used", 0) or 0)
+
         # set subvol metrics sliding window to 60sec
         out, _ = client.exec_command(
             sudo=True,
@@ -151,20 +176,35 @@ def run(ceph_cluster, **kw):
         fs_util.set_quota_attrs(client, "1000", QUOTA_3G, fuse_mount_dir)
         # wait for quota changes
         time.sleep(10)
+        parent_rbytes_baseline = helper.get_dir_rbytes(client, parent_mount_dir)
+        log.info(
+            "Captured parent rbytes baseline=%s (UUID rbytes=%s)",
+            parent_rbytes_baseline,
+            helper.get_dir_rbytes(client, fuse_mount_dir),
+        )
         # Step 1: Quota is 3G. Fill 2G and verify quota_bytes and used_bytes in metrics
         log.info(
-            "Step 1: Fill 2G data and verify quota_bytes = 3G and used_bytes vs du"
+            "Step 1: Fill 2G data and verify quota_bytes = 3G and "
+            "used_bytes == bytes_used + parent rbytes baseline"
         )
         if _fill_data(client, fuse_mount_dir, DATA_2G, "data_2g_1.bin") != 0:
             return 1
-        time.sleep(2)
-        result = _get_quota_and_used_from_metrics(
-            helper, client, default_fs, subvol_path, ranks
+        waited = helper.wait_for_metrics_used_bytes(
+            client,
+            default_fs,
+            subvol_path,
+            parent_rbytes_baseline,
+            _bytes_used,
+            expected_quota=QUOTA_3G,
+            ranks=ranks,
         )
-        if result is None:
+        if waited is None:
             log.error("Step 1: No subvolume metrics with quota_bytes/used_bytes found")
             return 1
-        quota_bytes, used_bytes = result
+        quota_bytes, used_bytes, expected_used_bytes = waited
+        expected_metrics_used = helper.expected_metrics_used_bytes(
+            expected_used_bytes, parent_rbytes_baseline
+        )
         if quota_bytes != QUOTA_3G:
             log.error(
                 "Step 1: quota_bytes mismatch: expected %s (3G), got %s",
@@ -172,64 +212,61 @@ def run(ceph_cluster, **kw):
                 quota_bytes,
             )
             return 1
-        subvol_info = fs_util.get_subvolume_info(
-            client, vol_name=vol_name, subvol_name=subvol_name
-        )
-        expected_used_bytes = subvol_info.get("bytes_used", 0)
-        if expected_used_bytes is None:
-            return 1
-        if used_bytes != expected_used_bytes:
-            log.error(
-                "Step 1: used_bytes mismatch with expected_used_bytes used_bytes=%s, expected_used_bytes=%s",
+        if used_bytes != expected_metrics_used:
+            _log_used_mismatch(
+                "Step 1",
                 used_bytes,
+                expected_metrics_used,
                 expected_used_bytes,
+                parent_rbytes_baseline,
             )
             return 1
         log.info(
-            "Step 1 Passed: quota_bytes = %s (3G), used_bytes = %s",
+            "Step 1 Passed: quota_bytes = %s (3G), used_bytes = %s "
+            "(bytes_used=%s baseline=%s)",
             quota_bytes,
             used_bytes,
+            expected_used_bytes,
+            parent_rbytes_baseline,
         )
 
         # Step 2: Remove quota (set to unlimited via set_quota_attrs 0,0), verify metrics update
         log.info("Step 2: Remove quota on mount (set_quota_attrs 0, 0)")
         fs_util.set_quota_attrs(client, "0", "0", fuse_mount_dir)
-        time.sleep(2)
-        retry_cnt = 0
-        while retry_cnt < 10:
-
-            result = _get_quota_and_used_from_metrics(
-                helper, client, default_fs, subvol_path, ranks
-            )
-            if result is None:
-                log.error(
-                    "Step 2: No subvolume metrics with quota_bytes/used_bytes found"
-                )
-                return 1
-            quota_bytes, used_bytes = result
-            # Unlimited quota is typically reported as 0 in Ceph
-            log.info("Step 2: quota_bytes after unlimited = %s", quota_bytes)
-            if quota_bytes != 0:
-                retry_cnt += 1
-                time.sleep(2)
-                continue
-            else:
-                break
+        waited = helper.wait_for_metrics_used_bytes(
+            client,
+            default_fs,
+            subvol_path,
+            parent_rbytes_baseline,
+            _bytes_used,
+            expected_quota=0,
+            ranks=ranks,
+        )
+        if waited is None:
+            log.error("Step 2: No subvolume metrics with quota_bytes/used_bytes found")
+            return 1
+        quota_bytes, used_bytes, expected_used_bytes = waited
+        expected_metrics_used = helper.expected_metrics_used_bytes(
+            expected_used_bytes, parent_rbytes_baseline
+        )
         if quota_bytes != 0:
             log.error("Step 2: Expected 0 for unlimited; got %s", quota_bytes)
             return 1
-        subvol_info = fs_util.get_subvolume_info(
-            client, vol_name=vol_name, subvol_name=subvol_name
-        )
-        expected_used_bytes = subvol_info.get("bytes_used", 0)
-        if used_bytes != expected_used_bytes:
-            log.error(
-                "Step 2: used_bytes mismatch with expected_used_bytes used_bytes=%s, expected_used_bytes=%s",
+        if used_bytes != expected_metrics_used:
+            _log_used_mismatch(
+                "Step 2",
                 used_bytes,
+                expected_metrics_used,
                 expected_used_bytes,
+                parent_rbytes_baseline,
             )
             return 1
-        log.info("Step 2 Passed: used_bytes = %s", used_bytes)
+        log.info(
+            "Step 2 Passed: used_bytes = %s (bytes_used=%s baseline=%s)",
+            used_bytes,
+            expected_used_bytes,
+            parent_rbytes_baseline,
+        )
 
         # Step 3: Add 2G more data (total 4G), then apply quota 5G via set_quota_attrs
         log.info("Step 3: Set quota to 5G on mount, add 2G more data")
@@ -238,42 +275,27 @@ def run(ceph_cluster, **kw):
         fs_util.set_quota_attrs(client, "1000", QUOTA_5G, fuse_mount_dir)
         if _fill_data(client, fuse_mount_dir, DATA_2G, "data_2g_2.bin") != 0:
             return 1
-        time.sleep(2)
 
-        # Step 4: Rerun metrics fetch and verify quota_bytes = 5G and used_bytes vs du
+        # Step 4: Rerun metrics fetch and verify quota_bytes = 5G and used_bytes
         log.info(
-            "Step 4: Verify quota_bytes = 5G and used_bytes vs expected_used_bytes in subvolume metrics"
+            "Step 4: Verify quota_bytes = 5G and used_bytes == bytes_used + baseline"
         )
-        retry_cnt = 0
-        while retry_cnt < 10:
-            subvol_info = fs_util.get_subvolume_info(
-                client, vol_name=vol_name, subvol_name=subvol_name
-            )
-            expected_used_bytes = subvol_info.get("bytes_used", 0)
-            result = _get_quota_and_used_from_metrics(
-                helper, client, default_fs, subvol_path, ranks
-            )
-            if result is None:
-                log.error(
-                    "Step 4: No subvolume metrics with quota_bytes/used_bytes found"
-                )
-                return 1
-            quota_bytes, used_bytes = result
-            log.info(
-                "Step 4: quota_bytes = %s (5G), used_bytes = %s",
-                quota_bytes,
-                used_bytes,
-            )
-            if quota_bytes != QUOTA_5G:
-                retry_cnt += 1
-                time.sleep(2)
-                continue
-            elif used_bytes != expected_used_bytes:
-                retry_cnt += 1
-                time.sleep(2)
-                continue
-            else:
-                break
+        waited = helper.wait_for_metrics_used_bytes(
+            client,
+            default_fs,
+            subvol_path,
+            parent_rbytes_baseline,
+            _bytes_used,
+            expected_quota=QUOTA_5G,
+            ranks=ranks,
+        )
+        if waited is None:
+            log.error("Step 4: No subvolume metrics with quota_bytes/used_bytes found")
+            return 1
+        quota_bytes, used_bytes, expected_used_bytes = waited
+        expected_metrics_used = helper.expected_metrics_used_bytes(
+            expected_used_bytes, parent_rbytes_baseline
+        )
         if quota_bytes != QUOTA_5G:
             log.error(
                 "Step 4: quota_bytes mismatch: expected %s (5G), got %s",
@@ -281,17 +303,22 @@ def run(ceph_cluster, **kw):
                 quota_bytes,
             )
             return 1
-        if used_bytes != expected_used_bytes:
-            log.error(
-                "Step 4: used_bytes mismatch with expected_used_bytes used_bytes=%s, expected_used_bytes=%s",
+        if used_bytes != expected_metrics_used:
+            _log_used_mismatch(
+                "Step 4",
                 used_bytes,
+                expected_metrics_used,
                 expected_used_bytes,
+                parent_rbytes_baseline,
             )
             return 1
         log.info(
-            "Step 4 Passed: quota_bytes = %s (5G), used_bytes = %s",
+            "Step 4 Passed: quota_bytes = %s (5G), used_bytes = %s "
+            "(bytes_used=%s baseline=%s)",
             quota_bytes,
             used_bytes,
+            expected_used_bytes,
+            parent_rbytes_baseline,
         )
 
         log.info("All steps passed: quota_bytes correctly reflects quota changes")
@@ -307,6 +334,12 @@ def run(ceph_cluster, **kw):
             cmd = f"ceph config set mds subv_metrics_window_interval {subv_metrics_window_interval_def}"
             client.exec_command(sudo=True, cmd=cmd, check_ec=False)
         try:
+            client.exec_command(
+                sudo=True, cmd=f"umount -l {parent_mount_dir}", check_ec=False
+            )
+            client.exec_command(
+                sudo=True, cmd=f"rm -rf {parent_mount_dir}", check_ec=False
+            )
             client.exec_command(
                 sudo=True, cmd=f"umount -l {fuse_mount_dir}", check_ec=False
             )

--- a/tests/cephfs/lib/cephfs_subvol_metric_utils.py
+++ b/tests/cephfs/lib/cephfs_subvol_metric_utils.py
@@ -19,6 +19,7 @@ class MDSMetricsHelper:
       - launch/wait for fio (background)
       - parse fio summary output
       - compare fio stats vs MDS counters (read/write/both)
+      - compare MDS used_bytes to subvolume info using a parent-rbytes baseline
     """
 
     def __init__(self, ceph_cluster, **kwargs):
@@ -252,6 +253,155 @@ class MDSMetricsHelper:
                 break
             time.sleep(1)
         return snapshots
+
+    # ---------------------------------------------------------------------
+    # used_bytes vs subvolume info (parent rbytes baseline)
+    # ---------------------------------------------------------------------
+
+    def parent_subvol_path(self, subvol_getpath: str) -> str:
+        """
+        Metrics label / nested-usage path: /volumes/_nogroup/<name>.
+        'ceph fs subvolume getpath' includes a UUID directory under that path.
+        """
+        return self._normalize_metrics_prefix(subvol_getpath) or subvol_getpath
+
+    def get_dir_rbytes(self, client, path: str) -> int:
+        """Return ceph.dir.rbytes for a mounted directory."""
+        path = path.rstrip("/") or path
+        out, _ = client.exec_command(
+            sudo=True,
+            cmd=f"getfattr --only-values -n ceph.dir.rbytes '{path}'",
+        )
+        for line in reversed((out or "").splitlines()):
+            token = line.strip()
+            if token.isdigit():
+                return int(token)
+        raise ValueError(f"Failed to parse ceph.dir.rbytes from output: {out!r}")
+
+    def get_quota_and_used(
+        self,
+        client,
+        fs_name: str,
+        subvol_path: str,
+        ranks: Optional[List[int]] = None,
+    ) -> Optional[Tuple[int, int]]:
+        """Return (quota_bytes, used_bytes) from MDS metrics for the subvolume."""
+        results = self.collect_subvolume_metrics(
+            client=client,
+            fs_name=fs_name,
+            role="active",
+            ranks=ranks or [0],
+            path_prefix=subvol_path,
+        )
+        for _mds_name, items in results.items():
+            for it in items:
+                if "quota_bytes" in it and "used_bytes" in it:
+                    return (int(it["quota_bytes"]), int(it["used_bytes"]))
+        return None
+
+    @staticmethod
+    def expected_metrics_used_bytes(
+        bytes_used: int, parent_rbytes_baseline: int
+    ) -> int:
+        """MDS used_bytes is parent rbytes: UUID bytes_used + pre-IO parent rbytes."""
+        return int(bytes_used) + int(parent_rbytes_baseline)
+
+    def wait_for_metrics_used_bytes(
+        self,
+        client,
+        fs_name: str,
+        subvol_path: str,
+        parent_rbytes_baseline: int,
+        get_bytes_used,
+        expected_quota: Optional[int] = None,
+        ranks: Optional[List[int]] = None,
+        retries: int = 20,
+        sleep_sec: int = 5,
+    ) -> Optional[Tuple[int, int, int]]:
+        """
+        Retry until metrics used_bytes == get_bytes_used() + parent_rbytes_baseline
+        and quota_bytes matches expected_quota when that is set.
+
+        MDS used_bytes tracks the parent path and can lag by a sliding window.
+        The wait is bounded: retries * sleep_sec (default 100s). It always
+        returns; it does not loop until metrics leave the parent baseline.
+
+        Returns (quota_bytes, used_bytes, bytes_used) on success. On timeout,
+        logs an error and returns the last sample, or None if metrics never
+        appeared. Caller must still assert the returned values.
+        """
+        last_quota: Optional[int] = None
+        last_used: Optional[int] = None
+        last_bu: Optional[int] = None
+        expected_used = 0
+        for attempt in range(1, retries + 1):
+            last_bu = int(get_bytes_used() or 0)
+            expected_used = self.expected_metrics_used_bytes(
+                last_bu, parent_rbytes_baseline
+            )
+            result = self.get_quota_and_used(
+                client, fs_name, subvol_path, ranks=ranks
+            )
+            if result is None:
+                log.info(
+                    "used_bytes wait %s/%s: no metrics yet "
+                    "(bytes_used=%s baseline=%s exp_used=%s)",
+                    attempt,
+                    retries,
+                    last_bu,
+                    parent_rbytes_baseline,
+                    expected_used,
+                )
+                if attempt < retries:
+                    time.sleep(sleep_sec)
+                continue
+            last_quota, last_used = result
+            quota_ok = expected_quota is None or last_quota == expected_quota
+            used_ok = last_used == expected_used
+            log.info(
+                "used_bytes wait %s/%s: quota=%s (exp=%s) used=%s "
+                "(exp=%s bytes_used=%s baseline=%s)",
+                attempt,
+                retries,
+                last_quota,
+                expected_quota,
+                last_used,
+                expected_used,
+                last_bu,
+                parent_rbytes_baseline,
+            )
+            if quota_ok and used_ok:
+                return (last_quota, last_used, last_bu)
+            if attempt < retries:
+                time.sleep(sleep_sec)
+
+        wait_s = retries * sleep_sec
+        if last_used is None:
+            log.error(
+                "used_bytes wait timed out after %ss (%s tries): "
+                "metrics never appeared",
+                wait_s,
+                retries,
+            )
+            return None
+        stuck = (
+            last_used == parent_rbytes_baseline
+            and expected_used != parent_rbytes_baseline
+        )
+        log.error(
+            "used_bytes wait timed out after %ss (%s tries): "
+            "quota=%s (exp=%s) used=%s (exp=%s bytes_used=%s baseline=%s)%s",
+            wait_s,
+            retries,
+            last_quota,
+            expected_quota,
+            last_used,
+            expected_used,
+            last_bu,
+            parent_rbytes_baseline,
+            " ; metrics still at parent rbytes baseline" if stuck else "",
+        )
+        return (last_quota, last_used, last_bu)
 
     # ---------------------------------------------------------------------
     # Internals

--- a/tests/cephfs/lib/cephfs_subvol_metric_utils.py
+++ b/tests/cephfs/lib/cephfs_subvol_metric_utils.py
@@ -158,6 +158,9 @@ class MDSMetricsHelper:
                 flat = self._flatten_subvolume_items(
                     items, fs_filter=fs_name, path_prefix=norm_prefix
                 )
+                # Only store MDS keys that have rows. Empty dump / no path match
+                # is omitted, so the return value can be {} even when MDS was
+                # queried (no active name, dump failed, or no IO in the window).
                 if flat:
                     results[mds_name] = flat
             except Exception as e:
@@ -339,9 +342,7 @@ class MDSMetricsHelper:
             expected_used = self.expected_metrics_used_bytes(
                 last_bu, parent_rbytes_baseline
             )
-            result = self.get_quota_and_used(
-                client, fs_name, subvol_path, ranks=ranks
-            )
+            result = self.get_quota_and_used(client, fs_name, subvol_path, ranks=ranks)
             if result is None:
                 log.info(
                     "used_bytes wait %s/%s: no metrics yet "


### PR DESCRIPTION
# Description

**Source of test case:** Regression Test (existing 9.1 CephFS feature-suite automation.

Fixes `suites/tentacle/cephfs/9_1_features_suite.yaml`.

- **CEPH-83632373** — `test_subvol_metrics_functional.py`: `used_bytes` was compared to the wrong path.
- **CEPH-83632428** — `test_mds_subvol_metrics_disruptive_ops.py`: three test races after MDS remove/add, empty dump after restart, and orch `host is offline` after reboot.

<details>
<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
      CEPH-83632373, CEPH-83632428 (existing; this PR only fixes the scripts)
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
      tentacle-test-executor #2914 IBM 9.1 / rhel-9 / rc SUCCESS
      tentacle-test-executor #2919 IBM 9.2 / rhel-10 / stable (20.2.2-316) SUCCESS
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
      N/A — not a customer BZ close loop
</details>

## Commits

### 1. Compare CephFS subvolume metrics used_bytes to parent rbytes baseline (`8d27c7c5c`)

**Polarion:** CEPH-83632373  
**Files:** `tests/cephfs/lib/cephfs_subvol_metric_utils.py`, `tests/cephfs/cephfs_subvol_metrics/test_subvol_metrics_functional.py`

**Problem**  
MDS `used_bytes` is parent-path `rstat.rbytes` (`/volumes/_nogroup/<name>`). `ceph fs subvolume info` `bytes_used` is the UUID dir only. They differ by the empty-dir extra on the parent (typically 130–138 bytes). The test treated them as the same integer.

**Issue seen**  
`tentacle-cephfs-regression-ci` #120–#128: CEPH-83632373 failed 9/9 (IBM 9.1/9.2, rhel-9/10). First dump still at ~130 while `bytes_used` was already GiB; later dumps off by the parent extra (`2147483786` vs `2147483648`). `quota_bytes` was already correct.

**Before**  
Mount UUID path only. After fill, assert `used_bytes == bytes_used` (comments still mentioned `du -sb`). One dump, or a short quota retry that still required exact `bytes_used`.

**Fix**  
Mount the parent path; snapshot `ceph.dir.rbytes` before IO as `BASE`. Assert `used_bytes == bytes_used + BASE`. `wait_for_metrics_used_bytes` (20 × 5s) so the first empty/baseline dump is not an immediate fail. Log stuck-at-`BASE` separately from any other mismatch.

**Now**  
Executor #2919 after 2G fill: `used_bytes = 2147483786` (`bytes_used=2147483648`, `baseline=138`).

---

### 2. Wait for exact MDS daemon count after orch remove before add (`792a3e943`)

**Polarion:** CEPH-83632428  
**File:** `tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py`

**Problem**  
`_wait_for_mds_daemon_count` used `running >= expected`. After shrink (3 hosts → 2), three daemons can still be running. `3 >= 2` returned immediately, then add (2 → 3) raced orch.

**Issue seen**  
tentacle-test-executor #2911 (IBM 9.1 / rhel-9 / rc): add timed out waiting for 3 running MDS while shrink had not finished.

**Before**  
Every wait was `>=` (setup, remove, and add).

**Fix**  
`match="gte"` for setup only (“at least N are up”). `match="eq"` after remove (count must drop) and after add (count back to original placement). Log daemon ids + `status_desc` while waiting.

**Now**  
Scale-down must actually finish before scale-up. Test race with `ceph orch apply`, not a product MDS-count bug.

---

### 3. Retry MDS subvolume metrics dump after disruptions until IO is seen (`17859265c`)

**Polarion:** CEPH-83632428  
**Files:** disruptive test (main); comments in functional + `cephfs_subvol_metric_utils.py`

**Problem**  
After MDS restart/reboot, `ceph tell mds dump` can be `{}` until the next write lands on the new MDS. The test treated `HEALTH_OK` / “MDS is up” as “dump is populated”.

**Issue seen**  
tentacle-test-executor #2907: `_validate_metrics` failed immediately with an empty dump after disruption.

**Before**  
One `collect_subvolume_metrics` call; empty dict → `RuntimeError`.

**Fix**  
`@retry` 21 tries, 30s apart (~10 min). Fail only if the dump stays empty. `collect_subvolume_metrics` omits MDS keys with no rows, so `{}` means “no matching metrics yet”, not only “no MDS”.

**Now**  
Post-disruption metrics wait for IO on the new MDS instead of failing the first empty dump.

---

### 4. Wait for orch to drop host-is-offline after MDS node reboot (`eed011f9e`)

**Polarion:** CEPH-83632428  
**File:** `tests/cephfs/cephfs_mds_observability/test_mds_subvol_metrics_disruptive_ops.py`

**Problem**  
`reboot_node` returns when test SSH works. Mgr can still have the host in `offline_hosts`. `ceph orch ps` then shows `host is offline`; background refresh skips that host. Remove-add can place MDS on a host orch still thinks is down.

**Issue seen**  
tentacle-test-executor #2913: remove-add after reboot failed with orch `host is offline`.

**Before**  
Reboot → immediately `_remove_add_mds_service()`.

**Fix**  
`_wait_for_orch_host_not_offline`: poll `ceph orch ps <hostname> --refresh` until daemons are listed and none have `status_desc == host is offline` (600s). `--refresh` forces mgr SSH (`cephadm ls`) and clears the stale offline bit.

**Now**  
Remove-add runs only after orch agrees the rebooted host is back.

## Test runs

- [x] tentacle-test-executor Jenkins 2914 — IBM 9.1 / rhel-9 / `RELEASE=rc` — `9_1_features_suite.yaml` SUCCESS
- [x] tentacle-test-executor Jenkins 2919 — IBM 9.2 / rhel-10 / `RELEASE=stable` (`20.2.2-316`) SUCCESS
[Job_2911.txt](https://github.com/user-attachments/files/32002863/Job_2911.txt)
[Job_2913.txt](https://github.com/user-attachments/files/32002867/Job_2913.txt)
[Job_2917.txt](https://github.com/user-attachments/files/32002871/Job_2917.txt)
[Job_2919_92_RHEL10.txt](https://github.com/user-attachments/files/32002876/Job_2919_92_RHEL10.txt)
[Job_2904.txt](https://github.com/user-attachments/files/32002879/Job_2904.txt)
[Job_2907.txt](https://github.com/user-attachments/files/32002887/Job_2907.txt)

---------------------
10-Sep-2026

IBM 9.2 / rhel-10 / stable, compose 20.2.2-316, 9_1_features_suite.yaml, fix-cephfs-newfeature-91.
2026-09-10 11:09:20 ... Captured parent rbytes baseline=138 (UUID rbytes=0)
2026-09-10 11:09:56 ... Step 1 Passed: quota_bytes = 3221225472 (3G), used_bytes = 2147483786 (bytes_used=2147483648 baseline=138)
2026-09-10 11:10:48 ... All steps passed: quota_bytes correctly reflects quota changes
2026-09-10 11:06:02 ... Metrics validation passed for stage: after MDS service remove-add
2026-09-10 11:06:02 ... TEST PASSED CEPH-83632428: metrics validated after MDS restart, MGR restart, MDS reboot, and MDS remove-add
Job URL: https://149.81.216.83/job/tentacle-test-executor/2977/

IBM 9.1 / rhel-9 / rc, compose 20.2.1-405, 9_1_features_suite.yaml, fix-cephfs-newfeature-91.
2026-09-10 11:22:44 ... Captured parent rbytes baseline=138 (UUID rbytes=0)
2026-09-10 11:23:15 ... Step 1 Passed: quota_bytes = 3221225472 (3G), used_bytes = 2147483786 (bytes_used=2147483648 baseline=138)
2026-09-10 11:24:02 ... All steps passed: quota_bytes correctly reflects quota changes
2026-09-10 11:20:52 ... Metrics validation passed for stage: after MDS service remove-add
2026-09-10 11:20:52 ... TEST PASSED CEPH-83632428: metrics validated after MDS restart, MGR restart, MDS reboot, and MDS remove-add
Job URL: https://149.81.216.83/job/tentacle-test-executor/2978/

[PR6146_91_RHEL09_RC_Jenkins2978.txt](https://github.com/user-attachments/files/32056538/PR6146_91_RHEL09_RC_Jenkins2978.txt)
[PR6146_92_RHEL10_Jenkins2977.txt](https://github.com/user-attachments/files/32056539/PR6146_92_RHEL10_Jenkins2977.txt)

