### PR TITLE
fix: use compose repos for RHCS 8.1 rc baseline in 8x-to-9x upgrade

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -31,6 +31,14 @@ __DEFAULT_KEYRING_PATH = "/etc/ceph/ceph.client.admin.keyring"
 __DEFAULT_SSH_PATH = "/etc/ceph/ceph.pub"
 
 
+def _manifest_has_cdn_tools_repo(manifest_obj: CephTestManifest) -> bool:
+    """Return True when the manifest defines a Red Hat CDN tools repo."""
+    if manifest_obj.product != "redhat":
+        return False
+    repo_ids = manifest_obj.build_info.get("repo_ids") or {}
+    return manifest_obj.platform in repo_ids
+
+
 def _detect_registry_tier(registry: str, build_type: str) -> str:
     """Return credential tier (cdn/stage/preprod) from registry host, else from build_type."""
     if not registry:
@@ -288,11 +296,15 @@ class BootstrapMixin:
         elif build_type == "cdn" or custom_repo.lower() == "cdn":
             custom_image = False
             self.cluster.use_cdn = True
-            self.set_cdn_tool_repo(_ceph_version, manifest_obj)
-        elif build_type == "released" and base_url == manifest_obj.repository:
+            self.set_cdn_tool_repo(ctm=manifest_obj)
+        elif (
+            build_type == "released"
+            and base_url == manifest_obj.repository
+            and _manifest_has_cdn_tools_repo(manifest_obj)
+        ):
             custom_image = False
             self.cluster.use_cdn = True
-            self.set_cdn_tool_repo(manifest_obj)
+            self.set_cdn_tool_repo(ctm=manifest_obj)
         elif custom_repo:
             self.set_tool_repo(repo=custom_repo)
         else:

--- a/suites/tentacle/upgrades/tier1-upgrade-ibm-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-ibm-8x-to-9x.yaml
@@ -31,7 +31,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: "rc"
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
           - config:

--- a/suites/tentacle/upgrades/tier1-upgrade-rhcs-8x-to-9x.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-rhcs-8x-to-9x.yaml
@@ -31,7 +31,7 @@ tests:
               service: cephadm
               args:
                 rhcs-version: 8.1
-                release: rc
+                release: released
                 mon-ip: node1
                 orphan-initial-daemons: true
           - config:

--- a/suites/tentacle/upgrades/tier1-upgrade-rhcs-9x-to-9x-latest.yaml
+++ b/suites/tentacle/upgrades/tier1-upgrade-rhcs-9x-to-9x-latest.yaml
@@ -1,13 +1,13 @@
 ##############################################################################################
 # Tier-Level: 1
 # Test-Suite: tier1-upgrade-rhcs-9x-to-9x.yaml
-# Scenario: Build to build Upgrade RHCS 9(GA) cluster to RHCS 9(Latest)
+# Scenario: Build to build Upgrade RHCS 9.1 z1 cluster to RHCS 9.1 (Latest)
 #
 # Cluster Configuration: conf/tentacle/upgrades/1admin-3node-1client-upgrade.yaml
 #
 # Test Steps:
-# - Deploy RHCS 9(GA) cluster
-# - Upgrade cluster from RHCS 9(GA) to RHCS 9(Latest)
+# - Deploy RHCS 9.1 z1 cluster
+# - Upgrade cluster from RHCS 9.1 z1 to RHCS 9.1 latest (released)
 # - Validate cluster status
 # - Run I/O's
 ################################################################################################
@@ -19,8 +19,8 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Bootstrap RHCS 9(GA) cluster and deploy services with label placements.
-      desc: Bootstrap RHCS 9(GA) cluster and deploy services with label placements.
+      name: Bootstrap RHCS 9.1 z1 cluster and deploy services with label placements.
+      desc: Bootstrap RHCS 9.1 z1 cluster and deploy services with label placements.
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       config:
@@ -30,8 +30,8 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 9.0
-                release: rc
+                rhcs-version: 9.1
+                release: z1
                 mon-ip: node1
                 orphan-initial-daemons: true
           - config:


### PR DESCRIPTION
Summary
Fixes bootstrap failure in the Tentacle RHCS 8.x → 9.x released upgrade suite (tier1-upgrade-rhcs-8x-to-9x.yaml).

Problem
Bootstrap tried to install RHCS 8.1 cephadm while enabling the 9.x CDN tools repo, so yum install cephadm failed before bootstrap ran.

Fix
bootstrap.py: Only use CDN tools repos when the manifest has repo_ids; pass ctm=manifest_obj to set_cdn_tool_repo.
Suite yaml: Set bootstrap release: released for the released pipeline.