### PR TITLE
Add test suite for infinite topic list

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -85,6 +85,16 @@ tests:
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
 
+  - test:
+      name: test bucket notifications with over 1K topics per tenant
+      desc: create more than 1K persistent kafka topics for a tenant and verify topic list is not truncated
+      module: sanity_rgw.py
+      polarion-id: CEPH-83632970
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications_1k_topics.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_1k_topics.yaml
+
   # kafka broker type none with persistent flag enabled
 
   - test:

--- a/suites/tentacle/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/tentacle/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -100,6 +100,16 @@ tests:
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_relaxed_topic_names.yaml
 
+  - test:
+      name: test bucket notifications with over 1K topics per tenant
+      desc: create more than 1K persistent kafka topics for a tenant and verify topic list is not truncated
+      module: sanity_rgw.py
+      polarion-id: CEPH-83632970
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications_1k_topics.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_1k_topics.yaml
+
   # kafka broker type none with persistent flag enabled
 
   - test:


### PR DESCRIPTION
# Description

RGW should process all persistent topics when a tenant has more than 1K of them, not loop on the first 1K. This test creates those topics, checks Kafka Delete events on first, later, and last, then confirms a new topic is picked up after refresh.

Logs

9.1 pass log - https://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-N3QL79/
9.0 pass log - https://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-Q5RYJV/
7.1 pass log - https://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-2I7D6Q/

jira: https://ibm-ceph.atlassian.net/browse/IBMCEPHQE-25725
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
