### PR TITLE
ocpvirt: wait for guest IPv6 when use_ipv6=true

### DIFF
--- a/compute/openshift.py
+++ b/compute/openshift.py
@@ -174,6 +174,63 @@ def _cloudinit_secret_name(vm_name: str) -> str:
     return f"{vm_name}-cloudinit"[:63].rstrip("-")
 
 
+def _iface_ip_candidates(iface: dict) -> List[str]:
+    """Unique IP strings from a VMI status.interfaces entry."""
+    seen = set()
+    out: List[str] = []
+    for ip in [iface.get("ipAddress"), *(iface.get("ipAddresses") or [])]:
+        if ip and ip not in seen:
+            seen.add(ip)
+            out.append(ip)
+    return out
+
+
+def is_global_ipv6(ip: str) -> bool:
+    """True for routable guest IPv6 (not link-local or loopback)."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return addr.version == 6 and not addr.is_link_local and not addr.is_loopback
+
+
+def pick_vmi_ipv6_ip(interfaces: List[dict]) -> Optional[str]:
+    """First global IPv6 on the VMI (skips link-local)."""
+    for iface in interfaces or []:
+        for ip in _iface_ip_candidates(iface):
+            if is_global_ipv6(ip):
+                return ip
+    return None
+
+
+def vm_wait_address(interfaces: List[dict], use_ipv6: bool) -> Optional[str]:
+    """Address to wait for before proceeding (IPv6 when requested, else IPv4)."""
+    if use_ipv6:
+        return pick_vmi_ipv6_ip(interfaces)
+    ipv4s: List[str] = []
+    for iface in interfaces or []:
+        for ip in _iface_ip_candidates(iface):
+            if ":" not in ip:
+                ipv4s.append(ip)
+    return ipv4s[0] if ipv4s else None
+
+
+def ipv6_subnet_from_cred(
+    cred: Optional[dict],
+    ipv6_address: Optional[str],
+) -> Optional[str]:
+    """IPv6 CIDR for ``public_network`` from cred or the guest address /64."""
+    for key in ("subnet6", "ipv6_subnet", "ipv6_network_cidr"):
+        if cred and cred.get(key):
+            return str(cred[key])
+    if not ipv6_address:
+        return None
+    try:
+        return str(ipaddress.IPv6Network(f"{ipv6_address}/64", strict=False))
+    except ValueError:
+        return None
+
+
 def build_virtualmachine_cr(
     node_name: str,
     namespace: str,
@@ -621,7 +678,13 @@ def resolve_ocpvirt_credentials(osp_cred: dict, custom_config=None) -> dict:
     """
     auth_cred = validate_ocpvirt_credentials(osp_cred)
     namespace_config = load_ocpvirt_namespace_config(custom_config)
-    return merge_ocpvirt_credentials(auth_cred, namespace_config)
+    merged = merge_ocpvirt_credentials(auth_cred, namespace_config)
+    from utility.utils import resolve_use_ipv6
+
+    if resolve_use_ipv6(custom_config, "ocpvirt", osp_cred):
+        merged = dict(merged)
+        merged["use_ipv6"] = True
+    return merged
 
 
 def validate_ocpvirt_inventory(
@@ -1001,10 +1064,12 @@ class CephVMNodeOCP:
         """Restore state and recreate API clients."""
         self.__dict__.update(state)
         self.custom_api, self.core_api = get_k8s_clients(self._ocp_cred)
+        self._cached_ip = None
+        self._cached_ipv6 = None
 
     @property
     def ip_address(self) -> str:
-        """Return the primary IP address of the VMI."""
+        """Primary IPv4 from the VMI (SSH / Ceph when not using IPv6)."""
         cached = getattr(self, "_cached_ip", None)
         if cached:
             return cached
@@ -1012,6 +1077,22 @@ class CephVMNodeOCP:
         if ip:
             self._cached_ip = ip
         return ip
+
+    @property
+    def ipv6_address(self) -> Optional[str]:
+        """Global IPv6 from the VMI (skips link-local)."""
+        cached = getattr(self, "_cached_ipv6", None)
+        if cached:
+            return cached
+        ip = pick_vmi_ipv6_ip(self._vmi_interfaces())
+        if ip:
+            self._cached_ipv6 = ip
+        return ip
+
+    @property
+    def ipv6_subnet(self) -> Optional[str]:
+        """IPv6 CIDR for ``public_network`` when ``use_ipv6=true``."""
+        return ipv6_subnet_from_cred(self._ocp_cred, self.ipv6_address)
 
     @property
     def hostname(self) -> str:
@@ -1377,36 +1458,27 @@ class CephVMNodeOCP:
             LOG.warning(f"get VMI {vm_name} failed: {exc}")
             return None
 
+    def _vmi_interfaces(self) -> List[dict]:
+        if not self.node:
+            return []
+        vm_name = self.node.get("metadata", {}).get("name")
+        if not vm_name:
+            return []
+        vmi = self._get_vmi(vm_name)
+        if not vmi:
+            return []
+        return (vmi.get("status") or {}).get("interfaces") or []
+
     def _get_vmi_ip(self) -> Optional[str]:
         if not self.node:
             return None
-        vm_name = self.node.get("metadata", {}).get("name")
-        if not vm_name:
-            return None
-        vmi = self._get_vmi(vm_name)
-        if not vmi:
-            return None
-        interfaces = (vmi.get("status") or {}).get("interfaces") or []
+        interfaces = self._vmi_interfaces()
         ipv4s: List[str] = []
-        ipv6s: List[str] = []
         for iface in interfaces:
-            candidates = []
-            if iface.get("ipAddress"):
-                candidates.append(iface["ipAddress"])
-            candidates.extend(iface.get("ipAddresses") or [])
-            for ip in candidates:
-                if not ip:
-                    continue
-                if ":" in ip:
-                    ipv6s.append(ip)
-                else:
+            for ip in _iface_ip_candidates(iface):
+                if ":" not in ip:
                     ipv4s.append(ip)
-        # Prefer IPv4: jump hosts / TenantEgress paths are often IPv4-only.
-        if ipv4s:
-            return ipv4s[0]
-        if ipv6s:
-            return ipv6s[0]
-        return None
+        return ipv4s[0] if ipv4s else None
 
     def _wait_until_vm_ready(
         self, vm_name: str, timeout: int = VM_POLL_TIMEOUT
@@ -1442,27 +1514,31 @@ class CephVMNodeOCP:
     def _wait_until_ip_known(
         self, vm_name: str, timeout: int = IP_POLL_TIMEOUT
     ) -> None:
-        """Poll VMI until an IPv4 address is assigned (fall back to any IP late)."""
+        """Poll VMI until the target address is assigned."""
+        use_ipv6 = bool(self._ocp_cred.get("use_ipv6"))
+        label = "IPv6" if use_ipv6 else "IPv4"
         for w in WaitUntil(timeout=timeout, interval=VM_POLL_INTERVAL):
-            # Refresh node so ip_address can read VMI
             self.node = self._get_vm(vm_name) or self.node
-            ip = self._get_vmi_ip()
-            if ip and ":" not in ip:
-                LOG.info(f"VirtualMachine {vm_name} has IP {ip}")
+            self._cached_ipv6 = None
+            addr = vm_wait_address(self._vmi_interfaces(), use_ipv6)
+            if addr:
+                LOG.info(f"VirtualMachine {vm_name} has {label} {addr}")
                 return
-            # Keep waiting while only IPv6 is visible — DHCP IPv4 often arrives later.
-            if ip:
-                LOG.debug(f"VirtualMachine {vm_name} has IPv6 {ip}; waiting for IPv4")
+            if w._attempt == 1 or w._attempt % 6 == 0:
+                LOG.info(f"Waiting for VirtualMachine {vm_name} {label}")
         if w.expired:
-            # Last chance: accept whatever IP is present
             self.node = self._get_vm(vm_name) or self.node
-            ip = self._get_vmi_ip()
-            if ip:
+            self._cached_ipv6 = None
+            addr = vm_wait_address(self._vmi_interfaces(), use_ipv6)
+            if addr:
                 LOG.warning(
-                    f"VirtualMachine {vm_name} timed out waiting for IPv4; using {ip}"
+                    f"VirtualMachine {vm_name} timed out waiting for {label}; "
+                    f"using {addr}"
                 )
                 return
-            raise NodeError(f"VirtualMachine {vm_name} has no IP within {timeout}s")
+            raise NodeError(
+                f"VirtualMachine {vm_name} has no {label} within {timeout}s"
+            )
 
     def _wait_until_vm_deleted(
         self, vm_name: str, timeout: int = VM_POLL_TIMEOUT

--- a/conf/ocpvirt/rdu3_ceph_ci.yaml
+++ b/conf/ocpvirt/rdu3_ceph_ci.yaml
@@ -4,6 +4,7 @@
 #
 # Auth (token, certificate_authority_data, private_key_path) stays in --osp-cred.
 # Cloud-init stays in --inventory; compute sizing uses ocpvirt_profile (cluster instance type).
+# IPv6: pass --custom-config use_ipv6=true (uses existing cephci IPv6 bootstrap path).
 
 server: https://10.5.229.33:6443
 namespace: ceph-ci--runtime-int
@@ -20,5 +21,6 @@ datasources:
 # access_modes:
 #   - ReadWriteOnce
 
-# Optional guest subnet hint for cephadm public_network auto-detect
+# Optional guest subnet hints for cephadm public_network (derived from guest IP if omitted)
 # subnet: 10.5.228.0/24
+# subnet6: 2620:52:8:2105::/64

--- a/conf/ocpvirt/rdu3_ceph_core.yaml
+++ b/conf/ocpvirt/rdu3_ceph_core.yaml
@@ -4,6 +4,7 @@
 #
 # Auth (token, certificate_authority_data, private_key_path) stays in --osp-cred.
 # Cloud-init stays in --inventory; compute sizing uses ocpvirt_profile (cluster instance type).
+# IPv6: pass --custom-config use_ipv6=true (uses existing cephci IPv6 bootstrap path).
 
 server: https://10.5.229.33:6443
 namespace: ceph-core--runtime-int
@@ -20,5 +21,6 @@ datasources:
 # access_modes:
 #   - ReadWriteOnce
 
-# Optional guest subnet hint for cephadm public_network auto-detect
+# Optional guest subnet hints for cephadm public_network (derived from guest IP if omitted)
 # subnet: 10.5.228.0/24
+# subnet6: 2620:52:8:2105::/64

--- a/conf/ocpvirt/rdu3_ceph_jenkins.yaml
+++ b/conf/ocpvirt/rdu3_ceph_jenkins.yaml
@@ -4,6 +4,7 @@
 #
 # Auth (token, certificate_authority_data, private_key_path) stays in --osp-cred.
 # Cloud-init stays in --inventory; compute sizing uses ocpvirt_profile (cluster instance type).
+# IPv6: pass --custom-config use_ipv6=true (uses existing cephci IPv6 bootstrap path).
 
 server: https://10.5.229.33:6443
 namespace: ceph-jenkins--runtime-int
@@ -20,5 +21,6 @@ datasources:
 # access_modes:
 #   - ReadWriteOnce
 
-# Optional guest subnet hint for cephadm public_network auto-detect
+# Optional guest subnet hints for cephadm public_network (derived from guest IP if omitted)
 # subnet: 10.5.228.0/24
+# subnet6: 2620:52:8:2105::/64

--- a/conf/ocpvirt/rdu3_ceph_perf.yaml
+++ b/conf/ocpvirt/rdu3_ceph_perf.yaml
@@ -4,6 +4,7 @@
 #
 # Auth (token, certificate_authority_data, private_key_path) stays in --osp-cred.
 # Cloud-init stays in --inventory; compute sizing uses ocpvirt_profile (cluster instance type).
+# IPv6: pass --custom-config use_ipv6=true (uses existing cephci IPv6 bootstrap path).
 
 server: https://10.5.229.33:6443
 namespace: ceph-perf--runtime-int
@@ -20,5 +21,6 @@ datasources:
 # access_modes:
 #   - ReadWriteOnce
 
-# Optional guest subnet hint for cephadm public_network auto-detect
+# Optional guest subnet hints for cephadm public_network (derived from guest IP if omitted)
 # subnet: 10.5.228.0/24
+# subnet6: 2620:52:8:2105::/64

--- a/conf/ocpvirt/rdu3_ceph_sys_test.yaml
+++ b/conf/ocpvirt/rdu3_ceph_sys_test.yaml
@@ -4,6 +4,7 @@
 #
 # Auth (token, certificate_authority_data, private_key_path) stays in --osp-cred.
 # Cloud-init stays in --inventory; compute sizing uses ocpvirt_profile (cluster instance type).
+# IPv6: pass --custom-config use_ipv6=true (uses existing cephci IPv6 bootstrap path).
 
 server: https://10.5.229.33:6443
 namespace: ceph-sys-test--runtime-int
@@ -20,5 +21,6 @@ datasources:
 # access_modes:
 #   - ReadWriteOnce
 
-# Optional guest subnet hint for cephadm public_network auto-detect
+# Optional guest subnet hints for cephadm public_network (derived from guest IP if omitted)
 # subnet: 10.5.228.0/24
+# subnet6: 2620:52:8:2105::/64

--- a/unittests/compute/test_openshift_batch.py
+++ b/unittests/compute/test_openshift_batch.py
@@ -9,7 +9,10 @@ from compute.openshift import (
     apply_ocpvirt_vm_profile,
     build_virtualmachine_cr,
     datavolume_names_from_vm,
+    ipv6_subnet_from_cred,
+    is_global_ipv6,
     load_ocpvirt_namespace_config,
+    pick_vmi_ipv6_ip,
     process_ocpvirt_custom_config,
     resolve_ocpvirt_credentials,
     resolve_ocpvirt_image_name,
@@ -18,6 +21,7 @@ from compute.openshift import (
     validate_ocpvirt_inventory,
     validate_ocpvirt_namespace_config,
     validate_precreated_volume_names,
+    vm_wait_address,
 )
 
 AUTH_OSP_CRED = {
@@ -225,3 +229,39 @@ def test_datavolume_names_from_vm_includes_root_and_precreated():
     assert "ceph-test-node-root" in names
     assert "ceph-test-node-vol-0" in names
     assert "ceph-test-node-vol-1" in names
+
+
+OCPVIRT_IFACES = [
+    {
+        "name": "default",
+        "ipAddress": "10.5.228.122",
+        "ipAddresses": [
+            "10.5.228.122",
+            "2620:52:8:2105:45c:88ff:fe0b:80d",
+            "fe80::2d:d0ff:fe40:d876",
+        ],
+    },
+]
+
+
+def test_is_global_ipv6():
+    assert is_global_ipv6("2620:52:8:2105:45c:88ff:fe0b:80d")
+    assert not is_global_ipv6("fe80::1")
+    assert not is_global_ipv6("10.5.228.122")
+
+
+def test_pick_vmi_ipv6_ip():
+    assert pick_vmi_ipv6_ip(OCPVIRT_IFACES) == "2620:52:8:2105:45c:88ff:fe0b:80d"
+
+
+def test_ipv6_subnet_from_cred():
+    addr = "2620:52:8:2105:45c:88ff:fe0b:80d"
+    assert ipv6_subnet_from_cred({}, addr) == "2620:52:8:2105::/64"
+    assert ipv6_subnet_from_cred({"subnet6": "2001:db8::/48"}, addr) == "2001:db8::/48"
+
+
+def test_vm_wait_address():
+    assert vm_wait_address(OCPVIRT_IFACES, use_ipv6=False) == "10.5.228.122"
+    assert vm_wait_address(OCPVIRT_IFACES, use_ipv6=True) == (
+        "2620:52:8:2105:45c:88ff:fe0b:80d"
+    )


### PR DESCRIPTION
# Description

Opt-in IPv6 for OCP Virt via existing use_ipv6. No change to Jenkins IPv4 unless that flag is set. 
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
