### PR TITLE
[NFS]: add rados command timeout coverage on squid v3

### DIFF
--- a/suites/squid/nfs/tier0-nfs-ganesha-v3.yaml
+++ b/suites/squid/nfs/tier0-nfs-ganesha-v3.yaml
@@ -133,190 +133,191 @@ tests:
       module: test_client.py
       name: configure client
 
-  # - test:
-  #     name: Nfs Ganesha File Lock
-  #     module: nfs_verify_file_lock.py
-  #     desc: Perform locking on same file from 2 different clients
-  #     polarion-id: CEPH-83577561
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 2
+  - test:
+      name: Nfs Ganesha File Lock
+      module: nfs_verify_file_lock.py
+      desc: Perform locking on same file from 2 different clients
+      polarion-id: CEPH-83577561
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 2
 
-  # - test:
-  #     name: Nfs Verify Readdir Ops
-  #     module: nfs_verify_readdir_ops.py
-  #     desc: Perform readir operation from clients
-  #     polarion-id: CEPH-83577590
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 4
+  - test:
+      name: Nfs Verify Readdir Ops
+      module: nfs_verify_readdir_ops.py
+      desc: Perform readir operation from clients
+      polarion-id: CEPH-83577590
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 4
 
-  # - test:
-  #     name: Nfs Ganesha rename operations
-  #     module: test_file_ops_renames.py
-  #     desc: Perform file and dir renaming and lookups in parallel
-  #     polarion-id: CEPH-83577594
-  #     abort-on-fail: true
-  #     config:
-  #       nfs_version: 3
-  #       clients: 3
-  #       num_files: 1000
-  #       num_dirs: 1000
+  - test:
+      name: Nfs Ganesha rename operations
+      module: test_file_ops_renames.py
+      desc: Perform file and dir renaming and lookups in parallel
+      polarion-id: CEPH-83577594
+      abort-on-fail: true
+      config:
+        nfs_version: 3
+        clients: 3
+        num_files: 1000
+        num_dirs: 1000
 
-  # - test:
-  #     name: Verify create file, create soflink and lookups from nfs clients
-  #     module: nfs_verify_file_ops_soft_links.py
-  #     desc: Verify create file, create soflink and lookups from nfs clients
-  #     polarion-id: CEPH-83577596
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 3
-  #       file_count: 100
+  - test:
+      name: Verify create file, create soflink and lookups from nfs clients
+      module: nfs_verify_file_ops_soft_links.py
+      desc: Verify create file, create soflink and lookups from nfs clients
+      polarion-id: CEPH-83577596
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        file_count: 100
 
-  # - test:
-  #     name: Nfs Verify File Operations
-  #     module: nfs_verify_file_operations.py
-  #     desc: Change the ownership (user and group) of files within the NFS export
-  #     polarion-id: CEPH-83577601
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 3
-  #       file_count: 100
-  #       operations:
-  #         client01 : create_files
-  #         client02 : change_ownership
-  #         client03 : perform_lookups
+  - test:
+      name: Nfs Verify File Operations
+      module: nfs_verify_file_operations.py
+      desc: Change the ownership (user and group) of files within the NFS export
+      polarion-id: CEPH-83577601
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        file_count: 100
+        operations:
+          client01 : create_files
+          client02 : change_ownership
+          client03 : perform_lookups
 
-  # - test:
-  #     name: Nfs Verify File Operations
-  #     module: nfs_verify_file_operations.py
-  #     desc: Set different file permissions (read, write, execute) for files within the NFS
-  #     polarion-id: CEPH-83577602
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 3
-  #       file_count: 100
-  #       operations:
-  #         client01 : create_files
-  #         client02 : change_permission
-  #         client03 : perform_lookups
+  - test:
+      name: Nfs Verify File Operations
+      module: nfs_verify_file_operations.py
+      desc: Set different file permissions (read, write, execute) for files within the NFS
+      polarion-id: CEPH-83577602
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        file_count: 100
+        operations:
+          client01 : create_files
+          client02 : change_permission
+          client03 : perform_lookups
 
-  # - test:
-  #     name: Nfs export Readonly parameter
-  #     module: test_export_readonly.py
-  #     desc: Test NFS export with Readonly
-  #     polarion-id: CEPH-83578392
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 1
+  - test:
+      name: Nfs export Readonly parameter
+      module: test_export_readonly.py
+      desc: Test NFS export with Readonly
+      polarion-id: CEPH-83578392
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
 
-  # - test:
-  #     name: Nfs export rootsquash permission
-  #     module: test_export_rootsquash.py
-  #     desc: Test NFS export with rootsquash
-  #     polarion-id: CEPH-83578393
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 1
+  - test:
+      name: Nfs export rootsquash permission
+      module: test_export_rootsquash.py
+      desc: Test NFS export with rootsquash
+      polarion-id: CEPH-83578393
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
 
-  # - test:
-  #     name: Nfs Verify locks over nfs mount with root_squash enabled
-  #     module: nfs_verify_file_lock_root_squash.py
-  #     desc: Perform lock on file with root_squash enabled
-  #     polarion-id: CEPH-83578386
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 4
+  - test:
+      name: Nfs Verify locks over nfs mount with root_squash enabled
+      module: nfs_verify_file_lock_root_squash.py
+      desc: Perform lock on file with root_squash enabled
+      polarion-id: CEPH-83578386
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 4
 
-  # - test:
-  #     name: NFS-Ganesha export config to mount with RO
-  #     desc: Verify edit export config to mount with RO
-  #     module: nfs_edit_export_config_with_ro.py
-  #     polarion-id: CEPH-83578395
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 1
+  - test:
+      name: NFS-Ganesha export config to mount with RO
+      desc: Verify edit export config to mount with RO
+      module: nfs_edit_export_config_with_ro.py
+      polarion-id: CEPH-83578395
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
 
-  # - test:
-  #     name: NFS-Ganesha export config to mount with 1 client access
-  #     desc: Verify edit the export config to mount with allow access to only 1 client
-  #     module: nfs_edit_export_config_with_1client_access.py
-  #     polarion-id: CEPH-83578397
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 2
+  - test:
+      name: NFS-Ganesha export config to mount with 1 client access
+      desc: Verify edit the export config to mount with allow access to only 1 client
+      module: nfs_edit_export_config_with_1client_access.py
+      polarion-id: CEPH-83578397
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 2
 
-  # - test:
-  #     name: Nfs Verify setuid bit set on a file
-  #     module: nfs_verify_setuid_bit.py
-  #     desc: Verify setuid bit set on a file
-  #     polarion-id:
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 3
-  #       file_count: 100
-  #       operations:
-  #         client01 : create_files
-  #         client02 : setuid_bit
-  #         client03 : perform_lookups
+  - test:
+      name: Nfs Verify setuid bit set on a file
+      module: nfs_verify_setuid_bit.py
+      desc: Verify setuid bit set on a file
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 3
+        file_count: 100
+        operations:
+          client01 : create_files
+          client02 : setuid_bit
+          client03 : perform_lookups
 
-  # - test:
-  #     name: NFS-Ganesha test cmount_path param in export file
-  #     desc: Verify cmount_path entry in export file
-  #     module: nfs_validate_cmount_path_export_conf.py
-  #     polarion-id: CEPH-83593816
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 1
+  - test:
+      name: NFS-Ganesha test cmount_path param in export file
+      desc: Verify cmount_path entry in export file
+      module: nfs_validate_cmount_path_export_conf.py
+      polarion-id: CEPH-83593816
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
 
-  # - test:
-  #     name: Running nfstest lock suite
-  #     module: nfs_run_nfslocktest_suite.py
-  #     desc: Running nfstest lock suite
-  #     polarion-id: CEPH-83577561
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 1
+  - test:
+      name: Running nfstest lock suite
+      module: nfs_run_nfslocktest_suite.py
+      desc: Running nfstest lock suite
+      polarion-id: CEPH-83577561
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
 
-  # - test:
-  #     name: Running single client byte lock test
-  #     module: nfs_single_client_byterange_filelock.py
-  #     desc: Running single client byte lock test
-  #     polarion-id: CEPH-83577561
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 1
+  - test:
+      name: Running single client byte lock test
+      module: nfs_single_client_byterange_filelock.py
+      desc: Running single client byte lock test
+      polarion-id: CEPH-83577561
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
 
-  # - test:
-  #     name: Running multi client byte lock test
-  #     module: nfs_multi_client_byterange_filelock.py
-  #     desc: Running multi client byte lock test
-  #     polarion-id: CEPH-83577561
-  #     abort-on-fail: false
-  #     config:
-  #       nfs_version: 3
-  #       clients: 4
+  - test:
+      name: Running multi client byte lock test
+      module: nfs_multi_client_byterange_filelock.py
+      desc: Running multi client byte lock test
+      polarion-id: CEPH-83577561
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 4
 
-  # Smoke-only: cephadm NFS RADOS timeout (no client mount).
+  # cephadm NFS RADOS timeout (no client mount, not NFSv3-specific).
+  # Last block only: test does OSD pause/unpause.
   # Unique service_id/ports vs 2049.
   - test:
-      name: NFS rados command timeout setup default NFS
+      name: NFS rados timeout setup
       module: test_nfs_rados_command_timeout.py
-      desc: Apply one healthy NFS cluster and leave it running (creates pool .nfs)
+      desc: Seed NFS and leave running (creates pool .nfs)
       polarion-id: CEPH-83632973
       abort-on-fail: true
       config:
@@ -326,10 +327,9 @@ tests:
         monitoring_port: 62600
 
   - test:
-      name: NFS rados command timeout default 30s
+      name: NFS rados timeout default 30s
       module: test_nfs_rados_command_timeout.py
-      desc: >-
-        get must be 30 (else Fail after measuring 30s health); pause; add new NFS cluster using spec; health 30s
+      desc: get must be 30; pause; new NFS spec; health 30s
       polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
@@ -344,10 +344,9 @@ tests:
         strict_get: true
 
   - test:
-      name: NFS rados command timeout set 60s
+      name: NFS rados timeout set 60s
       module: test_nfs_rados_command_timeout.py
-      desc: >-
-        config set 60; pause; new NFS; health timed out after 60.0 seconds; unpause
+      desc: config set 60; pause; new NFS; health timeout 60s
       polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
@@ -363,10 +362,9 @@ tests:
         strict_get: true
 
   - test:
-      name: NFS rados command timeout floor 5s
+      name: NFS rados timeout floor 5s
       module: test_nfs_rados_command_timeout.py
-      desc: >-
-        config set 5; pause; new NFS; health timed out after 5.0 seconds; unpause
+      desc: config set 5; pause; new NFS; health timeout 5s
       polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
@@ -382,10 +380,9 @@ tests:
         strict_get: true
 
   - test:
-      name: NFS rados command timeout below floor 0s
+      name: NFS rados timeout below 0s
       module: test_nfs_rados_command_timeout.py
-      desc: >-
-        config set 0; get must be 0 or 1 (not leftover 5); health 5.0; unpause
+      desc: set 0; get 0|1 not leftover 5; health 5s; unpause
       polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
@@ -402,9 +399,9 @@ tests:
         strict_get: true
 
   - test:
-      name: NFS rados command timeout teardown
+      name: NFS rados timeout teardown
       module: test_nfs_rados_command_timeout.py
-      desc: Unpause OSDs, config set timeout 30, orch rm seed and stall NFS
+      desc: Unpause OSDs, set timeout 30, orch rm seed and stalls
       polarion-id: CEPH-83632973
       abort-on-fail: false
       config:

--- a/suites/squid/nfs/tier0-nfs-ganesha-v3.yaml
+++ b/suites/squid/nfs/tier0-nfs-ganesha-v3.yaml
@@ -324,7 +324,6 @@ tests:
         service_id: nfs-14352-seed
         port: 62100
         monitoring_port: 62600
-        cluster_qos_port: 63100
 
   - test:
       name: NFS rados command timeout default 30s
@@ -339,7 +338,6 @@ tests:
         seed_service_id: nfs-14352-seed
         port: 62110
         monitoring_port: 62610
-        cluster_qos_port: 63110
         expect: 30.0
         get_ok:
           - "30"
@@ -358,7 +356,6 @@ tests:
         seed_service_id: nfs-14352-seed
         port: 62120
         monitoring_port: 62620
-        cluster_qos_port: 63120
         set_value: 60
         expect: 60.0
         get_ok:
@@ -378,7 +375,6 @@ tests:
         seed_service_id: nfs-14352-seed
         port: 62130
         monitoring_port: 62630
-        cluster_qos_port: 63130
         set_value: 5
         expect: 5.0
         get_ok:
@@ -398,7 +394,6 @@ tests:
         seed_service_id: nfs-14352-seed
         port: 62140
         monitoring_port: 62640
-        cluster_qos_port: 63140
         set_value: 0
         expect: 5.0
         get_ok:

--- a/suites/squid/nfs/tier0-nfs-ganesha-v3.yaml
+++ b/suites/squid/nfs/tier0-nfs-ganesha-v3.yaml
@@ -133,180 +133,290 @@ tests:
       module: test_client.py
       name: configure client
 
-  - test:
-      name: Nfs Ganesha File Lock
-      module: nfs_verify_file_lock.py
-      desc: Perform locking on same file from 2 different clients
-      polarion-id: CEPH-83577561
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 2
+  # - test:
+  #     name: Nfs Ganesha File Lock
+  #     module: nfs_verify_file_lock.py
+  #     desc: Perform locking on same file from 2 different clients
+  #     polarion-id: CEPH-83577561
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 2
 
-  - test:
-      name: Nfs Verify Readdir Ops
-      module: nfs_verify_readdir_ops.py
-      desc: Perform readir operation from clients
-      polarion-id: CEPH-83577590
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 4
+  # - test:
+  #     name: Nfs Verify Readdir Ops
+  #     module: nfs_verify_readdir_ops.py
+  #     desc: Perform readir operation from clients
+  #     polarion-id: CEPH-83577590
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 4
 
+  # - test:
+  #     name: Nfs Ganesha rename operations
+  #     module: test_file_ops_renames.py
+  #     desc: Perform file and dir renaming and lookups in parallel
+  #     polarion-id: CEPH-83577594
+  #     abort-on-fail: true
+  #     config:
+  #       nfs_version: 3
+  #       clients: 3
+  #       num_files: 1000
+  #       num_dirs: 1000
+
+  # - test:
+  #     name: Verify create file, create soflink and lookups from nfs clients
+  #     module: nfs_verify_file_ops_soft_links.py
+  #     desc: Verify create file, create soflink and lookups from nfs clients
+  #     polarion-id: CEPH-83577596
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 3
+  #       file_count: 100
+
+  # - test:
+  #     name: Nfs Verify File Operations
+  #     module: nfs_verify_file_operations.py
+  #     desc: Change the ownership (user and group) of files within the NFS export
+  #     polarion-id: CEPH-83577601
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 3
+  #       file_count: 100
+  #       operations:
+  #         client01 : create_files
+  #         client02 : change_ownership
+  #         client03 : perform_lookups
+
+  # - test:
+  #     name: Nfs Verify File Operations
+  #     module: nfs_verify_file_operations.py
+  #     desc: Set different file permissions (read, write, execute) for files within the NFS
+  #     polarion-id: CEPH-83577602
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 3
+  #       file_count: 100
+  #       operations:
+  #         client01 : create_files
+  #         client02 : change_permission
+  #         client03 : perform_lookups
+
+  # - test:
+  #     name: Nfs export Readonly parameter
+  #     module: test_export_readonly.py
+  #     desc: Test NFS export with Readonly
+  #     polarion-id: CEPH-83578392
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 1
+
+  # - test:
+  #     name: Nfs export rootsquash permission
+  #     module: test_export_rootsquash.py
+  #     desc: Test NFS export with rootsquash
+  #     polarion-id: CEPH-83578393
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 1
+
+  # - test:
+  #     name: Nfs Verify locks over nfs mount with root_squash enabled
+  #     module: nfs_verify_file_lock_root_squash.py
+  #     desc: Perform lock on file with root_squash enabled
+  #     polarion-id: CEPH-83578386
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 4
+
+  # - test:
+  #     name: NFS-Ganesha export config to mount with RO
+  #     desc: Verify edit export config to mount with RO
+  #     module: nfs_edit_export_config_with_ro.py
+  #     polarion-id: CEPH-83578395
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 1
+
+  # - test:
+  #     name: NFS-Ganesha export config to mount with 1 client access
+  #     desc: Verify edit the export config to mount with allow access to only 1 client
+  #     module: nfs_edit_export_config_with_1client_access.py
+  #     polarion-id: CEPH-83578397
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 2
+
+  # - test:
+  #     name: Nfs Verify setuid bit set on a file
+  #     module: nfs_verify_setuid_bit.py
+  #     desc: Verify setuid bit set on a file
+  #     polarion-id:
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 3
+  #       file_count: 100
+  #       operations:
+  #         client01 : create_files
+  #         client02 : setuid_bit
+  #         client03 : perform_lookups
+
+  # - test:
+  #     name: NFS-Ganesha test cmount_path param in export file
+  #     desc: Verify cmount_path entry in export file
+  #     module: nfs_validate_cmount_path_export_conf.py
+  #     polarion-id: CEPH-83593816
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 1
+
+  # - test:
+  #     name: Running nfstest lock suite
+  #     module: nfs_run_nfslocktest_suite.py
+  #     desc: Running nfstest lock suite
+  #     polarion-id: CEPH-83577561
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 1
+
+  # - test:
+  #     name: Running single client byte lock test
+  #     module: nfs_single_client_byterange_filelock.py
+  #     desc: Running single client byte lock test
+  #     polarion-id: CEPH-83577561
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 1
+
+  # - test:
+  #     name: Running multi client byte lock test
+  #     module: nfs_multi_client_byterange_filelock.py
+  #     desc: Running multi client byte lock test
+  #     polarion-id: CEPH-83577561
+  #     abort-on-fail: false
+  #     config:
+  #       nfs_version: 3
+  #       clients: 4
+
+  # Smoke-only: cephadm NFS RADOS timeout (no client mount).
+  # Unique service_id/ports vs 2049.
   - test:
-      name: Nfs Ganesha rename operations
-      module: test_file_ops_renames.py
-      desc: Perform file and dir renaming and lookups in parallel
-      polarion-id: CEPH-83577594
+      name: NFS rados command timeout setup default NFS
+      module: test_nfs_rados_command_timeout.py
+      desc: Apply one healthy NFS cluster and leave it running (creates pool .nfs)
+      polarion-id: CEPH-83632973
       abort-on-fail: true
       config:
-        nfs_version: 3
-        clients: 3
-        num_files: 1000
-        num_dirs: 1000
+        mode: setup
+        service_id: nfs-14352-seed
+        port: 62100
+        monitoring_port: 62600
+        cluster_qos_port: 63100
 
   - test:
-      name: Verify create file, create soflink and lookups from nfs clients
-      module: nfs_verify_file_ops_soft_links.py
-      desc: Verify create file, create soflink and lookups from nfs clients
-      polarion-id: CEPH-83577596
+      name: NFS rados command timeout default 30s
+      module: test_nfs_rados_command_timeout.py
+      desc: >-
+        get must be 30 (else Fail after measuring 30s health); pause; add new NFS cluster using spec; health 30s
+      polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
-        nfs_version: 3
-        clients: 3
-        file_count: 100
+        mode: timeout
+        service_id: nfs-14352-stall-30
+        seed_service_id: nfs-14352-seed
+        port: 62110
+        monitoring_port: 62610
+        cluster_qos_port: 63110
+        expect: 30.0
+        get_ok:
+          - "30"
+        strict_get: true
 
   - test:
-      name: Nfs Verify File Operations
-      module: nfs_verify_file_operations.py
-      desc: Change the ownership (user and group) of files within the NFS export
-      polarion-id: CEPH-83577601
+      name: NFS rados command timeout set 60s
+      module: test_nfs_rados_command_timeout.py
+      desc: >-
+        config set 60; pause; new NFS; health timed out after 60.0 seconds; unpause
+      polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
-        nfs_version: 3
-        clients: 3
-        file_count: 100
-        operations:
-          client01 : create_files
-          client02 : change_ownership
-          client03 : perform_lookups
+        mode: timeout
+        service_id: nfs-14352-stall-60
+        seed_service_id: nfs-14352-seed
+        port: 62120
+        monitoring_port: 62620
+        cluster_qos_port: 63120
+        set_value: 60
+        expect: 60.0
+        get_ok:
+          - "60"
+        strict_get: true
 
   - test:
-      name: Nfs Verify File Operations
-      module: nfs_verify_file_operations.py
-      desc: Set different file permissions (read, write, execute) for files within the NFS
-      polarion-id: CEPH-83577602
+      name: NFS rados command timeout floor 5s
+      module: test_nfs_rados_command_timeout.py
+      desc: >-
+        config set 5; pause; new NFS; health timed out after 5.0 seconds; unpause
+      polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
-        nfs_version: 3
-        clients: 3
-        file_count: 100
-        operations:
-          client01 : create_files
-          client02 : change_permission
-          client03 : perform_lookups
+        mode: timeout
+        service_id: nfs-14352-stall-5
+        seed_service_id: nfs-14352-seed
+        port: 62130
+        monitoring_port: 62630
+        cluster_qos_port: 63130
+        set_value: 5
+        expect: 5.0
+        get_ok:
+          - "5"
+        strict_get: true
 
   - test:
-      name: Nfs export Readonly parameter
-      module: test_export_readonly.py
-      desc: Test NFS export with Readonly
-      polarion-id: CEPH-83578392
+      name: NFS rados command timeout below floor 0s
+      module: test_nfs_rados_command_timeout.py
+      desc: >-
+        config set 0; get must be 0 or 1 (not leftover 5); health 5.0; unpause
+      polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
-        nfs_version: 3
-        clients: 1
+        mode: timeout
+        service_id: nfs-14352-stall-0
+        seed_service_id: nfs-14352-seed
+        port: 62140
+        monitoring_port: 62640
+        cluster_qos_port: 63140
+        set_value: 0
+        expect: 5.0
+        get_ok:
+          - "0"
+          - "1"
+        strict_get: true
 
   - test:
-      name: Nfs export rootsquash permission
-      module: test_export_rootsquash.py
-      desc: Test NFS export with rootsquash
-      polarion-id: CEPH-83578393
+      name: NFS rados command timeout teardown
+      module: test_nfs_rados_command_timeout.py
+      desc: Unpause OSDs, config set timeout 30, orch rm seed and stall NFS
+      polarion-id: CEPH-83632973
       abort-on-fail: false
       config:
-        nfs_version: 3
-        clients: 1
-
-  - test:
-      name: Nfs Verify locks over nfs mount with root_squash enabled
-      module: nfs_verify_file_lock_root_squash.py
-      desc: Perform lock on file with root_squash enabled
-      polarion-id: CEPH-83578386
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 4
-
-  - test:
-      name: NFS-Ganesha export config to mount with RO
-      desc: Verify edit export config to mount with RO
-      module: nfs_edit_export_config_with_ro.py
-      polarion-id: CEPH-83578395
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 1
-
-  - test:
-      name: NFS-Ganesha export config to mount with 1 client access
-      desc: Verify edit the export config to mount with allow access to only 1 client
-      module: nfs_edit_export_config_with_1client_access.py
-      polarion-id: CEPH-83578397
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 2
-
-  - test:
-      name: Nfs Verify setuid bit set on a file
-      module: nfs_verify_setuid_bit.py
-      desc: Verify setuid bit set on a file
-      polarion-id:
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 3
-        file_count: 100
-        operations:
-          client01 : create_files
-          client02 : setuid_bit
-          client03 : perform_lookups
-
-  - test:
-      name: NFS-Ganesha test cmount_path param in export file
-      desc: Verify cmount_path entry in export file
-      module: nfs_validate_cmount_path_export_conf.py
-      polarion-id: CEPH-83593816
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 1
-
-  - test:
-      name: Running nfstest lock suite
-      module: nfs_run_nfslocktest_suite.py
-      desc: Running nfstest lock suite
-      polarion-id: CEPH-83577561
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 1
-
-  - test:
-      name: Running single client byte lock test
-      module: nfs_single_client_byterange_filelock.py
-      desc: Running single client byte lock test
-      polarion-id: CEPH-83577561
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 1
-
-  - test:
-      name: Running multi client byte lock test
-      module: nfs_multi_client_byterange_filelock.py
-      desc: Running multi client byte lock test
-      polarion-id: CEPH-83577561
-      abort-on-fail: false
-      config:
-        nfs_version: 3
-        clients: 4
+        mode: teardown
+        service_id: nfs-14352-seed
+        stall_service_ids:
+          - nfs-14352-stall-30
+          - nfs-14352-stall-60
+          - nfs-14352-stall-5
+          - nfs-14352-stall-0

--- a/tests/nfs/test_nfs_rados_command_timeout.py
+++ b/tests/nfs/test_nfs_rados_command_timeout.py
@@ -52,10 +52,6 @@ Harness (not product):
     health is still polled; other apply CommandFailed Fails immediately.
   * Unique service_id and ports per stall. ``cluster_qos_port`` is
     optional (tentacle); omit it on squid/8.1 NFS specs.
-  * Around every ``config set`` of this option, log ``ceph -s``,
-    ``ceph orch ps``, and ``ceph orch ps --daemon-type mgr --refresh
-    --format json``. Not Pass/Fail; later review from Jenkins whether
-    mgr failed over or restarted.
 """
 
 import json
@@ -164,40 +160,9 @@ def _config_get_timeout(installer):
     return out.strip()
 
 
-def _log_cmd(installer, cmd):
-    """Run ``cmd`` and log stdout/stderr. Never Fail the timeout row."""
-    out, err = _ceph(installer, cmd, check_ec=False)
-    body = "\n".join(p for p in (out, err) if p) or "(empty)"
-    log.info("%s:\n%s", cmd, body)
-
-
-def _log_mgr_snapshots(installer, when, value):
-    """Capture cluster/mgr status around a timeout ``config set``. Log only."""
-    log.info(
-        "MGR SNAPSHOT %s config set %s=%s (not asserted)",
-        when,
-        TIMEOUT_OPTION,
-        value,
-    )
-    _log_cmd(installer, "ceph -s")
-    _log_cmd(installer, "ceph orch ps")
-    _log_cmd(
-        installer,
-        "ceph orch ps --daemon-type mgr --refresh --format json",
-    )
-    log.info(
-        "MGR SNAPSHOT %s end %s=%s",
-        when,
-        TIMEOUT_OPTION,
-        value,
-    )
-
-
 def _config_set_timeout(installer, value):
     log.info("ceph config set mgr %s %s (not config rm)", TIMEOUT_OPTION, value)
-    _log_mgr_snapshots(installer, "before", value)
     _ceph(installer, f"ceph config set mgr {TIMEOUT_OPTION} {value}")
-    _log_mgr_snapshots(installer, "after", value)
 
 
 def _osd_pause(installer, timeout=PAUSE_FLAG_WAIT):

--- a/tests/nfs/test_nfs_rados_command_timeout.py
+++ b/tests/nfs/test_nfs_rados_command_timeout.py
@@ -52,6 +52,10 @@ Harness (not product):
     health is still polled; other apply CommandFailed Fails immediately.
   * Unique service_id and ports per stall. ``cluster_qos_port`` is
     optional (tentacle); omit it on squid/8.1 NFS specs.
+  * Around every ``config set`` of this option, log ``ceph -s``,
+    ``ceph orch ps``, and ``ceph orch ps --daemon-type mgr --refresh
+    --format json``. Not Pass/Fail; later review from Jenkins whether
+    mgr failed over or restarted.
 """
 
 import json
@@ -160,9 +164,40 @@ def _config_get_timeout(installer):
     return out.strip()
 
 
+def _log_cmd(installer, cmd):
+    """Run ``cmd`` and log stdout/stderr. Never Fail the timeout row."""
+    out, err = _ceph(installer, cmd, check_ec=False)
+    body = "\n".join(p for p in (out, err) if p) or "(empty)"
+    log.info("%s:\n%s", cmd, body)
+
+
+def _log_mgr_snapshots(installer, when, value):
+    """Capture cluster/mgr status around a timeout ``config set``. Log only."""
+    log.info(
+        "MGR SNAPSHOT %s config set %s=%s (not asserted)",
+        when,
+        TIMEOUT_OPTION,
+        value,
+    )
+    _log_cmd(installer, "ceph -s")
+    _log_cmd(installer, "ceph orch ps")
+    _log_cmd(
+        installer,
+        "ceph orch ps --daemon-type mgr --refresh --format json",
+    )
+    log.info(
+        "MGR SNAPSHOT %s end %s=%s",
+        when,
+        TIMEOUT_OPTION,
+        value,
+    )
+
+
 def _config_set_timeout(installer, value):
     log.info("ceph config set mgr %s %s (not config rm)", TIMEOUT_OPTION, value)
+    _log_mgr_snapshots(installer, "before", value)
     _ceph(installer, f"ceph config set mgr {TIMEOUT_OPTION} {value}")
+    _log_mgr_snapshots(installer, "after", value)
 
 
 def _osd_pause(installer, timeout=PAUSE_FLAG_WAIT):

--- a/tests/nfs/test_nfs_rados_command_timeout.py
+++ b/tests/nfs/test_nfs_rados_command_timeout.py
@@ -50,7 +50,8 @@ Harness (not product):
   * After unpause succeeds: 15s settle for mon/mgr. Do not poll MDS.
   * Paused apply SSH wait is max(120, 2N+60). SSH timeout is logged and
     health is still polled; other apply CommandFailed Fails immediately.
-  * Unique service_id and ports per stall (tentacle cluster_qos_port).
+  * Unique service_id and ports per stall. ``cluster_qos_port`` is
+    optional (tentacle); omit it on squid/8.1 NFS specs.
 """
 
 import json
@@ -267,7 +268,13 @@ def _require_dot_nfs_pool(installer):
         )
 
 
-def _nfs_spec(service_id, hosts, port, monitoring_port, qos_port):
+def _nfs_spec(service_id, hosts, port, monitoring_port, qos_port=None):
+    spec = {
+        "port": int(port),
+        "monitoring_port": int(monitoring_port),
+    }
+    if qos_port is not None:
+        spec["cluster_qos_port"] = int(qos_port)
     return {
         "service_type": "nfs",
         "service_id": service_id,
@@ -275,22 +282,19 @@ def _nfs_spec(service_id, hosts, port, monitoring_port, qos_port):
             "hosts": list(hosts),
             "count": len(hosts),
         },
-        "spec": {
-            "port": int(port),
-            "monitoring_port": int(monitoring_port),
-            "cluster_qos_port": int(qos_port),
-        },
+        "spec": spec,
     }
 
 
 def _ports_from_config(config):
-    for key in ("port", "monitoring_port", "cluster_qos_port"):
+    for key in ("port", "monitoring_port"):
         if config.get(key) is None:
             raise ConfigError(f"config.{key} is required (unique per NFS service)")
+    qos = config.get("cluster_qos_port")
     return (
         int(config["port"]),
         int(config["monitoring_port"]),
-        int(config["cluster_qos_port"]),
+        int(qos) if qos is not None else None,
     )
 
 


### PR DESCRIPTION
# Description

**Source of test case:** IBMCEPH-17453 close-loop (8.1z backport of IBMCEPH-14352). Same QE charter as tentacle PR 6140.

Fixes `suites/squid/nfs/tier0-nfs-ganesha-v3.yaml` (conf `conf/squid/nfs/1admin-7node-3client.yaml`).

- **CEPH-83632973** — `test_nfs_rados_command_timeout.py`: `mgr/cephadm/nfs_rados_command_timeout` under OSD pause (default 30s, set 60, floor 5, set 0 → health 5s). Pass/Fail is `config get` + `ceph health detail` (`CEPHADM_APPLY_SPEC_FAIL`, `timed out after N` / `N.0`). Lab stall is `rados get conf-nfs.*` on `.nfs`, not `ganesha-rados-grace`. Restore 30 with `config set … 30`, not `config rm`.

<details>
<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
  CEPH-83632973 (existing from 14352 / PR 6140)
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
  squid-test-executor #332 / #338 IBM 8.1 / rhel-9 / stable (`19.2.1-410.el9cp`) SUCCESS
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
  IBMCEPH-17453 still ON_QA; Verified + coverage after this lands

</details>

## Commits

### 1. Optional `cluster_qos_port` on NFS timeout specs

**Polarion:** CEPH-83632973
**File:** `tests/nfs/test_nfs_rados_command_timeout.py`

**Problem**
8.1 NFS `ServiceSpec` has no `cluster_qos_port`. Tentacle YAML still sends it. The module required the key, so squid apply failed with `Error EINVAL: unexpected keyword argument 'cluster_qos_port'`.

**Issue seen**
squid-test-executor #329: setup Fail, later timeout rows skipped.

**Before**
`_ports_from_config` / `_nfs_spec` always set `cluster_qos_port`.

**Fix**
Key is optional. Omit it when unset (squid/8.1). Tentacle YAML still sets it; that file is not in this PR (already #6140).

**Now**
8.1 apply uses port + monitoring_port only.

---

### 2. Timeout rows last on squid NFS v3

**Polarion:** CEPH-83632973
**File:** `suites/squid/nfs/tier0-nfs-ganesha-v3.yaml`

**Fix**
Append six tests after multi-client byte lock (OSD pause last). Existing v3 mount tests are unchanged. Rows: setup seed NFS; default 30; set 60; floor 5; set 0 (get 0|1, health 5s); teardown. Unique `service_id` / ports vs 2049. No `cluster_qos_port`.

**Now**
Health strings on 8.1: `timed out after` 30 / `60.0` / `5.0` / `5` (floor for set 0).

## Test runs

- [x] squid-test-executor [332](https://149.81.216.83/job/squid-test-executor/332/) — IBM 8.1 / rhel-9 / stable (`19.2.1-410.el9cp`) — timeout rows SUCCESS
- [x] squid-test-executor [338](https://149.81.216.83/job/squid-test-executor/338/) — same — SUCCESS
- [x] squid-test-executor [339](https://149.81.216.83/job/squid-test-executor/339/) — same — SUCCESS (optional; mgr `started` unchanged across `config set`)
[Squid_338.txt](https://github.com/user-attachments/files/32144136/Squid_338.txt)
[Squid_339.txt](https://github.com/user-attachments/files/32144138/Squid_339.txt)

 /Users/manankhanna/Downloads/Squid_339.txt (6 hits)
	Line  25333: 2026-09-11 04:13:11,028 - cephci - test_nfs_rados_command_timeout:535 - INFO - TEST PASSED - NFS rados command timeout setup nfs.nfs-14352-seed; pool .nfs present
	Line  25594: 2026-09-11 04:14:59,311 - cephci - test_nfs_rados_command_timeout:694 - INFO - TEST PASSED - NFS rados command timeout case nfs.nfs-14352-stall-30 expect=30.0
	Line  26173: 2026-09-11 04:17:29,750 - cephci - test_nfs_rados_command_timeout:694 - INFO - TEST PASSED - NFS rados command timeout case nfs.nfs-14352-stall-60 expect=60.0
	Line  26718: 2026-09-11 04:19:05,540 - cephci - test_nfs_rados_command_timeout:694 - INFO - TEST PASSED - NFS rados command timeout case nfs.nfs-14352-stall-5 expect=5.0
	Line  27214: 2026-09-11 04:20:44,782 - cephci - test_nfs_rados_command_timeout:694 - INFO - TEST PASSED - NFS rados command timeout case nfs.nfs-14352-stall-0 expect=5.0
	Line  27565: 2026-09-11 04:22:03,481 - cephci - test_nfs_rados_command_timeout:575 - INFO - TEST PASSED - NFS rados command timeout teardown; OSDs unpaused, timeout 30, orch rm done
